### PR TITLE
fix(docs): use documented d2 install form; exclude diagrams/.gitignore

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Install D2
         run: |
-          curl -fsSL https://d2lang.com/install.sh | sh -s -- --prefix="$HOME/.local"
+          curl -fsSL https://d2lang.com/install.sh | sh -s --
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Render D2 diagrams
         run: docs/diagrams/render.sh

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,6 +29,7 @@ exclude:
   - vendor/
   # D2 sources + helpers are build-time inputs only; the rendered *.svg
   # outputs in the same directory are what get published.
+  - "diagrams/.gitignore"
   - "diagrams/*.d2"
   - "diagrams/render.sh"
   - "diagrams/README.md"


### PR DESCRIPTION
## Summary
This PR makes two adjustments to the D2 diagram build process: fixes the D2 installation command in the GitHub Actions workflow and excludes the diagrams/.gitignore file from Jekyll's build output.

## Key Changes
- **D2 installation fix**: Removed the `--prefix="$HOME/.local"` argument from the D2 install script invocation. The install script is now called with just `sh -s --`, allowing it to use its default installation behavior.
- **Jekyll exclusion**: Added `diagrams/.gitignore` to the exclude list in `_config.yml` to prevent it from being published with the site, consistent with other build-time artifacts in the diagrams directory.

## Implementation Details
The D2 installation command was simplified from `sh -s -- --prefix="$HOME/.local"` to `sh -s --`. The PATH is still explicitly updated to include `$HOME/.local/bin`, ensuring the D2 binary is available in the workflow regardless of where the install script places it.

https://claude.ai/code/session_01E7yfHF7QG17LPD2W9ZhGP6