### PR TITLE
fix(interactions): add lambda:InvokeFunction permission for Function URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Thumbs.db
 # lives at .claude/settings.json (commit that instead if you want the
 # allowlist shared across the team).
 .claude/settings.local.json
+
+.make

--- a/terraform/interactions.tf
+++ b/terraform/interactions.tf
@@ -105,6 +105,16 @@ resource "aws_lambda_function_url" "interactions" {
   }
 }
 
+# Since October 2025, Lambda Function URLs require both lambda:InvokeFunctionUrl
+# (created automatically by aws_lambda_function_url) and lambda:InvokeFunction.
+resource "aws_lambda_permission" "interactions_url_invoke" {
+  statement_id           = "FunctionURLInvokeAllowPublicAccess"
+  action                 = "lambda:InvokeFunction"
+  function_name          = aws_lambda_function.interactions.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
 output "interactions_invoke_url" {
   description = "Paste this into the 'Interactions Endpoint URL' field in the Discord Developer Portal"
   value       = "https://discord.${var.hosted_zone_name}/"


### PR DESCRIPTION
## Summary

- Since October 2025, Lambda Function URLs require **both** `lambda:InvokeFunctionUrl` (created automatically by `aws_lambda_function_url`) **and** `lambda:InvokeFunction` in the resource-based policy
- Without the second permission, any request to the Function URL receives `403 Forbidden` before the Lambda handler runs — this was causing Discord's endpoint validation PING to fail with "could not be verified"
- Adds `aws_lambda_permission.interactions_url_invoke` to `interactions.tf` to codify the fix; the permission was already applied as a hotfix via `aws lambda add-permission`
- Also ignores `.make/` in `.gitignore`

## Test plan

- [x] Hotfix applied: `curl -X POST https://discord.codercoco.com/` now returns `401 invalid request signature` (handler reached) instead of `403 Forbidden`
- [ ] Run `terraform plan` — should show only the new `aws_lambda_permission` resource (no destructive changes)
- [ ] Run `terraform apply` — permission is already in place; Terraform should reconcile cleanly
- [ ] Re-enter the interactions endpoint URL in the Discord Developer Portal and confirm "Successfully verified" 

🤖 Generated with [Claude Code](https://claude.com/claude-code)