### PR TITLE
chore: add post-deploy checklist to tf-apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,17 +98,17 @@ tf-apply: $(LAMBDAS_STAMP) tf-init
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@echo "  Post-deploy checklist"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	@INVOKE_URL=$$(cd $(TF_DIR) && terraform output -raw interactions_invoke_url 2>/dev/null) && \
-	  echo "" && \
-	  echo "  Interactions Endpoint URL (copy this):" && \
-	  echo "    $${INVOKE_URL:-(not available - did apply succeed?)}" && \
-	  echo "" && \
-	  echo "  1. Paste the URL above into the Discord Developer Portal:" && \
-	  echo "     App -> General Information -> Interactions Endpoint URL" && \
-	  echo "" && \
-	  echo "  2. Enter bot token + public key in the management app Credentials tab" && \
-	  echo "     (skip if already pre-seeded in terraform.tfvars)" && \
-	  echo "" && \
+	@INVOKE_URL=$$(cd $(TF_DIR) && terraform output -raw interactions_invoke_url 2>/dev/null); \
+	  echo ""; \
+	  echo "  Interactions Endpoint URL (copy this):"; \
+	  echo "    $${INVOKE_URL:-(not available - did apply succeed?)}"; \
+	  echo ""; \
+	  echo "  1. Paste the URL above into the Discord Developer Portal:"; \
+	  echo "     App -> General Information -> Interactions Endpoint URL"; \
+	  echo ""; \
+	  echo "  2. Enter bot token + public key in the management app Credentials tab"; \
+	  echo "     (skip if already pre-seeded in terraform.tfvars)"; \
+	  echo ""; \
 	  echo "  3. Click 'Register commands' in the management app for each guild"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,23 @@ tf-plan: $(LAMBDAS_STAMP) tf-init
 
 tf-apply: $(LAMBDAS_STAMP) tf-init
 	cd $(TF_DIR) && terraform apply
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "  Post-deploy checklist"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@INVOKE_URL=$$(cd $(TF_DIR) && terraform output -raw interactions_invoke_url 2>/dev/null) && \
+	  echo "" && \
+	  echo "  Interactions Endpoint URL (copy this):" && \
+	  echo "    $${INVOKE_URL:-(not available - did apply succeed?)}" && \
+	  echo "" && \
+	  echo "  1. Paste the URL above into the Discord Developer Portal:" && \
+	  echo "     App -> General Information -> Interactions Endpoint URL" && \
+	  echo "" && \
+	  echo "  2. Enter bot token + public key in the management app Credentials tab" && \
+	  echo "     (skip if already pre-seeded in terraform.tfvars)" && \
+	  echo "" && \
+	  echo "  3. Click 'Register commands' in the management app for each guild"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 tf-destroy: tf-init
 	cd $(TF_DIR) && terraform destroy


### PR DESCRIPTION
## Summary
Enhanced the `tf-apply` Makefile target to display a helpful post-deployment checklist after Terraform apply completes successfully.

## Changes
- Added formatted output after `terraform apply` that displays:
  - The Interactions Endpoint URL retrieved from Terraform outputs
  - Step-by-step instructions for completing post-deployment configuration:
    1. Updating the Discord Developer Portal with the endpoint URL
    2. Entering bot credentials in the management app
    3. Registering commands in the management app for each guild
  - Graceful fallback message if the Terraform output is unavailable

## Implementation Details
- Uses `terraform output -raw interactions_invoke_url` to dynamically retrieve the endpoint URL
- Includes decorative box drawing characters for visual clarity
- Suppresses Terraform output errors with `2>/dev/null` to avoid cluttering the display
- Provides helpful context about when steps can be skipped (e.g., pre-seeded credentials)

https://claude.ai/code/session_01XUefURjrrjJvLWNc5uGxod