### PR TITLE
docs: migrate README to Jekyll site with comprehensive guides

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,10 +1,14 @@
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+name: Deploy Jekyll docs site to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch that touch the docs site
+  # (or this workflow itself).
   push:
     branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/jekyll-gh-pages.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -33,7 +37,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -1,164 +1,93 @@
 # Game Server Manager
 
-A cost-efficient multi-game dedicated server platform on **AWS Fargate** with a local web UI to manage everything. Servers only run (and cost money) when you want to play.
+A cost-efficient multi-game dedicated server platform on **AWS Fargate** with a
+local web UI and a fully serverless Discord bot. Servers only run — and only
+cost money — while someone is playing.
 
-## Architecture
+> 📚 Full documentation lives at **[codercoco.github.io/game-server-deploy](https://codercoco.github.io/game-server-deploy/)**
+> (built from [`docs/`](./docs) by GitHub Pages). The rest of this README is a
+> quick tour; deep-dives, setup steps, and architecture diagrams are on the
+> site.
 
-- **AWS Fargate** — runs game server containers on-demand via `RunTask` (no persistent ECS Service, no idle costs)
-- **EFS** — persists world saves across server restarts
-- **Route 53** — auto-updates `{game}.yourdomain.com` DNS records when tasks start/stop via a Lambda
-- **Watchdog Lambda** — automatically shuts down idle servers based on network traffic
-- **Terraform** — provisions all AWS infrastructure
-- **Nest.js + React management app** — local dashboard to start/stop servers, edit config, monitor costs, stream logs, and manage Discord credentials
-- **Discord bot (serverless)** — two Node.js Lambdas + DynamoDB + Secrets Manager serve Discord HTTP interactions; permitted Discord users/roles can `/server-start`, `/server-stop`, `/server-status`, and `/server-list` from chat without any 24/7 process running
+## What you get
 
-### Auto-DNS
+- **AWS Fargate** — runs game server containers on-demand via `RunTask` (no
+  persistent ECS Service, no idle costs).
+- **EFS** — persists world saves across server restarts, one access point
+  per game.
+- **Route 53** — a Lambda auto-UPSERTs `{game}.yourdomain.com` on task start
+  and DELETEs it on stop.
+- **Optional ALB + ACM** — for any game marked `https = true`, traffic goes
+  through a load balancer with TLS termination.
+- **Watchdog Lambda** — automatically shuts down idle servers based on
+  `NetworkPacketsIn`.
+- **Terraform** — provisions every AWS resource.
+- **Nest.js + React management app** — local dashboard to start/stop servers,
+  edit config, monitor costs, stream logs, and manage Discord credentials.
+- **Serverless Discord bot** — two Node.js Lambdas + DynamoDB + Secrets
+  Manager serve Discord HTTP interactions. Permitted Discord users/roles
+  can `/server-start`, `/server-stop`, `/server-status`, and `/server-list`
+  from chat without any 24/7 process running.
 
-An EventBridge rule watches for ECS task state changes and triggers a Lambda that UPSERTs the DNS record on `RUNNING` and DELETEs it on `STOPPED`. DNS is managed entirely by the Lambda — not Terraform.
+## Documentation
 
-### Watchdog
+The [docs site](https://codercoco.github.io/game-server-deploy/) is
+organised around three roles. Pick the one that matches what you need to do.
 
-A Lambda runs on a configurable schedule (default every 15 minutes). For each running task it checks `NetworkPacketsIn` via CloudWatch. If packets fall below `watchdog_min_packets` for `watchdog_idle_checks` consecutive intervals, the task is stopped and its DNS record removed.
+| Guide | You are… |
+|---|---|
+| [**Setup guide**](https://codercoco.github.io/game-server-deploy/setup/) | Going from a blank AWS account to a running Fargate task. |
+| [**User guide**](https://codercoco.github.io/game-server-deploy/guides/user/) | Driving an already-provisioned deployment — the dashboard, Discord commands, day-to-day ops. |
+| [**Maintainer guide**](https://codercoco.github.io/game-server-deploy/guides/maintainer/) | Working on this codebase. |
+| [**Private parent + submodule guide**](https://codercoco.github.io/game-server-deploy/guides/submodule/) | Wrapping this repo in a private repo that holds `terraform.tfvars`, `server_config.json`, and tfstate. |
 
-**Default**: 15 min × 4 checks = **60 minutes idle** before auto-shutdown.
+Component deep-dives:
 
-## AWS Setup
+- [**Architecture**](https://codercoco.github.io/game-server-deploy/architecture/) — full diagram + `/server-start` sequence.
+- [**Terraform**](https://codercoco.github.io/game-server-deploy/components/terraform/) — every `.tf` file, variables, outputs, gotchas.
+- [**Management app**](https://codercoco.github.io/game-server-deploy/components/management-app/) — Nest.js API, React dashboard, `@gsd/shared`.
+- [**Lambdas**](https://codercoco.github.io/game-server-deploy/components/lambdas/) — interactions, followup, update-dns, watchdog.
 
-### 1. Create an IAM User
-
-1. Go to the [AWS IAM Console](https://console.aws.amazon.com/iam/) → **Users** → **Create user**
-2. Give it a name (e.g. `game-server-deploy`)
-3. On the permissions step, choose **Attach policies directly** → skip past the managed-policy picker without selecting anything, and create the user.
-4. After creating the user, open it → **Permissions** tab → **Add permissions** → **Create inline policy** → **JSON** tab, and paste the single policy below. Name it `GameServerDeployAll` (or anything).
-5. **Security credentials** → **Create access key** → choose **Command Line Interface (CLI)**.
-6. Save the **Access Key ID** and **Secret Access Key** — you won't see the secret again.
-
-> **Why one inline policy instead of stacking managed policies?** AWS caps each IAM user at 10 directly-attached managed policies by default, and this project needs permissions across ~14 services. Putting everything in one inline policy sidesteps that quota entirely and keeps the full list of what the deploy user can do visible in one place. Trade-off: you lose AWS's auto-maintenance of the managed policies' action lists — but since we're granting `{service}:*` for each, there's nothing to maintain.
-
-#### The inline policy
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "GameServerDeploy",
-      "Effect": "Allow",
-      "Action": [
-        "ecs:*",
-        "elasticfilesystem:*",
-        "ec2:*",
-        "lambda:*",
-        "logs:*",
-        "cloudwatch:*",
-        "events:*",
-        "route53:*",
-        "iam:*",
-        "ce:*",
-        "elasticloadbalancing:*",
-        "acm:*",
-        "dynamodb:*",
-        "secretsmanager:*"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-That's it — no additional managed policies, no additional inline policies. If you previously attached any of `AmazonECS_FullAccess`, `AmazonElasticFileSystemFullAccess`, `AmazonVPCFullAccess`, `AWSLambda_FullAccess`, `CloudWatchFullAccess`, `AmazonEventBridgeFullAccess`, `AmazonRoute53FullAccess`, `IAMFullAccess`, `AWSCostExplorerReadOnlyAccess`, `ElasticLoadBalancingFullAccess`, `AWSCertificateManagerFullAccess`, `AmazonDynamoDBFullAccess`, or `SecretsManagerReadWrite`, you can **detach them all** after attaching this inline policy.
-
-> **Tip**: For a tighter security boundary on a shared AWS account, replace this with a custom policy scoped to the specific resource ARNs Terraform creates — the list above is `{service}:*` for a personal-project deploy user.
-
-### 2. Configure AWS CLI
+## Quick start
 
 ```bash
-aws configure
-```
-
-Enter your credentials when prompted:
-
-```
-AWS Access Key ID:     AKIA...
-AWS Secret Access Key: ****
-Default region name:   us-east-1   # must match aws_region in terraform.tfvars
-Default output format: json
-```
-
-This writes to `~/.aws/credentials` and `~/.aws/config`, which Terraform and the management app both read automatically.
-
-### 3. Verify
-
-```bash
-aws sts get-caller-identity
-```
-
-You should see your account ID and user ARN. If this works, you're ready to run Terraform.
-
----
-
-## Quick Start
-
-### Option A — Run the app directly
-
-```bash
-# 1. Run setup (installs Python deps, inits Terraform)
+# 1. First-time bootstrap (installs node/terraform/aws CLI on Debian/Ubuntu,
+#    npm-installs all workspaces, builds Lambda bundles, runs terraform init)
 chmod +x setup.sh && ./setup.sh
 
-# 2. Configure your servers
-cp terraform/terraform.example.tfvars terraform/terraform.tfvars
-# Edit terraform/terraform.tfvars
+# 2. Configure
+$EDITOR terraform/terraform.tfvars        # game_servers, hosted_zone_name, ...
 
-# 3. Deploy infrastructure
-cd terraform
-terraform plan
-terraform apply
+# 3. Deploy infra
+cd terraform && terraform apply
 
-# 4. Launch the management UI
-cd ../app
-python3 app.py
-# Open http://localhost:5000
-```
+# 4a. Run the management app in dev mode
+cd ../app && npm run dev
+#     http://localhost:5173  (Nest on :3001, Vite proxy)
 
-### Option B — Run the app in Docker
-
-```bash
-# 1. Deploy infrastructure first (see above)
-
-# 2. Create the persistence file that gets bind-mounted (first run only).
-#    It must exist on the host or Docker creates a directory in its place.
-#    (Discord credentials now live in AWS Secrets Manager, not a local file.)
+# 4b. …or in Docker (production mode — requires a bearer token)
+cd ..
 touch app/server_config.json
-
-# 3. Set an API token — REQUIRED in production mode (which Docker uses).
-#    Generate a random 32-byte hex string or anything long & hard to guess.
 export API_TOKEN="$(openssl rand -hex 32)"
-
-# 4. Start the app
 docker compose up --build
-# Open http://localhost:5000 — the dashboard will prompt you for the token;
-# paste the value of $API_TOKEN and click "Save & reload".
+#     http://localhost:5000  (dashboard prompts for $API_TOKEN)
 ```
 
-The Docker setup mounts `./terraform` (read-only for state), `./app/server_config.json`, and `~/.aws` credentials. The Discord bot reads its config from the DynamoDB table provisioned by Terraform, so no `discord_config.json` bind mount is needed.
+See the [setup guide](https://codercoco.github.io/game-server-deploy/setup/)
+for the full walkthrough, including the IAM policy, Discord bot setup, and
+troubleshooting.
 
-## Configuration
+## Configuration at a glance
 
-Copy `terraform/terraform.example.tfvars` to `terraform/terraform.tfvars` and customize:
+Edit `terraform/terraform.tfvars`. The `game_servers` map is the single
+source of truth — task definitions, EFS access points, DNS, watchdog config,
+and Discord command autocomplete all derive from it.
 
 ```hcl
-aws_region   = "us-east-1"
-project_name = "game-servers"
+aws_region       = "us-east-1"
+project_name     = "game-servers"
+hosted_zone_name = "yourdomain.com"   # must exist in Route 53
 
-# Route 53 hosted zone — creates {game}.yourdomain.com records
-hosted_zone_name = "yourdomain.com"
-
-# Watchdog settings
-watchdog_interval_minutes = 15   # how often to check (minutes)
-watchdog_idle_checks      = 4    # consecutive idle checks before shutdown
-watchdog_min_packets      = 100  # packets/interval to be considered "active"
-
-# Add one entry per game server
 game_servers = {
   palworld = {
     image  = "thijsvanloef/palworld-server-docker:latest"
@@ -169,167 +98,55 @@ game_servers = {
       { container = 27015, protocol = "udp" },
     ]
     environment = [
-      { name = "PLAYERS",        value = "8" },
-      { name = "SERVER_NAME",    value = "My Palworld Server" },
-      { name = "ADMIN_PASSWORD", value = "your_secure_password_here" },
-      # ...
+      { name = "PLAYERS",     value = "8" },
+      { name = "SERVER_NAME", value = "My Palworld Server" },
     ]
     efs_path = "/palworld"
+    https    = false
   }
 }
 ```
 
-## Management App Features
+Cost ballpark: **Fargate 2 vCPU / 8 GB ≈ $0.12/hr** while running; EFS is
+pennies/month. Playing 4 hours/day, 5 days/week ≈ **$10–12/month**, vs.
+~$60/month for a 24/7 t3.large.
 
-- **Games list** — auto-discovers all configured game servers from Terraform state
-- **Start/Stop** — launches or stops Fargate tasks per game
-- **Status** — shows running state and public IP / DNS hostname per game
-- **Server Config** — edit watchdog settings (interval, idle checks, min packets)
-- **Cost Monitoring** — per-game Fargate cost estimates and AWS Cost Explorer actuals
-- **Live Logs** — streams CloudWatch log events from the most recent task
-- **Discord Bot** — configure bot token, guild allowlist, admins, and per-game permissions (see next section)
+## Repository structure
 
-## API Authentication
-
-Every `/api/*` route on the management app is gated behind a bearer token, so the dashboard can't be driven by anyone who can reach the port. The token is read (in order of precedence) from:
-
-1. The `API_TOKEN` environment variable, or
-2. The `api_token` field in `app/server_config.json`.
-
-Set it to any long random secret, e.g.:
-
-```bash
-# POSIX
-export API_TOKEN="$(openssl rand -hex 32)"
-```
-
-Or add the following to `app/server_config.json`:
-
-```json
-{
-  "api_token": "your-long-random-secret-here"
-}
-```
-
-When the dashboard loads in a browser it will prompt for the token once; it's stored in `localStorage` and attached to every subsequent API call as `Authorization: Bearer <token>`. Clear the stored value by clearing your browser data.
-
-**Production startup safety.** When `NODE_ENV=production` (the default for Docker), the app **refuses to start** if no token is configured. In dev (`npm run dev`) it logs a warning and allows unauthenticated requests, so local iteration isn't blocked.
-
-## Discord Bot
-
-The Discord bot is fully serverless — it runs as two AWS Lambdas (plus a DynamoDB table for config and pending interactions, and two Secrets Manager secrets for credentials), all provisioned by Terraform. The management app no longer needs to run 24/7 for the bot to work; it's only used to edit bot configuration. The bot **rejects commands from any guild that isn't on the allowlist** you configure in the web UI.
-
-### Commands
-
-| Command | What it does |
-|---------|--------------|
-| `/server-start <game>` | Start a configured game server |
-| `/server-stop <game>`  | Stop a running game server |
-| `/server-status [game]` | Show status of a game (or all if omitted) |
-| `/server-list` | List all configured games and their current state |
-
-Replies are ephemeral (only the invoker sees them), so commands don't spam the channel.
-
-### Permission model
-
-Every command invocation is checked in this order:
-
-1. **Guild allowlist** — if the guild isn't allowlisted, the bot refuses entirely.
-2. **Server-wide admins** — any user ID or role ID in the admin lists can run every command on every game.
-3. **Per-game permissions** — otherwise the command is permitted only if the user's ID or one of their role IDs is listed for that game *and* the requested action (`start` / `stop` / `status`) is in that entry's allowed actions.
-
-Admins and per-game entries are kept separate, so you can give one group of Discord users full control and another group stop-only access to a single game.
-
-### Setup
-
-1. **Create a Discord application.** Visit <https://discord.com/developers/applications> → **New Application** → add a **Bot**. From the General Information page you'll copy three values; each has a specific job:
-
-   | Value | Where it goes | What the bot uses it for |
-   |---|---|---|
-   | **Application ID** (aka Client ID) | DynamoDB (`clientId` in the Discord config row) | Identifies your app when the management server calls Discord's REST API to install the four slash commands into a guild — the endpoint is `PUT /applications/{APPLICATION_ID}/guilds/{GUILD_ID}/commands`. Without it, the "Register commands" button in the UI errors with "clientId is not configured". Public value, not a secret. |
-   | **Bot Token** | AWS Secrets Manager (`${project_name}/discord/bot-token`) | Authenticates the same REST call as `Authorization: Bot <token>`. Treat like a password. |
-   | **Application Public Key** | AWS Secrets Manager (`${project_name}/discord/public-key`) | Ed25519 key the InteractionsLambda uses to verify that every incoming interaction was actually signed by Discord. Public value but sensitive to tampering, so it lives in Secrets Manager. |
-
-   You do **not** need to enable any *Privileged Gateway Intents* — the HTTP-interactions model reads the invoker's role IDs directly from the request body.
-2. **Deploy the serverless Discord stack** by running `terraform apply`. This provisions the DynamoDB table, two Secrets Manager secrets, the interactions and followup Lambdas, and a Lambda Function URL that Discord can reach. The URL is surfaced as the `interactions_invoke_url` Terraform output. You can seed credentials two ways:
-   - **Via tfvars (recommended if you're comfortable putting the token in `terraform.tfvars`).** Set `discord_application_id`, `discord_bot_token`, and `discord_public_key` in `terraform.tfvars` — `.tfvars` is gitignored. Terraform writes the App ID to DynamoDB and the two secrets to Secrets Manager on the first apply. Subsequent applies don't overwrite them (`ignore_changes` on both) so the UI can still edit them later. To rotate a value via tfvars after that first apply, `terraform taint` the relevant resource (`aws_secretsmanager_secret_version.discord_bot_token`, `.discord_public_key`, or `aws_dynamodb_table_item.discord_config_seed`) before the next apply.
-   - **Via the web UI.** Leave the three variables unset. Terraform seeds the secrets with a `"placeholder"` string (and skips the DynamoDB config row entirely); you paste the real values into the Credentials tab of the dashboard, which writes them to the correct backing store at runtime.
-3. **Invite the bot to your Discord server.** In the Developer Portal:
-   - Under **Installation → Installation Contexts**, enable **Guild Install** (the bot operates on guild-scoped resources — allowlist, role-based permissions — so user install doesn't apply here). Disable User Install if Discord defaulted it on.
-   - Under **OAuth2 → URL Generator**, tick scopes `bot` and `applications.commands`. In the **Bot Permissions** grid that appears below, tick **Send Messages** and **Use Slash Commands** (this is Discord's display name for the `USE_APPLICATION_COMMANDS` permission bit — same permission, renamed in the UI).
-   - Copy the generated URL and open it to add the bot to your server.
-4. **Enable Developer Mode in Discord** (User Settings → Advanced → Developer Mode) so you can right-click a server/user/role and **Copy ID**.
-5. **Start the management app** (Option A or B under Quick Start) and **open the dashboard** → the **Discord Bot** panel has four tabs:
-   - **Credentials** — if you didn't seed via tfvars, paste the Application (Client) ID, Bot Token, and Application Public Key, then Save. The Application ID goes to DynamoDB (the bot needs it to register slash commands); the bot token and public key go to AWS Secrets Manager. Copy the Interactions Endpoint URL shown beneath the form into the same Discord Developer Portal page — that step is always done via the UI since the URL is a Terraform output.
-   - **Guilds** — add the ID of each Discord server the bot should operate in, then click **Register commands** next to that guild to install the slash commands via Discord's REST API.
-   - **Admins** — comma-separated user IDs and/or role IDs who can run every command on every game.
-   - **Per-Game Permissions** — select a game, paste allowed user/role IDs, tick which actions (`start`/`stop`/`status`) they can invoke, Save.
-
-### Troubleshooting
-
-- **Badge shows `awaiting credentials`** — the bot token or public key is still at the Terraform placeholder; open the Credentials tab and save the real values.
-- **Badge shows `terraform not applied`** — the `interactions_invoke_url` Terraform output is missing; run `cd app && npm run build:lambdas && cd ../terraform && terraform apply`.
-- **Slash commands don't appear in Discord** — click **Register commands** for that guild in the Guilds tab; the bot must also have been invited with the `applications.commands` scope.
-- **Discord returns "invalid interactions endpoint URL"** — the Application Public Key in Secrets Manager doesn't match Discord's when signatures are verified. Re-copy the public key from the Developer Portal and re-save in the Credentials tab.
-- **Command replies "You don't have permission…"** — confirm your Discord user ID or one of your role IDs is in the admin list or the per-game entry, *and* that the action you invoked is ticked.
-
-## Cost Tracking
-
-All resources are tagged with `Project = "game-servers-poc"` (via Terraform `default_tags`). To break down costs by this project in Cost Explorer:
-
-1. Go to **AWS Billing → Cost allocation tags**
-2. Find `Project` under user-defined tags and click **Activate**
-3. Wait up to 24 hours — then in **Cost Explorer** you can filter or group by `Project` to see all spend attributed to this deployment
-
-## Cost Breakdown
-
-| Resource | Cost |
-|----------|------|
-| Fargate (2 vCPU, 8 GB) | ~$0.12/hr while running |
-| EFS storage | ~$0.30/GB/month |
-| Lambda / EventBridge | effectively free at this scale |
-
-**Example**: Playing 4 hours/day, 5 days/week ≈ **$10–12/month**.
-
-Compare to a t3.large running 24/7 ≈ $60/month.
-
-## Project Structure
-
-```
+```text
 game-server-deploy/
-├── terraform/
-│   ├── main.tf                  # VPC, ECS cluster, EFS, IAM, security groups
-│   ├── variables.tf             # All configurable parameters
-│   ├── outputs.tf               # Values consumed by the management app
-│   ├── route53.tf               # DNS updater Lambda + EventBridge rule
-│   ├── watchdog.tf              # Watchdog Lambda + EventBridge schedule
-│   ├── lambda/
-│   │   ├── update_dns.py        # Auto-updates Route 53 on task start/stop
-│   │   └── watchdog.py          # Shuts down idle servers
-│   └── terraform.example.tfvars
-├── app/
-│   ├── packages/
-│   │   ├── shared/              # @gsd/shared — types, canRun, formatters, DynamoDB + Secrets helpers
-│   │   ├── server/              # @gsd/server — Nest.js API (controllers, services, guards)
-│   │   ├── web/                 # @gsd/web — React/Vite dashboard
-│   │   └── lambda/
-│   │       ├── interactions/    # Discord HTTP interactions (Ed25519 verify + deferred-ack)
-│   │       ├── followup/        # Async ECS RunTask/StopTask + Discord webhook PATCH
-│   │       ├── update-dns/      # Port of update_dns.py — Route 53 + Discord followup on RUNNING
-│   │       └── watchdog/        # Port of watchdog.py — idle-detect + auto-stop
-│   ├── server_config.json       # Watchdog config (persisted locally, gitignored)
-│   └── vitest.config.ts         # Test runner config
+├── app/                       # Nest.js + React monorepo (npm workspaces)
+│   └── packages/
+│       ├── shared/            # @gsd/shared
+│       ├── server/            # @gsd/server (Nest.js API)
+│       ├── web/               # @gsd/web   (React + Vite)
+│       └── lambda/
+│           ├── interactions/  # Discord Function URL entry point
+│           ├── followup/      # Async ECS work + Discord PATCH
+│           ├── update-dns/    # Route 53 + ALB on task state change
+│           └── watchdog/      # Idle detection + auto-stop
+├── terraform/                 # All AWS infra (VPC, ECS, EFS, 4 Lambdas, DDB…)
+├── docs/                      # Documentation site (published via GH Pages)
 ├── Dockerfile
 ├── docker-compose.yml
-├── requirements.txt
-├── setup.sh
-└── README.md
+├── setup.sh                   # First-time bootstrap (node/terraform/aws)
+├── CLAUDE.md                  # Project instructions + invariants
+├── CONTRIBUTING.md            # PR conventions, local checks
+└── README.md                  # this file
 ```
 
-## Tearing Down
+## Tearing it down
+
+Stop every server from the dashboard first (so the update-dns Lambda cleans
+its records), then:
 
 ```bash
-# Stop all servers via the UI first, then:
-cd terraform
-terraform destroy
+cd terraform && terraform destroy
 ```
+
+The two Discord Secrets Manager secrets use `recovery_window_in_days = 0`,
+so they are deleted immediately and a later `apply` is clean.
+
+## License
+
+See [LICENSE](./LICENSE).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,29 @@
+title: Game Server Deploy
+description: >-
+  Cost-efficient multi-game dedicated server platform on AWS Fargate with a
+  local management UI and a fully serverless Discord bot.
+theme: jekyll-theme-cayman
+
+# Jekyll only processes this docs/ folder. The repo README, LICENSE, CLAUDE.md,
+# CONTRIBUTING.md and all application/terraform source live outside of it and
+# are not published.
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor/
+
+# Kramdown + GFM for tables and fenced code blocks.
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+plugins:
+  - jekyll-relative-links
+  - jekyll-optional-front-matter
+  - jekyll-readme-index
+  - jekyll-default-layout
+  - jekyll-titles-from-headings
+
+# Make every *.md file reachable as /foo/ rather than /foo.html.
+permalink: pretty

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -15,7 +15,7 @@
       div.textContent = el.textContent;
       el.parentElement.replaceWith(div);
     });
-    mermaid.initialize({ startOnLoad: false, theme: 'default', securityLevel: 'loose' });
+    mermaid.initialize({ startOnLoad: false, theme: 'default', securityLevel: 'strict' });
     mermaid.run();
   });
 </script>

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,27 @@
+<!--
+  Mermaid support. Cayman is a minimal GitHub Pages theme that doesn't bundle
+  Mermaid, so we pull the ESM build from a pinned CDN version and render any
+  fenced block of the form ```mermaid ... ```. The build-time Kramdown/Rouge
+  pipeline emits `<pre><code class="language-mermaid">` for these blocks; the
+  runtime script below rewrites them into `<div class="mermaid">` so that
+  `mermaid.run()` can process them.
+-->
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.esm.min.mjs';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('pre > code.language-mermaid').forEach((el) => {
+      const div = document.createElement('div');
+      div.className = 'mermaid';
+      div.textContent = el.textContent;
+      el.parentElement.replaceWith(div);
+    });
+    mermaid.initialize({ startOnLoad: false, theme: 'default', securityLevel: 'loose' });
+    mermaid.run();
+  });
+</script>
+<style>
+  /* Keep long tables / diagrams from blowing out Cayman's narrow content
+     column on mobile. */
+  .main-content table { display: block; overflow-x: auto; }
+  .main-content .mermaid { overflow-x: auto; background: #fff; padding: 0.5rem; }
+</style>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,183 @@
+---
+title: Architecture
+---
+
+# Architecture
+
+Three loosely-coupled pieces, all sharing types and helpers through a single
+workspace package, `@gsd/shared`:
+
+1. **Terraform** provisions every AWS resource.
+2. The **management app** (Nest.js API + React dashboard) is a local control
+   plane. It reads `terraform.tfstate` directly to discover what the infra
+   looks like and drives AWS via SDK v3.
+3. Four **Lambdas** run the always-on control flow: two for Discord, one for
+   DNS, one for the idle watchdog.
+
+There is **no persistent ECS service**. Game servers only exist while a
+RunTask is in flight — Start triggers `ecs.runTask`, Stop triggers
+`ecs.stopTask`, and the Watchdog Lambda stops tasks that look idle.
+
+## Component diagram
+
+```mermaid
+flowchart TB
+  classDef local fill:#eef,stroke:#66f
+  classDef aws fill:#fef6e4,stroke:#b58900
+  classDef ext fill:#efe,stroke:#393
+
+  subgraph Local[Operator laptop / container]
+    direction LR
+    Web["@gsd/web<br/>React + Vite"]:::local
+    Server["@gsd/server<br/>Nest.js + Winston"]:::local
+    Web -- "/api/* + Bearer" --> Server
+  end
+
+  subgraph AWS[AWS account]
+    direction TB
+
+    subgraph Data[Game plane]
+      direction LR
+      ECS["ECS Fargate<br/>{game}-server task defs"]:::aws
+      EFS["EFS + per-game<br/>access points"]:::aws
+      ALB["ALB + ACM<br/>(HTTPS games only)"]:::aws
+      ECS -- "nfs" --> EFS
+      ALB --> ECS
+    end
+
+    subgraph Ctrl[Control plane]
+      direction LR
+      IX["interactions Lambda<br/>Function URL"]:::aws
+      FU["followup Lambda"]:::aws
+      UD["update-dns Lambda"]:::aws
+      WD["watchdog Lambda"]:::aws
+      EB{{"EventBridge"}}:::aws
+      IX -- "async invoke" --> FU
+      EB -- "rate(N min)" --> WD
+      EB -- "ECS Task State Change" --> UD
+    end
+
+    subgraph State[State]
+      direction LR
+      DDB[("DynamoDB<br/>CONFIG#discord + PENDING#arn")]:::aws
+      SM[("Secrets Manager<br/>bot-token + public-key")]:::aws
+      R53[("Route 53<br/>{game}.yourdomain.com")]:::aws
+      CW[("CloudWatch<br/>logs + NetworkPacketsIn")]:::aws
+    end
+
+    Server -. "read tfstate (local file)" .-> TF[("terraform.tfstate")]:::aws
+    Server -- "RunTask / StopTask<br/>DescribeTasks" --> ECS
+    Server -- "put CONFIG#discord" --> DDB
+    Server -- "put bot-token / public-key" --> SM
+    Server -. "GetLogEvents" .-> CW
+
+    FU -- "RunTask / StopTask" --> ECS
+    FU -- "put PENDING#arn" --> DDB
+    IX -- "get public-key" --> SM
+    IX -- "get CONFIG#discord" --> DDB
+    ECS -- "state change" --> EB
+    UD -- "UPSERT/DELETE A" --> R53
+    UD -- "register/deregister targets" --> ALB
+    UD -- "get+delete PENDING#arn" --> DDB
+    WD -- "GetMetricStatistics" --> CW
+    WD -- "StopTask + tag" --> ECS
+    WD -- "cleanup" --> R53
+    WD -- "cleanup" --> ALB
+  end
+
+  Discord(["Discord<br/>application"]):::ext
+  Player(["Player"]):::ext
+
+  Discord -- "HTTP interaction" --> IX
+  IX -- "PATCH @original" --> Discord
+  FU -- "PATCH @original" --> Discord
+  UD -- "PATCH @original" --> Discord
+  Player -- "UDP / TCP / HTTPS" --> ECS
+  Player -. "DNS lookup" .-> R53
+```
+
+## The `/server-start` critical path
+
+When a user types `/server-start palworld` in Discord, five AWS services and
+three Lambdas cooperate to return a usable `palworld.yourdomain.com` without
+ever letting the interaction time out.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as User
+  participant D as Discord
+  participant I as interactions Lambda
+  participant F as followup Lambda
+  participant E as ECS
+  participant EB as EventBridge
+  participant UD as update-dns Lambda
+  participant R as Route 53
+  participant DB as DynamoDB
+
+  U->>D: /server-start palworld
+  D->>I: POST FunctionURL (signed)
+  I->>I: Ed25519 verify + canRun()
+  I-->>D: type:5 deferred ack (within 3s)
+  I--)F: async invoke (FollowupPayload)
+  F->>E: RunTask palworld-server
+  E-->>F: taskArn
+  F->>DB: put PENDING#taskArn (TTL 15 min)
+  F->>D: PATCH @original "starting..."
+  Note over E: task pulls image, mounts EFS...
+  E-->>EB: ECS Task State Change (RUNNING)
+  EB->>UD: event
+  UD->>E: DescribeTasks → ENI → public IP
+  UD->>R: UPSERT A palworld.example.com
+  UD->>DB: get + delete PENDING#taskArn
+  UD->>D: PATCH @original "🟢 running — palworld.example.com"
+  U->>R: DNS lookup
+  U->>E: UDP 8211
+```
+
+After the session: either the user types `/server-stop palworld` (same flow
+but `stopTask` + `DELETE` A record), or the Watchdog Lambda notices
+`NetworkPacketsIn < min_packets` for four consecutive 15-minute windows and
+stops the task itself.
+
+## Invariants
+
+These are easy to break by accident. They are spelled out in `CLAUDE.md`, the
+maintainer guide, and inline in a few Terraform files. If you change one,
+write the PR description as if you're explaining the new design.
+
+1. **`game_servers` in `terraform.tfvars` is the single source of truth.**
+   Task definitions, EFS access points, log groups, security-group rules, and
+   the `GAME_NAMES` env var on three Lambdas are all produced by `for_each`
+   over this map. Adding or removing a game means editing exactly one place.
+
+2. **DNS is Lambda-managed, not Terraform-managed.** The Route 53 zone is
+   a data source; individual A records are created and deleted by the
+   update-dns Lambda in response to ECS task state changes. Adding an
+   `aws_route53_record` resource would fight the Lambda.
+
+3. **Lambdas use `AWS_REGION_` (trailing underscore).** The standard
+   `AWS_REGION` name is reserved by the Lambda runtime and cannot be
+   overridden. Every Lambda reads `process.env.AWS_REGION_` instead.
+
+4. **Secrets never leave AWS.** The bot token and the Discord public key
+   live in Secrets Manager. The management app can write them and
+   `getEffectiveToken()` once (to register guild commands), but they are
+   never sent to the browser — the API only returns `botTokenSet` /
+   `publicKeySet` booleans.
+
+5. **Per-guild command registration only.** `DiscordCommandRegistrar.registerForGuild`
+   PUTs to `applications/{client_id}/guilds/{guild_id}/commands`. Do not
+   register global commands — they would leak to every guild the bot is
+   invited to.
+
+6. **Permission resolution lives in `canRun()` in `@gsd/shared`.** The server
+   and both Discord Lambdas import the same function. Do not duplicate the
+   logic; do not reorder the checks (guild allowlist → admin → per-game).
+
+7. **Watchdog state lives in ECS task tags.** There is no DynamoDB/SSM for
+   the idle counter — it is an `idle_checks` tag on each running task.
+   Counter resets when a task stops, which is free.
+
+See the [maintainer guide]({{ '/guides/maintainer/' | relative_url }}) for
+what tends to break these and what the failure modes look like.

--- a/docs/components/lambdas.md
+++ b/docs/components/lambdas.md
@@ -1,0 +1,219 @@
+---
+title: Lambdas (interactions, followup, update-dns, watchdog)
+---
+
+# Lambdas
+
+Four TypeScript Lambda packages live under `app/packages/lambda/`. Each
+builds via esbuild to a single CJS file at `dist/handler.cjs`; Terraform's
+`archive_file` data source zips that at apply time.
+
+```bash
+cd app && npm run build:lambdas        # produces every dist/handler.cjs
+```
+
+All four Lambdas read AWS region from `process.env.AWS_REGION_`
+(trailing underscore — `AWS_REGION` is reserved by the Lambda runtime).
+Terraform sets the variable with that name in every function definition.
+
+## interactions
+
+| | |
+|---|---|
+| **Package** | `@gsd/lambda-interactions` |
+| **Trigger** | Lambda Function URL (public HTTPS, `auth_type = NONE`, CORS for `https://discord.com`) — Discord POSTs every interaction here. |
+| **Terraform** | `terraform/interactions.tf`. Output: `interactions_invoke_url`. |
+| **IAM** | `dynamodb:GetItem` on the Discord table, `secretsmanager:GetSecretValue` on the public-key secret, `lambda:InvokeFunction` on the followup Lambda. |
+| **Env vars** | `AWS_REGION_`, `TABLE_NAME`, `DISCORD_PUBLIC_KEY_SECRET_ARN`, `FOLLOWUP_LAMBDA_NAME`, `GAME_NAMES`, `HOSTED_ZONE_NAME`. |
+
+### Behaviour
+
+1. **Signature verify** — reads `x-signature-ed25519` + `x-signature-timestamp`
+   headers, fetches the public key from Secrets Manager (5-minute cache via
+   `@gsd/shared/secrets`), and verifies with `@noble/ed25519` over
+   `timestamp + rawBody`. Rejects 401 on mismatch; without a valid signature
+   Discord stops routing to the URL.
+2. **PING** (`type === 1`) → respond `{ type: 1 }` (PONG).
+3. **Autocomplete** (`type === 4`) → filter `GAME_NAMES` by the user's
+   partial input, then filter by `canRun()` against the DynamoDB config,
+   return choices synchronously. No ECS calls — has to fit in Discord's
+   3-second budget.
+4. **Application command** (`type === 2`):
+   - Confirm the guild is in `allowedGuilds`.
+   - Confirm `canRun(cfg, { userId, roleIds, game, action })`.
+   - Return a **deferred ack** (`type: 5`, ephemeral flag `64`) immediately.
+   - Async-invoke the followup Lambda (`InvokeCommand` with `InvocationType:
+     'Event'`) with a `FollowupPayload` (`kind`, applicationId,
+     interactionToken, userId, guildId, roleIds, optional game).
+
+If anything above throws, Discord sees either a non-200 response or a
+silent timeout — the user gets no reply, which is the correct failure
+mode (replying with an error would require another signed response, which
+we can't forge).
+
+## followup
+
+| | |
+|---|---|
+| **Package** | `@gsd/lambda-followup` |
+| **Trigger** | Async invoke from the interactions Lambda (`InvocationType: 'Event'`). Not exposed externally. |
+| **Terraform** | `terraform/followup.tf`. |
+| **IAM** | `ecs:RunTask` / `StopTask` / `ListTasks` / `DescribeTasks` / `TagResource`, `iam:PassRole` (task execution role — required for RunTask with Fargate), `ec2:DescribeNetworkInterfaces`, `dynamodb:GetItem` / `PutItem`, `secretsmanager:GetSecretValue` on the public key (only read for downstream calls in some paths). |
+| **Env vars** | `AWS_REGION_`, `TABLE_NAME`, `ECS_CLUSTER`, `SUBNET_IDS` (comma-separated), `SECURITY_GROUP_ID`, `DOMAIN_NAME`, `GAME_NAMES`. |
+
+### Behaviour
+
+Event is a `FollowupPayload`:
+
+```ts
+type FollowupPayload = {
+  kind: 'start' | 'stop' | 'status' | 'list'
+  applicationId: string
+  interactionToken: string
+  userId: string
+  guildId: string
+  roleIds: string[]
+  game?: string
+}
+```
+
+1. Re-fetch the Discord config (defensive re-check — the interactions
+   Lambda already ran `canRun`, but config could change between the two
+   invocations).
+2. Dispatch by `kind`:
+   - **`start`** — `runStart()`: `ecs.runTask` with the game's task
+     definition family (`{game}-server`), public-IP-enabled network
+     config, the Fargate launch type. If successful, call `putPending()`
+     (`PENDING#{taskArn}` with 15-min TTL); then PATCH the original
+     interaction with "starting …".
+   - **`stop`** — find the running task via `findRunningTask()`, call
+     `ecs.stopTask`, PATCH "stopping …".
+   - **`status`** — single-game `getStatus()` (ListTasks → DescribeTasks →
+     `ec2.describeNetworkInterfaces` for the public IP), PATCH with the
+     resolved state + hostname/IP.
+   - **`list`** — status for every game the user has at least `status`
+     permission for, joined into one ephemeral message.
+3. PATCH the Discord webhook at
+   `https://discord.com/api/v10/webhooks/{applicationId}/{interactionToken}/messages/@original`.
+   Valid for 15 minutes after the original interaction.
+
+Failure modes:
+
+- ECS call fails → error message in the PATCH body.
+- CloudWatch ENI lag (task RUNNING but no ENI yet) → `getStatus()` returns
+  `{ state: 'error', message: ... }`; caller sees it in Discord.
+- DynamoDB write fails (for `start`) → logged, PATCH still happens so user
+  sees "starting"; but update-dns won't later PATCH with the final IP
+  because the pending row doesn't exist.
+- Discord PATCH fails (stale token, network) → logged; user's deferred
+  message is not edited.
+
+## update-dns
+
+| | |
+|---|---|
+| **Package** | `@gsd/lambda-update-dns` |
+| **Trigger** | EventBridge rule on `source: aws.ecs`, `detail-type: 'ECS Task State Change'`, `lastStatus` in `['RUNNING', 'STOPPED']`. |
+| **Terraform** | `terraform/route53.tf`. |
+| **IAM** | `route53:ChangeResourceRecordSets`, `route53:ListResourceRecordSets`, `ecs:DescribeTasks`, `ec2:DescribeNetworkInterfaces`, `elasticloadbalancing:RegisterTargets` / `DeregisterTargets`, `dynamodb:GetItem` / `DeleteItem`. |
+| **Env vars** | `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `DNS_TTL`, `AWS_REGION_`, `HTTPS_GAMES`, `ALB_TARGET_GROUPS` (JSON map game → target group ARN), `TABLE_NAME`. |
+
+### Behaviour
+
+Event shape (simplified):
+
+```json
+{
+  "detail": {
+    "lastStatus": "RUNNING" | "STOPPED",
+    "taskArn": "...",
+    "clusterArn": "...",
+    "group": "family:palworld-server"
+  }
+}
+```
+
+1. Parse the task family from `detail.group`, map to a game via
+   `FAMILY_TO_GAME`. Skip unknown families.
+2. Determine whether the game is **HTTPS** (present in `HTTPS_GAMES`) or
+   **direct**.
+3. **Direct games**:
+   - On `RUNNING`: `resolveIp('public')` — retries up to 5 times with
+     3-second sleeps to survive ENI attach lag; then `upsertDns()` writes
+     an A record `{game}.{domain}` → IP with `DNS_TTL`.
+   - On `STOPPED`: read the current record, verify its IP, `deleteDns()`.
+4. **HTTPS games**:
+   - On `RUNNING`: resolve the **private** IP, `registerAlb()` (adds it to
+     the target group).
+   - On `STOPPED`: `deregisterAlb()`.
+5. On `RUNNING`, regardless of game type: call `notifyDiscordIfPending()`
+   — look up `PENDING#{taskArn}` in DynamoDB, format a final status
+   message, PATCH the original Discord interaction, delete the pending
+   row.
+
+Failure modes:
+
+- IP not available after 5 retries → log warning, skip. Next state change
+  will retry; meanwhile the task is up but unreachable by DNS.
+- Route 53 / ALB call fails → log, continue. The STOPPED path is
+  eventually consistent because the watchdog cleans up too.
+- Pending row missing (expired / never written / `stop` flow) → skip the
+  Discord PATCH; no user-visible issue.
+- Discord PATCH fails (stale token) → log, continue.
+
+## watchdog
+
+| | |
+|---|---|
+| **Package** | `@gsd/lambda-watchdog` |
+| **Trigger** | EventBridge schedule at `rate(${watchdog_interval_minutes} minute(s))`. No event payload. |
+| **Terraform** | `terraform/watchdog.tf`. |
+| **IAM** | `ecs:ListTasks` / `DescribeTasks` / `StopTask` / `TagResource` / `ListTagsForResource`, `cloudwatch:GetMetricStatistics`, `route53:ChangeResourceRecordSets` / `ListResourceRecordSets`, `elasticloadbalancing:DeregisterTargets`, `ec2:DescribeNetworkInterfaces`. |
+| **Env vars** | `ECS_CLUSTER`, `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `IDLE_CHECKS`, `MIN_PACKETS`, `CHECK_WINDOW_MINUTES`, `AWS_REGION_`, `HTTPS_GAMES`, `ALB_TARGET_GROUPS`. |
+
+### Behaviour
+
+1. `ListTasks(desiredStatus: RUNNING)` across the cluster. Paginates.
+2. `DescribeTasks` on the batch to get attachments and tags.
+3. For each task:
+   - Resolve the ENI ID from attachments.
+   - `cloudwatch.GetMetricStatistics` → `AWS/EC2/NetworkPacketsIn` over
+     the last `CHECK_WINDOW_MINUTES`. If the call fails, assume **active**
+     (fails-safe for fresh tasks with no metrics yet).
+   - If `packets < MIN_PACKETS`:
+     - Increment the `idle_checks` tag.
+     - If the counter reaches `IDLE_CHECKS`:
+       - HTTPS game → `DeregisterTargets`.
+       - Direct game → delete the Route 53 record.
+       - `StopTask` with reason `Watchdog: idle for {N} minutes`.
+     - Otherwise persist the incremented counter via `TagResource`.
+   - Else (active), if the counter is non-zero, reset it to 0.
+
+Watchdog state lives **only** in the `idle_checks` ECS task tag. It's
+inherently scoped to the task — when the task goes away, so does the
+state, which is exactly what we want. Do not move it to DDB/SSM.
+
+Failure modes:
+
+- CloudWatch query fails → treated as active (no accidental shutdowns).
+- Tagging fails → logged; a task might hang around a cycle longer than
+  intended.
+- `StopTask` fails → logged; next schedule tick retries.
+
+## The `/server-start` critical path, assembled
+
+```
+User types /server-start palworld
+  → Discord POSTs to interactions Function URL
+    → interactions verifies + returns type:5 ack + async-invokes followup
+      → followup RunTask + put PENDING#{arn} + PATCH @original "starting"
+        → ECS reaches RUNNING
+          → EventBridge fires update-dns
+            → update-dns resolves IP + UPSERT A + get+delete PENDING#{arn}
+              + PATCH @original "🟢 running — palworld.example.com"
+```
+
+Every Lambda has its own CloudWatch log group; when a step goes wrong, the
+group with the latest events is the one that last ran. The interactions
+Lambda logs the `async invoke of followup` line; if you see that but no
+followup logs, check IAM.

--- a/docs/components/management-app.md
+++ b/docs/components/management-app.md
@@ -1,0 +1,193 @@
+---
+title: Management app (server + web + shared)
+---
+
+# Management app
+
+A TypeScript npm-workspaces monorepo under `app/`. Three packages are shipped
+as the local control plane — a Nest.js API, a React dashboard, and a pure
+library — plus the four Lambda packages documented
+[here]({{ '/components/lambdas/' | relative_url }}).
+
+Install everything from the root:
+
+```bash
+cd app && npm install
+```
+
+Dev mode runs the Nest API on **:3001** and the Vite dev server on
+**:5173** (with `/api` proxied). Production is a single Node process on
+**:3001**; inside Docker that's published as **:5000**.
+
+## `@gsd/shared`
+
+`app/packages/shared` — zero-runtime-dependency TypeScript consumed by the
+server **and** all four Lambdas. The canonical location for cross-boundary
+types and permission logic.
+
+| Module | Purpose |
+|---|---|
+| `types.ts` | `DiscordAction`, `DiscordConfig`, `RedactedDiscordConfig`, `GameStatus`, `StartResult`, `PendingInteraction`. The API shapes every other package agrees on. |
+| `canRun.ts` | The pure permission-check function. Order: **guild allowlist → admin user/role → per-game user/role + action**. Imported verbatim by the Nest server and both Discord Lambdas. |
+| `commands.ts` | `COMMAND_DESCRIPTORS` — static JSON for the four slash commands. `actionForCommand(name)` maps to the `start`/`stop`/`status` bucket used by `canRun()`. |
+| `sanitize.ts` | `isSafeGameKey()` (blocks `__proto__`, `constructor`, `prototype`), `asString()`, `asStringArray()`, `sanitizeGamePermission()`. Applied on DDB reads where input is operator-provided. |
+| `formatStatus.ts` | `formatGameStatus(status)` — Discord-ready one-liner with emoji and hostname. |
+| `ddb/client.ts` | Lazy DynamoDB DocumentClient. Region fallback: `AWS_REGION_` → `AWS_REGION` → `AWS_DEFAULT_REGION` → `us-east-1`. |
+| `ddb/configStore.ts` | `getDiscordConfig()` / `putDiscordConfig()` for the `CONFIG#discord` row. |
+| `ddb/pendingStore.ts` | `getPending()` / `putPending()` / `deletePending()` for `PENDING#{taskArn}`. `putPending()` sets `expiresAt = now + 15 minutes` so DDB TTL reaps stale rows. |
+| `secrets/secretsStore.ts` | Secrets Manager wrapper with a 5-minute in-process cache. Recognises Terraform's `"placeholder"` seed as "not configured". `invalidateSecretsCache()` is called by the Nest credentials endpoint. |
+
+**Invariants**: `canRun()` lives in exactly one place; the four slash
+commands are JSON descriptors, not classes; secrets' raw values never
+leave this package's own callers.
+
+## `@gsd/server`
+
+`app/packages/server` — Nest.js on `@nestjs/platform-express`. The boot
+sequence in `src/main.ts`:
+
+1. `NestFactory.create(AppModule)`.
+2. If `NODE_ENV=production` and no `API_TOKEN` configured → **refuses to
+   start** (loud exit, not a warning).
+3. In production, serves the built React bundle from `../web/dist` as
+   static files.
+4. Listens on `process.env.PORT || 3001`.
+
+### Module graph
+
+- **`AppModule`** — root. Imports `AwsModule` and `DiscordModule`. Installs
+  `ApiTokenGuard` as `APP_GUARD` (so it applies to every controller), and
+  attaches `RequestLoggerMiddleware` for structured access logs.
+- **`AwsModule`** — provides `ConfigService`, `Ec2Service`, `EcsService`,
+  `LogsService`, `CostService`, `FileManagerService`. All exported.
+- **`DiscordModule`** — imports `AwsModule`; provides
+  `DiscordConfigService` and `DiscordCommandRegistrar`. No discord.js,
+  no gateway — the bot is two Lambdas plus Discord's REST API.
+
+### Controllers and endpoints
+
+Every route is under `/api/*` and gated by `ApiTokenGuard`.
+
+| Controller | Endpoints | Purpose |
+|---|---|---|
+| `GamesController` | `GET /api/games`, `GET /api/status`, `GET /api/status/:game`, `POST /api/start/:game`, `POST /api/stop/:game` | List/read status, trigger RunTask/StopTask. Invalidates ConfigService's tfstate cache on list/status reads so fresh applies are picked up without restarting. |
+| `ConfigController` | `GET /api/config`, `POST /api/config` | Read/write watchdog knobs in `server_config.json`. Takes effect on next `terraform apply` (the values are baked into Lambda env). |
+| `CostsController` | `GET /api/costs/estimate`, `GET /api/costs/actual?days=N` | Per-game Fargate estimates; Cost Explorer actuals grouped by the `Project` tag. |
+| `LogsController` | `GET /api/logs/:game?limit=50` | Last N log events from `/ecs/{game}-server` on the most recent task. |
+| `FilesController` | `GET /api/files/:game`, `POST /api/files/:game/start`, `POST /api/files/:game/stop` | Ad-hoc FileBrowser task against the game's EFS access point. |
+| `DiscordController` | `GET/PUT /api/discord/config`, `POST /api/discord/guilds`, `DELETE /api/discord/guilds/:id`, `POST /api/discord/guilds/:id/register-commands`, `PUT /api/discord/admins`, `PUT /api/discord/permissions/:game`, `DELETE /api/discord/permissions/:game` | Read-redacted config, save credentials, manage guild allowlist + commands, admins, per-game permissions. |
+
+### Key services
+
+- **`ConfigService`** — single place that parses `terraform.tfstate` into a
+  `TfOutputs` object (cluster ARN, subnets, SGs, EFS access points, game
+  names, hosted zone, Discord table + secret ARNs, interactions URL).
+  Caches in-memory; `invalidateCache()` is called by the games controller
+  on list/status so a new `terraform apply` is picked up without a server
+  restart. Also resolves the bearer token from `API_TOKEN` (wins) or
+  `server_config.json:api_token`. Returns `null` from `getTfOutputs()` if
+  tfstate is missing/unparseable — callers degrade gracefully so the
+  dashboard can render even pre-apply.
+- **`DiscordConfigService`** — persistence facade over DynamoDB
+  (`CONFIG#discord`) + Secrets Manager. Concurrent reads are coalesced via
+  an inflight-promise pattern. `getRedacted()` returns
+  `botTokenSet` / `publicKeySet` booleans only.
+  `getEffectiveToken()` is the single escape hatch — used only by the
+  command registrar.
+- **`DiscordCommandRegistrar`** — calls
+  `PUT https://discord.com/api/v10/applications/{clientId}/guilds/{guildId}/commands`.
+  Validates `guildId` as a 17–20-digit Discord snowflake before calling out
+  (no path traversal, no SSRF).
+- **`EcsService` / `Ec2Service` / `LogsService` / `CostService` /
+  `FileManagerService`** — thin wrappers over the AWS SDK v3 clients.
+
+### Auth
+
+`ApiTokenGuard` (`src/guards/api-token.guard.ts`) is installed as
+`APP_GUARD` in `AppModule`. On every request it:
+
+- Reads the configured token from `ConfigService` (not cached — rotation
+  takes effect immediately).
+- Matches `Authorization: Bearer <token>` exactly.
+- In dev mode, if no token is configured: logs once and allows the
+  request.
+- In production, boot is refused if no token is configured, so the
+  "allow unauthenticated" branch is unreachable there.
+
+### Logging
+
+Winston in `src/logger.ts`. Dev: colourised timestamps + JSON metadata.
+Prod: JSON lines with ISO timestamps. Use `logger.info` / `warn` / `error`
+everywhere, not `console.log`.
+
+### Env vars
+
+| Name | Default | Purpose |
+|---|---|---|
+| `NODE_ENV` | `development` | `production` enforces the token-at-boot check. |
+| `API_TOKEN` | — | Bearer token; wins over `server_config.json:api_token`. |
+| `PORT` | `3001` | HTTP listen port. |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | — | SDK region. Fallback via `ConfigService`. |
+
+## `@gsd/web`
+
+`app/packages/web` — React + Vite.
+
+- **Entry**: `src/main.tsx` → `src/App.tsx`. The app wires a 401 handler
+  (`setUnauthorizedHandler` in `api.ts`) that clears the stored token and
+  shows the token-prompt modal whenever any request comes back 401.
+- **Auth**: bearer token in `localStorage` under key `apiToken`, attached
+  as `Authorization: Bearer` by `request<T>()` in `src/api.ts`.
+
+### Dashboard layout
+
+1. **Game cards** — per-game Start/Stop, state badge, IP/hostname. Polls
+   `/api/status` and `/api/costs/estimate` every 20 s via
+   `hooks/useGameStatus`.
+2. **Cost panel** — hourly/daily/4h-per-day estimates + last-7-days actual
+   from Cost Explorer (requires the `Project` cost-allocation tag to be
+   activated in AWS Billing).
+3. **Server Config** — watchdog knobs. Saves go to `server_config.json`;
+   take effect on next `terraform apply`.
+4. **Discord Bot** — four tabs: Credentials, Guilds, Admins, Per-Game
+   Permissions. See the [user guide]({{ '/guides/user/' | relative_url }})
+   for the day-to-day workflow.
+5. **Live Logs** — tails the last N events from
+   `/ecs/{game}-server` for the most recent task.
+6. **File Manager modal** — spawns a FileBrowser Fargate task against the
+   game's EFS access point so you can inspect/upload saves without
+   starting the game itself.
+
+### API layer
+
+`src/api.ts` exports a single `api` object with one method per endpoint.
+All calls go through `request<T>()`, which:
+
+- Attaches the bearer header.
+- Converts non-2xx responses to thrown errors.
+- On 401, clears the stored token and invokes the handler registered at
+  startup (shows the token prompt).
+
+### Vite dev config
+
+`vite.config.ts` serves on `:5173` and proxies `/api` to
+`http://localhost:3001`. Production builds to `dist/` which the Nest server
+serves as static files at `/`.
+
+## Docker
+
+`Dockerfile` is node:20-slim:
+
+1. Copy `package.json` + workspace manifests, `npm ci --ignore-scripts`.
+2. Copy source, `npm run build` (shared → server → web).
+3. `CMD ["node", "packages/server/dist/main.js"]`.
+
+Only the **server** and **web** packages are baked into the image — the
+four Lambda packages are deployed separately via `terraform apply` and have
+no place inside the container.
+
+`docker-compose.yml` mounts `./terraform` read-only (for tfstate),
+`./app/server_config.json` (must exist on the host first), and `~/.aws`
+read-only (credentials). Publishes `3001` as `5000`. Requires `API_TOKEN`
+to be set in the shell before `docker compose up` (the compose file uses
+`${API_TOKEN:?…}` so it fails fast with a clear error if missing).

--- a/docs/components/terraform.md
+++ b/docs/components/terraform.md
@@ -1,0 +1,100 @@
+---
+title: Terraform
+---
+
+# Terraform
+
+All AWS infrastructure lives under `terraform/`. State is local by default
+(`terraform.tfstate` in the directory) — swap to an S3 backend if you're
+running this for real; see the
+[submodule guide]({{ '/guides/submodule/' | relative_url }}).
+
+## Files
+
+| File | What it provisions |
+|---|---|
+| `main.tf` | VPC, Internet Gateway, two public subnets across AZs, route table, IAM execution role, EFS filesystem + mount targets + **per-game access points**, ECS cluster, **one Fargate task definition per game**, CloudWatch log groups, game-server + file-manager + EFS security groups. |
+| `alb.tf` | Conditional on any game having `https = true`: ACM certificate (DNS-validated), ALB + target groups per HTTPS game, HTTPS listener + HTTP→HTTPS redirect, Route 53 ALIAS records. |
+| `route53.tf` | Route 53 zone **data source** (zone must exist); the `update-dns` Lambda with its IAM, EventBridge rule on `ECS Task State Change`. |
+| `watchdog.tf` | `watchdog` Lambda with its IAM, EventBridge schedule at `rate(${watchdog_interval_minutes} minute(s))`. |
+| `interactions.tf` | `interactions` Lambda with IAM + Function URL (`auth_type = NONE`, CORS for `https://discord.com`). Exposes `interactions_invoke_url`. |
+| `followup.tf` | `followup` Lambda with IAM (`ecs:RunTask`, `StopTask`, `DescribeTasks`, `iam:PassRole`, `dynamodb:GetItem`/`PutItem`, `ec2:DescribeNetworkInterfaces`). Async-invoked by interactions. |
+| `discord_store.tf` | DynamoDB table (pk+sk, TTL on `expiresAt`), two Secrets Manager secrets (`${project_name}/discord/bot-token`, `/discord/public-key`) with `recovery_window_in_days = 0` and `lifecycle.ignore_changes` on seeded secret values. Optional `CONFIG#discord` DynamoDB item seeded from tfvars. |
+| `variables.tf` | Every configurable input. See the table below. |
+| `outputs.tf` | Every value the management app (and humans) consume. |
+| `terraform.tfvars.example` | Starting point for your `terraform.tfvars`. |
+
+## Variables
+
+| Name | Type | Default | Purpose |
+|---|---|---|---|
+| `aws_region` | `string` | `us-east-1` | AWS region for all resources. |
+| `project_name` | `string` | `game-servers` | Prefix for named resources and the Secrets Manager paths. |
+| `vpc_cidr` | `string` | `10.0.0.0/16` | Parent CIDR; subnets are /24s within it. |
+| `game_servers` | `map(object)` | — | The single source of truth. Per-game: `image`, `cpu`, `memory`, `ports[]`, `environment[]`, `efs_path`, `https`. |
+| `hosted_zone_name` | `string` | `codercoco.com` | Existing Route 53 zone looked up as a data source. |
+| `acm_certificate_domain` | `string` | `null` → `*.{hosted_zone_name}` | Wildcard ACM cert for the ALB listener. |
+| `dns_ttl` | `number` | `30` | TTL on Route 53 A records the update-dns Lambda writes. Keep low for fast task churn. |
+| `watchdog_interval_minutes` | `number` | `15` | How often the watchdog schedule fires. |
+| `watchdog_idle_checks` | `number` | `4` | Consecutive idle windows before `StopTask`. |
+| `watchdog_min_packets` | `number` | `100` | Below this `NetworkPacketsIn` per window = idle. |
+| `discord_application_id` | `string` | `""` | Seeds `CONFIG#discord` in DynamoDB on first apply. Skipped if empty. |
+| `discord_bot_token` | `string` (sensitive) | `""` | Seeds `${project_name}/discord/bot-token`. Empty → Terraform writes `"placeholder"`. |
+| `discord_public_key` | `string` (sensitive) | `""` | Seeds `${project_name}/discord/public-key`. Same placeholder behaviour. |
+| `tags` | `map(string)` | defaults | Merged into `default_tags` for cost allocation (`Project`). |
+
+## Outputs
+
+| Output | Consumer |
+|---|---|
+| `vpc_id`, `subnet_ids`, `security_group_id`, `file_manager_security_group_id` | followup Lambda env + any manual ops. |
+| `ecs_cluster_name`, `ecs_cluster_arn` | watchdog + followup Lambda env + the management app. |
+| `efs_file_system_id`, `efs_access_points` | Reference; each task mounts its own AP. |
+| `game_names` | interactions / followup / update-dns / watchdog Lambdas (env var `GAME_NAMES`). |
+| `task_definitions` | Ops (`aws ecs run-task --task-definition palworld-server`). |
+| `hosted_zone_id`, `domain_name`, `dns_records` | update-dns / watchdog Lambda env + DNS checks. |
+| `alb_dns_name`, `acm_certificate_arn` | Null if no HTTPS games; public reference otherwise. |
+| `discord_table_name`, `discord_bot_token_secret_arn`, `discord_public_key_secret_arn` | Management app reads via the parsed tfstate to reach DynamoDB + Secrets. |
+| `interactions_invoke_url` | Pasted into Discord Developer Portal → General Information → Interactions Endpoint URL. |
+| `watchdog_function_name` | Ops / debugging. |
+| `aws_region` | Reference + the management app. |
+
+## AWS services in use
+
+- **Compute**: ECS (cluster + per-game Fargate task definitions), Lambda (4 functions).
+- **Networking**: VPC, subnets, route tables, IGW, security groups, ALB + target groups + listener rules (if HTTPS games).
+- **Storage**: EFS filesystem, mount targets, per-game access points.
+- **DNS / TLS**: Route 53 zone (data source) + Lambda-managed A records, ACM cert (DNS-validated), ALB ALIAS records.
+- **Events**: EventBridge rule (ECS task state change), EventBridge schedule (watchdog).
+- **State**: DynamoDB (CONFIG + PENDING rows with TTL), Secrets Manager (bot token + public key).
+- **Observability**: CloudWatch log groups (`/ecs/{game}-server` + Lambda logs), CloudWatch metrics (`NetworkPacketsIn`), Cost Explorer (read from the management app).
+- **IAM**: task execution role, four per-Lambda execution roles, inline policies (least-privilege).
+
+## Gotchas
+
+- **Build Lambdas before `terraform apply`.** Terraform zips
+  `app/packages/lambda/*/dist/handler.cjs` via `archive_file`; missing files
+  are an init-time error.
+- **`AWS_REGION_` (trailing underscore)** on every Lambda env var set from
+  Terraform. `AWS_REGION` is reserved by the runtime.
+- **DNS A records for non-HTTPS games are NOT Terraform resources.** The
+  update-dns Lambda owns them on task state change. Adding
+  `aws_route53_record` for them would cause a loop.
+- **HTTPS games get ALB ALIAS records in Terraform**, plus the Lambda
+  registers/deregisters the ENI IP as an ALB target on RUNNING/STOPPED.
+- **EFS access points are UID/GID 1000 and mode 0755.** Game images that
+  run as a different UID will fail to write to the volume.
+- **Secrets use `recovery_window_in_days = 0`** so `terraform destroy` +
+  re-`apply` is clean. The first `apply` seeds them; `lifecycle.ignore_changes`
+  lets the dashboard edit them afterwards without Terraform stomping on the
+  value. To rotate via tfvars after seeding, `terraform taint` the specific
+  `aws_secretsmanager_secret_version.discord_*` resource.
+- **`events:TagResource` / `UntagResource` / `ListTagsForResource`** aren't
+  in any AWS-managed policy — you need `events:*` (or at least those three)
+  on the deploy user. The setup guide's inline policy already covers this.
+- **Removing a game from the map deletes its task definition** but does not
+  stop running tasks. Stop the game from the dashboard first, then remove
+  the key.
+- **Local `terraform.tfstate`** is fine for a single operator. Switch to
+  an S3 backend (with DynamoDB lock) if more than one person applies — see
+  the [submodule guide]({{ '/guides/submodule/' | relative_url }}).

--- a/docs/guides/maintainer.md
+++ b/docs/guides/maintainer.md
@@ -1,0 +1,288 @@
+---
+title: Maintainer guide
+---
+
+# Maintainer guide
+
+You're here to change the code. This page is the shortest path from "clean
+clone" to "PR merged" plus the invariants that are load-bearing enough that
+CI can't always catch you breaking them.
+
+Read [`CLAUDE.md`](https://github.com/codercoco/game-server-deploy/blob/main/CLAUDE.md)
+and [`CONTRIBUTING.md`](https://github.com/codercoco/game-server-deploy/blob/main/CONTRIBUTING.md)
+first. They are the source of truth for test/lint conventions and PR titles.
+This page is documentation over the top of them, not a replacement.
+
+## Repository layout
+
+```text
+game-server-deploy/
+├── app/                                 # npm-workspaces monorepo
+│   ├── package.json                     # workspaces root; `npm run` scripts fan out
+│   ├── eslint.config.js                 # flat config; recommended TS + React presets
+│   ├── tsconfig.base.json               # shared TS config
+│   ├── vitest.config.ts
+│   └── packages/
+│       ├── shared/                      # @gsd/shared — pure TS + DDB/Secrets helpers
+│       ├── server/                      # @gsd/server — Nest.js API
+│       ├── web/                         # @gsd/web   — React + Vite dashboard
+│       └── lambda/
+│           ├── interactions/            # esbuild → dist/handler.cjs
+│           ├── followup/
+│           ├── update-dns/
+│           └── watchdog/
+├── terraform/                           # all AWS infra
+│   ├── main.tf alb.tf route53.tf watchdog.tf interactions.tf followup.tf
+│   ├── discord_store.tf variables.tf outputs.tf
+│   └── terraform.tfvars.example
+├── docs/                                # this site
+├── .github/workflows/                   # lint.yml, test.yml, jekyll-gh-pages.yml
+├── Dockerfile docker-compose.yml
+└── setup.sh
+```
+
+`app/` is a single npm workspace. One `npm install` at the root installs
+everything. Lambdas are built via esbuild to single-file CJS bundles at
+`app/packages/lambda/*/dist/handler.cjs`; Terraform's `archive_file`
+zips them at apply time, so CI and local dev must build them before any
+terraform operation.
+
+## Everyday loop
+
+```bash
+# One-time
+cd app && npm install
+cd ../terraform && terraform init
+
+# Dev servers — Nest on :3001, Vite on :5173 with /api proxied
+cd app && npm run dev
+
+# Before pushing
+cd app && npm run lint && npm test && npm run build
+cd ../terraform && terraform fmt -check -recursive && terraform validate && tflint
+```
+
+### Useful scripts (from `app/`)
+
+| Command | What it does |
+|---|---|
+| `npm run dev` | `concurrently` Nest (`tsx watch`) + Vite. |
+| `npm run build` | Build shared → server → web in order. |
+| `npm run build:lambdas` | esbuild every Lambda to `dist/handler.cjs`. Required before `terraform apply`. |
+| `npm start` | Run the built Nest server (`node packages/server/dist/main.js`). |
+| `npm test` | `vitest run` across every workspace. |
+| `npm run test:watch` | Same but watch mode. |
+| `npm run lint` / `lint:fix` | ESLint flat config over all packages. |
+
+## Test + naming conventions (short form)
+
+From `CLAUDE.md`, paraphrased. CI will fail you on the first two even though
+ESLint won't always catch them.
+
+- **Test names** start with "should" and read like a natural sentence —
+  `it('should return null when the state file is missing')`, not
+  `it('returns null...')`.
+- **TSDoc** on non-trivial functions, helpers, and notable constants. Also
+  on test-file factories/fixtures.
+- **Don't cast with `as unknown as T`** — prefer `vi.mocked(fn)` for module
+  mocks, and `Partial<T>` + a single `as T` for service-shaped stubs.
+- **No raw `process.env` in business logic** — wrap behind a service method
+  so tests can `vi.spyOn` rather than mutating `process.env`.
+
+## PR conventions (short form)
+
+See `CONTRIBUTING.md` for the full list. Two things that bite people:
+
+- **We squash-merge**, so the PR title becomes the commit subject on `main`
+  verbatim. It MUST be Conventional Commits:
+  `<type>(<optional-scope>): <imperative summary>`, under ~70 chars.
+- **Copilot comments**: decline most. The bar is genuine bug, security
+  issue, or broken behaviour. Style, naming, "consider", "might want" —
+  decline on the thread with a one-line reason, don't enter a fix-and-repush
+  loop.
+
+## CI
+
+Three workflows live in `.github/workflows/`:
+
+- **`lint.yml`** — ESLint + `tflint` + `terraform fmt -check -recursive` +
+  `terraform validate`. Runs on every push/PR.
+- **`test.yml`** — `vitest run` across all workspaces.
+- **`jekyll-gh-pages.yml`** — publishes this site. Only triggers on
+  `docs/**` and the workflow itself on `main`, plus `workflow_dispatch`.
+  If you want to preview doc changes locally, run `jekyll serve --source docs`
+  in a Ruby environment with the `github-pages` gem.
+
+There is also CodeQL security analysis configured at the org level (see
+`CONTRIBUTING.md`).
+
+## Invariants that hurt to break
+
+These are load-bearing design choices. Reviews will push back hard if a PR
+appears to touch one without calling it out.
+
+### 1. Don't introduce a long-running ECS service
+
+The whole cost-saving argument is that game tasks run via `RunTask` and stop
+with `StopTask`. Adding `aws_ecs_service` anywhere means you pay for a task
+24/7 and defeat the watchdog.
+
+### 2. `game_servers` is the single source of truth
+
+Every per-game resource — task definition, EFS access point, CloudWatch log
+group, security-group rules, the `GAME_NAMES` env var on three Lambdas — is
+driven by `for_each` over `var.game_servers`. Do not hand-write new
+per-game resources. To add a game, a user edits `terraform.tfvars` and
+that's it.
+
+### 3. DNS is Lambda-managed, not Terraform-managed
+
+`route53.tf` has a `data "aws_route53_zone"` and the updater Lambda, but no
+`aws_route53_record` resources for the game hostnames. The update-dns
+Lambda creates and deletes them on ECS task state changes.
+
+Exception: for HTTPS games, Route 53 ALIAS records pointing to the ALB *are*
+Terraform-managed (in `alb.tf`); the Lambda only manages ALB target
+membership for those.
+
+### 4. Watchdog state lives in ECS task tags
+
+The `idle_checks` counter per task is an ECS tag. No DynamoDB, no SSM. The
+tag disappears with the task, which is the whole point. Do not move it to
+persistent storage.
+
+### 5. `AWS_REGION_` has a trailing underscore
+
+Lambda reserves `AWS_REGION`. All four Lambdas read `process.env.AWS_REGION_`
+instead. Check every Terraform file that sets Lambda env vars and every
+Lambda handler. The shared `ddb/client.ts` has a fallback chain
+(`AWS_REGION_` → `AWS_REGION` → `AWS_DEFAULT_REGION` → `us-east-1`) so
+shared code works in both the server and the Lambdas.
+
+### 6. Secrets never leave AWS
+
+The bot token and Discord public key live in Secrets Manager.
+`DiscordConfigService.getRedacted()` returns `botTokenSet` and
+`publicKeySet` booleans; `getEffectiveToken()` is the single escape hatch,
+used only by `DiscordCommandRegistrar`. Do not add an endpoint that returns
+the raw values.
+
+### 7. Per-guild command registration only
+
+`DiscordCommandRegistrar.registerForGuild` PUTs to
+`applications/{client_id}/guilds/{guild_id}/commands`. Do not register global
+commands — they would leak to every guild the bot is invited to. The
+dashboard button is labelled "Register commands" for exactly this reason —
+it's one guild at a time.
+
+### 8. `canRun()` ordering
+
+`guild allowlist → admin → per-game user/role + action`. The function is in
+`@gsd/shared` and imported verbatim by the server and both Discord Lambdas.
+Do not duplicate the logic — one copy, tested once.
+
+### 9. Slash commands are JSON descriptors, not classes
+
+`COMMAND_DESCRIPTORS` in `@gsd/shared/commands.ts` is the only source of
+truth for the four slash commands. The interactions Lambda dispatches with
+a ~40-line switch. To add a new command:
+
+1. Append a descriptor in `commands.ts`.
+2. Add a case to the switch in `app/packages/lambda/interactions/src/handler.ts`
+   and to the followup handler's `event.kind` switch.
+3. Update `actionForCommand()` so `canRun()` gets the right bucket.
+4. Rebuild Lambdas, `terraform apply`, click **Register commands** per guild.
+
+### 10. ApiTokenGuard is global
+
+It's registered as `APP_GUARD` in `AppModule` (see
+`app/packages/server/src/app.module.ts`). Every `/api/*` route is behind a
+bearer token. Do not `@UseGuards()` on individual controllers — that's
+additive, not override. Do not add a `@Public()` decorator pattern unless
+there is a documented reason.
+
+### 11. Events IAM
+
+AWS tags EventBridge rules on creation; `events:TagResource` /
+`UntagResource` / `ListTagsForResource` are required and not in any managed
+policy. The setup guide's inline policy grants `events:*` which covers this.
+If you tighten the policy later, keep those three actions.
+
+## How the Lambdas get deployed
+
+Every time:
+
+1. `cd app && npm run build:lambdas` — esbuild emits
+   `app/packages/lambda/*/dist/handler.cjs`.
+2. `cd terraform && terraform apply` — `data "archive_file"` reads the CJS
+   bundle, zips it, and uploads it to each `aws_lambda_function`. The
+   function URL, IAM role, env vars, and EventBridge rule are all in the
+   matching `.tf` file.
+
+Because the zip hash is derived from the file content, `terraform plan`
+will only report a Lambda change when the bundle bytes actually change.
+You can rebuild freely without generating spurious diffs.
+
+There is no separate CI pipeline for Lambdas — deploys happen from your
+laptop or wherever you run `terraform apply`.
+
+## When you touch Terraform
+
+Minimum you owe the reviewer:
+
+- `terraform fmt -recursive` (or `terraform fmt -check -recursive` to
+  verify).
+- `terraform validate`.
+- `tflint` with the AWS ruleset.
+- Run `terraform plan` against a real account and paste the relevant
+  resource changes into the PR description. Seeing new/destroyed
+  resources in the plan output is what actually catches mistakes.
+
+For anything that touches Lambda IAM, list the exact actions added/removed
+in the PR body — least-privilege roles are easy to silently widen.
+
+## When you touch the Nest server
+
+- New endpoint → add it to the matching controller under
+  `app/packages/server/src/controllers/`, not a new folder layer.
+- New AWS call → add a method to the appropriate service under
+  `services/`. Services are `@Injectable()` and wired through `AwsModule` /
+  `DiscordModule`.
+- Use Winston (`logger` from `logger.ts`) for structured logs. No
+  `console.log` in production paths.
+- Wrap environment access behind a service method — don't reach for
+  `process.env` directly in request handlers.
+- Add a matching `.test.ts` file next to the service/controller. Mock the
+  AWS SDK v3 clients with `aws-sdk-client-mock`.
+
+## When you touch the web client
+
+- API calls go through `packages/web/src/api.ts`. Don't bypass the 401
+  handler — it's what triggers the re-auth flow.
+- New endpoint stubs keep the same shape as existing ones (one method per
+  route, return a typed promise).
+- The Vite dev server proxies `/api` to `:3001`; nothing else should be
+  hardcoded to port.
+
+## Release / deploy
+
+There is no versioned release. "Deploying" = running `terraform apply` and
+`npm run build && npm start` (or `docker compose up --build`) from whatever
+machine holds the AWS credentials.
+
+If you're wrapping this repo as a submodule inside a private parent repo
+that holds `terraform.tfvars` and state — which is the
+pattern we recommend for anyone running this for real — see the
+[submodule guide]({{ '/guides/submodule/' | relative_url }}) for that
+layout.
+
+## Useful references
+
+- [`CLAUDE.md`](https://github.com/codercoco/game-server-deploy/blob/main/CLAUDE.md) —
+  project instructions in full, including the "why" for every invariant.
+- [`CONTRIBUTING.md`](https://github.com/codercoco/game-server-deploy/blob/main/CONTRIBUTING.md) —
+  PR rules, review policy, local-check commands.
+- [Architecture]({{ '/architecture/' | relative_url }}) —
+  component and sequence diagrams.
+- [Component docs]({{ '/' | relative_url }}#component-reference) —
+  deep-dives on terraform, the management app, and the Lambdas.

--- a/docs/guides/submodule.md
+++ b/docs/guides/submodule.md
@@ -1,0 +1,385 @@
+---
+title: Private parent repo + submodule
+---
+
+# Private parent repo + submodule
+
+This is the pattern we recommend if you're running the stack for real: a
+**private parent repo** you own, with this repo vendored as a git submodule,
+plus all the per-deployment secrets sitting alongside. Nothing sensitive ever
+lives in a public fork, and pulling upstream changes is `git submodule update
+--remote`.
+
+If you're just kicking the tyres, the plain
+[setup guide]({{ '/setup/' | relative_url }}) is fine. Come back to this
+page when you're ready to commit your config to source control.
+
+## Why this layout
+
+`terraform.tfvars` (with your hosted zone, and optionally Discord
+credentials), `server_config.json` (watchdog knobs and the bearer token),
+and `terraform.tfstate` (raw infrastructure state including IAM role
+names and the DNS zone ID) are **yours**. None of them belong in this
+public repo. A submodule keeps upstream code cleanly separated from your
+deployment-specific configuration without forking.
+
+```mermaid
+flowchart LR
+  classDef public fill:#e6f7ff,stroke:#1890ff
+  classDef priv   fill:#fff7e6,stroke:#fa8c16
+
+  subgraph Parent["your-private-games (private)"]
+    direction TB
+    PTF["terraform.tfvars"]:::priv
+    PCFG["server_config.json"]:::priv
+    PSTATE["state/<br/>terraform.tfstate<br/>(or S3 backend config)"]:::priv
+    PENV[".env<br/>API_TOKEN=…"]:::priv
+    PSCRIPT["scripts/<br/>apply.sh, dev.sh, …"]:::priv
+    PSUB["gsd/<br/>→ submodule"]:::priv
+  end
+
+  subgraph Upstream["game-server-deploy (public)"]
+    direction TB
+    UAPP["app/"]:::public
+    UTF["terraform/*.tf"]:::public
+    USET["setup.sh"]:::public
+  end
+
+  PSUB -- "git submodule" --> Upstream
+  PTF -. "symlinked or copied into" .-> UTF
+  PCFG -. "symlinked or bind-mounted into" .-> UAPP
+  PSTATE -. "tfstate (or remote backend)" .-> UTF
+```
+
+The secret-bearing files stay in the parent; the submodule stays
+upstream-clean.
+
+## Reference layout
+
+```text
+your-private-games/                 # private repo you own
+├── .gitmodules
+├── .gitignore                      # ignores state/, .env, secrets/
+├── .env                            # API_TOKEN, AWS_PROFILE, etc. — gitignored
+├── README.md                       # your personal runbook
+├── gsd/                            # submodule → codercoco/game-server-deploy
+├── config/
+│   ├── terraform.tfvars            # YOUR copy; checked in
+│   └── server_config.json          # checked in (minus api_token)
+├── state/                          # tfstate if using local backend
+│   └── terraform.tfstate           # gitignored
+├── docker-compose.override.yml     # optional — custom mounts
+└── scripts/
+    ├── setup.sh                    # wrapper around gsd/setup.sh
+    ├── apply.sh
+    └── dev.sh
+```
+
+## Step by step
+
+### 1. Create the private repo
+
+```bash
+# On GitHub, create `your-private-games` (or whatever) as a private repo.
+git clone git@github.com:you/your-private-games.git
+cd your-private-games
+```
+
+### 2. Add the submodule
+
+```bash
+git submodule add https://github.com/codercoco/game-server-deploy.git gsd
+
+# Pin to a known-good commit (recommended):
+cd gsd && git checkout <sha-or-tag> && cd ..
+git add .gitmodules gsd
+git commit -m "chore: pin gsd submodule"
+```
+
+Using a pinned SHA/tag means upstream changes don't silently affect your
+next apply; you update explicitly with:
+
+```bash
+cd gsd && git fetch && git checkout <new-sha> && cd ..
+git add gsd && git commit -m "chore: bump gsd to <new-sha>"
+```
+
+### 3. `.gitignore` the things that must never leak
+
+```gitignore
+# Local tfstate (if you don't use a remote backend)
+state/*.tfstate
+state/*.tfstate.backup
+state/.terraform/
+state/.terraform.lock.hcl
+
+# Shell env with the bearer token and sometimes AWS creds
+.env
+
+# Anything you keep outside config/ that's sensitive
+secrets/
+
+# Editor / OS noise
+.DS_Store
+.vscode/
+```
+
+### 4. Put your tfvars and server config in `config/`
+
+```bash
+mkdir -p config state
+cp gsd/terraform/terraform.tfvars.example config/terraform.tfvars
+# edit config/terraform.tfvars with your real values
+
+cat > config/server_config.json <<'JSON'
+{
+  "watchdog_interval_minutes": 15,
+  "watchdog_idle_checks": 4,
+  "watchdog_min_packets": 100
+}
+JSON
+```
+
+Now wire those into the submodule's expected paths. Two options:
+
+- **Symlinks** (simplest, works on Linux + macOS):
+
+  ```bash
+  ln -sf "$(pwd)/config/terraform.tfvars" gsd/terraform/terraform.tfvars
+  ln -sf "$(pwd)/config/server_config.json" gsd/app/server_config.json
+  ```
+
+  Both paths are gitignored inside `gsd/`, so the symlinks won't pollute the
+  submodule's working tree.
+
+- **Script-driven copies** (works on Windows, or if you dislike symlinks):
+  have `scripts/apply.sh` copy `config/*` into `gsd/terraform/` and
+  `gsd/app/` at the start of every run. The copy target is already
+  gitignored inside the submodule.
+
+### 5. Decide where tfstate lives
+
+Two reasonable choices:
+
+- **Local state in the parent repo** — simplest, fine for a single
+  operator. Add a backend override file inside the symlinked tfvars or
+  point `terraform init` at an explicit `-chdir` pattern:
+
+  ```bash
+  terraform -chdir=gsd/terraform init \
+    -backend-config="path=$(pwd)/state/terraform.tfstate"
+  ```
+
+- **S3 + DynamoDB remote backend** — better for teams, CI, or "don't
+  lose your laptop". Add a `backend.tf` in `config/` with:
+
+  ```hcl
+  terraform {
+    backend "s3" {
+      bucket         = "your-tf-state-bucket"
+      key            = "gsd/terraform.tfstate"
+      region         = "us-east-1"
+      dynamodb_table = "tf-state-lock"
+      encrypt        = true
+    }
+  }
+  ```
+
+  and symlink it into `gsd/terraform/backend.tf`. The bucket and lock
+  table need to be created once, either by hand or by a tiny bootstrap
+  terraform in its own directory.
+
+### 6. Put the bearer token in `.env`
+
+`app/server_config.json` can hold an `api_token` field, but if your
+`server_config.json` is committed to the parent repo you don't want the
+token in there. Put it in `.env` instead (gitignored):
+
+```bash
+# .env
+export API_TOKEN="$(openssl rand -hex 32)"
+export AWS_PROFILE="games"    # if you use named profiles
+```
+
+Source it before running anything:
+
+```bash
+source .env
+cd gsd/app && npm run dev
+# or
+cd gsd && docker compose up --build
+```
+
+`server_config.json` stays token-free and public to whoever reads the
+private parent; the actual secret comes from the environment at runtime.
+
+### 7. Write a thin wrapper script
+
+A minimal `scripts/apply.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Ensure submodule is at the committed SHA
+git submodule update --init --recursive
+
+# (Re)link config into the submodule
+ln -sf "$(pwd)/config/terraform.tfvars" gsd/terraform/terraform.tfvars
+ln -sf "$(pwd)/config/server_config.json" gsd/app/server_config.json
+
+# Build Lambdas, then apply
+cd gsd/app && npm ci && npm run build:lambdas
+cd ../terraform && terraform init && terraform apply
+```
+
+Similar `dev.sh` for the management app:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source .env
+cd gsd/app
+npm ci
+npm run dev
+```
+
+Run `chmod +x scripts/*.sh` and you're one command away from each action.
+
+### 8. Docker: override mounts, don't rewrite the compose file
+
+If you're using `docker compose`, create a `docker-compose.override.yml` in
+the parent. Compose merges it with `gsd/docker-compose.yml`:
+
+```yaml
+# docker-compose.override.yml — kept in the parent repo
+services:
+  app:
+    volumes:
+      - ./config/server_config.json:/app/server_config.json
+      - ./state:/app/terraform/state:ro   # if using local tfstate outside gsd/
+    env_file:
+      - .env
+```
+
+Run it from inside the submodule:
+
+```bash
+cd gsd
+docker compose -f docker-compose.yml -f ../docker-compose.override.yml up --build
+```
+
+## Discord credentials: pick a home
+
+There are three reasonable places for the Application ID, Bot Token, and
+Public Key. Trade-offs:
+
+| Location | Pros | Cons |
+|---|---|---|
+| **tfvars in the private parent** | One source of truth; `terraform apply` seeds them. Rotation via `terraform taint`. | They're on disk wherever the parent repo is cloned. |
+| **Environment at apply time** (`TF_VAR_discord_bot_token=…`) | Never on disk. | Every operator needs the token in their shell to apply. |
+| **Dashboard only** | Token only exists in Secrets Manager. | You have to paste it once per fresh environment, and the DDB `CONFIG#discord` row is seeded manually. |
+
+The tfvars route is what most people pick. `.tfvars` is gitignored in the
+*submodule*, and your parent repo is private, so it ends up covered by the
+same "private-repo trust boundary" as everything else.
+
+Rotation after the first apply (tfvars route):
+
+```bash
+terraform taint aws_secretsmanager_secret_version.discord_bot_token
+# or: aws_secretsmanager_secret_version.discord_public_key
+# or: aws_dynamodb_table_item.discord_config_seed
+terraform apply
+```
+
+## Keeping up with upstream
+
+```bash
+cd gsd
+git fetch
+git log --oneline HEAD..origin/main           # preview
+git checkout origin/main                      # or a new tag
+cd ..
+git add gsd && git commit -m "chore: bump gsd to $(git -C gsd rev-parse --short HEAD)"
+```
+
+Always run `npm run build:lambdas` + `terraform plan` after a bump and
+eyeball the plan diff before applying. Breaking changes in the upstream
+Lambda env-var shape or IAM policies will show up as Lambda changes in the
+plan.
+
+Things that tend to need attention after a bump:
+
+- New or renamed Terraform variables → add them to your
+  `config/terraform.tfvars`.
+- New environment variables on the Lambdas → typically Terraform handles
+  this automatically, but verify in the plan output.
+- Changes to the four slash-command descriptors → re-click **Register
+  commands** in the dashboard so Discord picks them up per guild.
+
+## CI in the parent repo (optional)
+
+A useful GitHub Actions pattern if you want automated drift detection:
+
+```yaml
+# .github/workflows/plan.yml in the parent repo
+name: terraform plan
+on:
+  pull_request:
+  schedule:
+    - cron: "0 9 * * 1"       # Monday 09:00 UTC drift check
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd gsd/app && npm ci && npm run build:lambdas
+      - run: |
+          ln -sf "$(pwd)/config/terraform.tfvars" gsd/terraform/terraform.tfvars
+          cd gsd/terraform && terraform init && terraform plan -no-color
+```
+
+Use OIDC → an IAM role for `aws-actions/configure-aws-credentials` rather
+than stashing long-lived keys. The role's policy is the same
+`GameServerDeployAll` inline policy from the [setup guide]({{ '/setup/' |
+relative_url }}).
+
+## What NOT to do
+
+- **Don't fork the public repo and edit it.** The submodule pattern gives
+  you every pinning benefit of a fork without the merge conflicts. If you
+  need a real code change, contribute upstream and bump your submodule to
+  the new commit.
+- **Don't commit `terraform.tfvars` inside the submodule.** Even a private
+  parent doesn't save you if someone later runs `git submodule foreach git
+  push origin HEAD`. Keep your config in `config/` in the parent and
+  symlink it in.
+- **Don't commit `terraform.tfstate` anywhere in the public repo path.**
+  Keep it in `state/` (gitignored) or in a remote backend.
+- **Don't expose `API_TOKEN` in `server_config.json` if that file is
+  committed.** Environment variable only, or commit the file without the
+  `api_token` field.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `terraform apply` inside the submodule can't find `terraform.tfvars` | Symlink missing or broken | Re-run `scripts/apply.sh` which recreates them, or `ln -sf ../../config/terraform.tfvars gsd/terraform/terraform.tfvars`. |
+| `docker compose` ignores your override | Running from the wrong directory | From `gsd/`, pass both files explicitly: `-f docker-compose.yml -f ../docker-compose.override.yml`. |
+| `git submodule update --remote` silently pulls main and breaks apply | You hadn't pinned; `remote` moves to origin/HEAD | Either pin to a SHA (`git -C gsd checkout <sha>`) or add `branch = main` in `.gitmodules` and review diffs before every bump. |
+| After bumping upstream, Discord commands have wrong arguments | Descriptors in `@gsd/shared/commands.ts` changed | Click **Register commands** for each guild in the dashboard. |
+| CI plan shows a Lambda recreating every run | Bundle hash changes between builds | Run `npm ci` (not `npm install`) in CI to pin dependencies; commit `app/package-lock.json` via the submodule bump. |

--- a/docs/guides/user.md
+++ b/docs/guides/user.md
@@ -1,0 +1,237 @@
+---
+title: User guide
+---
+
+# User guide
+
+You're an operator — you want to play a game, or let your friends play. The
+infrastructure has already been provisioned, the dashboard is running, and the
+Discord bot is registered. This page covers everyday use.
+
+If any of those assumptions isn't true yet, start at the
+[setup guide]({{ '/setup/' | relative_url }}).
+
+## Two ways to drive it
+
+| From | What you get | Who can do it |
+|---|---|---|
+| **Dashboard** (`localhost:5000` or `:5173`) | Full control: start/stop, edit watchdog knobs, view cost estimates, read live logs, manage Discord permissions. | Whoever has the bearer token. |
+| **Discord slash commands** | `/server-start`, `/server-stop`, `/server-status`, `/server-list`. Replies are ephemeral, so the channel doesn't get spammy. | Whoever is in the admin list or the relevant per-game entry. |
+
+Both talk to the same AWS resources. You can start a server from Discord and
+stop it from the dashboard, or vice versa. Status always reflects reality.
+
+## The dashboard
+
+### Logging in
+
+First load prompts for the bearer token (the `API_TOKEN` env var or the
+`api_token` field in `app/server_config.json`). Paste it once; it lives in
+`localStorage` under `apiToken` and is attached to every subsequent `/api/*`
+call as `Authorization: Bearer`. Clear browser data to revoke.
+
+### Game cards
+
+Each game from `terraform.tfvars` shows up as a card with:
+
+- A state emoji and label — `stopped`, `pending`, `running`, `error`.
+- The resolved hostname (`{game}.yourdomain.com`) and public IP once running.
+- **Start** / **Stop** buttons. Start kicks off `ecs.runTask`; the dashboard
+  polls `/api/status` every 20 s so you'll see the state transition
+  automatically.
+
+Two caveats:
+
+- A fresh start takes **2–5 minutes** — Fargate pulls the image, mounts the
+  EFS access point, waits for ENI attachment, then the game itself starts.
+- DNS propagation is bounded by `dns_ttl` in Terraform (default 30 s). Your
+  local resolver may cache longer; `dig +nocache` or wait it out.
+
+### Cost panel
+
+Two numbers per game:
+
+- **Estimate** — Fargate CPU/memory unit price × your task size. Shown as
+  hourly, daily (24 h), and "4 hours a day × 30 days" figures.
+- **Actual** — Cost Explorer grouped by the `Project` tag over the last
+  7 days. Only populated if you activated the `Project` tag for cost
+  allocation (Billing → Cost allocation tags → activate). Allow up to 24 h
+  the first time.
+
+### Server Config (watchdog)
+
+Edits the `watchdog_interval_minutes`, `watchdog_idle_checks`, and
+`watchdog_min_packets` values that get baked into the watchdog Lambda's
+environment. **Changes take effect on the next `terraform apply`**, not
+immediately — the dashboard saves them to `server_config.json` but the
+Lambda reads them from its env vars.
+
+| Knob | What it does | Raise it when… |
+|---|---|---|
+| `watchdog_interval_minutes` | How often the Lambda checks. | You want faster shutdown (down to 1 min). |
+| `watchdog_idle_checks` | Consecutive idle windows before stop. | Your game has legitimate quiet periods. |
+| `watchdog_min_packets` | Packets/window below which it's "idle". | Your game's idle floor is higher than 100. |
+
+Total grace before auto-stop = `interval × idle_checks` minutes. The default
+(15 × 4) is 60 min.
+
+### Live Logs
+
+Pick a game; the panel fetches the last N events (default 50) from the
+game's CloudWatch log group `/ecs/{game}-server`. It reads from the most
+recent task only — if you stopped + restarted recently, switch back to the
+game once the new task is RUNNING.
+
+### Discord Bot panel
+
+Four tabs. Everything here writes to the DynamoDB table and the two Secrets
+Manager secrets created by Terraform:
+
+1. **Credentials** — Application ID, Bot Token, Application Public Key.
+   Saving writes the App ID to DynamoDB (`CONFIG#discord` row) and the
+   two sensitive values to Secrets Manager. The **Interactions Endpoint
+   URL** shown here is the `interactions_invoke_url` Terraform output —
+   copy it to the Discord Developer Portal.
+2. **Guilds** — allowlist of Discord server IDs. The interactions Lambda
+   rejects any command from a guild not on the list. **Register commands**
+   next to a guild ID PUTs the four slash commands into it — Discord
+   needs ~30 s for them to appear in clients.
+3. **Admins** — user IDs and role IDs that can run every command on every
+   game. Overrides per-game permissions.
+4. **Per-Game Permissions** — for each game, which user/role IDs can run
+   which actions (`start` / `stop` / `status`). Save per game.
+
+The resolution order is always: **guild allowlist → admin → per-game +
+action**. A user who is neither an admin nor listed for a game sees
+"You don't have permission …".
+
+## Discord slash commands
+
+All four are `/server-*`. Replies are ephemeral (only the invoker sees
+them).
+
+### `/server-start <game>`
+
+Autocomplete filters the game list by what you've typed and by what you're
+allowed to run. Press enter and you'll see a deferred ack within 3 s, then
+an edit to "starting …", and finally (1–5 min later) a green
+"running — `{game}.yourdomain.com`".
+
+Behind the scenes: interactions Lambda verifies the signature and kicks off
+the followup Lambda; followup runs ECS `RunTask` and writes a 15-minute
+`PENDING#{taskArn}` row to DynamoDB; when EventBridge sees the task
+transition to RUNNING, the update-dns Lambda upserts the A record and PATCHes
+your original Discord message with the resolved hostname.
+
+### `/server-stop <game>`
+
+Runs `ecs.stopTask`. The update-dns Lambda cleans the Route 53 record (or
+deregisters the ALB target for HTTPS games) when the STOPPED event fires.
+Confirmation edit usually within a few seconds.
+
+### `/server-status [game]`
+
+One game if specified, otherwise every game you have `status` permission
+on. The followup Lambda calls `ListTasks` + `DescribeTasks` and resolves
+the ENI public IP if running.
+
+### `/server-list`
+
+Same as `/server-status` with no game argument — shows everything you can
+see.
+
+## Playing on a server
+
+Once a game is RUNNING:
+
+- DNS: `{game}.yourdomain.com` resolves to the task's public IP after up to
+  `dns_ttl` seconds (default 30).
+- Ports: whatever you configured in `terraform.tfvars` under `ports`. UDP
+  is open directly to the internet on game tasks (`https = false`); HTTPS
+  games go through an ALB on 443.
+- Reconnect if the task restarts: the new task has a different public IP,
+  but the DNS record is re-UPSERTed within seconds of RUNNING. Use the
+  hostname, not the IP.
+
+## When the watchdog will stop you
+
+The watchdog runs on an EventBridge schedule — default every 15 minutes —
+and for every running task it:
+
+1. Reads `NetworkPacketsIn` for the task's ENI over the last window.
+2. If it's below `watchdog_min_packets`, increments the `idle_checks` tag on
+   the task.
+3. If the counter reaches `watchdog_idle_checks`, issues `StopTask` with
+   reason `Watchdog: idle for N minutes` and cleans up DNS/ALB.
+4. If there's activity, resets the counter to 0.
+
+So a burst of actual traffic resets the clock; an empty server shuts down
+after `interval × idle_checks` minutes (default 60). If you need the server
+up longer with no players (e.g. running a backup), temporarily bump
+`watchdog_idle_checks` in the Server Config panel and re-apply.
+
+## Cost, quickly
+
+The three numbers that matter:
+
+- **Fargate**: ~$0.12 / hour for 2 vCPU + 8 GB. Charged while the task is
+  running, per-second (1-minute minimum).
+- **EFS**: ~$0.30 / GB-month standard. Save files are small; this is pennies.
+- **Lambda / EventBridge / DynamoDB / Secrets Manager**: effectively free at
+  personal-use scale.
+
+Running four hours a day, five days a week, on a 2 vCPU / 8 GB task is
+roughly **$10–12 / month**. Compare a t3.large running 24/7 at ~$60/month.
+
+The dashboard's Cost panel shows both the hourly estimate and the last 7
+days of actual spend from Cost Explorer (once you've activated the
+`Project` tag in **Billing → Cost allocation tags**).
+
+## Recipes
+
+### Add a second game
+
+1. Append a new key to `game_servers` in `terraform/terraform.tfvars`.
+2. `cd app && npm run build:lambdas`.
+3. `cd ../terraform && terraform apply`.
+4. Refresh the dashboard — the new card appears because the server
+   re-reads `terraform.tfstate` on `/api/games` and `/api/status`.
+5. Grant yourself permission in the Discord Bot → Per-Game Permissions tab
+   if you want to drive it from Discord.
+
+### Reset a stuck game
+
+If a card shows `error` or a task is hung in `PENDING`:
+
+1. Dashboard → Stop (or `aws ecs stop-task --cluster … --task …`).
+2. Wait ~30 s for EventBridge → update-dns to clean up the DNS record.
+3. Check the CloudWatch log group `/ecs/{game}-server` for the underlying
+   error — image pull failure, EFS mount failure, OOM, etc.
+4. Fix the tfvars entry, `terraform apply`, Start again.
+
+### Rotate the bearer token
+
+`export API_TOKEN=$(openssl rand -hex 32)`, restart the app, re-paste into
+the browser prompt.
+
+### Revoke a Discord user
+
+Remove their user ID from the admin list and from any per-game entry.
+Their existing slash commands will fail on the next invocation — nothing
+to invalidate server-side.
+
+### Take a save backup
+
+Start the **File Manager** modal for the game; it launches a short-lived
+FileBrowser task with the same EFS access point mounted at `/data`.
+Browse/download/upload there, then stop it. The game server itself can
+remain stopped during this.
+
+## Further reading
+
+- [Architecture]({{ '/architecture/' | relative_url }}) — the full diagram
+  and the `/server-start` sequence, end to end.
+- [Lambdas]({{ '/components/lambdas/' | relative_url }}) — what each
+  Lambda does on every invocation.
+- [Management app]({{ '/components/management-app/' | relative_url }}) — the
+  API routes you're hitting through the dashboard.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,142 @@
+---
+title: Game Server Deploy
+---
+
+# Game Server Deploy
+
+A cost-efficient, multi-game dedicated server platform on **AWS Fargate** with a
+local management UI and a fully serverless Discord bot. Servers only run — and
+only cost money — while somebody is playing; the rest of the time the account
+is silent except for a handful of near-free Lambdas.
+
+## What you get
+
+- **On-demand Fargate tasks** per game (no persistent ECS service, no idle cost).
+- **EFS with per-game access points** so each world is isolated yet persistent.
+- **Auto-DNS** — a Lambda UPSERTs `{game}.{yourdomain}` on task start and
+  DELETEs it on stop. Optional ALB with ACM for HTTPS-fronted games.
+- **Watchdog Lambda** that stops servers after a configurable idle window.
+- **Local Nest.js + React dashboard** to start/stop, edit config, stream logs,
+  and track costs.
+- **Serverless Discord bot** — two Node.js Lambdas plus DynamoDB and Secrets
+  Manager handle every slash command; no 24/7 bot process.
+
+## Choose your path
+
+The rest of the site is organised around three roles. Pick the one that
+matches what you're doing right now:
+
+- **[Setup guide]({{ '/setup/' | relative_url }})** — from a blank AWS account
+  to a running game server, in order.
+- **[User guide]({{ '/guides/user/' | relative_url }})** — day-to-day
+  operation: starting/stopping servers from the dashboard or Discord, reading
+  the cost panel, checking logs.
+- **[Maintainer guide]({{ '/guides/maintainer/' | relative_url }})** — working
+  on the code: monorepo layout, tests, lint, CI, release/deploy mechanics,
+  load-bearing invariants not to break.
+- **[Submodule guide]({{ '/guides/submodule/' | relative_url }})** — the
+  pattern of wrapping this repo as a git submodule inside a private parent
+  repo that holds `terraform.tfvars`, `server_config.json`, state, and
+  anything else secret.
+
+## Component reference
+
+Deep-dives on each piece, for when the guides hand-wave past something:
+
+- [Architecture overview]({{ '/architecture/' | relative_url }}) — the diagram
+  below in full, with every arrow annotated.
+- [Terraform]({{ '/components/terraform/' | relative_url }}) — every `.tf`
+  file, variables, outputs, and AWS services touched.
+- [Management app]({{ '/components/management-app/' | relative_url }}) — the
+  Nest.js API, React dashboard, and `@gsd/shared` library.
+- [Lambdas]({{ '/components/lambdas/' | relative_url }}) — the four Node.js
+  Lambdas (interactions, followup, update-dns, watchdog).
+
+## High-level architecture
+
+```mermaid
+flowchart LR
+  subgraph Operator["Operator's laptop"]
+    UI["React dashboard<br/>(@gsd/web)"]
+    API["Nest.js API<br/>(@gsd/server)"]
+    UI -- "Bearer token" --> API
+  end
+
+  subgraph AWS["AWS account"]
+    subgraph Net["VPC / public subnets"]
+      ECS["ECS Fargate tasks<br/>(one per game, on-demand)"]
+      EFS["EFS<br/>(per-game access points)"]
+      ALB["ALB + ACM<br/>(only if https=true)"]
+      ECS --- EFS
+      ALB --> ECS
+    end
+
+    subgraph Bot["Serverless Discord bot"]
+      IX["interactions Lambda<br/>(Function URL)"]
+      FU["followup Lambda"]
+      DDB[("DynamoDB<br/>config + pending")]
+      SM[("Secrets Manager<br/>bot token + public key")]
+    end
+
+    DNS["update-dns Lambda"]
+    WD["watchdog Lambda"]
+    R53[("Route 53 zone<br/>{game}.yourdomain.com")]
+    EB{{"EventBridge"}}
+    CW[("CloudWatch<br/>logs + metrics")]
+
+    API -- "RunTask / StopTask<br/>DescribeTasks" --> ECS
+    API -- "read tfstate<br/>write secrets" --> SM
+    API -- "read/write config" --> DDB
+    API -. "tail logs" .-> CW
+
+    IX -- "Ed25519 verify<br/>+ deferred ack" --> FU
+    FU -- "RunTask / StopTask" --> ECS
+    FU -- "PENDING#taskArn" --> DDB
+    FU -- "PATCH @original" --> Discord
+    IX -- "fetch public key" --> SM
+    IX -- "read config" --> DDB
+
+    ECS -- "state change" --> EB
+    EB --> DNS
+    DNS -- "UPSERT / DELETE A" --> R53
+    DNS -- "PATCH @original" --> Discord
+    DNS -- "register/deregister" --> ALB
+
+    EB -- "rate(N min)" --> WD
+    WD -- "NetworkPacketsIn" --> CW
+    WD -- "StopTask + tag" --> ECS
+    WD -- "DELETE / deregister" --> R53
+  end
+
+  Discord(["Discord<br/>slash commands"])
+  Discord -- "HTTP interaction" --> IX
+  Player(["Player"]) -- "UDP / TCP / HTTPS" --> ECS
+  Player -. "queries" .-> R53
+```
+
+> Run Terraform from your laptop (or a CI runner); after that the control
+> plane is the dashboard, the Discord bot, or EventBridge schedules. No
+> persistent server process — only the Fargate tasks themselves cost money,
+> and only while they're running.
+
+## Repository map
+
+```text
+game-server-deploy/
+├── app/                       # Nest.js + React monorepo (npm workspaces)
+│   └── packages/
+│       ├── shared/            # @gsd/shared
+│       ├── server/            # @gsd/server (Nest.js API)
+│       ├── web/               # @gsd/web   (React + Vite)
+│       └── lambda/
+│           ├── interactions/  # Discord Function URL entry point
+│           ├── followup/      # async ECS work + Discord PATCH
+│           ├── update-dns/    # Route 53 + ALB on task state change
+│           └── watchdog/      # idle detection + auto-stop
+├── terraform/                 # all AWS infra (VPC, ECS, EFS, Lambdas, DDB...)
+├── docs/                      # this site
+├── Dockerfile                 # containerised management app
+├── docker-compose.yml
+├── setup.sh                   # first-time bootstrap (node/terraform/aws)
+└── README.md
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,360 @@
+---
+title: Setup guide
+---
+
+# Setup guide
+
+This is the end-to-end walkthrough, from a blank AWS account to a running
+Fargate task you can connect to from your game client, plus the optional
+Discord bot. Allow ~30 minutes the first time; most of that is waiting for
+`terraform apply`.
+
+The [submodule guide]({{ '/guides/submodule/' | relative_url }}) covers the
+alternative workflow of vendoring this repo inside a private parent that
+holds `terraform.tfvars` and state. Come back here afterwards for the
+per-step detail.
+
+## Prerequisites
+
+On the machine that will run `terraform apply` and the management app:
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | 20+ | Enforced by `setup.sh` and the Nest server boot. |
+| npm | 10+ | Ships with Node 20. |
+| Terraform | 1.5+ | Installed automatically by `setup.sh` on Debian/Ubuntu. |
+| AWS CLI | v2 | Installed automatically by `setup.sh` on Linux. |
+| Docker | 24+ | Only if you plan to run the app via `docker compose`. |
+
+On the AWS side you need:
+
+- An AWS account you control (pure personal use is fine).
+- **A Route 53 hosted zone you already own** — e.g. `yourdomain.com`.
+  Terraform looks it up as a data source and will not create it for you.
+  If you use an external registrar, delegate the zone's NS records to
+  Route 53 before running Terraform or DNS updates will go nowhere.
+
+## 1. Create and authorise an IAM user
+
+1. In the **[AWS IAM console](https://console.aws.amazon.com/iam/)** →
+   **Users → Create user**, give it a name like `game-server-deploy`.
+2. On the permissions step, choose **Attach policies directly** and skip
+   through without selecting any managed policy. Create the user.
+3. Open the new user → **Permissions → Add permissions → Create inline
+   policy → JSON**. Paste the policy below, name it `GameServerDeployAll`,
+   and save.
+4. **Security credentials → Create access key → Command Line Interface (CLI)**.
+   Copy the Access Key ID and Secret Access Key. Treat the secret like a
+   password — AWS will not show it again.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GameServerDeploy",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:*",
+        "elasticfilesystem:*",
+        "ec2:*",
+        "lambda:*",
+        "logs:*",
+        "cloudwatch:*",
+        "events:*",
+        "route53:*",
+        "iam:*",
+        "ce:*",
+        "elasticloadbalancing:*",
+        "acm:*",
+        "dynamodb:*",
+        "secretsmanager:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+> **Why one inline policy instead of stacking managed policies?** AWS caps
+> each user at 10 directly-attached managed policies, and this stack touches
+> ~14 services. One inline policy also keeps the full blast radius visible
+> in one place. Trade-off: you lose AWS's auto-maintenance of action lists,
+> but since everything is `{service}:*` there is nothing to maintain.
+
+You also need a tiny extra permission that is **not** in any AWS-managed
+policy: the AWS provider tags EventBridge rules on creation, which requires
+`events:TagResource`, `events:UntagResource`, and `events:ListTagsForResource`.
+`events:*` above already grants these — if you tighten the policy later, keep
+those three actions in.
+
+## 2. Configure the AWS CLI
+
+```bash
+aws configure
+#   AWS Access Key ID:     AKIA...
+#   AWS Secret Access Key: ****
+#   Default region name:   us-east-1          # must match terraform.tfvars
+#   Default output format: json
+
+aws sts get-caller-identity                   # verify
+```
+
+Both Terraform and the management app read `~/.aws/credentials` and
+`~/.aws/config` automatically. If you prefer environment variables, export
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`
+instead — the management app will pick them up too.
+
+## 3. Clone and bootstrap
+
+```bash
+git clone https://github.com/codercoco/game-server-deploy.git
+cd game-server-deploy
+chmod +x setup.sh
+./setup.sh
+```
+
+`setup.sh` is idempotent. It:
+
+1. Checks for Node 20+, and installs Terraform and the AWS CLI if missing
+   (Debian/Ubuntu only; macOS users should install those manually first).
+2. Runs `npm ci` from `app/` so all workspaces are installed.
+3. Runs `npm run build:lambdas` to produce `app/packages/lambda/*/dist/handler.cjs`
+   — Terraform's `archive_file` data sources zip these at apply time, so
+   the bundles **must** exist on disk before `terraform apply` or init will
+   fail.
+4. Copies `terraform/terraform.tfvars.example` to `terraform/terraform.tfvars`
+   if the latter doesn't exist yet.
+5. Runs `terraform init` inside `terraform/`.
+
+## 4. Configure your servers
+
+Open `terraform/terraform.tfvars` in your editor and fill in:
+
+```hcl
+aws_region       = "us-east-1"
+project_name     = "game-servers"
+hosted_zone_name = "yourdomain.com"    # must already exist in Route 53
+
+# Watchdog knobs (defaults shown)
+watchdog_interval_minutes = 15
+watchdog_idle_checks      = 4          # 15 × 4 = 60 min grace before auto-stop
+watchdog_min_packets      = 100
+
+# One entry per game. Everything downstream iterates over this map.
+game_servers = {
+  palworld = {
+    image  = "thijsvanloef/palworld-server-docker:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 8211,  protocol = "udp" },
+      { container = 27015, protocol = "udp" },
+    ]
+    environment = [
+      { name = "PLAYERS",        value = "8" },
+      { name = "SERVER_NAME",    value = "My Palworld Server" },
+      { name = "ADMIN_PASSWORD", value = "CHANGE_ME" },
+    ]
+    efs_path = "/palworld"
+    https    = false
+  }
+}
+```
+
+Rules worth knowing before you save:
+
+- **`efs_path`** maps to a dedicated EFS access point — each game is isolated
+  in its own directory with UID/GID 1000 ownership. Game images that run as
+  a different UID will fail to mount.
+- **`https = true`** routes the game through an ALB + ACM + Route 53 ALIAS.
+  Only set it on games that actually serve HTTP(S); UDP games (most game
+  servers) must stay `false`. The ALB is only created if at least one game
+  has `https = true`.
+- **CPU / memory** must be a valid Fargate pair (see the
+  [Fargate task size table](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size)).
+- **Do not write `aws_route53_record` resources** — the update-dns Lambda
+  owns that.
+
+Optionally seed Discord credentials here too. If you leave them out, you can
+paste them into the dashboard later:
+
+```hcl
+discord_application_id = "123456789012345678"
+discord_bot_token      = "xxxx.yyyy.zzzz"          # sensitive
+discord_public_key     = "abcd...ef01"             # sensitive
+```
+
+`terraform.tfvars` is gitignored, so these stay on your machine. Rotation
+after the first apply takes one `terraform taint`; see the
+[submodule guide]({{ '/guides/submodule/' | relative_url }}) for the pattern
+that puts this file in a private parent repo.
+
+## 5. Apply the infrastructure
+
+```bash
+cd terraform
+terraform plan
+terraform apply
+```
+
+`apply` takes 5–10 minutes end-to-end. It creates the VPC, two public
+subnets, an ECS cluster, one task definition + EFS access point +
+CloudWatch log group **per game**, the four Lambdas, a DynamoDB table, two
+Secrets Manager secrets, the EventBridge rule + schedule, and (if any game
+has `https = true`) an ALB with an ACM certificate.
+
+When it finishes, note two outputs:
+
+- `interactions_invoke_url` — the Lambda Function URL you'll paste into the
+  Discord Developer Portal for the bot.
+- `ecs_cluster_name` / `game_names` — used by the dashboard (it reads
+  `terraform.tfstate` directly, so you normally don't need to copy these
+  by hand).
+
+## 6. Run the management app
+
+Pick one.
+
+### Option A — dev mode
+
+```bash
+cd app
+npm run dev
+```
+
+Serves the Nest API on **:3001** and the Vite dev server on **:5173** (with
+`/api` proxied to :3001). Open `http://localhost:5173`. In dev mode, if no
+`API_TOKEN` is configured the app logs a warning and allows unauthenticated
+requests — fine for local iteration, not safe to expose.
+
+### Option B — Docker (production-equivalent)
+
+```bash
+# First run only: ensure the persisted config file exists on the host so
+# Compose can bind-mount it.  Without this the bind will error.
+touch app/server_config.json
+
+# REQUIRED: the app refuses to start in production without a bearer token.
+export API_TOKEN="$(openssl rand -hex 32)"
+
+docker compose up --build
+```
+
+Opens on `http://localhost:5000`. The dashboard will prompt you for the
+token on first load; paste the value of `$API_TOKEN` and click
+**Save & reload**.
+
+`docker-compose.yml` bind-mounts `./terraform` read-only (for
+`terraform.tfstate`), `./app/server_config.json` (persisted watchdog
+config), and `~/.aws` (credentials). If you prefer
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars, uncomment the
+corresponding block in `docker-compose.yml`.
+
+## 7. (Optional) Wire up the Discord bot
+
+The serverless bot is two Lambdas, one DynamoDB table, and two Secrets
+Manager secrets — all created by `terraform apply` in step 5. You now
+connect it to a Discord application.
+
+1. **Create a Discord application** at
+   <https://discord.com/developers/applications> → **New Application** →
+   add a **Bot**. Copy three values from **General Information**:
+
+   | Value | Where it goes | Used for |
+   |---|---|---|
+   | **Application ID** (Client ID) | DynamoDB `CONFIG#discord` row | Needed when the server registers slash commands for a guild. Public, not a secret. |
+   | **Bot Token** | Secrets Manager `${project_name}/discord/bot-token` | `Authorization: Bot <token>` for the REST call that registers commands. Treat like a password. |
+   | **Application Public Key** | Secrets Manager `${project_name}/discord/public-key` | The interactions Lambda verifies every incoming interaction against this Ed25519 key. |
+
+   You do **not** need any Privileged Gateway Intents — HTTP interactions
+   deliver the invoker's role IDs directly in the request body.
+
+2. **Seed the credentials.** Either:
+   - Set `discord_application_id`, `discord_bot_token`, and
+     `discord_public_key` in `terraform.tfvars` and re-apply. Terraform
+     writes them once and then `ignore_changes` lets the dashboard edit
+     them without being overwritten on subsequent applies. To rotate via
+     tfvars later, `terraform taint` the relevant resource first.
+   - Or leave them empty and open the **Credentials** tab in the dashboard;
+     paste and Save. The dashboard writes directly to DynamoDB and Secrets
+     Manager.
+
+3. **Copy the interactions endpoint URL** (the `interactions_invoke_url`
+   Terraform output, also shown in the dashboard Credentials tab) into the
+   Discord Developer Portal under **General Information → Interactions
+   Endpoint URL → Save**. Discord sends a PING on save; the Lambda replies
+   PONG and Discord accepts the URL.
+
+4. **Invite the bot to your server.** In the Developer Portal:
+   - **Installation → Installation Contexts**: enable **Guild Install**,
+     disable **User Install**.
+   - **OAuth2 → URL Generator**: tick scopes `bot` and
+     `applications.commands`; under **Bot Permissions**, tick
+     **Send Messages** and **Use Slash Commands** (Discord's UI name for
+     the `USE_APPLICATION_COMMANDS` permission).
+   - Open the generated URL and add the bot to your server.
+
+5. **Enable Developer Mode in Discord** (User Settings → Advanced →
+   Developer Mode) so you can right-click servers/users/roles and
+   **Copy ID**.
+
+6. **In the dashboard's Discord Bot panel:**
+   - **Guilds tab**: add the guild ID and click **Register commands** so
+     Discord learns about `/server-start`, `/server-stop`, `/server-status`,
+     `/server-list`. This is a per-guild REST call; there are no global
+     commands.
+   - **Admins tab**: user IDs and/or role IDs that can run everything on
+     everything.
+   - **Per-Game Permissions tab**: for each game, which users/roles can
+     invoke which subset of `start` / `stop` / `status`.
+
+The [user guide]({{ '/guides/user/' | relative_url }}) has the day-to-day
+command reference; the
+[interactions/followup Lambda docs]({{ '/components/lambdas/' | relative_url }})
+have the wire-level detail.
+
+## 8. Smoke test
+
+With infra applied, the app running, and (optionally) a Discord guild
+configured:
+
+1. Open the dashboard → the game you configured should appear as
+   **stopped**.
+2. Click **Start**. Watch the card transition through `PROVISIONING` →
+   `PENDING` → `RUNNING`. DNS is updated by the update-dns Lambda as soon
+   as the task reaches RUNNING.
+3. `dig {game}.yourdomain.com` should return the task's public IP within
+   `dns_ttl` seconds (default 30). Connect your game client.
+4. Click **Stop**, or type `/server-stop {game}` in Discord, or do nothing
+   for `watchdog_interval_minutes × watchdog_idle_checks` minutes — any of
+   the three stops the task and removes the DNS record.
+
+## 9. Tear it down
+
+Stop every server from the dashboard first (so the DNS updater gets a clean
+STOPPED event and removes records), then:
+
+```bash
+cd terraform
+terraform destroy
+```
+
+The two Secrets Manager secrets use `recovery_window_in_days = 0`, so they
+are deleted immediately — you can `terraform apply` again tomorrow without
+hitting "already scheduled for deletion".
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `terraform apply` fails with "data source not found for zone" | `hosted_zone_name` doesn't exist in Route 53 | Create the hosted zone first (or delegate your registrar's NS records). |
+| `archive_file` fails during `terraform apply` | You didn't run `npm run build:lambdas` | `cd app && npm run build:lambdas`, then re-apply. |
+| App refuses to start under `NODE_ENV=production` | No bearer token configured | `export API_TOKEN=$(openssl rand -hex 32)` or set `api_token` in `app/server_config.json`. |
+| Dashboard says **terraform not applied** in the Discord panel | `interactions_invoke_url` output missing | Re-run `cd app && npm run build:lambdas && cd ../terraform && terraform apply`. |
+| Dashboard says **awaiting credentials** | Secrets still contain the Terraform `"placeholder"` seed | Paste the real bot token + public key in the Credentials tab and Save. |
+| Discord rejects the interactions URL with "invalid interactions endpoint URL" | Public key in Secrets Manager doesn't match Discord's | Re-copy the Application Public Key from the Developer Portal and Save. |
+| `/server-*` slash commands don't appear in Discord | Per-guild registration not done | Guilds tab → **Register commands** next to the guild ID. |
+| `/server-start` says "You don't have permission" | Your user/role isn't in admins or per-game permissions, or the `start` action isn't ticked | Admins tab or Per-Game Permissions tab, then retry. |
+| Task reaches RUNNING but DNS never updates | update-dns Lambda errored; EventBridge rule might be disabled | Check the Lambda's CloudWatch logs; verify the EventBridge rule is enabled. |
+| Watchdog stops tasks too aggressively | Low `watchdog_min_packets`, short `watchdog_interval_minutes`, or low `watchdog_idle_checks` | Tune the three knobs via the dashboard **Server Config** panel and re-apply. |


### PR DESCRIPTION
## Summary

Migrated the monolithic README into a comprehensive Jekyll documentation site hosted on GitHub Pages, with role-based guides and component deep-dives. The README now serves as a quick tour with links to the full docs.

## Key changes

- **New documentation site** (`docs/`) with Jekyll + Cayman theme:
  - `index.md` — landing page with high-level overview and role picker
  - `setup.md` — end-to-end AWS setup walkthrough (IAM, CLI, Terraform, Discord)
  - `architecture.md` — component diagram and `/server-start` sequence diagram
  - `guides/user.md` — day-to-day operations (dashboard, Discord commands, watchdog tuning)
  - `guides/maintainer.md` — development workflow, test/lint conventions, CI, load-bearing invariants
  - `guides/submodule.md` — pattern for wrapping this repo as a git submodule in a private parent
  - `components/terraform.md` — `.tf` file breakdown, variables, outputs
  - `components/management-app.md` — Nest.js API, React dashboard, `@gsd/shared` library
  - `components/lambdas.md` — all four Lambda packages (interactions, followup, update-dns, watchdog)
  - `_config.yml` — Jekyll theme and metadata
  - `_includes/head_custom.html` — Mermaid diagram support via CDN

- **Streamlined README.md**:
  - Removed ~160 lines of detailed setup and architecture explanation
  - Kept only a brief feature list and quick-start snippet
  - Added prominent link to the docs site (`codercoco.github.io/game-server-deploy`)
  - Organized content by role (Setup, User, Maintainer, Submodule guides)

- **Updated CI** (`.github/workflows/jekyll-gh-pages.yml`):
  - Renamed workflow to "Deploy Jekyll docs site to GitHub Pages"
  - Configured to trigger on `docs/**` changes and `main` branch pushes

## Notable details

- Documentation uses Jekyll's `relative_url` filter for portable internal links
- Mermaid diagrams (component flowchart, `/server-start` sequence) embedded in markdown with custom head include for runtime rendering
- All sensitive setup details (IAM policy, tfvars examples) preserved in full; just moved to the docs site
- Submodule guide includes reference layout, step-by-step instructions, and Docker Compose patterns
- Maintainer guide calls out load-bearing invariants (no persistent ECS service, `game_servers` as single source of truth)

https://claude.ai/code/session_01V9hLVNUzk5gdmBQSPJ9tsv