### PR TITLE
Add comprehensive test suite for server services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,10 @@ The AWS provider tags EventBridge rules on creation, which requires `events:TagR
 ## Cost Tagging
 
 All resources inherit `default_tags` from `provider "aws"` (`Project = "game-servers-poc"`, `Environment = "poc"`, `ManagedBy = "terraform"`). For Cost Explorer breakdowns, the `Project` cost allocation tag must be activated manually in AWS Billing — this is a one-time console action, not Terraform-managed.
+
+## Code & Test Conventions
+
+- **Test names**: every `it(...)` case must read as a natural-language sentence starting with "should" — e.g. `it('should return null when state file is missing')`, not `it('returns null...')`.
+- **TSDoc comments**: document non-trivial functions, helpers, and notable constants/variables with TSDoc (`/** ... */`) so their intent is clear later. This applies to test-file helpers (stub factories, fixtures) as well as production code.
+- **Typing in tests**: avoid `as unknown as SomeType` casts. Prefer `vi.mocked(fn)` for mocked modules and `Partial<T>` + a single `as T` for service-shaped stubs.
+- **No raw `process.env` in business logic**: wrap environment access behind a service method so tests can stub it via `vi.spyOn` instead of mutating `process.env` (which is flaky and leaks across tests).

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -25,10 +25,12 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "aws-sdk-client-mock": "^4.0.1",
         "concurrently": "^8.2.2",
         "tsx": "^4.15.7",
         "typescript": "^5.5.2",
-        "vite": "^5.3.1"
+        "vite": "^5.3.1",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2001,6 +2003,47 @@
         "win32"
       ]
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.16",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
@@ -2860,6 +2903,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
@@ -2885,6 +2945,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -2932,11 +3105,33 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.19",
@@ -3039,6 +3234,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3089,6 +3294,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3117,6 +3339,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cliui": {
@@ -3322,6 +3554,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3339,6 +3581,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -3407,6 +3659,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3478,6 +3737,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3485,6 +3754,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -3887,6 +4166,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -3929,6 +4215,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3937,6 +4230,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4042,6 +4345,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -4111,6 +4448,23 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4529,6 +4883,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4554,6 +4947,13 @@
         "node": "*"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4562,6 +4962,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4634,6 +5041,50 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4705,6 +5156,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -4862,6 +5323,29 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
@@ -5292,6 +5776,89 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,9 @@
     "dev:server": "tsx watch --tsconfig tsconfig.server.json src/server/index.ts",
     "dev:client": "vite",
     "build": "tsc -p tsconfig.server.json && vite build",
-    "start": "node dist/server/index.js"
+    "start": "node dist/server/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.600.0",
@@ -28,9 +30,11 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "aws-sdk-client-mock": "^4.0.1",
     "concurrently": "^8.2.2",
     "tsx": "^4.15.7",
     "typescript": "^5.5.2",
-    "vite": "^5.3.1"
+    "vite": "^5.3.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/app/src/server/services/ConfigService.test.ts
+++ b/app/src/server/services/ConfigService.test.ts
@@ -1,0 +1,174 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { ConfigService } from './ConfigService.js';
+
+const mockExists = existsSync as unknown as ReturnType<typeof vi.fn>;
+const mockRead = readFileSync as unknown as ReturnType<typeof vi.fn>;
+const mockWrite = writeFileSync as unknown as ReturnType<typeof vi.fn>;
+
+function makeState(outputs: Record<string, { value: unknown }>): string {
+  return JSON.stringify({ outputs });
+}
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+
+  beforeEach(() => {
+    service = new ConfigService();
+  });
+
+  describe('getTfOutputs', () => {
+    it('returns null and warns when state file does not exist', () => {
+      mockExists.mockReturnValue(false);
+      expect(service.getTfOutputs()).toBeNull();
+    });
+
+    it('parses outputs and fills defaults for missing keys', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(
+        makeState({
+          aws_region: { value: 'us-west-2' },
+          ecs_cluster_name: { value: 'my-cluster' },
+          game_names: { value: ['minecraft', 'factorio'] },
+        }),
+      );
+
+      const outputs = service.getTfOutputs();
+      expect(outputs).not.toBeNull();
+      expect(outputs!.aws_region).toBe('us-west-2');
+      expect(outputs!.ecs_cluster_name).toBe('my-cluster');
+      expect(outputs!.game_names).toEqual(['minecraft', 'factorio']);
+      expect(outputs!.subnet_ids).toBe('');
+      expect(outputs!.alb_dns_name).toBeNull();
+      expect(outputs!.efs_access_points).toEqual({});
+    });
+
+    it('applies fallback aws_region when outputs omit it', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(makeState({}));
+      expect(service.getTfOutputs()!.aws_region).toBe('us-east-1');
+    });
+
+    it('caches parsed outputs across calls', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(makeState({ aws_region: { value: 'eu-central-1' } }));
+
+      service.getTfOutputs();
+      service.getTfOutputs();
+
+      expect(mockRead).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateCache forces a re-read', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(makeState({ aws_region: { value: 'a' } }));
+
+      service.getTfOutputs();
+      service.invalidateCache();
+      mockRead.mockReturnValue(makeState({ aws_region: { value: 'b' } }));
+
+      expect(service.getTfOutputs()!.aws_region).toBe('b');
+      expect(mockRead).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns null on invalid JSON', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('not-json{');
+      expect(service.getTfOutputs()).toBeNull();
+    });
+  });
+
+  describe('getRegion', () => {
+    it('uses aws_region from outputs when available', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(makeState({ aws_region: { value: 'ap-south-1' } }));
+      expect(service.getRegion()).toBe('ap-south-1');
+    });
+
+    it('falls back to AWS_DEFAULT_REGION env var when outputs unavailable', () => {
+      mockExists.mockReturnValue(false);
+      const prev = process.env['AWS_DEFAULT_REGION'];
+      process.env['AWS_DEFAULT_REGION'] = 'eu-west-3';
+      try {
+        expect(service.getRegion()).toBe('eu-west-3');
+      } finally {
+        if (prev === undefined) delete process.env['AWS_DEFAULT_REGION'];
+        else process.env['AWS_DEFAULT_REGION'] = prev;
+      }
+    });
+
+    it('falls back to us-east-1 when no outputs and no env var', () => {
+      mockExists.mockReturnValue(false);
+      const prev = process.env['AWS_DEFAULT_REGION'];
+      delete process.env['AWS_DEFAULT_REGION'];
+      try {
+        expect(service.getRegion()).toBe('us-east-1');
+      } finally {
+        if (prev !== undefined) process.env['AWS_DEFAULT_REGION'] = prev;
+      }
+    });
+  });
+
+  describe('getConfig', () => {
+    it('returns defaults when config file missing', () => {
+      mockExists.mockReturnValue(false);
+      expect(service.getConfig()).toEqual({
+        watchdog_interval_minutes: 15,
+        watchdog_idle_checks: 4,
+        watchdog_min_packets: 100,
+      });
+    });
+
+    it('merges saved config over defaults', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(
+        JSON.stringify({ watchdog_idle_checks: 10, watchdog_min_packets: 250 }),
+      );
+      expect(service.getConfig()).toEqual({
+        watchdog_interval_minutes: 15,
+        watchdog_idle_checks: 10,
+        watchdog_min_packets: 250,
+      });
+    });
+
+    it('returns defaults if config file is malformed', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('{bad json');
+      const config = service.getConfig();
+      expect(config.watchdog_interval_minutes).toBe(15);
+      expect(config.watchdog_idle_checks).toBe(4);
+      expect(config.watchdog_min_packets).toBe(100);
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('writes JSON-stringified config to disk', () => {
+      const config = {
+        watchdog_interval_minutes: 30,
+        watchdog_idle_checks: 6,
+        watchdog_min_packets: 500,
+      };
+      service.saveConfig(config);
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+      const [, payload] = mockWrite.mock.calls[0]!;
+      expect(JSON.parse(payload as string)).toEqual(config);
+    });
+  });
+});

--- a/app/src/server/services/ConfigService.test.ts
+++ b/app/src/server/services/ConfigService.test.ts
@@ -19,15 +19,21 @@ vi.mock('../logger.js', () => ({
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { ConfigService } from './ConfigService.js';
 
-const mockExists = existsSync as unknown as ReturnType<typeof vi.fn>;
-const mockRead = readFileSync as unknown as ReturnType<typeof vi.fn>;
-const mockWrite = writeFileSync as unknown as ReturnType<typeof vi.fn>;
+/** Strongly-typed mock handles for the `fs` module. */
+const mockExists = vi.mocked(existsSync);
+const mockRead = vi.mocked(readFileSync);
+const mockWrite = vi.mocked(writeFileSync);
 
+/**
+ * Build a Terraform state file payload from an `outputs` map.
+ * Mirrors the shape that `terraform.tfstate` uses on disk.
+ */
 function makeState(outputs: Record<string, { value: unknown }>): string {
   return JSON.stringify({ outputs });
 }
 
 describe('ConfigService', () => {
+  /** Fresh instance per test; each has its own in-memory tfstate cache. */
   let service: ConfigService;
 
   beforeEach(() => {
@@ -35,12 +41,12 @@ describe('ConfigService', () => {
   });
 
   describe('getTfOutputs', () => {
-    it('returns null and warns when state file does not exist', () => {
+    it('should return null and warn when the state file does not exist', () => {
       mockExists.mockReturnValue(false);
       expect(service.getTfOutputs()).toBeNull();
     });
 
-    it('parses outputs and fills defaults for missing keys', () => {
+    it('should parse outputs and fill defaults for missing keys', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(
         makeState({
@@ -60,13 +66,13 @@ describe('ConfigService', () => {
       expect(outputs!.efs_access_points).toEqual({});
     });
 
-    it('applies fallback aws_region when outputs omit it', () => {
+    it('should apply the fallback aws_region when outputs omit it', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(makeState({}));
       expect(service.getTfOutputs()!.aws_region).toBe('us-east-1');
     });
 
-    it('caches parsed outputs across calls', () => {
+    it('should cache parsed outputs across calls', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(makeState({ aws_region: { value: 'eu-central-1' } }));
 
@@ -76,7 +82,7 @@ describe('ConfigService', () => {
       expect(mockRead).toHaveBeenCalledTimes(1);
     });
 
-    it('invalidateCache forces a re-read', () => {
+    it('should force a re-read after invalidateCache', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(makeState({ aws_region: { value: 'a' } }));
 
@@ -88,7 +94,7 @@ describe('ConfigService', () => {
       expect(mockRead).toHaveBeenCalledTimes(2);
     });
 
-    it('returns null on invalid JSON', () => {
+    it('should return null when the state file contains invalid JSON', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue('not-json{');
       expect(service.getTfOutputs()).toBeNull();
@@ -96,38 +102,27 @@ describe('ConfigService', () => {
   });
 
   describe('getRegion', () => {
-    it('uses aws_region from outputs when available', () => {
+    it('should use aws_region from outputs when available', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(makeState({ aws_region: { value: 'ap-south-1' } }));
       expect(service.getRegion()).toBe('ap-south-1');
     });
 
-    it('falls back to AWS_DEFAULT_REGION env var when outputs unavailable', () => {
+    it('should fall back to readEnvRegion when outputs unavailable', () => {
       mockExists.mockReturnValue(false);
-      const prev = process.env['AWS_DEFAULT_REGION'];
-      process.env['AWS_DEFAULT_REGION'] = 'eu-west-3';
-      try {
-        expect(service.getRegion()).toBe('eu-west-3');
-      } finally {
-        if (prev === undefined) delete process.env['AWS_DEFAULT_REGION'];
-        else process.env['AWS_DEFAULT_REGION'] = prev;
-      }
+      vi.spyOn(service, 'readEnvRegion').mockReturnValue('eu-west-3');
+      expect(service.getRegion()).toBe('eu-west-3');
     });
 
-    it('falls back to us-east-1 when no outputs and no env var', () => {
+    it('should fall back to us-east-1 when no outputs and no env region', () => {
       mockExists.mockReturnValue(false);
-      const prev = process.env['AWS_DEFAULT_REGION'];
-      delete process.env['AWS_DEFAULT_REGION'];
-      try {
-        expect(service.getRegion()).toBe('us-east-1');
-      } finally {
-        if (prev !== undefined) process.env['AWS_DEFAULT_REGION'] = prev;
-      }
+      vi.spyOn(service, 'readEnvRegion').mockReturnValue(undefined);
+      expect(service.getRegion()).toBe('us-east-1');
     });
   });
 
   describe('getConfig', () => {
-    it('returns defaults when config file missing', () => {
+    it('should return defaults when the config file is missing', () => {
       mockExists.mockReturnValue(false);
       expect(service.getConfig()).toEqual({
         watchdog_interval_minutes: 15,
@@ -136,7 +131,7 @@ describe('ConfigService', () => {
       });
     });
 
-    it('merges saved config over defaults', () => {
+    it('should merge saved config over defaults', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(
         JSON.stringify({ watchdog_idle_checks: 10, watchdog_min_packets: 250 }),
@@ -148,7 +143,7 @@ describe('ConfigService', () => {
       });
     });
 
-    it('returns defaults if config file is malformed', () => {
+    it('should return defaults when the config file is malformed', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue('{bad json');
       const config = service.getConfig();
@@ -159,7 +154,7 @@ describe('ConfigService', () => {
   });
 
   describe('saveConfig', () => {
-    it('writes JSON-stringified config to disk', () => {
+    it('should write JSON-stringified config to disk', () => {
       const config = {
         watchdog_interval_minutes: 30,
         watchdog_idle_checks: 6,

--- a/app/src/server/services/ConfigService.ts
+++ b/app/src/server/services/ConfigService.ts
@@ -82,10 +82,19 @@ export class ConfigService {
     }
   }
 
+  /**
+   * Read the AWS region hint from the process environment.
+   * Extracted so tests can stub env access via `vi.spyOn` instead of
+   * mutating `process.env` directly (which is flaky across tests).
+   */
+  readEnvRegion(): string | undefined {
+    return process.env['AWS_DEFAULT_REGION'];
+  }
+
   getRegion(): string {
     return (
       this.getTfOutputs()?.aws_region ??
-      process.env['AWS_DEFAULT_REGION'] ??
+      this.readEnvRegion() ??
       'us-east-1'
     );
   }

--- a/app/src/server/services/CostService.test.ts
+++ b/app/src/server/services/CostService.test.ts
@@ -1,0 +1,113 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  CostExplorerClient,
+  GetCostAndUsageCommand,
+} from '@aws-sdk/client-cost-explorer';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { CostService } from './CostService.js';
+
+const ceMock = mockClient(CostExplorerClient);
+
+describe('CostService', () => {
+  let service: CostService;
+
+  beforeEach(() => {
+    ceMock.reset();
+    service = new CostService();
+  });
+
+  describe('estimateForSpec', () => {
+    it('computes Fargate hourly / daily / monthly costs for 1 vCPU + 2 GiB', () => {
+      const est = service.estimateForSpec(1024, 2048);
+      expect(est.vcpu).toBe(1);
+      expect(est.memoryGb).toBe(2);
+      // 1 * 0.04048 + 2 * 0.004445 = 0.04937
+      expect(est.costPerHour).toBeCloseTo(0.0494, 4);
+      // 0.04937 * 24 = 1.18488 -> 1.18
+      expect(est.costPerDay24h).toBeCloseTo(1.18, 2);
+      // 0.04937 * 4 * 30 = 5.9244 -> 5.92
+      expect(est.costPerMonth4hpd).toBeCloseTo(5.92, 2);
+    });
+
+    it('scales linearly with CPU and memory', () => {
+      const half = service.estimateForSpec(512, 1024);
+      const full = service.estimateForSpec(1024, 2048);
+      expect(half.costPerHour).toBeCloseTo(full.costPerHour / 2, 6);
+    });
+
+    it('rounds hourly cost to 4 decimals and daily/monthly to 2 decimals', () => {
+      const est = service.estimateForSpec(256, 512);
+      expect(Number.isFinite(est.costPerHour)).toBe(true);
+      const hourStr = est.costPerHour.toString();
+      const decimals = hourStr.split('.')[1] ?? '';
+      expect(decimals.length).toBeLessThanOrEqual(4);
+    });
+  });
+
+  describe('getActualCosts', () => {
+    it('aggregates daily costs and returns total', async () => {
+      ceMock.on(GetCostAndUsageCommand).resolves({
+        ResultsByTime: [
+          { TimePeriod: { Start: '2026-04-10', End: '2026-04-11' }, Total: { UnblendedCost: { Amount: '1.2345', Unit: 'USD' } } },
+          { TimePeriod: { Start: '2026-04-11', End: '2026-04-12' }, Total: { UnblendedCost: { Amount: '2.5000', Unit: 'USD' } } },
+        ],
+      });
+
+      const result = await service.getActualCosts(2);
+      expect(result.days).toBe(2);
+      expect(result.currency).toBe('USD');
+      expect(result.daily).toEqual([
+        { date: '2026-04-10', cost: 1.2345 },
+        { date: '2026-04-11', cost: 2.5 },
+      ]);
+      // 1.2345 + 2.5 = 3.7345 -> rounded to 2 decimals = 3.73
+      expect(result.total).toBeCloseTo(3.73, 2);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('filters by ECS and Fargate services', async () => {
+      ceMock.on(GetCostAndUsageCommand).resolves({ ResultsByTime: [] });
+      await service.getActualCosts(7);
+      const calls = ceMock.commandCalls(GetCostAndUsageCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.Filter?.Dimensions?.Key).toBe('SERVICE');
+      expect(input.Filter?.Dimensions?.Values).toEqual([
+        'Amazon Elastic Container Service',
+        'AWS Fargate',
+      ]);
+      expect(input.Granularity).toBe('DAILY');
+      expect(input.Metrics).toEqual(['UnblendedCost']);
+    });
+
+    it('returns error shape when Cost Explorer throws', async () => {
+      ceMock.on(GetCostAndUsageCommand).rejects(new Error('AccessDenied'));
+      const result = await service.getActualCosts(7);
+      expect(result.total).toBe(0);
+      expect(result.daily).toEqual([]);
+      expect(result.days).toBe(7);
+      expect(result.error).toContain('AccessDenied');
+    });
+
+    it('handles missing cost amount gracefully', async () => {
+      ceMock.on(GetCostAndUsageCommand).resolves({
+        ResultsByTime: [{ TimePeriod: { Start: '2026-04-10' }, Total: {} }],
+      });
+      const result = await service.getActualCosts(1);
+      expect(result.daily).toEqual([{ date: '2026-04-10', cost: 0 }]);
+      expect(result.total).toBe(0);
+    });
+
+    it('defaults to 7 days when called with no argument', async () => {
+      ceMock.on(GetCostAndUsageCommand).resolves({ ResultsByTime: [] });
+      const result = await service.getActualCosts();
+      expect(result.days).toBe(7);
+    });
+  });
+});

--- a/app/src/server/services/CostService.test.ts
+++ b/app/src/server/services/CostService.test.ts
@@ -12,9 +12,11 @@ vi.mock('../logger.js', () => ({
 
 import { CostService } from './CostService.js';
 
+/** Typed stand-in for the AWS Cost Explorer SDK client. */
 const ceMock = mockClient(CostExplorerClient);
 
 describe('CostService', () => {
+  /** Fresh service instance per test to avoid cached SDK clients leaking. */
   let service: CostService;
 
   beforeEach(() => {
@@ -23,7 +25,7 @@ describe('CostService', () => {
   });
 
   describe('estimateForSpec', () => {
-    it('computes Fargate hourly / daily / monthly costs for 1 vCPU + 2 GiB', () => {
+    it('should compute Fargate hourly, daily, and monthly costs for 1 vCPU + 2 GiB', () => {
       const est = service.estimateForSpec(1024, 2048);
       expect(est.vcpu).toBe(1);
       expect(est.memoryGb).toBe(2);
@@ -35,23 +37,22 @@ describe('CostService', () => {
       expect(est.costPerMonth4hpd).toBeCloseTo(5.92, 2);
     });
 
-    it('scales linearly with CPU and memory', () => {
+    it('should scale cost linearly with CPU and memory', () => {
       const half = service.estimateForSpec(512, 1024);
       const full = service.estimateForSpec(1024, 2048);
       expect(half.costPerHour).toBeCloseTo(full.costPerHour / 2, 6);
     });
 
-    it('rounds hourly cost to 4 decimals and daily/monthly to 2 decimals', () => {
+    it('should round hourly cost to at most 4 decimals', () => {
       const est = service.estimateForSpec(256, 512);
       expect(Number.isFinite(est.costPerHour)).toBe(true);
-      const hourStr = est.costPerHour.toString();
-      const decimals = hourStr.split('.')[1] ?? '';
+      const decimals = est.costPerHour.toString().split('.')[1] ?? '';
       expect(decimals.length).toBeLessThanOrEqual(4);
     });
   });
 
   describe('getActualCosts', () => {
-    it('aggregates daily costs and returns total', async () => {
+    it('should aggregate daily costs and return a total', async () => {
       ceMock.on(GetCostAndUsageCommand).resolves({
         ResultsByTime: [
           { TimePeriod: { Start: '2026-04-10', End: '2026-04-11' }, Total: { UnblendedCost: { Amount: '1.2345', Unit: 'USD' } } },
@@ -71,7 +72,7 @@ describe('CostService', () => {
       expect(result.error).toBeUndefined();
     });
 
-    it('filters by ECS and Fargate services', async () => {
+    it('should filter by ECS and Fargate services', async () => {
       ceMock.on(GetCostAndUsageCommand).resolves({ ResultsByTime: [] });
       await service.getActualCosts(7);
       const calls = ceMock.commandCalls(GetCostAndUsageCommand);
@@ -86,7 +87,7 @@ describe('CostService', () => {
       expect(input.Metrics).toEqual(['UnblendedCost']);
     });
 
-    it('returns error shape when Cost Explorer throws', async () => {
+    it('should return an error shape when Cost Explorer throws', async () => {
       ceMock.on(GetCostAndUsageCommand).rejects(new Error('AccessDenied'));
       const result = await service.getActualCosts(7);
       expect(result.total).toBe(0);
@@ -95,16 +96,16 @@ describe('CostService', () => {
       expect(result.error).toContain('AccessDenied');
     });
 
-    it('handles missing cost amount gracefully', async () => {
+    it('should handle a missing cost amount gracefully', async () => {
       ceMock.on(GetCostAndUsageCommand).resolves({
-        ResultsByTime: [{ TimePeriod: { Start: '2026-04-10' }, Total: {} }],
+        ResultsByTime: [{ TimePeriod: { Start: '2026-04-10', End: '2026-04-11' }, Total: {} }],
       });
       const result = await service.getActualCosts(1);
       expect(result.daily).toEqual([{ date: '2026-04-10', cost: 0 }]);
       expect(result.total).toBe(0);
     });
 
-    it('defaults to 7 days when called with no argument', async () => {
+    it('should default to 7 days when called with no argument', async () => {
       ceMock.on(GetCostAndUsageCommand).resolves({ ResultsByTime: [] });
       const result = await service.getActualCosts();
       expect(result.days).toBe(7);

--- a/app/src/server/services/Ec2Service.test.ts
+++ b/app/src/server/services/Ec2Service.test.ts
@@ -1,0 +1,81 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EC2Client,
+  DescribeNetworkInterfacesCommand,
+} from '@aws-sdk/client-ec2';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { Ec2Service } from './Ec2Service.js';
+import type { ConfigService } from './ConfigService.js';
+
+const ec2Mock = mockClient(EC2Client);
+
+function makeConfig(): ConfigService {
+  return { getRegion: () => 'us-east-1' } as unknown as ConfigService;
+}
+
+describe('Ec2Service', () => {
+  let service: Ec2Service;
+
+  beforeEach(() => {
+    ec2Mock.reset();
+    service = new Ec2Service(makeConfig());
+  });
+
+  describe('getPublicIp', () => {
+    it('returns the public IP when attached', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
+        NetworkInterfaces: [{ Association: { PublicIp: '54.1.2.3' } }],
+      });
+      expect(await service.getPublicIp('eni-abc')).toBe('54.1.2.3');
+    });
+
+    it('returns null when no association/public IP', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
+        NetworkInterfaces: [{}],
+      });
+      expect(await service.getPublicIp('eni-abc')).toBeNull();
+    });
+
+    it('returns null when no interfaces returned', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({ NetworkInterfaces: [] });
+      expect(await service.getPublicIp('eni-abc')).toBeNull();
+    });
+
+    it('returns null on API error', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).rejects(new Error('boom'));
+      expect(await service.getPublicIp('eni-abc')).toBeNull();
+    });
+
+    it('passes ENI id to the command', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({ NetworkInterfaces: [] });
+      await service.getPublicIp('eni-123');
+      const input = ec2Mock.commandCalls(DescribeNetworkInterfacesCommand)[0]!.args[0].input;
+      expect(input.NetworkInterfaceIds).toEqual(['eni-123']);
+    });
+  });
+
+  describe('getPrivateIp', () => {
+    it('returns the private IP when present', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
+        NetworkInterfaces: [{ PrivateIpAddress: '10.0.1.5' }],
+      });
+      expect(await service.getPrivateIp('eni-abc')).toBe('10.0.1.5');
+    });
+
+    it('returns null when absent', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({ NetworkInterfaces: [{}] });
+      expect(await service.getPrivateIp('eni-abc')).toBeNull();
+    });
+
+    it('returns null on API error', async () => {
+      ec2Mock.on(DescribeNetworkInterfacesCommand).rejects(new Error('nope'));
+      expect(await service.getPrivateIp('eni-abc')).toBeNull();
+    });
+  });
+});

--- a/app/src/server/services/Ec2Service.test.ts
+++ b/app/src/server/services/Ec2Service.test.ts
@@ -13,13 +13,20 @@ vi.mock('../logger.js', () => ({
 import { Ec2Service } from './Ec2Service.js';
 import type { ConfigService } from './ConfigService.js';
 
+/** Typed stand-in for the AWS EC2 SDK client. */
 const ec2Mock = mockClient(EC2Client);
 
+/**
+ * Build a minimal ConfigService stub exposing only the members Ec2Service
+ * actually reads at runtime.
+ */
 function makeConfig(): ConfigService {
-  return { getRegion: () => 'us-east-1' } as unknown as ConfigService;
+  const stub: Partial<ConfigService> = { getRegion: () => 'us-east-1' };
+  return stub as ConfigService;
 }
 
 describe('Ec2Service', () => {
+  /** Service under test, freshly constructed per test. */
   let service: Ec2Service;
 
   beforeEach(() => {
@@ -28,31 +35,31 @@ describe('Ec2Service', () => {
   });
 
   describe('getPublicIp', () => {
-    it('returns the public IP when attached', async () => {
+    it('should return the public IP when attached', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
         NetworkInterfaces: [{ Association: { PublicIp: '54.1.2.3' } }],
       });
       expect(await service.getPublicIp('eni-abc')).toBe('54.1.2.3');
     });
 
-    it('returns null when no association/public IP', async () => {
+    it('should return null when there is no association or public IP', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
         NetworkInterfaces: [{}],
       });
       expect(await service.getPublicIp('eni-abc')).toBeNull();
     });
 
-    it('returns null when no interfaces returned', async () => {
+    it('should return null when no interfaces are returned', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({ NetworkInterfaces: [] });
       expect(await service.getPublicIp('eni-abc')).toBeNull();
     });
 
-    it('returns null on API error', async () => {
+    it('should return null on API error', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).rejects(new Error('boom'));
       expect(await service.getPublicIp('eni-abc')).toBeNull();
     });
 
-    it('passes ENI id to the command', async () => {
+    it('should pass the ENI id through to the SDK command', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({ NetworkInterfaces: [] });
       await service.getPublicIp('eni-123');
       const input = ec2Mock.commandCalls(DescribeNetworkInterfacesCommand)[0]!.args[0].input;
@@ -61,19 +68,19 @@ describe('Ec2Service', () => {
   });
 
   describe('getPrivateIp', () => {
-    it('returns the private IP when present', async () => {
+    it('should return the private IP when present', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
         NetworkInterfaces: [{ PrivateIpAddress: '10.0.1.5' }],
       });
       expect(await service.getPrivateIp('eni-abc')).toBe('10.0.1.5');
     });
 
-    it('returns null when absent', async () => {
+    it('should return null when the private IP is absent', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({ NetworkInterfaces: [{}] });
       expect(await service.getPrivateIp('eni-abc')).toBeNull();
     });
 
-    it('returns null on API error', async () => {
+    it('should return null on API error', async () => {
       ec2Mock.on(DescribeNetworkInterfacesCommand).rejects(new Error('nope'));
       expect(await service.getPrivateIp('eni-abc')).toBeNull();
     });

--- a/app/src/server/services/EcsService.test.ts
+++ b/app/src/server/services/EcsService.test.ts
@@ -20,8 +20,13 @@ import { EcsService } from './EcsService.js';
 import type { ConfigService, TfOutputs } from './ConfigService.js';
 import type { Ec2Service } from './Ec2Service.js';
 
+/** Typed stand-in for the AWS ECS SDK client. */
 const ecsMock = mockClient(ECSClient);
 
+/**
+ * A canonical set of Terraform outputs used by most tests. Individual tests
+ * spread over this to tweak specific fields (e.g. clearing `domain_name`).
+ */
 const DEFAULT_OUTPUTS: TfOutputs = {
   aws_region: 'us-east-1',
   ecs_cluster_name: 'game-cluster',
@@ -37,15 +42,27 @@ const DEFAULT_OUTPUTS: TfOutputs = {
   acm_certificate_arn: null,
 };
 
+/**
+ * Build a minimal ConfigService stub with just the methods EcsService reads.
+ * Pass `null` to simulate "terraform apply hasn't been run yet".
+ */
 function makeConfig(outputs: TfOutputs | null = DEFAULT_OUTPUTS): ConfigService {
-  return {
+  const stub: Partial<ConfigService> = {
     getRegion: () => 'us-east-1',
     getTfOutputs: () => outputs,
-  } as unknown as ConfigService;
+  };
+  return stub as ConfigService;
 }
 
+/**
+ * Build an Ec2Service stub whose `getPublicIp` resolves to the given value.
+ * Defaults to a non-null placeholder so tests don't have to pass it in.
+ */
 function makeEc2(ip: string | null = '1.2.3.4'): Ec2Service {
-  return { getPublicIp: vi.fn().mockResolvedValue(ip) } as unknown as Ec2Service;
+  const stub: Partial<Ec2Service> = {
+    getPublicIp: vi.fn().mockResolvedValue(ip),
+  };
+  return stub as Ec2Service;
 }
 
 describe('EcsService', () => {
@@ -54,7 +71,7 @@ describe('EcsService', () => {
   });
 
   describe('extractEniId', () => {
-    it('returns ENI id from ElasticNetworkInterface attachment', () => {
+    it('should return the ENI id from an ElasticNetworkInterface attachment', () => {
       const service = new EcsService(makeConfig(), makeEc2());
       const task: Task = {
         attachments: [
@@ -70,13 +87,13 @@ describe('EcsService', () => {
       expect(service.extractEniId(task)).toBe('eni-abc');
     });
 
-    it('returns null when no ENI attachment present', () => {
+    it('should return null when no ENI attachment is present', () => {
       const service = new EcsService(makeConfig(), makeEc2());
       expect(service.extractEniId({ attachments: [] })).toBeNull();
       expect(service.extractEniId({})).toBeNull();
     });
 
-    it('ignores non-ENI attachment types', () => {
+    it('should ignore non-ENI attachment types', () => {
       const service = new EcsService(makeConfig(), makeEc2());
       const task: Task = {
         attachments: [
@@ -91,13 +108,13 @@ describe('EcsService', () => {
   });
 
   describe('findRunningTask', () => {
-    it('returns null when no tasks listed', async () => {
+    it('should return null when no tasks are listed', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.findRunningTask('cluster', 'minecraft')).toBeNull();
     });
 
-    it('scopes list to {game}-server family and RUNNING desired status', async () => {
+    it('should scope the list call to {game}-server family and RUNNING desired status', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       const service = new EcsService(makeConfig(), makeEc2());
       await service.findRunningTask('my-cluster', 'factorio');
@@ -107,7 +124,7 @@ describe('EcsService', () => {
       expect(input.cluster).toBe('my-cluster');
     });
 
-    it('filters out STOPPED and DEPROVISIONING tasks', async () => {
+    it('should filter out STOPPED and DEPROVISIONING tasks', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1', 'arn2'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [
@@ -120,7 +137,7 @@ describe('EcsService', () => {
       expect(task?.taskArn).toBe('arn2');
     });
 
-    it('returns null on API errors', async () => {
+    it('should return null on API errors', async () => {
       ecsMock.on(ListTasksCommand).rejects(new Error('api-fail'));
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.findRunningTask('c', 'g')).toBeNull();
@@ -128,14 +145,14 @@ describe('EcsService', () => {
   });
 
   describe('getStatus', () => {
-    it('returns not_deployed when terraform outputs missing', async () => {
+    it('should return not_deployed when terraform outputs are missing', async () => {
       const service = new EcsService(makeConfig(null), makeEc2());
       const status = await service.getStatus('minecraft');
       expect(status.state).toBe('not_deployed');
       expect(status.message).toMatch(/terraform apply/i);
     });
 
-    it('returns running with public IP + hostname for RUNNING task', async () => {
+    it('should return running with public IP and hostname for a RUNNING task', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [
@@ -160,7 +177,7 @@ describe('EcsService', () => {
       expect(ec2.getPublicIp).toHaveBeenCalledWith('eni-xyz');
     });
 
-    it('returns starting when task not yet RUNNING', async () => {
+    it('should return starting when the task is not yet RUNNING', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [{ taskArn: 'arn1', lastStatus: 'PROVISIONING' }],
@@ -171,14 +188,14 @@ describe('EcsService', () => {
       expect(status.taskArn).toBe('arn1');
     });
 
-    it('returns stopped when no running task', async () => {
+    it('should return stopped when no running task is found', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       const service = new EcsService(makeConfig(), makeEc2());
       const status = await service.getStatus('minecraft');
       expect(status.state).toBe('stopped');
     });
 
-    it('omits hostname when no domain_name configured', async () => {
+    it('should omit hostname when no domain_name is configured', async () => {
       const outputs: TfOutputs = { ...DEFAULT_OUTPUTS, domain_name: '' };
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
       ecsMock.on(DescribeTasksCommand).resolves({
@@ -192,14 +209,14 @@ describe('EcsService', () => {
   });
 
   describe('start', () => {
-    it('returns failure if terraform outputs missing', async () => {
+    it('should return failure if terraform outputs are missing', async () => {
       const service = new EcsService(makeConfig(null), makeEc2());
       const result = await service.start('minecraft');
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/terraform apply/i);
     });
 
-    it('refuses to start if a task is already running', async () => {
+    it('should refuse to start if a task is already running', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING' }],
@@ -210,7 +227,7 @@ describe('EcsService', () => {
       expect(result.message).toMatch(/already running/i);
     });
 
-    it('launches task with correct cluster/family/subnets/SG when no running task', async () => {
+    it('should launch a task with the correct cluster, family, subnets, and SG', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       ecsMock.on(RunTaskCommand).resolves({ tasks: [{ taskArn: 'arn-new' }] });
 
@@ -228,7 +245,7 @@ describe('EcsService', () => {
       expect(input.networkConfiguration?.awsvpcConfiguration?.assignPublicIp).toBe('ENABLED');
     });
 
-    it('returns failure with reason when RunTask reports failures', async () => {
+    it('should return failure with reason when RunTask reports failures', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       ecsMock.on(RunTaskCommand).resolves({
         tasks: [],
@@ -240,7 +257,7 @@ describe('EcsService', () => {
       expect(result.message).toContain('CAPACITY');
     });
 
-    it('returns failure when RunTask throws', async () => {
+    it('should return failure when RunTask throws', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       ecsMock.on(RunTaskCommand).rejects(new Error('throttled'));
       const service = new EcsService(makeConfig(), makeEc2());
@@ -251,13 +268,13 @@ describe('EcsService', () => {
   });
 
   describe('stop', () => {
-    it('returns failure if terraform outputs missing', async () => {
+    it('should return failure if terraform outputs are missing', async () => {
       const service = new EcsService(makeConfig(null), makeEc2());
       const result = await service.stop('minecraft');
       expect(result.success).toBe(false);
     });
 
-    it('returns failure when nothing is running', async () => {
+    it('should return failure when nothing is running', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       const service = new EcsService(makeConfig(), makeEc2());
       const result = await service.stop('minecraft');
@@ -265,7 +282,7 @@ describe('EcsService', () => {
       expect(result.message).toMatch(/not currently running/i);
     });
 
-    it('stops task when found', async () => {
+    it('should stop the task when one is found', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING' }],
@@ -279,7 +296,7 @@ describe('EcsService', () => {
       expect(input.cluster).toBe('game-cluster');
     });
 
-    it('returns failure when StopTask throws', async () => {
+    it('should return failure when StopTask throws', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING' }],
@@ -293,7 +310,7 @@ describe('EcsService', () => {
   });
 
   describe('getTaskDefinition', () => {
-    it('parses cpu, memory, executionRoleArn from task definition', async () => {
+    it('should parse cpu, memory, and executionRoleArn from the task definition', async () => {
       ecsMock.on(DescribeTaskDefinitionCommand).resolves({
         taskDefinition: {
           cpu: '512',
@@ -310,7 +327,7 @@ describe('EcsService', () => {
       });
     });
 
-    it('applies default cpu/memory when fields absent', async () => {
+    it('should apply default cpu and memory when fields are absent', async () => {
       ecsMock.on(DescribeTaskDefinitionCommand).resolves({
         taskDefinition: { executionRoleArn: 'arn:...' },
       });
@@ -320,13 +337,13 @@ describe('EcsService', () => {
       expect(td?.memory).toBe(2048);
     });
 
-    it('returns null when no taskDefinition returned', async () => {
+    it('should return null when no taskDefinition is returned', async () => {
       ecsMock.on(DescribeTaskDefinitionCommand).resolves({});
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.getTaskDefinition('minecraft')).toBeNull();
     });
 
-    it('returns null on error', async () => {
+    it('should return null on API error', async () => {
       ecsMock.on(DescribeTaskDefinitionCommand).rejects(new Error('bad'));
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.getTaskDefinition('minecraft')).toBeNull();
@@ -334,7 +351,7 @@ describe('EcsService', () => {
   });
 
   describe('registerTaskDefinition', () => {
-    it('returns ARN on success', async () => {
+    it('should return the ARN on success', async () => {
       ecsMock.on(RegisterTaskDefinitionCommand).resolves({
         taskDefinition: { taskDefinitionArn: 'arn:aws:ecs:::task-definition/foo:1' },
       });
@@ -343,7 +360,7 @@ describe('EcsService', () => {
       expect(arn).toBe('arn:aws:ecs:::task-definition/foo:1');
     });
 
-    it('returns null on error', async () => {
+    it('should return null on API error', async () => {
       ecsMock.on(RegisterTaskDefinitionCommand).rejects(new Error('nope'));
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.registerTaskDefinition({ family: 'foo' })).toBeNull();
@@ -351,7 +368,7 @@ describe('EcsService', () => {
   });
 
   describe('runTask', () => {
-    it('returns taskArn when launch succeeds', async () => {
+    it('should return taskArn when the launch succeeds', async () => {
       ecsMock.on(RunTaskCommand).resolves({ tasks: [{ taskArn: 'arn-x' }] });
       const service = new EcsService(makeConfig(), makeEc2());
       const result = await service.runTask({
@@ -362,7 +379,7 @@ describe('EcsService', () => {
       expect(result).toEqual({ taskArn: 'arn-x' });
     });
 
-    it('returns null when RunTask reports failures', async () => {
+    it('should return null when RunTask reports failures', async () => {
       ecsMock.on(RunTaskCommand).resolves({
         tasks: [],
         failures: [{ reason: 'CAPACITY' }],
@@ -373,7 +390,7 @@ describe('EcsService', () => {
       ).toBeNull();
     });
 
-    it('returns null on error', async () => {
+    it('should return null on API error', async () => {
       ecsMock.on(RunTaskCommand).rejects(new Error('boom'));
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.runTask({ cluster: 'c', taskDefinition: 'td' })).toBeNull();
@@ -381,13 +398,13 @@ describe('EcsService', () => {
   });
 
   describe('listTasksByStartedBy', () => {
-    it('returns empty when no task ARNs match', async () => {
+    it('should return empty when no task ARNs match', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.listTasksByStartedBy('c', 'filemgr-minecraft')).toEqual([]);
     });
 
-    it('filters out STOPPED/DEPROVISIONING tasks', async () => {
+    it('should filter out STOPPED and DEPROVISIONING tasks', async () => {
       ecsMock.on(ListTasksCommand).resolves({ taskArns: ['a', 'b', 'c'] });
       ecsMock.on(DescribeTasksCommand).resolves({
         tasks: [
@@ -402,7 +419,7 @@ describe('EcsService', () => {
       expect(tasks[0]!.taskArn).toBe('a');
     });
 
-    it('returns empty array on error', async () => {
+    it('should return an empty array on error', async () => {
       ecsMock.on(ListTasksCommand).rejects(new Error('err'));
       const service = new EcsService(makeConfig(), makeEc2());
       expect(await service.listTasksByStartedBy('c', 'k')).toEqual([]);
@@ -410,7 +427,7 @@ describe('EcsService', () => {
   });
 
   describe('stopTask', () => {
-    it('sends StopTaskCommand with provided args', async () => {
+    it('should send StopTaskCommand with the provided args', async () => {
       ecsMock.on(StopTaskCommand).resolves({});
       const service = new EcsService(makeConfig(), makeEc2());
       await service.stopTask('cluster', 'arn', 'because');

--- a/app/src/server/services/EcsService.test.ts
+++ b/app/src/server/services/EcsService.test.ts
@@ -1,0 +1,423 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  ECSClient,
+  ListTasksCommand,
+  DescribeTasksCommand,
+  RunTaskCommand,
+  StopTaskCommand,
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+  type Task,
+} from '@aws-sdk/client-ecs';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { EcsService } from './EcsService.js';
+import type { ConfigService, TfOutputs } from './ConfigService.js';
+import type { Ec2Service } from './Ec2Service.js';
+
+const ecsMock = mockClient(ECSClient);
+
+const DEFAULT_OUTPUTS: TfOutputs = {
+  aws_region: 'us-east-1',
+  ecs_cluster_name: 'game-cluster',
+  ecs_cluster_arn: 'arn:aws:ecs:us-east-1:123:cluster/game-cluster',
+  subnet_ids: 'subnet-a, subnet-b',
+  security_group_id: 'sg-game',
+  file_manager_security_group_id: 'sg-files',
+  efs_file_system_id: 'fs-1',
+  efs_access_points: { minecraft: 'fsap-1' },
+  domain_name: 'example.com',
+  game_names: ['minecraft'],
+  alb_dns_name: null,
+  acm_certificate_arn: null,
+};
+
+function makeConfig(outputs: TfOutputs | null = DEFAULT_OUTPUTS): ConfigService {
+  return {
+    getRegion: () => 'us-east-1',
+    getTfOutputs: () => outputs,
+  } as unknown as ConfigService;
+}
+
+function makeEc2(ip: string | null = '1.2.3.4'): Ec2Service {
+  return { getPublicIp: vi.fn().mockResolvedValue(ip) } as unknown as Ec2Service;
+}
+
+describe('EcsService', () => {
+  beforeEach(() => {
+    ecsMock.reset();
+  });
+
+  describe('extractEniId', () => {
+    it('returns ENI id from ElasticNetworkInterface attachment', () => {
+      const service = new EcsService(makeConfig(), makeEc2());
+      const task: Task = {
+        attachments: [
+          {
+            type: 'ElasticNetworkInterface',
+            details: [
+              { name: 'subnetId', value: 'subnet-a' },
+              { name: 'networkInterfaceId', value: 'eni-abc' },
+            ],
+          },
+        ],
+      };
+      expect(service.extractEniId(task)).toBe('eni-abc');
+    });
+
+    it('returns null when no ENI attachment present', () => {
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(service.extractEniId({ attachments: [] })).toBeNull();
+      expect(service.extractEniId({})).toBeNull();
+    });
+
+    it('ignores non-ENI attachment types', () => {
+      const service = new EcsService(makeConfig(), makeEc2());
+      const task: Task = {
+        attachments: [
+          {
+            type: 'SomethingElse',
+            details: [{ name: 'networkInterfaceId', value: 'eni-wrong' }],
+          },
+        ],
+      };
+      expect(service.extractEniId(task)).toBeNull();
+    });
+  });
+
+  describe('findRunningTask', () => {
+    it('returns null when no tasks listed', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.findRunningTask('cluster', 'minecraft')).toBeNull();
+    });
+
+    it('scopes list to {game}-server family and RUNNING desired status', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      const service = new EcsService(makeConfig(), makeEc2());
+      await service.findRunningTask('my-cluster', 'factorio');
+      const input = ecsMock.commandCalls(ListTasksCommand)[0]!.args[0].input;
+      expect(input.family).toBe('factorio-server');
+      expect(input.desiredStatus).toBe('RUNNING');
+      expect(input.cluster).toBe('my-cluster');
+    });
+
+    it('filters out STOPPED and DEPROVISIONING tasks', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1', 'arn2'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [
+          { taskArn: 'arn1', lastStatus: 'STOPPED' },
+          { taskArn: 'arn2', lastStatus: 'RUNNING' },
+        ],
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const task = await service.findRunningTask('c', 'g');
+      expect(task?.taskArn).toBe('arn2');
+    });
+
+    it('returns null on API errors', async () => {
+      ecsMock.on(ListTasksCommand).rejects(new Error('api-fail'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.findRunningTask('c', 'g')).toBeNull();
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns not_deployed when terraform outputs missing', async () => {
+      const service = new EcsService(makeConfig(null), makeEc2());
+      const status = await service.getStatus('minecraft');
+      expect(status.state).toBe('not_deployed');
+      expect(status.message).toMatch(/terraform apply/i);
+    });
+
+    it('returns running with public IP + hostname for RUNNING task', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [
+          {
+            taskArn: 'arn1',
+            lastStatus: 'RUNNING',
+            attachments: [
+              {
+                type: 'ElasticNetworkInterface',
+                details: [{ name: 'networkInterfaceId', value: 'eni-xyz' }],
+              },
+            ],
+          },
+        ],
+      });
+      const ec2 = makeEc2('9.9.9.9');
+      const service = new EcsService(makeConfig(), ec2);
+      const status = await service.getStatus('minecraft');
+      expect(status.state).toBe('running');
+      expect(status.publicIp).toBe('9.9.9.9');
+      expect(status.hostname).toBe('minecraft.example.com');
+      expect(ec2.getPublicIp).toHaveBeenCalledWith('eni-xyz');
+    });
+
+    it('returns starting when task not yet RUNNING', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [{ taskArn: 'arn1', lastStatus: 'PROVISIONING' }],
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const status = await service.getStatus('minecraft');
+      expect(status.state).toBe('starting');
+      expect(status.taskArn).toBe('arn1');
+    });
+
+    it('returns stopped when no running task', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const status = await service.getStatus('minecraft');
+      expect(status.state).toBe('stopped');
+    });
+
+    it('omits hostname when no domain_name configured', async () => {
+      const outputs: TfOutputs = { ...DEFAULT_OUTPUTS, domain_name: '' };
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING', attachments: [] }],
+      });
+      const service = new EcsService(makeConfig(outputs), makeEc2(null));
+      const status = await service.getStatus('minecraft');
+      expect(status.state).toBe('running');
+      expect(status.hostname).toBeUndefined();
+    });
+  });
+
+  describe('start', () => {
+    it('returns failure if terraform outputs missing', async () => {
+      const service = new EcsService(makeConfig(null), makeEc2());
+      const result = await service.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/terraform apply/i);
+    });
+
+    it('refuses to start if a task is already running', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING' }],
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/already running/i);
+    });
+
+    it('launches task with correct cluster/family/subnets/SG when no running task', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      ecsMock.on(RunTaskCommand).resolves({ tasks: [{ taskArn: 'arn-new' }] });
+
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.start('minecraft');
+
+      expect(result.success).toBe(true);
+      expect(result.taskArn).toBe('arn-new');
+      const input = ecsMock.commandCalls(RunTaskCommand)[0]!.args[0].input;
+      expect(input.cluster).toBe('game-cluster');
+      expect(input.taskDefinition).toBe('minecraft-server');
+      expect(input.launchType).toBe('FARGATE');
+      expect(input.networkConfiguration?.awsvpcConfiguration?.subnets).toEqual(['subnet-a', 'subnet-b']);
+      expect(input.networkConfiguration?.awsvpcConfiguration?.securityGroups).toEqual(['sg-game']);
+      expect(input.networkConfiguration?.awsvpcConfiguration?.assignPublicIp).toBe('ENABLED');
+    });
+
+    it('returns failure with reason when RunTask reports failures', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      ecsMock.on(RunTaskCommand).resolves({
+        tasks: [],
+        failures: [{ reason: 'CAPACITY' }],
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('CAPACITY');
+    });
+
+    it('returns failure when RunTask throws', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      ecsMock.on(RunTaskCommand).rejects(new Error('throttled'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('throttled');
+    });
+  });
+
+  describe('stop', () => {
+    it('returns failure if terraform outputs missing', async () => {
+      const service = new EcsService(makeConfig(null), makeEc2());
+      const result = await service.stop('minecraft');
+      expect(result.success).toBe(false);
+    });
+
+    it('returns failure when nothing is running', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.stop('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/not currently running/i);
+    });
+
+    it('stops task when found', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING' }],
+      });
+      ecsMock.on(StopTaskCommand).resolves({});
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.stop('minecraft');
+      expect(result.success).toBe(true);
+      const input = ecsMock.commandCalls(StopTaskCommand)[0]!.args[0].input;
+      expect(input.task).toBe('arn1');
+      expect(input.cluster).toBe('game-cluster');
+    });
+
+    it('returns failure when StopTask throws', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['arn1'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [{ taskArn: 'arn1', lastStatus: 'RUNNING' }],
+      });
+      ecsMock.on(StopTaskCommand).rejects(new Error('stop-error'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.stop('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('stop-error');
+    });
+  });
+
+  describe('getTaskDefinition', () => {
+    it('parses cpu, memory, executionRoleArn from task definition', async () => {
+      ecsMock.on(DescribeTaskDefinitionCommand).resolves({
+        taskDefinition: {
+          cpu: '512',
+          memory: '1024',
+          executionRoleArn: 'arn:aws:iam::123:role/exec',
+        },
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const td = await service.getTaskDefinition('minecraft');
+      expect(td).toEqual({
+        cpu: 512,
+        memory: 1024,
+        executionRoleArn: 'arn:aws:iam::123:role/exec',
+      });
+    });
+
+    it('applies default cpu/memory when fields absent', async () => {
+      ecsMock.on(DescribeTaskDefinitionCommand).resolves({
+        taskDefinition: { executionRoleArn: 'arn:...' },
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const td = await service.getTaskDefinition('minecraft');
+      expect(td?.cpu).toBe(1024);
+      expect(td?.memory).toBe(2048);
+    });
+
+    it('returns null when no taskDefinition returned', async () => {
+      ecsMock.on(DescribeTaskDefinitionCommand).resolves({});
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.getTaskDefinition('minecraft')).toBeNull();
+    });
+
+    it('returns null on error', async () => {
+      ecsMock.on(DescribeTaskDefinitionCommand).rejects(new Error('bad'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.getTaskDefinition('minecraft')).toBeNull();
+    });
+  });
+
+  describe('registerTaskDefinition', () => {
+    it('returns ARN on success', async () => {
+      ecsMock.on(RegisterTaskDefinitionCommand).resolves({
+        taskDefinition: { taskDefinitionArn: 'arn:aws:ecs:::task-definition/foo:1' },
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const arn = await service.registerTaskDefinition({ family: 'foo' });
+      expect(arn).toBe('arn:aws:ecs:::task-definition/foo:1');
+    });
+
+    it('returns null on error', async () => {
+      ecsMock.on(RegisterTaskDefinitionCommand).rejects(new Error('nope'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.registerTaskDefinition({ family: 'foo' })).toBeNull();
+    });
+  });
+
+  describe('runTask', () => {
+    it('returns taskArn when launch succeeds', async () => {
+      ecsMock.on(RunTaskCommand).resolves({ tasks: [{ taskArn: 'arn-x' }] });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.runTask({
+        cluster: 'c',
+        taskDefinition: 'td',
+        launchType: 'FARGATE',
+      });
+      expect(result).toEqual({ taskArn: 'arn-x' });
+    });
+
+    it('returns null when RunTask reports failures', async () => {
+      ecsMock.on(RunTaskCommand).resolves({
+        tasks: [],
+        failures: [{ reason: 'CAPACITY' }],
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(
+        await service.runTask({ cluster: 'c', taskDefinition: 'td' }),
+      ).toBeNull();
+    });
+
+    it('returns null on error', async () => {
+      ecsMock.on(RunTaskCommand).rejects(new Error('boom'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.runTask({ cluster: 'c', taskDefinition: 'td' })).toBeNull();
+    });
+  });
+
+  describe('listTasksByStartedBy', () => {
+    it('returns empty when no task ARNs match', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.listTasksByStartedBy('c', 'filemgr-minecraft')).toEqual([]);
+    });
+
+    it('filters out STOPPED/DEPROVISIONING tasks', async () => {
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: ['a', 'b', 'c'] });
+      ecsMock.on(DescribeTasksCommand).resolves({
+        tasks: [
+          { taskArn: 'a', lastStatus: 'RUNNING' },
+          { taskArn: 'b', lastStatus: 'STOPPED' },
+          { taskArn: 'c', lastStatus: 'DEPROVISIONING' },
+        ],
+      });
+      const service = new EcsService(makeConfig(), makeEc2());
+      const tasks = await service.listTasksByStartedBy('cluster', 'key');
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]!.taskArn).toBe('a');
+    });
+
+    it('returns empty array on error', async () => {
+      ecsMock.on(ListTasksCommand).rejects(new Error('err'));
+      const service = new EcsService(makeConfig(), makeEc2());
+      expect(await service.listTasksByStartedBy('c', 'k')).toEqual([]);
+    });
+  });
+
+  describe('stopTask', () => {
+    it('sends StopTaskCommand with provided args', async () => {
+      ecsMock.on(StopTaskCommand).resolves({});
+      const service = new EcsService(makeConfig(), makeEc2());
+      await service.stopTask('cluster', 'arn', 'because');
+      const input = ecsMock.commandCalls(StopTaskCommand)[0]!.args[0].input;
+      expect(input.cluster).toBe('cluster');
+      expect(input.task).toBe('arn');
+      expect(input.reason).toBe('because');
+    });
+  });
+});

--- a/app/src/server/services/FileManagerService.test.ts
+++ b/app/src/server/services/FileManagerService.test.ts
@@ -1,0 +1,251 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import type { Task } from '@aws-sdk/client-ecs';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { FileManagerService } from './FileManagerService.js';
+import type { ConfigService, TfOutputs } from './ConfigService.js';
+import type { EcsService } from './EcsService.js';
+import type { Ec2Service } from './Ec2Service.js';
+
+const DEFAULT_OUTPUTS: TfOutputs = {
+  aws_region: 'us-east-1',
+  ecs_cluster_name: 'game-cluster',
+  ecs_cluster_arn: 'arn:...',
+  subnet_ids: 'subnet-a,subnet-b',
+  security_group_id: 'sg-game',
+  file_manager_security_group_id: 'sg-files',
+  efs_file_system_id: 'fs-1',
+  efs_access_points: { minecraft: 'fsap-mc' },
+  domain_name: 'example.com',
+  game_names: ['minecraft'],
+  alb_dns_name: null,
+  acm_certificate_arn: null,
+};
+
+type EcsStub = {
+  listTasksByStartedBy: ReturnType<typeof vi.fn>;
+  extractEniId: ReturnType<typeof vi.fn>;
+  getTaskDefinition: ReturnType<typeof vi.fn>;
+  registerTaskDefinition: ReturnType<typeof vi.fn>;
+  runTask: ReturnType<typeof vi.fn>;
+  stopTask: ReturnType<typeof vi.fn>;
+};
+
+function makeConfig(outputs: TfOutputs | null = DEFAULT_OUTPUTS): ConfigService {
+  return {
+    getTfOutputs: () => outputs,
+    getRegion: () => 'us-east-1',
+  } as unknown as ConfigService;
+}
+
+function makeEcs(overrides: Partial<EcsStub> = {}): EcsService & EcsStub {
+  return {
+    listTasksByStartedBy: vi.fn().mockResolvedValue([]),
+    extractEniId: vi.fn().mockReturnValue(null),
+    getTaskDefinition: vi.fn().mockResolvedValue({
+      cpu: 1024,
+      memory: 2048,
+      executionRoleArn: 'arn:aws:iam::123:role/exec',
+    }),
+    registerTaskDefinition: vi.fn().mockResolvedValue('arn:aws:ecs:::task-definition/filebrowser-minecraft:1'),
+    runTask: vi.fn().mockResolvedValue({ taskArn: 'arn-fm' }),
+    stopTask: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as EcsService & EcsStub;
+}
+
+function makeEc2(ip: string | null = '1.2.3.4'): Ec2Service {
+  return { getPublicIp: vi.fn().mockResolvedValue(ip) } as unknown as Ec2Service;
+}
+
+describe('FileManagerService', () => {
+  describe('getStatus', () => {
+    it('returns not_deployed when terraform outputs missing', async () => {
+      const svc = new FileManagerService(makeConfig(null), makeEcs(), makeEc2());
+      expect((await svc.getStatus('minecraft')).state).toBe('not_deployed');
+    });
+
+    it('returns stopped when no tasks exist', async () => {
+      const ecs = makeEcs({ listTasksByStartedBy: vi.fn().mockResolvedValue([]) });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      expect((await svc.getStatus('minecraft')).state).toBe('stopped');
+      expect(ecs.listTasksByStartedBy).toHaveBeenCalledWith('game-cluster', 'filemgr-minecraft');
+    });
+
+    it('returns running with URL built from public IP on port 8080', async () => {
+      const task: Task = { taskArn: 'arn-fm', lastStatus: 'RUNNING' };
+      const ecs = makeEcs({
+        listTasksByStartedBy: vi.fn().mockResolvedValue([task]),
+        extractEniId: vi.fn().mockReturnValue('eni-1'),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2('5.6.7.8'));
+      const status = await svc.getStatus('minecraft');
+      expect(status.state).toBe('running');
+      expect(status.url).toBe('http://5.6.7.8:8080');
+      expect(status.taskArn).toBe('arn-fm');
+    });
+
+    it('returns running without URL when public IP cannot be resolved', async () => {
+      const ecs = makeEcs({
+        listTasksByStartedBy: vi.fn().mockResolvedValue([{ lastStatus: 'RUNNING' }]),
+        extractEniId: vi.fn().mockReturnValue('eni-1'),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2(null));
+      const status = await svc.getStatus('minecraft');
+      expect(status.state).toBe('running');
+      expect(status.url).toBeUndefined();
+    });
+
+    it('returns starting when task not yet running', async () => {
+      const ecs = makeEcs({
+        listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'arn-fm', lastStatus: 'PROVISIONING' }]),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const status = await svc.getStatus('minecraft');
+      expect(status.state).toBe('starting');
+      expect(status.taskArn).toBe('arn-fm');
+    });
+  });
+
+  describe('start', () => {
+    it('fails if terraform outputs missing', async () => {
+      const svc = new FileManagerService(makeConfig(null), makeEcs(), makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/terraform apply/i);
+    });
+
+    it('fails when game has no EFS access point', async () => {
+      const outputs: TfOutputs = { ...DEFAULT_OUTPUTS, efs_access_points: {} };
+      const svc = new FileManagerService(makeConfig(outputs), makeEcs(), makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/no efs access point/i);
+    });
+
+    it('fails when file_manager_security_group_id not set', async () => {
+      const outputs: TfOutputs = { ...DEFAULT_OUTPUTS, file_manager_security_group_id: '' };
+      const svc = new FileManagerService(makeConfig(outputs), makeEcs(), makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/file_manager_security_group_id/);
+    });
+
+    it('fails when file manager is already running', async () => {
+      const ecs = makeEcs({
+        listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'existing' }]),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/already running/i);
+    });
+
+    it('fails when the game task definition has no execution role', async () => {
+      const ecs = makeEcs({
+        getTaskDefinition: vi.fn().mockResolvedValue(null),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/execution role/i);
+    });
+
+    it('registers a filebrowser task definition then runs it', async () => {
+      const ecs = makeEcs();
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.start('minecraft');
+
+      expect(result.success).toBe(true);
+      expect(result.taskArn).toBe('arn-fm');
+
+      const regArgs = ecs.registerTaskDefinition.mock.calls[0]![0];
+      expect(regArgs.family).toBe('filebrowser-minecraft');
+      expect(regArgs.networkMode).toBe('awsvpc');
+      expect(regArgs.requiresCompatibilities).toEqual(['FARGATE']);
+      expect(regArgs.cpu).toBe('256');
+      expect(regArgs.memory).toBe('512');
+      expect(regArgs.executionRoleArn).toBe('arn:aws:iam::123:role/exec');
+
+      const volume = regArgs.volumes[0];
+      expect(volume.efsVolumeConfiguration.fileSystemId).toBe('fs-1');
+      expect(volume.efsVolumeConfiguration.authorizationConfig.accessPointId).toBe('fsap-mc');
+      expect(volume.efsVolumeConfiguration.transitEncryption).toBe('ENABLED');
+
+      const container = regArgs.containerDefinitions[0];
+      expect(container.image).toContain('filebrowser');
+      expect(container.portMappings[0].containerPort).toBe(8080);
+      expect(container.mountPoints[0].containerPath).toBe('/srv');
+      expect(container.command).toContain('--noauth');
+      expect(container.logConfiguration.options['awslogs-group']).toBe('/ecs/filebrowser-minecraft');
+      expect(container.logConfiguration.options['awslogs-region']).toBe('us-east-1');
+
+      const runArgs = ecs.runTask.mock.calls[0]![0];
+      expect(runArgs.cluster).toBe('game-cluster');
+      expect(runArgs.taskDefinition).toBe('filebrowser-minecraft');
+      expect(runArgs.startedBy).toBe('filemgr-minecraft');
+      expect(runArgs.networkConfiguration.awsvpcConfiguration.subnets).toEqual(['subnet-a', 'subnet-b']);
+      expect(runArgs.networkConfiguration.awsvpcConfiguration.securityGroups).toEqual(['sg-files']);
+      expect(runArgs.networkConfiguration.awsvpcConfiguration.assignPublicIp).toBe('ENABLED');
+    });
+
+    it('fails when task-definition registration returns null', async () => {
+      const ecs = makeEcs({
+        registerTaskDefinition: vi.fn().mockResolvedValue(null),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(ecs.runTask).not.toHaveBeenCalled();
+    });
+
+    it('fails when runTask returns null', async () => {
+      const ecs = makeEcs({
+        runTask: vi.fn().mockResolvedValue(null),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.start('minecraft');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('stop', () => {
+    it('fails when outputs missing', async () => {
+      const svc = new FileManagerService(makeConfig(null), makeEcs(), makeEc2());
+      expect((await svc.stop('minecraft')).success).toBe(false);
+    });
+
+    it('fails when no file manager running', async () => {
+      const ecs = makeEcs({ listTasksByStartedBy: vi.fn().mockResolvedValue([]) });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.stop('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/no file manager running/i);
+    });
+
+    it('stops the first task when running', async () => {
+      const ecs = makeEcs({
+        listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'arn-1' }]),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.stop('minecraft');
+      expect(result.success).toBe(true);
+      expect(ecs.stopTask).toHaveBeenCalledWith('game-cluster', 'arn-1', expect.any(String));
+    });
+
+    it('returns failure when stopTask throws', async () => {
+      const ecs = makeEcs({
+        listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'arn-1' }]),
+        stopTask: vi.fn().mockRejectedValue(new Error('nope')),
+      });
+      const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
+      const result = await svc.stop('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('nope');
+    });
+  });
+});

--- a/app/src/server/services/FileManagerService.test.ts
+++ b/app/src/server/services/FileManagerService.test.ts
@@ -11,6 +11,10 @@ import type { ConfigService, TfOutputs } from './ConfigService.js';
 import type { EcsService } from './EcsService.js';
 import type { Ec2Service } from './Ec2Service.js';
 
+/**
+ * A canonical set of Terraform outputs used by most tests. Individual tests
+ * spread over this to tweak specific fields (e.g. clearing EFS access points).
+ */
 const DEFAULT_OUTPUTS: TfOutputs = {
   aws_region: 'us-east-1',
   ecs_cluster_name: 'game-cluster',
@@ -26,24 +30,41 @@ const DEFAULT_OUTPUTS: TfOutputs = {
   acm_certificate_arn: null,
 };
 
-type EcsStub = {
-  listTasksByStartedBy: ReturnType<typeof vi.fn>;
-  extractEniId: ReturnType<typeof vi.fn>;
-  getTaskDefinition: ReturnType<typeof vi.fn>;
-  registerTaskDefinition: ReturnType<typeof vi.fn>;
-  runTask: ReturnType<typeof vi.fn>;
-  stopTask: ReturnType<typeof vi.fn>;
-};
+/**
+ * Subset of EcsService that FileManagerService actually calls. Tests create
+ * instances of this shape and cast once to `EcsService`, which keeps the
+ * `vi.fn()` return types intact for assertions like `.mock.calls[0]`.
+ */
+type EcsStub = Pick<
+  EcsService,
+  | 'listTasksByStartedBy'
+  | 'extractEniId'
+  | 'getTaskDefinition'
+  | 'registerTaskDefinition'
+  | 'runTask'
+  | 'stopTask'
+>;
 
+/**
+ * Build a minimal ConfigService stub. Pass `null` to simulate "terraform
+ * apply hasn't been run yet".
+ */
 function makeConfig(outputs: TfOutputs | null = DEFAULT_OUTPUTS): ConfigService {
-  return {
+  const stub: Partial<ConfigService> = {
     getTfOutputs: () => outputs,
     getRegion: () => 'us-east-1',
-  } as unknown as ConfigService;
+  };
+  return stub as ConfigService;
 }
 
-function makeEcs(overrides: Partial<EcsStub> = {}): EcsService & EcsStub {
-  return {
+/**
+ * Build an EcsService stub with sensible "happy path" defaults, plus the
+ * ability to override specific methods per test. Returns both the stub and
+ * an EcsService-typed alias so we can hand the alias to the SUT while still
+ * making assertions against the stub's `vi.fn()` handles.
+ */
+function makeEcs(overrides: Partial<EcsStub> = {}): { stub: EcsStub; service: EcsService } {
+  const stub: EcsStub = {
     listTasksByStartedBy: vi.fn().mockResolvedValue([]),
     extractEniId: vi.fn().mockReturnValue(null),
     getTaskDefinition: vi.fn().mockResolvedValue({
@@ -55,30 +76,38 @@ function makeEcs(overrides: Partial<EcsStub> = {}): EcsService & EcsStub {
     runTask: vi.fn().mockResolvedValue({ taskArn: 'arn-fm' }),
     stopTask: vi.fn().mockResolvedValue(undefined),
     ...overrides,
-  } as unknown as EcsService & EcsStub;
+  };
+  return { stub, service: stub as EcsService };
 }
 
+/**
+ * Build an Ec2Service stub whose `getPublicIp` resolves to the given value.
+ */
 function makeEc2(ip: string | null = '1.2.3.4'): Ec2Service {
-  return { getPublicIp: vi.fn().mockResolvedValue(ip) } as unknown as Ec2Service;
+  const stub: Partial<Ec2Service> = {
+    getPublicIp: vi.fn().mockResolvedValue(ip),
+  };
+  return stub as Ec2Service;
 }
 
 describe('FileManagerService', () => {
   describe('getStatus', () => {
-    it('returns not_deployed when terraform outputs missing', async () => {
-      const svc = new FileManagerService(makeConfig(null), makeEcs(), makeEc2());
+    it('should return not_deployed when terraform outputs are missing', async () => {
+      const { service: ecs } = makeEcs();
+      const svc = new FileManagerService(makeConfig(null), ecs, makeEc2());
       expect((await svc.getStatus('minecraft')).state).toBe('not_deployed');
     });
 
-    it('returns stopped when no tasks exist', async () => {
-      const ecs = makeEcs({ listTasksByStartedBy: vi.fn().mockResolvedValue([]) });
+    it('should return stopped when no tasks exist', async () => {
+      const { stub, service: ecs } = makeEcs({ listTasksByStartedBy: vi.fn().mockResolvedValue([]) });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
       expect((await svc.getStatus('minecraft')).state).toBe('stopped');
-      expect(ecs.listTasksByStartedBy).toHaveBeenCalledWith('game-cluster', 'filemgr-minecraft');
+      expect(stub.listTasksByStartedBy).toHaveBeenCalledWith('game-cluster', 'filemgr-minecraft');
     });
 
-    it('returns running with URL built from public IP on port 8080', async () => {
+    it('should return running with a URL built from the public IP on port 8080', async () => {
       const task: Task = { taskArn: 'arn-fm', lastStatus: 'RUNNING' };
-      const ecs = makeEcs({
+      const { service: ecs } = makeEcs({
         listTasksByStartedBy: vi.fn().mockResolvedValue([task]),
         extractEniId: vi.fn().mockReturnValue('eni-1'),
       });
@@ -89,8 +118,8 @@ describe('FileManagerService', () => {
       expect(status.taskArn).toBe('arn-fm');
     });
 
-    it('returns running without URL when public IP cannot be resolved', async () => {
-      const ecs = makeEcs({
+    it('should return running without a URL when the public IP cannot be resolved', async () => {
+      const { service: ecs } = makeEcs({
         listTasksByStartedBy: vi.fn().mockResolvedValue([{ lastStatus: 'RUNNING' }]),
         extractEniId: vi.fn().mockReturnValue('eni-1'),
       });
@@ -100,8 +129,8 @@ describe('FileManagerService', () => {
       expect(status.url).toBeUndefined();
     });
 
-    it('returns starting when task not yet running', async () => {
-      const ecs = makeEcs({
+    it('should return starting when the task is not yet running', async () => {
+      const { service: ecs } = makeEcs({
         listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'arn-fm', lastStatus: 'PROVISIONING' }]),
       });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
@@ -112,31 +141,34 @@ describe('FileManagerService', () => {
   });
 
   describe('start', () => {
-    it('fails if terraform outputs missing', async () => {
-      const svc = new FileManagerService(makeConfig(null), makeEcs(), makeEc2());
+    it('should fail if terraform outputs are missing', async () => {
+      const { service: ecs } = makeEcs();
+      const svc = new FileManagerService(makeConfig(null), ecs, makeEc2());
       const result = await svc.start('minecraft');
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/terraform apply/i);
     });
 
-    it('fails when game has no EFS access point', async () => {
+    it('should fail when the game has no EFS access point', async () => {
       const outputs: TfOutputs = { ...DEFAULT_OUTPUTS, efs_access_points: {} };
-      const svc = new FileManagerService(makeConfig(outputs), makeEcs(), makeEc2());
+      const { service: ecs } = makeEcs();
+      const svc = new FileManagerService(makeConfig(outputs), ecs, makeEc2());
       const result = await svc.start('minecraft');
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/no efs access point/i);
     });
 
-    it('fails when file_manager_security_group_id not set', async () => {
+    it('should fail when file_manager_security_group_id is not set', async () => {
       const outputs: TfOutputs = { ...DEFAULT_OUTPUTS, file_manager_security_group_id: '' };
-      const svc = new FileManagerService(makeConfig(outputs), makeEcs(), makeEc2());
+      const { service: ecs } = makeEcs();
+      const svc = new FileManagerService(makeConfig(outputs), ecs, makeEc2());
       const result = await svc.start('minecraft');
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/file_manager_security_group_id/);
     });
 
-    it('fails when file manager is already running', async () => {
-      const ecs = makeEcs({
+    it('should fail when the file manager is already running', async () => {
+      const { service: ecs } = makeEcs({
         listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'existing' }]),
       });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
@@ -145,8 +177,8 @@ describe('FileManagerService', () => {
       expect(result.message).toMatch(/already running/i);
     });
 
-    it('fails when the game task definition has no execution role', async () => {
-      const ecs = makeEcs({
+    it('should fail when the game task definition has no execution role', async () => {
+      const { service: ecs } = makeEcs({
         getTaskDefinition: vi.fn().mockResolvedValue(null),
       });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
@@ -155,15 +187,15 @@ describe('FileManagerService', () => {
       expect(result.message).toMatch(/execution role/i);
     });
 
-    it('registers a filebrowser task definition then runs it', async () => {
-      const ecs = makeEcs();
+    it('should register a filebrowser task definition and then run it', async () => {
+      const { stub, service: ecs } = makeEcs();
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
       const result = await svc.start('minecraft');
 
       expect(result.success).toBe(true);
       expect(result.taskArn).toBe('arn-fm');
 
-      const regArgs = ecs.registerTaskDefinition.mock.calls[0]![0];
+      const regArgs = vi.mocked(stub.registerTaskDefinition).mock.calls[0]![0];
       expect(regArgs.family).toBe('filebrowser-minecraft');
       expect(regArgs.networkMode).toBe('awsvpc');
       expect(regArgs.requiresCompatibilities).toEqual(['FARGATE']);
@@ -171,40 +203,40 @@ describe('FileManagerService', () => {
       expect(regArgs.memory).toBe('512');
       expect(regArgs.executionRoleArn).toBe('arn:aws:iam::123:role/exec');
 
-      const volume = regArgs.volumes[0];
-      expect(volume.efsVolumeConfiguration.fileSystemId).toBe('fs-1');
-      expect(volume.efsVolumeConfiguration.authorizationConfig.accessPointId).toBe('fsap-mc');
-      expect(volume.efsVolumeConfiguration.transitEncryption).toBe('ENABLED');
+      const volume = regArgs.volumes![0]!;
+      expect(volume.efsVolumeConfiguration!.fileSystemId).toBe('fs-1');
+      expect(volume.efsVolumeConfiguration!.authorizationConfig!.accessPointId).toBe('fsap-mc');
+      expect(volume.efsVolumeConfiguration!.transitEncryption).toBe('ENABLED');
 
-      const container = regArgs.containerDefinitions[0];
+      const container = regArgs.containerDefinitions![0]!;
       expect(container.image).toContain('filebrowser');
-      expect(container.portMappings[0].containerPort).toBe(8080);
-      expect(container.mountPoints[0].containerPath).toBe('/srv');
+      expect(container.portMappings![0]!.containerPort).toBe(8080);
+      expect(container.mountPoints![0]!.containerPath).toBe('/srv');
       expect(container.command).toContain('--noauth');
-      expect(container.logConfiguration.options['awslogs-group']).toBe('/ecs/filebrowser-minecraft');
-      expect(container.logConfiguration.options['awslogs-region']).toBe('us-east-1');
+      expect(container.logConfiguration!.options!['awslogs-group']).toBe('/ecs/filebrowser-minecraft');
+      expect(container.logConfiguration!.options!['awslogs-region']).toBe('us-east-1');
 
-      const runArgs = ecs.runTask.mock.calls[0]![0];
+      const runArgs = vi.mocked(stub.runTask).mock.calls[0]![0];
       expect(runArgs.cluster).toBe('game-cluster');
       expect(runArgs.taskDefinition).toBe('filebrowser-minecraft');
       expect(runArgs.startedBy).toBe('filemgr-minecraft');
-      expect(runArgs.networkConfiguration.awsvpcConfiguration.subnets).toEqual(['subnet-a', 'subnet-b']);
-      expect(runArgs.networkConfiguration.awsvpcConfiguration.securityGroups).toEqual(['sg-files']);
-      expect(runArgs.networkConfiguration.awsvpcConfiguration.assignPublicIp).toBe('ENABLED');
+      expect(runArgs.networkConfiguration!.awsvpcConfiguration!.subnets).toEqual(['subnet-a', 'subnet-b']);
+      expect(runArgs.networkConfiguration!.awsvpcConfiguration!.securityGroups).toEqual(['sg-files']);
+      expect(runArgs.networkConfiguration!.awsvpcConfiguration!.assignPublicIp).toBe('ENABLED');
     });
 
-    it('fails when task-definition registration returns null', async () => {
-      const ecs = makeEcs({
+    it('should fail when task-definition registration returns null', async () => {
+      const { stub, service: ecs } = makeEcs({
         registerTaskDefinition: vi.fn().mockResolvedValue(null),
       });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
       const result = await svc.start('minecraft');
       expect(result.success).toBe(false);
-      expect(ecs.runTask).not.toHaveBeenCalled();
+      expect(stub.runTask).not.toHaveBeenCalled();
     });
 
-    it('fails when runTask returns null', async () => {
-      const ecs = makeEcs({
+    it('should fail when runTask returns null', async () => {
+      const { service: ecs } = makeEcs({
         runTask: vi.fn().mockResolvedValue(null),
       });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
@@ -214,31 +246,32 @@ describe('FileManagerService', () => {
   });
 
   describe('stop', () => {
-    it('fails when outputs missing', async () => {
-      const svc = new FileManagerService(makeConfig(null), makeEcs(), makeEc2());
+    it('should fail when outputs are missing', async () => {
+      const { service: ecs } = makeEcs();
+      const svc = new FileManagerService(makeConfig(null), ecs, makeEc2());
       expect((await svc.stop('minecraft')).success).toBe(false);
     });
 
-    it('fails when no file manager running', async () => {
-      const ecs = makeEcs({ listTasksByStartedBy: vi.fn().mockResolvedValue([]) });
+    it('should fail when no file manager is running', async () => {
+      const { service: ecs } = makeEcs({ listTasksByStartedBy: vi.fn().mockResolvedValue([]) });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
       const result = await svc.stop('minecraft');
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/no file manager running/i);
     });
 
-    it('stops the first task when running', async () => {
-      const ecs = makeEcs({
+    it('should stop the first task when running', async () => {
+      const { stub, service: ecs } = makeEcs({
         listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'arn-1' }]),
       });
       const svc = new FileManagerService(makeConfig(), ecs, makeEc2());
       const result = await svc.stop('minecraft');
       expect(result.success).toBe(true);
-      expect(ecs.stopTask).toHaveBeenCalledWith('game-cluster', 'arn-1', expect.any(String));
+      expect(stub.stopTask).toHaveBeenCalledWith('game-cluster', 'arn-1', expect.any(String));
     });
 
-    it('returns failure when stopTask throws', async () => {
-      const ecs = makeEcs({
+    it('should return failure when stopTask throws', async () => {
+      const { service: ecs } = makeEcs({
         listTasksByStartedBy: vi.fn().mockResolvedValue([{ taskArn: 'arn-1' }]),
         stopTask: vi.fn().mockRejectedValue(new Error('nope')),
       });

--- a/app/src/server/services/LogsService.test.ts
+++ b/app/src/server/services/LogsService.test.ts
@@ -1,0 +1,99 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  CloudWatchLogsClient,
+  DescribeLogStreamsCommand,
+  GetLogEventsCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { LogsService } from './LogsService.js';
+import type { ConfigService } from './ConfigService.js';
+
+const cwMock = mockClient(CloudWatchLogsClient);
+
+function makeConfig(): ConfigService {
+  return { getRegion: () => 'us-east-1' } as unknown as ConfigService;
+}
+
+describe('LogsService', () => {
+  let service: LogsService;
+
+  beforeEach(() => {
+    cwMock.reset();
+    service = new LogsService(makeConfig());
+  });
+
+  it('returns "no streams" message when log group has no streams', async () => {
+    cwMock.on(DescribeLogStreamsCommand).resolves({ logStreams: [] });
+    const lines = await service.getRecentLogs('minecraft');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/no log streams/i);
+  });
+
+  it('uses /ecs/{game}-server log group and fetches newest stream', async () => {
+    cwMock.on(DescribeLogStreamsCommand).resolves({
+      logStreams: [{ logStreamName: 'ecs/stream1' }],
+    });
+    cwMock.on(GetLogEventsCommand).resolves({
+      events: [{ message: 'line1' }, { message: 'line2' }],
+    });
+
+    const lines = await service.getRecentLogs('minecraft', 25);
+    expect(lines).toEqual(['line1', 'line2']);
+
+    const descInput = cwMock.commandCalls(DescribeLogStreamsCommand)[0]!.args[0].input;
+    expect(descInput.logGroupName).toBe('/ecs/minecraft-server');
+    expect(descInput.orderBy).toBe('LastEventTime');
+    expect(descInput.descending).toBe(true);
+    expect(descInput.limit).toBe(1);
+
+    const getInput = cwMock.commandCalls(GetLogEventsCommand)[0]!.args[0].input;
+    expect(getInput.logGroupName).toBe('/ecs/minecraft-server');
+    expect(getInput.logStreamName).toBe('ecs/stream1');
+    expect(getInput.limit).toBe(25);
+    expect(getInput.startFromHead).toBe(false);
+  });
+
+  it('defaults event limit to 50', async () => {
+    cwMock.on(DescribeLogStreamsCommand).resolves({
+      logStreams: [{ logStreamName: 's' }],
+    });
+    cwMock.on(GetLogEventsCommand).resolves({ events: [] });
+    await service.getRecentLogs('minecraft');
+    const input = cwMock.commandCalls(GetLogEventsCommand)[0]!.args[0].input;
+    expect(input.limit).toBe(50);
+  });
+
+  it('returns empty array when events undefined', async () => {
+    cwMock.on(DescribeLogStreamsCommand).resolves({
+      logStreams: [{ logStreamName: 's' }],
+    });
+    cwMock.on(GetLogEventsCommand).resolves({});
+    const lines = await service.getRecentLogs('minecraft');
+    expect(lines).toEqual([]);
+  });
+
+  it('maps missing event.message to empty string', async () => {
+    cwMock.on(DescribeLogStreamsCommand).resolves({
+      logStreams: [{ logStreamName: 's' }],
+    });
+    cwMock.on(GetLogEventsCommand).resolves({
+      events: [{ message: 'a' }, {}],
+    });
+    const lines = await service.getRecentLogs('minecraft');
+    expect(lines).toEqual(['a', '']);
+  });
+
+  it('returns an error message when the API throws', async () => {
+    cwMock.on(DescribeLogStreamsCommand).rejects(new Error('denied'));
+    const lines = await service.getRecentLogs('minecraft');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/error fetching logs for minecraft/i);
+    expect(lines[0]).toContain('denied');
+  });
+});

--- a/app/src/server/services/LogsService.test.ts
+++ b/app/src/server/services/LogsService.test.ts
@@ -14,13 +14,20 @@ vi.mock('../logger.js', () => ({
 import { LogsService } from './LogsService.js';
 import type { ConfigService } from './ConfigService.js';
 
+/** Typed stand-in for the AWS CloudWatch Logs SDK client. */
 const cwMock = mockClient(CloudWatchLogsClient);
 
+/**
+ * Build a minimal ConfigService stub exposing only the members LogsService
+ * actually reads at runtime.
+ */
 function makeConfig(): ConfigService {
-  return { getRegion: () => 'us-east-1' } as unknown as ConfigService;
+  const stub: Partial<ConfigService> = { getRegion: () => 'us-east-1' };
+  return stub as ConfigService;
 }
 
 describe('LogsService', () => {
+  /** Service under test, freshly constructed per test. */
   let service: LogsService;
 
   beforeEach(() => {
@@ -28,14 +35,14 @@ describe('LogsService', () => {
     service = new LogsService(makeConfig());
   });
 
-  it('returns "no streams" message when log group has no streams', async () => {
+  it('should return a "no streams" message when the log group has no streams', async () => {
     cwMock.on(DescribeLogStreamsCommand).resolves({ logStreams: [] });
     const lines = await service.getRecentLogs('minecraft');
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/no log streams/i);
   });
 
-  it('uses /ecs/{game}-server log group and fetches newest stream', async () => {
+  it('should query the /ecs/{game}-server log group and fetch the newest stream', async () => {
     cwMock.on(DescribeLogStreamsCommand).resolves({
       logStreams: [{ logStreamName: 'ecs/stream1' }],
     });
@@ -59,7 +66,7 @@ describe('LogsService', () => {
     expect(getInput.startFromHead).toBe(false);
   });
 
-  it('defaults event limit to 50', async () => {
+  it('should default the event limit to 50', async () => {
     cwMock.on(DescribeLogStreamsCommand).resolves({
       logStreams: [{ logStreamName: 's' }],
     });
@@ -69,7 +76,7 @@ describe('LogsService', () => {
     expect(input.limit).toBe(50);
   });
 
-  it('returns empty array when events undefined', async () => {
+  it('should return an empty array when events are undefined', async () => {
     cwMock.on(DescribeLogStreamsCommand).resolves({
       logStreams: [{ logStreamName: 's' }],
     });
@@ -78,7 +85,7 @@ describe('LogsService', () => {
     expect(lines).toEqual([]);
   });
 
-  it('maps missing event.message to empty string', async () => {
+  it('should map a missing event.message to an empty string', async () => {
     cwMock.on(DescribeLogStreamsCommand).resolves({
       logStreams: [{ logStreamName: 's' }],
     });
@@ -89,7 +96,7 @@ describe('LogsService', () => {
     expect(lines).toEqual(['a', '']);
   });
 
-  it('returns an error message when the API throws', async () => {
+  it('should return an error message when the API throws', async () => {
     cwMock.on(DescribeLogStreamsCommand).rejects(new Error('denied'));
     const lines = await service.getRecentLogs('minecraft');
     expect(lines).toHaveLength(1);

--- a/app/tsconfig.server.json
+++ b/app/tsconfig.server.json
@@ -16,5 +16,6 @@
     "allowSyntheticDefaultImports": true,
     "composite": true
   },
-  "include": ["src/server"]
+  "include": ["src/server"],
+  "exclude": ["src/server/**/*.test.ts"]
 }

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    globals: false,
+    clearMocks: true,
+    restoreMocks: true,
+  },
+  esbuild: {
+    target: 'es2022',
+  },
+});


### PR DESCRIPTION
## Summary
This PR adds a complete test suite for the server-side services using Vitest and AWS SDK client mocks. The tests cover core functionality for ECS, EC2, CloudWatch Logs, Cost Explorer, file manager, and configuration services.

## Key Changes
- **EcsService.test.ts**: 423 lines of tests covering task management, status retrieval, task definition registration, and lifecycle operations (start/stop)
- **FileManagerService.test.ts**: 251 lines of tests for file manager deployment, status tracking, and task orchestration
- **ConfigService.test.ts**: 174 lines of tests for Terraform output parsing, caching, region resolution, and configuration persistence
- **CostService.test.ts**: 113 lines of tests for Fargate cost estimation and actual cost retrieval from AWS Cost Explorer
- **LogsService.test.ts**: 99 lines of tests for CloudWatch Logs retrieval and stream handling
- **Ec2Service.test.ts**: 81 lines of tests for ENI public/private IP resolution
- **vitest.config.ts**: New Vitest configuration with Node environment and proper TypeScript support
- **package.json**: Added `test` and `test:watch` scripts, plus Vitest and related dependencies
- **tsconfig.server.json**: Excluded test files from TypeScript compilation

## Notable Implementation Details
- Uses `aws-sdk-client-mock` for mocking AWS SDK v3 clients
- Comprehensive mocking of logger to avoid console output during tests
- Tests cover both happy paths and error scenarios
- Validates AWS API call parameters and response handling
- Tests include edge cases like missing configuration, API failures, and null returns
- All tests use Vitest's `describe`/`it` syntax with proper setup/teardown via `beforeEach`

https://claude.ai/code/session_01ChQpGknsSfrqG4KYRBUqyQ