### PR TITLE
feat: add Windows PowerShell setup script

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -85,6 +85,7 @@ game-server-deploy/
 ├── docs/                      # this site
 ├── Dockerfile                 # containerised management app
 ├── docker-compose.yml
-├── setup.sh                   # first-time bootstrap (node/terraform/aws)
+├── setup.sh                   # first-time bootstrap — Linux / macOS
+├── setup.ps1                  # first-time bootstrap — Windows (PowerShell)
 └── README.md
 ```

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -21,10 +21,10 @@ On the machine that will run `terraform apply` and the management app:
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| Node.js | 20+ | Enforced by `setup.sh` and the Nest server boot. |
+| Node.js | 20+ | Enforced by both setup scripts and the Nest server boot. |
 | npm | 10+ | Ships with Node 20. |
-| Terraform | 1.5+ | Installed automatically by `setup.sh` on Debian/Ubuntu. |
-| AWS CLI | v2 | Installed automatically by `setup.sh` on Linux. |
+| Terraform | 1.5+ | Installed automatically by `setup.sh` (Debian/Ubuntu) or `setup.ps1` (Windows via winget). |
+| AWS CLI | v2 | Installed automatically by `setup.sh` (Linux) or `setup.ps1` (Windows via MSI). |
 | Docker | 24+ | Only if you plan to run the app via `docker compose`. |
 
 On the AWS side you need:
@@ -124,6 +124,8 @@ instead — the management app will pick them up too.
 
 ## 3. Clone and bootstrap
 
+**Linux / macOS:**
+
 ```bash
 git clone https://github.com/codercoco/game-server-deploy.git
 cd game-server-deploy
@@ -131,10 +133,22 @@ chmod +x setup.sh
 ./setup.sh
 ```
 
-`setup.sh` is idempotent — safe to re-run at any time. It:
+**Windows (PowerShell 5.1+):**
+
+```powershell
+git clone https://github.com/codercoco/game-server-deploy.git
+cd game-server-deploy
+.\setup.ps1
+```
+
+> If PowerShell blocks the script with an execution-policy error, run
+> `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser` once, then retry.
+
+Both scripts are idempotent — safe to re-run at any time. They:
 
 1. Checks for Node 20+, and installs Terraform and the AWS CLI if missing
-   (Debian/Ubuntu only; macOS users should install those manually first).
+   (`setup.sh` uses apt on Debian/Ubuntu; `setup.ps1` uses winget + the AWS MSI
+   installer on Windows; macOS users should install those tools manually first).
 2. Runs `npm ci` from `app/` so all workspaces are installed.
 3. Runs `npm run build:lambdas` to produce `app/packages/lambda/*/dist/handler.cjs`
    — Terraform's `archive_file` data sources zip these at apply time, so

--- a/setup.ps1
+++ b/setup.ps1
@@ -28,6 +28,16 @@ function Test-Command {
   return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+# $ErrorActionPreference = 'Stop' only traps cmdlet errors, not native-exe exit codes.
+# Wrap every native call with this so a non-zero exit code throws immediately.
+function Invoke-Native {
+  param([scriptblock]$Block)
+  & $Block
+  if ($LASTEXITCODE -ne 0) {
+    throw "Command failed with exit code $LASTEXITCODE."
+  }
+}
+
 function Install-WithWinget {
   param([string]$PackageId, [string]$DisplayName)
   if (-not (Test-Command 'winget')) {
@@ -35,7 +45,7 @@ function Install-WithWinget {
     exit 1
   }
   Write-Host "  Installing $DisplayName via winget..."
-  winget install --id $PackageId --silent --accept-package-agreements --accept-source-agreements
+  Invoke-Native { winget install --id $PackageId --silent --accept-package-agreements --accept-source-agreements }
   # Refresh PATH for the current session so subsequent Test-Command calls work.
   $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
               [System.Environment]::GetEnvironmentVariable('PATH', 'User')
@@ -95,11 +105,11 @@ Write-Host "  Prerequisites found (node, terraform, aws cli)"
 Write-Host ""
 Write-Host "  Installing Node dependencies..."
 Set-Location (Join-Path $ScriptDir 'app')
-npm ci
+Invoke-Native { npm ci }
 
 Write-Host ""
 Write-Host "  Building Lambda bundles..."
-npm run build:lambdas
+Invoke-Native { npm run build:lambdas }
 
 # ---------------------------------------------------------------------------
 # 3. Bootstrap S3 backend + Terraform init
@@ -142,27 +152,33 @@ if ($bucketExists) {
 } else {
   Write-Host "   Creating S3 bucket $TfStateBucket..."
   if ($TfRegion -eq 'us-east-1') {
-    aws s3api create-bucket --bucket $TfStateBucket --region $TfRegion
+    Invoke-Native { aws s3api create-bucket --bucket $TfStateBucket --region $TfRegion }
   } else {
-    aws s3api create-bucket `
-      --bucket $TfStateBucket `
-      --region $TfRegion `
-      --create-bucket-configuration "LocationConstraint=$TfRegion"
+    Invoke-Native {
+      aws s3api create-bucket `
+        --bucket $TfStateBucket `
+        --region $TfRegion `
+        --create-bucket-configuration "LocationConstraint=$TfRegion"
+    }
   }
-  aws s3api put-bucket-versioning `
-    --bucket $TfStateBucket `
-    --versioning-configuration Status=Enabled `
-    --region $TfRegion
-
-  aws s3api put-public-access-block `
-    --bucket $TfStateBucket `
-    --public-access-block-configuration 'BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true' `
-    --region $TfRegion
-
-  aws s3api put-bucket-encryption `
-    --bucket $TfStateBucket `
-    --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},"BucketKeyEnabled":true}]}' `
-    --region $TfRegion
+  Invoke-Native {
+    aws s3api put-bucket-versioning `
+      --bucket $TfStateBucket `
+      --versioning-configuration Status=Enabled `
+      --region $TfRegion
+  }
+  Invoke-Native {
+    aws s3api put-public-access-block `
+      --bucket $TfStateBucket `
+      --public-access-block-configuration 'BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true' `
+      --region $TfRegion
+  }
+  Invoke-Native {
+    aws s3api put-bucket-encryption `
+      --bucket $TfStateBucket `
+      --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},"BucketKeyEnabled":true}]}' `
+      --region $TfRegion
+  }
 }
 
 # DynamoDB lock table
@@ -176,15 +192,16 @@ if ($tableExists) {
   Write-Host "   DynamoDB table $TfLockTable already exists - skipping."
 } else {
   Write-Host "   Creating DynamoDB lock table $TfLockTable..."
-  aws dynamodb create-table `
-    --table-name $TfLockTable `
-    --attribute-definitions AttributeName=LockID,AttributeType=S `
-    --key-schema AttributeName=LockID,KeyType=HASH `
-    --billing-mode PAY_PER_REQUEST `
-    --region $TfRegion
-
+  Invoke-Native {
+    aws dynamodb create-table `
+      --table-name $TfLockTable `
+      --attribute-definitions AttributeName=LockID,AttributeType=S `
+      --key-schema AttributeName=LockID,KeyType=HASH `
+      --billing-mode PAY_PER_REQUEST `
+      --region $TfRegion
+  }
   Write-Host "   Waiting for DynamoDB table to become ACTIVE..."
-  aws dynamodb wait table-exists --table-name $TfLockTable --region $TfRegion
+  Invoke-Native { aws dynamodb wait table-exists --table-name $TfLockTable --region $TfRegion }
 }
 
 # terraform init (with optional state migration)
@@ -198,9 +215,9 @@ $tfInitArgs = @(
 
 if (Test-Path 'terraform.tfstate') {
   Write-Host "   Local terraform.tfstate detected - migrating state to S3..."
-  echo 'yes' | terraform init -migrate-state @tfInitArgs
+  Invoke-Native { 'yes' | terraform init -migrate-state @tfInitArgs }
 } else {
-  terraform init @tfInitArgs
+  Invoke-Native { terraform init @tfInitArgs }
 }
 
 # ---------------------------------------------------------------------------

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,228 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Game Server Manager — Windows setup script (PowerShell equivalent of setup.sh).
+
+.DESCRIPTION
+  Checks prerequisites (Node.js 20+, Terraform, AWS CLI), installs missing tools
+  where possible, installs npm workspaces, builds Lambda bundles, bootstraps the
+  S3 + DynamoDB Terraform backend, and runs `terraform init`.
+#>
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$ScriptDir = $PSScriptRoot
+
+Write-Host ""
+Write-Host "  Game Server Manager - Setup"
+Write-Host "  --------------------------------------"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Test-Command {
+  param([string]$Name)
+  return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Install-WithWinget {
+  param([string]$PackageId, [string]$DisplayName)
+  if (-not (Test-Command 'winget')) {
+    Write-Host "  winget is not available. Please install $DisplayName manually."
+    exit 1
+  }
+  Write-Host "  Installing $DisplayName via winget..."
+  winget install --id $PackageId --silent --accept-package-agreements --accept-source-agreements
+  # Refresh PATH for the current session so subsequent Test-Command calls work.
+  $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+              [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+}
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisites
+# ---------------------------------------------------------------------------
+
+# Node.js 20+
+if (-not (Test-Command 'node')) {
+  Write-Host "  Node.js not found."
+  Install-WithWinget 'OpenJS.NodeJS.LTS' 'Node.js LTS'
+  if (-not (Test-Command 'node')) {
+    Write-Host "  Node.js still not found after install. Open a new terminal and re-run."
+    exit 1
+  }
+}
+
+$nodeMajor = [int](node -p "process.versions.node.split('.')[0]")
+if ($nodeMajor -lt 20) {
+  Write-Host "  Node.js 20+ required (detected $nodeMajor). Please upgrade and re-run."
+  exit 1
+}
+
+# Terraform
+if (-not (Test-Command 'terraform')) {
+  Write-Host "  terraform not found — installing via winget..."
+  Install-WithWinget 'HashiCorp.Terraform' 'Terraform'
+  if (-not (Test-Command 'terraform')) {
+    Write-Host "  Terraform still not found after install. Open a new terminal and re-run."
+    exit 1
+  }
+}
+
+# AWS CLI
+if (-not (Test-Command 'aws')) {
+  Write-Host "  AWS CLI not found — downloading and installing v2..."
+  $msiPath = Join-Path $env:TEMP 'AWSCLIV2.msi'
+  Invoke-WebRequest -Uri 'https://awscli.amazonaws.com/AWSCLIV2.msi' -OutFile $msiPath
+  Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -Wait -Verb RunAs
+  Remove-Item $msiPath -ErrorAction SilentlyContinue
+  $env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+              [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+  if (-not (Test-Command 'aws')) {
+    Write-Host "  AWS CLI still not found after install. Open a new terminal and re-run."
+    exit 1
+  }
+}
+
+Write-Host "  Prerequisites found (node, terraform, aws cli)"
+
+# ---------------------------------------------------------------------------
+# 2. Install JS dependencies and build Lambda bundles
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "  Installing Node dependencies..."
+Set-Location (Join-Path $ScriptDir 'app')
+npm ci
+
+Write-Host ""
+Write-Host "  Building Lambda bundles..."
+npm run build:lambdas
+
+# ---------------------------------------------------------------------------
+# 3. Bootstrap S3 backend + Terraform init
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "  Initializing Terraform..."
+Set-Location (Join-Path $ScriptDir 'terraform')
+
+$tfvarsPath = 'terraform.tfvars'
+if (-not (Test-Path $tfvarsPath)) {
+  Copy-Item 'terraform.tfvars.example' $tfvarsPath
+  Write-Host "   Created terraform.tfvars from example - edit it with your settings."
+}
+
+# Parse project_name and aws_region from terraform.tfvars (fall back to defaults).
+$tfvarsContent = Get-Content $tfvarsPath -Raw
+
+$projectMatch = [regex]::Match($tfvarsContent, '(?m)^\s*project_name\s*=\s*"([^"]+)"')
+$regionMatch  = [regex]::Match($tfvarsContent, '(?m)^\s*aws_region\s*=\s*"([^"]+)"')
+
+$TfProject = if ($projectMatch.Success) { $projectMatch.Groups[1].Value } else { 'game-servers' }
+$TfRegion  = if ($regionMatch.Success)  { $regionMatch.Groups[1].Value }  else { 'us-east-1' }
+
+$TfStateBucket = "$TfProject-tf-state"
+$TfLockTable   = "$TfProject-tf-locks"
+
+Write-Host ""
+Write-Host "  Bootstrapping S3 backend (bucket: $TfStateBucket, region: $TfRegion)..."
+
+# S3 bucket
+$bucketExists = $false
+try {
+  aws s3api head-bucket --bucket $TfStateBucket --region $TfRegion 2>$null
+  $bucketExists = ($LASTEXITCODE -eq 0)
+} catch { $bucketExists = $false }
+
+if ($bucketExists) {
+  Write-Host "   S3 bucket $TfStateBucket already exists - skipping."
+} else {
+  Write-Host "   Creating S3 bucket $TfStateBucket..."
+  if ($TfRegion -eq 'us-east-1') {
+    aws s3api create-bucket --bucket $TfStateBucket --region $TfRegion
+  } else {
+    aws s3api create-bucket `
+      --bucket $TfStateBucket `
+      --region $TfRegion `
+      --create-bucket-configuration "LocationConstraint=$TfRegion"
+  }
+  aws s3api put-bucket-versioning `
+    --bucket $TfStateBucket `
+    --versioning-configuration Status=Enabled `
+    --region $TfRegion
+
+  aws s3api put-public-access-block `
+    --bucket $TfStateBucket `
+    --public-access-block-configuration 'BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true' `
+    --region $TfRegion
+
+  aws s3api put-bucket-encryption `
+    --bucket $TfStateBucket `
+    --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"},"BucketKeyEnabled":true}]}' `
+    --region $TfRegion
+}
+
+# DynamoDB lock table
+$tableExists = $false
+try {
+  aws dynamodb describe-table --table-name $TfLockTable --region $TfRegion 2>$null
+  $tableExists = ($LASTEXITCODE -eq 0)
+} catch { $tableExists = $false }
+
+if ($tableExists) {
+  Write-Host "   DynamoDB table $TfLockTable already exists - skipping."
+} else {
+  Write-Host "   Creating DynamoDB lock table $TfLockTable..."
+  aws dynamodb create-table `
+    --table-name $TfLockTable `
+    --attribute-definitions AttributeName=LockID,AttributeType=S `
+    --key-schema AttributeName=LockID,KeyType=HASH `
+    --billing-mode PAY_PER_REQUEST `
+    --region $TfRegion
+
+  Write-Host "   Waiting for DynamoDB table to become ACTIVE..."
+  aws dynamodb wait table-exists --table-name $TfLockTable --region $TfRegion
+}
+
+# terraform init (with optional state migration)
+$tfInitArgs = @(
+  "-backend-config=bucket=$TfStateBucket"
+  "-backend-config=key=$TfProject/terraform.tfstate"
+  "-backend-config=region=$TfRegion"
+  "-backend-config=dynamodb_table=$TfLockTable"
+  "-backend-config=encrypt=true"
+)
+
+if (Test-Path 'terraform.tfstate') {
+  Write-Host "   Local terraform.tfstate detected - migrating state to S3..."
+  echo 'yes' | terraform init -migrate-state @tfInitArgs
+} else {
+  terraform init @tfInitArgs
+}
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "  Setup complete!"
+Write-Host ""
+Write-Host "  Next steps:"
+Write-Host "    1. Edit terraform/terraform.tfvars with your game servers and domain"
+Write-Host "    2. Run: cd terraform; terraform plan"
+Write-Host "    3. Run: cd terraform; terraform apply"
+Write-Host "    4. Run the management app:"
+Write-Host "         Dev:     cd app; npm run dev"
+Write-Host "         Docker:  docker compose up --build"
+Write-Host "    5. Open http://localhost:5173 (dev) or http://localhost:5000 (docker)"
+Write-Host ""
+Write-Host "  Discord bot setup (serverless):"
+Write-Host "    - Open Credentials tab in the web UI and save the Application ID,"
+Write-Host "      Bot Token, and Application Public Key from the Discord Developer Portal."
+Write-Host "    - Copy the 'Interactions Endpoint URL' from the same tab and paste it"
+Write-Host "      into the Discord Developer Portal under General Information."
+Write-Host "    - Add a guild ID under the Guilds tab and click 'Register commands'."
+Write-Host ""


### PR DESCRIPTION
## Summary
Add a PowerShell equivalent of the existing `setup.sh` script to enable Windows developers to set up the Game Server Manager project with a single command.

## Key Changes
- **New `setup.ps1` script** that provides Windows-native setup automation with the following functionality:
  - Prerequisite validation and installation (Node.js 20+, Terraform, AWS CLI v2)
  - Automatic tool installation via `winget` where available, with fallback to manual download for AWS CLI
  - npm workspace dependency installation and Lambda bundle building
  - S3 backend bucket creation with versioning, encryption, and public access blocking
  - DynamoDB lock table creation for Terraform state locking
  - Terraform initialization with automatic state migration from local to S3 backend
  - User-friendly setup guidance with next steps and Discord bot configuration instructions

## Implementation Details
- Uses PowerShell 5.1+ with strict error handling (`$ErrorActionPreference = 'Stop'`)
- Includes helper functions for command detection and tool installation
- Parses `terraform.tfvars` to extract project name and AWS region for backend configuration
- Handles region-specific S3 bucket creation (special handling for `us-east-1`)
- Gracefully skips resource creation if S3 bucket or DynamoDB table already exist
- Provides clear console output with progress indicators and actionable error messages
- Mirrors the functionality and user experience of the existing bash setup script

https://claude.ai/code/session_01LHDg9ZNoZmERqW6zAN61bj