### PR TITLE
fix(ci): sudo chmod _site — runner cannot chmod root-owned files

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,5 +1,4 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll docs site to GitHub Pages
+name: Deploy Docs
 
 on:
   # Runs on pushes targeting the default branch that touch the docs site

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
           source: ./docs
           destination: ./_site
       - name: Fix _site permissions
-        run: chmod -R +rX _site/
+        run: sudo chmod -R +rX _site/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
## Summary

- `chmod -R +rX _site/` was failing with "Operation not permitted" because `actions/jekyll-build-pages@v1` writes `_site/` as root inside its Docker container.
- The outer `runner` user can read but cannot change permissions on root-owned files without elevated privileges.
- Fix: prefix the `chmod` with `sudo` so it has the necessary privileges.

## Test plan

- [ ] Verify the Pages workflow runs to completion without `chmod: Operation not permitted` errors
- [ ] Confirm `tar` can package `_site/` and the artifact uploads successfully

https://claude.ai/code/session_01E7yfHF7QG17LPD2W9ZhGP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7yfHF7QG17LPD2W9ZhGP6)_