### PR TITLE
feat(terraform): add custom Discord domain via CloudFront

### DIFF
--- a/terraform/discord-domain.tf
+++ b/terraform/discord-domain.tf
@@ -1,0 +1,154 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Discord custom domain — discord.{hosted_zone_name}
+#
+# Lambda Function URLs can't be Route 53 ALIAS targets, so we front the
+# interactions Lambda with a CloudFront distribution and point the custom
+# subdomain at it:
+#
+#   discord.codercoco.com
+#     → Route 53 ALIAS → CloudFront distribution
+#       → Lambda Function URL (HTTPS origin)
+#
+# CloudFront is in the global edge network but the ACM certificate must be in
+# us-east-1. Since that's the default region for this project, no provider
+# alias is required.
+#
+# Cache is fully disabled — every Discord interaction is unique. Discord's
+# signature headers (X-Signature-Ed25519, X-Signature-Timestamp) are forwarded
+# to the Lambda via the AllViewerExceptHostHeader origin request policy, which
+# passes all viewer headers except Host (the Lambda Function URL uses its own
+# Host header for routing).
+# ──────────────────────────────────────────────────────────────────────────────
+
+locals {
+  discord_domain = "discord.${var.hosted_zone_name}"
+
+  # Strip "https://" and trailing "/" from the Lambda Function URL to get the
+  # bare hostname CloudFront needs as its origin domain.
+  interactions_lambda_domain = trimsuffix(
+    replace(aws_lambda_function_url.interactions.function_url, "https://", ""),
+    "/"
+  )
+}
+
+# ── ACM Certificate ───────────────────────────────────────────────────────────
+
+resource "aws_acm_certificate" "discord" {
+  domain_name       = local.discord_domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "${var.project_name}-discord-tls" }
+}
+
+resource "aws_route53_record" "discord_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.discord.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 300
+
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "discord" {
+  certificate_arn         = aws_acm_certificate.discord.arn
+  validation_record_fqdns = [for r in aws_route53_record.discord_acm_validation : r.fqdn]
+}
+
+# ── CloudFront Distribution ───────────────────────────────────────────────────
+
+resource "aws_cloudfront_distribution" "discord" {
+  comment             = "${var.project_name} Discord interactions proxy"
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_100" # US, Canada, Europe — cheapest tier
+  aliases             = [local.discord_domain]
+  wait_for_deployment = false
+
+  origin {
+    domain_name = local.interactions_lambda_domain
+    origin_id   = "interactions-lambda"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "interactions-lambda"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+
+    # Managed policy: CachingDisabled — every Discord request must reach the Lambda
+    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+
+    # Managed policy: AllViewerExceptHostHeader — forwards Content-Type,
+    # X-Signature-Ed25519, X-Signature-Timestamp, and all other viewer headers
+    # to the Lambda, while letting CloudFront set Host to the origin hostname.
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.discord.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = { Name = "${var.project_name}-discord-cf" }
+}
+
+# ── Route 53 ALIAS record ─────────────────────────────────────────────────────
+
+resource "aws_route53_record" "discord" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = local.discord_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.discord.domain_name
+    zone_id                = aws_cloudfront_distribution.discord.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# IPv6
+resource "aws_route53_record" "discord_aaaa" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = local.discord_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.discord.domain_name
+    zone_id                = aws_cloudfront_distribution.discord.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# ── Output ────────────────────────────────────────────────────────────────────
+
+output "discord_interactions_url" {
+  description = "Custom domain URL for the Discord interactions endpoint"
+  value       = "https://${local.discord_domain}/"
+}

--- a/terraform/discord-domain.tf
+++ b/terraform/discord-domain.tf
@@ -9,9 +9,9 @@
 #     → Route 53 ALIAS → CloudFront distribution
 #       → Lambda Function URL (HTTPS origin)
 #
-# CloudFront is in the global edge network but the ACM certificate must be in
-# us-east-1. Since that's the default region for this project, no provider
-# alias is required.
+# CloudFront is in the global edge network but ACM certificates must always be
+# in us-east-1, regardless of var.aws_region. The aws.us_east_1 provider alias
+# (defined in main.tf) is used for the certificate and its validation resource.
 #
 # Cache is fully disabled — every Discord interaction is unique. Discord's
 # signature headers (X-Signature-Ed25519, X-Signature-Timestamp) are forwarded
@@ -34,6 +34,7 @@ locals {
 # ── ACM Certificate ───────────────────────────────────────────────────────────
 
 resource "aws_acm_certificate" "discord" {
+  provider          = aws.us_east_1
   domain_name       = local.discord_domain
   validation_method = "DNS"
 
@@ -63,6 +64,7 @@ resource "aws_route53_record" "discord_acm_validation" {
 }
 
 resource "aws_acm_certificate_validation" "discord" {
+  provider                = aws.us_east_1
   certificate_arn         = aws_acm_certificate.discord.arn
   validation_record_fqdns = [for r in aws_route53_record.discord_acm_validation : r.fqdn]
 }

--- a/terraform/interactions.tf
+++ b/terraform/interactions.tf
@@ -107,5 +107,5 @@ resource "aws_lambda_function_url" "interactions" {
 
 output "interactions_invoke_url" {
   description = "Paste this into the 'Interactions Endpoint URL' field in the Discord Developer Portal"
-  value       = aws_lambda_function_url.interactions.function_url
+  value       = "https://discord.${var.hosted_zone_name}/"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,6 +27,17 @@ provider "aws" {
   }
 }
 
+# CloudFront ACM certificates must always be in us-east-1, regardless of the
+# deployment region. This alias is used only for those certificate resources.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
 # ── Data Sources ─────────────────────────────────────────────────────────────
 
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
## Summary
This PR adds a custom domain (`discord.{hosted_zone_name}`) for the Discord interactions endpoint by fronting the Lambda Function URL with a CloudFront distribution. This is necessary because Lambda Function URLs cannot be direct Route 53 ALIAS targets.

## Key Changes
- **New Terraform module** (`discord-domain.tf`): Implements the complete infrastructure for the custom Discord domain:
  - ACM certificate for TLS/HTTPS with DNS validation
  - CloudFront distribution configured as an HTTPS proxy to the Lambda Function URL
  - Route 53 ALIAS records (A and AAAA) pointing the custom subdomain to CloudFront
  - Output of the custom domain URL for Discord Developer Portal configuration

- **Updated interactions endpoint output**: Changed the `interactions_invoke_url` output from the raw Lambda Function URL to the custom domain URL (`https://discord.{hosted_zone_name}/`)

## Implementation Details
- CloudFront is configured with caching fully disabled since every Discord interaction is unique
- The `AllViewerExceptHostHeader` origin request policy is used to forward Discord's signature headers (`X-Signature-Ed25519`, `X-Signature-Timestamp`) to the Lambda while allowing CloudFront to set the appropriate Host header
- CloudFront is set to the cheapest price class (`PriceClass_100`) covering US, Canada, and Europe
- ACM certificate is automatically validated via Route 53 DNS records
- Both IPv4 (A) and IPv6 (AAAA) DNS records are created for the custom domain

https://claude.ai/code/session_019TkSZQdc7EuLF89qp5tNGL