### PR TITLE
chore(terraform): migrate backend to S3 with DynamoDB locking

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ echo ""
 echo "🧱  Building Lambda bundles..."
 npm run build:lambdas
 
-# 3. Terraform init
+# 3. Bootstrap S3 backend, then Terraform init
 echo ""
 echo "🔧  Initializing Terraform..."
 cd "$SCRIPT_DIR/terraform"
@@ -63,7 +63,69 @@ if [ ! -f terraform.tfvars ]; then
   cp terraform.tfvars.example terraform.tfvars
   echo "   Created terraform.tfvars from example — edit it with your settings."
 fi
-terraform init
+
+# Derive bucket/table names from terraform.tfvars (fall back to defaults).
+TF_PROJECT=$(grep -E '^project_name\s*=' terraform.tfvars | head -1 | sed 's/.*=\s*"\(.*\)".*/\1/')
+TF_REGION=$(grep -E '^aws_region\s*=' terraform.tfvars | head -1 | sed 's/.*=\s*"\(.*\)".*/\1/')
+TF_PROJECT="${TF_PROJECT:-game-servers}"
+TF_REGION="${TF_REGION:-us-east-1}"
+TF_STATE_BUCKET="${TF_PROJECT}-tf-state"
+TF_LOCK_TABLE="${TF_PROJECT}-tf-locks"
+
+echo ""
+echo "☁️   Bootstrapping S3 backend (bucket: ${TF_STATE_BUCKET}, region: ${TF_REGION})..."
+
+# Create S3 bucket if it doesn't already exist.
+# us-east-1 is the only region that rejects --create-bucket-configuration.
+if aws s3api head-bucket --bucket "$TF_STATE_BUCKET" --region "$TF_REGION" 2>/dev/null; then
+  echo "   S3 bucket ${TF_STATE_BUCKET} already exists — skipping."
+else
+  echo "   Creating S3 bucket ${TF_STATE_BUCKET}..."
+  if [ "$TF_REGION" = "us-east-1" ]; then
+    aws s3api create-bucket \
+      --bucket "$TF_STATE_BUCKET" \
+      --region "$TF_REGION"
+  else
+    aws s3api create-bucket \
+      --bucket "$TF_STATE_BUCKET" \
+      --region "$TF_REGION" \
+      --create-bucket-configuration "LocationConstraint=${TF_REGION}"
+  fi
+  aws s3api put-bucket-versioning \
+    --bucket "$TF_STATE_BUCKET" \
+    --versioning-configuration Status=Enabled \
+    --region "$TF_REGION"
+  aws s3api put-public-access-block \
+    --bucket "$TF_STATE_BUCKET" \
+    --public-access-block-configuration \
+    "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true" \
+    --region "$TF_REGION"
+  aws s3api put-bucket-encryption \
+    --bucket "$TF_STATE_BUCKET" \
+    --server-side-encryption-configuration \
+    '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},"BucketKeyEnabled":true}]}' \
+    --region "$TF_REGION"
+fi
+
+# Create DynamoDB lock table if it doesn't already exist.
+if aws dynamodb describe-table --table-name "$TF_LOCK_TABLE" --region "$TF_REGION" 2>/dev/null; then
+  echo "   DynamoDB table ${TF_LOCK_TABLE} already exists — skipping."
+else
+  echo "   Creating DynamoDB lock table ${TF_LOCK_TABLE}..."
+  aws dynamodb create-table \
+    --table-name "$TF_LOCK_TABLE" \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --region "$TF_REGION"
+fi
+
+terraform init \
+  -backend-config="bucket=${TF_STATE_BUCKET}" \
+  -backend-config="key=${TF_PROJECT}/terraform.tfstate" \
+  -backend-config="region=${TF_REGION}" \
+  -backend-config="dynamodb_table=${TF_LOCK_TABLE}" \
+  -backend-config="encrypt=true"
 
 echo ""
 echo "  ✅  Setup complete!"

--- a/setup.sh
+++ b/setup.sh
@@ -118,14 +118,28 @@ else
     --key-schema AttributeName=LockID,KeyType=HASH \
     --billing-mode PAY_PER_REQUEST \
     --region "$TF_REGION"
+  echo "   Waiting for DynamoDB table to become ACTIVE..."
+  aws dynamodb wait table-exists \
+    --table-name "$TF_LOCK_TABLE" \
+    --region "$TF_REGION"
 fi
 
-terraform init \
-  -backend-config="bucket=${TF_STATE_BUCKET}" \
-  -backend-config="key=${TF_PROJECT}/terraform.tfstate" \
-  -backend-config="region=${TF_REGION}" \
-  -backend-config="dynamodb_table=${TF_LOCK_TABLE}" \
+# If a local state file exists the backend is being migrated from local → S3.
+# Pass -migrate-state and auto-confirm so the script doesn't hang waiting for
+# interactive input.
+TF_INIT_FLAGS=(
+  -backend-config="bucket=${TF_STATE_BUCKET}"
+  -backend-config="key=${TF_PROJECT}/terraform.tfstate"
+  -backend-config="region=${TF_REGION}"
+  -backend-config="dynamodb_table=${TF_LOCK_TABLE}"
   -backend-config="encrypt=true"
+)
+if [ -f terraform.tfstate ]; then
+  echo "   Local terraform.tfstate detected — migrating state to S3..."
+  echo "yes" | terraform init -migrate-state "${TF_INIT_FLAGS[@]}"
+else
+  terraform init "${TF_INIT_FLAGS[@]}"
+fi
 
 echo ""
 echo "  ✅  Setup complete!"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,9 +12,11 @@ terraform {
     }
   }
 
-  backend "local" {
-    path = "terraform.tfstate"
-  }
+  # Backend config is supplied at `terraform init` time by setup.sh so the
+  # bucket/table names stay in sync with the values it creates.  When running
+  # init manually, pass the same -backend-config flags that setup.sh uses, or
+  # run setup.sh directly.
+  backend "s3" {}
 }
 
 provider "aws" {


### PR DESCRIPTION
## Summary
This PR migrates the Terraform backend from local state storage to remote S3 storage with DynamoDB-based state locking. The setup script now automatically bootstraps the required AWS infrastructure before initializing Terraform.

## Key Changes
- **setup.sh**: Enhanced to bootstrap S3 backend and DynamoDB lock table before `terraform init`
  - Extracts `project_name` and `aws_region` from `terraform.tfvars` to derive resource names
  - Creates S3 bucket with versioning, encryption (AES256), and public access blocking enabled
  - Creates DynamoDB table for state locking with on-demand billing
  - Passes backend configuration to `terraform init` via `-backend-config` flags
  - Handles region-specific S3 bucket creation (us-east-1 doesn't support LocationConstraint)

- **terraform/main.tf**: Updated backend configuration
  - Changed from `backend "local"` to `backend "s3"` with empty configuration block
  - Added comment explaining that backend config is supplied at init time by setup.sh to keep values in sync

## Implementation Details
- Backend configuration is intentionally supplied at `terraform init` time rather than hardcoded in `main.tf` to ensure the bucket and table names stay synchronized with what setup.sh creates
- The script includes idempotent checks to skip creation if resources already exist
- S3 bucket encryption uses AES256 (server-side encryption) with bucket keys enabled for cost optimization
- DynamoDB table uses PAY_PER_REQUEST billing mode for simplicity

https://claude.ai/code/session_011aS7mECZnPKK6y75YJkZo2