### PR TITLE
docs: add required inline IAM policies section to README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Lambda env vars named `AWS_REGION` are reserved by the runtime. All four Lambdas
 
 ## AWS IAM Requirement Not Covered by Managed Policies
 
-The AWS provider tags EventBridge rules on creation, which requires `events:TagResource` / `UntagResource` / `ListTagsForResource`. These are **not** in any of the managed policies listed in the README. An inline policy granting them must be attached to the deploy user or `terraform apply` will fail. See README "Additional inline policy required".
+The AWS provider tags EventBridge rules on creation, which requires `events:TagResource` / `UntagResource` / `ListTagsForResource`. These are **not** in any of the managed policies listed in the README. An inline policy granting them must be attached to the deploy user or `terraform apply` will fail. See README "Additional inline policies required".
 
 ## Cost Tagging
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,58 @@ Cost ballpark: **Fargate 2 vCPU / 8 GB ≈ $0.12/hr** while running; EFS is
 pennies/month. Playing 4 hours/day, 5 days/week ≈ **$10–12/month**, vs.
 ~$60/month for a 24/7 t3.large.
 
+## Additional inline policies required
+
+Two actions used by Terraform are **not** covered by any AWS managed policy and
+must be granted as inline policies on the deploy user/role. Without them
+`terraform apply` will fail with `AccessDenied`.
+
+### EventBridge tag operations
+
+The AWS provider tags EventBridge rules on creation, which requires three
+actions absent from `AmazonEventBridgeFullAccess`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "events:TagResource",
+      "events:UntagResource",
+      "events:ListTagsForResource"
+    ],
+    "Resource": "*"
+  }]
+}
+```
+
+### CloudFront (Discord custom domain)
+
+The Discord interactions endpoint is fronted by a CloudFront distribution.
+CloudFront is not included in any of the managed policies attached during
+setup:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "cloudfront:CreateDistribution",
+      "cloudfront:CreateDistributionWithTags",
+      "cloudfront:GetDistribution",
+      "cloudfront:UpdateDistribution",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:ListTagsForResource"
+    ],
+    "Resource": "arn:aws:cloudfront::*:distribution/*"
+  }]
+}
+```
+
 ## Repository structure
 
 ```text

--- a/terraform/discord-domain.tf
+++ b/terraform/discord-domain.tf
@@ -1,0 +1,154 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Discord custom domain — discord.{hosted_zone_name}
+#
+# Lambda Function URLs can't be Route 53 ALIAS targets, so we front the
+# interactions Lambda with a CloudFront distribution and point the custom
+# subdomain at it:
+#
+#   discord.codercoco.com
+#     → Route 53 ALIAS → CloudFront distribution
+#       → Lambda Function URL (HTTPS origin)
+#
+# CloudFront is in the global edge network but the ACM certificate must be in
+# us-east-1. Since that's the default region for this project, no provider
+# alias is required.
+#
+# Cache is fully disabled — every Discord interaction is unique. Discord's
+# signature headers (X-Signature-Ed25519, X-Signature-Timestamp) are forwarded
+# to the Lambda via the AllViewerExceptHostHeader origin request policy, which
+# passes all viewer headers except Host (the Lambda Function URL uses its own
+# Host header for routing).
+# ──────────────────────────────────────────────────────────────────────────────
+
+locals {
+  discord_domain = "discord.${var.hosted_zone_name}"
+
+  # Strip "https://" and trailing "/" from the Lambda Function URL to get the
+  # bare hostname CloudFront needs as its origin domain.
+  interactions_lambda_domain = trimsuffix(
+    replace(aws_lambda_function_url.interactions.function_url, "https://", ""),
+    "/"
+  )
+}
+
+# ── ACM Certificate ───────────────────────────────────────────────────────────
+
+resource "aws_acm_certificate" "discord" {
+  domain_name       = local.discord_domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = { Name = "${var.project_name}-discord-tls" }
+}
+
+resource "aws_route53_record" "discord_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.discord.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 300
+
+  allow_overwrite = true
+}
+
+resource "aws_acm_certificate_validation" "discord" {
+  certificate_arn         = aws_acm_certificate.discord.arn
+  validation_record_fqdns = [for r in aws_route53_record.discord_acm_validation : r.fqdn]
+}
+
+# ── CloudFront Distribution ───────────────────────────────────────────────────
+
+resource "aws_cloudfront_distribution" "discord" {
+  comment             = "${var.project_name} Discord interactions proxy"
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_100" # US, Canada, Europe — cheapest tier
+  aliases             = [local.discord_domain]
+  wait_for_deployment = false
+
+  origin {
+    domain_name = local.interactions_lambda_domain
+    origin_id   = "interactions-lambda"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "interactions-lambda"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["GET", "HEAD"]
+
+    # Managed policy: CachingDisabled — every Discord request must reach the Lambda
+    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+
+    # Managed policy: AllViewerExceptHostHeader — forwards Content-Type,
+    # X-Signature-Ed25519, X-Signature-Timestamp, and all other viewer headers
+    # to the Lambda, while letting CloudFront set Host to the origin hostname.
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.discord.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = { Name = "${var.project_name}-discord-cf" }
+}
+
+# ── Route 53 ALIAS record ─────────────────────────────────────────────────────
+
+resource "aws_route53_record" "discord" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = local.discord_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.discord.domain_name
+    zone_id                = aws_cloudfront_distribution.discord.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# IPv6
+resource "aws_route53_record" "discord_aaaa" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = local.discord_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.discord.domain_name
+    zone_id                = aws_cloudfront_distribution.discord.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# ── Output ────────────────────────────────────────────────────────────────────
+
+output "discord_interactions_url" {
+  description = "Custom domain URL for the Discord interactions endpoint"
+  value       = "https://${local.discord_domain}/"
+}

--- a/terraform/discord-domain.tf
+++ b/terraform/discord-domain.tf
@@ -9,9 +9,9 @@
 #     → Route 53 ALIAS → CloudFront distribution
 #       → Lambda Function URL (HTTPS origin)
 #
-# CloudFront is in the global edge network but the ACM certificate must be in
-# us-east-1. Since that's the default region for this project, no provider
-# alias is required.
+# CloudFront is in the global edge network but ACM certificates must always be
+# in us-east-1, regardless of var.aws_region. The aws.us_east_1 provider alias
+# (defined in main.tf) is used for the certificate and its validation resource.
 #
 # Cache is fully disabled — every Discord interaction is unique. Discord's
 # signature headers (X-Signature-Ed25519, X-Signature-Timestamp) are forwarded
@@ -34,6 +34,7 @@ locals {
 # ── ACM Certificate ───────────────────────────────────────────────────────────
 
 resource "aws_acm_certificate" "discord" {
+  provider          = aws.us_east_1
   domain_name       = local.discord_domain
   validation_method = "DNS"
 
@@ -63,6 +64,7 @@ resource "aws_route53_record" "discord_acm_validation" {
 }
 
 resource "aws_acm_certificate_validation" "discord" {
+  provider                = aws.us_east_1
   certificate_arn         = aws_acm_certificate.discord.arn
   validation_record_fqdns = [for r in aws_route53_record.discord_acm_validation : r.fqdn]
 }

--- a/terraform/interactions.tf
+++ b/terraform/interactions.tf
@@ -107,5 +107,5 @@ resource "aws_lambda_function_url" "interactions" {
 
 output "interactions_invoke_url" {
   description = "Paste this into the 'Interactions Endpoint URL' field in the Discord Developer Portal"
-  value       = aws_lambda_function_url.interactions.function_url
+  value       = "https://discord.${var.hosted_zone_name}/"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -27,6 +27,17 @@ provider "aws" {
   }
 }
 
+# CloudFront ACM certificates must always be in us-east-1, regardless of the
+# deployment region. This alias is used only for those certificate resources.
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
 # ── Data Sources ─────────────────────────────────────────────────────────────
 
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
## Summary

- Documents the two inline IAM policies that must be attached to the deploy user for `terraform apply` to succeed — neither is covered by any AWS managed policy.
- **EventBridge tag actions** (`events:TagResource/UntagResource/ListTagsForResource`) — needed because the AWS provider tags EventBridge rules on creation.
- **CloudFront actions** — needed for the Discord custom domain distribution introduced in #22.

## Test plan

- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm both inline policies unblock `terraform apply` in a fresh deploy

https://claude.ai/code/session_019TkSZQdc7EuLF89qp5tNGL

---
_Generated by [Claude Code](https://claude.ai/code/session_019TkSZQdc7EuLF89qp5tNGL)_