### PR TITLE
fix(server): inject ConfigService into ApiTokenGuard via useFactory

### DIFF
--- a/app/packages/server/src/app.module.ts
+++ b/app/packages/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { APP_GUARD } from '@nestjs/core';
 import type { Request, Response, NextFunction } from 'express';
 import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
+import { ConfigService } from './services/ConfigService.js';
 import { GamesController } from './controllers/games.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
 import { CostsController } from './controllers/costs.controller.js';
@@ -51,7 +52,13 @@ class RequestLoggerMiddleware implements NestMiddleware {
     FilesController,
     DiscordController,
   ],
-  providers: [{ provide: APP_GUARD, useClass: ApiTokenGuard }],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useFactory: (config: ConfigService) => new ApiTokenGuard(config),
+      inject: [ConfigService],
+    },
+  ],
 })
 export class AppModule implements NestModule {
   /** Attaches the request logger to every route so each HTTP call emits one structured line. */


### PR DESCRIPTION
## Summary
Updated the `ApiTokenGuard` provider configuration to use a factory function that injects the `ConfigService` dependency, allowing the guard to access configuration at runtime.

## Key Changes
- Added import of `ConfigService` to `app.module.ts`
- Changed `ApiTokenGuard` provider from a simple class provider to a factory provider
- The factory function receives `ConfigService` as an injected dependency and passes it to the `ApiTokenGuard` constructor
- This enables `ApiTokenGuard` to access configuration values during authentication checks

## Implementation Details
The provider configuration was updated from:
```typescript
providers: [{ provide: APP_GUARD, useClass: ApiTokenGuard }]
```

To:
```typescript
providers: [
  {
    provide: APP_GUARD,
    useFactory: (config: ConfigService) => new ApiTokenGuard(config),
    inject: [ConfigService],
  },
]
```

This change allows `ApiTokenGuard` to be instantiated with configuration dependencies, making it more flexible for token validation logic that may depend on runtime configuration.

https://claude.ai/code/session_01TutexsuMCT24musZH7MH72