### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/app/src/server/index.ts
+++ b/app/src/server/index.ts
@@ -1,5 +1,6 @@
 import './container.js'; // must be first — sets up DI registrations
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { container } from 'tsyringe';
@@ -23,6 +24,14 @@ const isDev = process.env['NODE_ENV'] !== 'production';
 const app = express();
 app.use(express.json());
 app.use(requestLogger);
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 1000, // limit each IP to 1000 requests per window
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+app.use(limiter);
 
 // Resolve services from DI container
 const configService = container.resolve(ConfigService);


### PR DESCRIPTION
Potential fix for [https://github.com/CoderCoco/game-server-deploy/security/code-scanning/1](https://github.com/CoderCoco/game-server-deploy/security/code-scanning/1)

Add a standard Express rate-limiting middleware and apply it before routes so requests (including the `*` fallback with `sendFile`) are throttled. The best minimal fix is to use `express-rate-limit` with a reasonable window and max request count, then register it with `app.use(...)` after existing basic middleware and before route mounting. This preserves existing behavior while adding protection against request floods.

In `app/src/server/index.ts`:
1. Add `import rateLimit from 'express-rate-limit';` near other imports.
2. Define a limiter instance after app initialization (for example, 15-minute window, max 1000 requests/IP).
3. Apply it globally with `app.use(limiter);` before mounting `/api` and static/fallback routes.

No route logic changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
