### PR TITLE
feat(discord): add Terraform-managed base allowlist and admins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,15 @@ The full deploy IAM policy (`GameServerDeployAll`) lives in **`docs/setup.md`** 
 
 All resources inherit `default_tags` from `provider "aws"` (`Project = "game-servers-poc"`, `Environment = "poc"`, `ManagedBy = "terraform"`). For Cost Explorer breakdowns, the `Project` cost allocation tag must be activated manually in AWS Billing — this is a one-time console action, not Terraform-managed.
 
+## Checklist for Terraform variable changes
+
+Any time you add or remove Terraform variables, update **all four** of these in the same commit — failing to touch any one of them is a common oversight:
+
+1. `terraform/variables.tf` — the variable declaration itself.
+2. `terraform/terraform.tfvars.example` — a commented-out example entry with a short explanation so operators know how to use it.
+3. `docs/docs/components/terraform.md` — the Variables table row.
+4. `docs/docs/setup.md` — any relevant step in the setup guide (especially if the variable affects the Discord bot or a core workflow).
+
 ## Code & Test Conventions
 
 - **Test names**: every `it(...)` case must read as a natural-language sentence starting with "should" — e.g. `it('should return null when state file is missing')`, not `it('returns null...')`.

--- a/app/packages/lambda/followup/src/handler.test.ts
+++ b/app/packages/lambda/followup/src/handler.test.ts
@@ -16,13 +16,13 @@ import {
   EC2Client,
 } from '@aws-sdk/client-ec2';
 
-const getDiscordConfigMock = vi.fn();
+const getEffectiveDiscordConfigMock = vi.fn();
 const putPendingMock = vi.fn();
 vi.mock('@gsd/shared', async () => {
   const actual = await vi.importActual<typeof import('@gsd/shared')>('@gsd/shared');
   return {
     ...actual,
-    getDiscordConfig: (...args: unknown[]) => getDiscordConfigMock(...args),
+    getEffectiveDiscordConfig: (...args: unknown[]) => getEffectiveDiscordConfigMock(...args),
     putPending: (...args: unknown[]) => putPendingMock(...args),
   };
 });
@@ -69,9 +69,9 @@ beforeEach(() => {
   ecsMock.reset();
   ec2Mock.reset();
   fetchMock.mockReset();
-  getDiscordConfigMock.mockReset();
+  getEffectiveDiscordConfigMock.mockReset();
   putPendingMock.mockReset();
-  getDiscordConfigMock.mockResolvedValue(PERMISSIVE_CONFIG);
+  getEffectiveDiscordConfigMock.mockResolvedValue(PERMISSIVE_CONFIG);
   fetchMock.mockResolvedValue({ ok: true, text: async () => '' });
 });
 
@@ -116,7 +116,7 @@ describe('FollowupLambda: start', () => {
   });
 
   it('should deny the start when canRun() rejects the caller', async () => {
-    getDiscordConfigMock.mockResolvedValue({
+    getEffectiveDiscordConfigMock.mockResolvedValue({
       ...PERMISSIVE_CONFIG,
       admins: { userIds: [], roleIds: [] },
       gamePermissions: { palworld: { userIds: [], roleIds: [], actions: [] } },
@@ -193,7 +193,7 @@ describe('FollowupLambda: status', () => {
 
 describe('FollowupLambda: list', () => {
   it('should only fetch status for games the caller can view, and join lines with newlines', async () => {
-    getDiscordConfigMock.mockResolvedValue({
+    getEffectiveDiscordConfigMock.mockResolvedValue({
       ...PERMISSIVE_CONFIG,
       admins: { userIds: [], roleIds: [] },
       gamePermissions: {
@@ -211,7 +211,7 @@ describe('FollowupLambda: list', () => {
   });
 
   it('should return a helpful message when the caller can see nothing', async () => {
-    getDiscordConfigMock.mockResolvedValue({
+    getEffectiveDiscordConfigMock.mockResolvedValue({
       ...PERMISSIVE_CONFIG,
       admins: { userIds: [], roleIds: [] },
       gamePermissions: {},

--- a/app/packages/lambda/followup/src/handler.ts
+++ b/app/packages/lambda/followup/src/handler.ts
@@ -24,7 +24,7 @@ import {
   EC2Client,
   DescribeNetworkInterfacesCommand,
 } from '@aws-sdk/client-ec2';
-import { canRun, formatGameStatus, getDiscordConfig, putPending } from '@gsd/shared';
+import { canRun, formatGameStatus, getEffectiveDiscordConfig, putPending } from '@gsd/shared';
 import type { DiscordAction, DiscordConfig, GameStatus } from '@gsd/shared';
 
 interface FollowupEvent {
@@ -252,7 +252,7 @@ function recheck(event: FollowupEvent, cfg: DiscordConfig, action: DiscordAction
  */
 export const handler = async (event: FollowupEvent): Promise<void> => {
   const tableName = requireEnv('TABLE_NAME');
-  const cfg = await getDiscordConfig(tableName);
+  const cfg = await getEffectiveDiscordConfig(tableName);
 
   let content: string;
   try {

--- a/app/packages/lambda/interactions/src/handler.test.ts
+++ b/app/packages/lambda/interactions/src/handler.test.ts
@@ -20,13 +20,13 @@ vi.mock('@noble/ed25519', () => ({
 
 // Mock the shared config + secrets stores so we never hit AWS.
 const getPublicKeyMock = vi.fn();
-const getDiscordConfigMock = vi.fn();
+const getEffectiveDiscordConfigMock = vi.fn();
 vi.mock('@gsd/shared', async () => {
   const actual = await vi.importActual<typeof import('@gsd/shared')>('@gsd/shared');
   return {
     ...actual,
     getPublicKey: (...args: unknown[]) => getPublicKeyMock(...args),
-    getDiscordConfig: (...args: unknown[]) => getDiscordConfigMock(...args),
+    getEffectiveDiscordConfig: (...args: unknown[]) => getEffectiveDiscordConfigMock(...args),
   };
 });
 
@@ -69,9 +69,9 @@ beforeEach(() => {
   lambdaMock.reset();
   verifyAsyncMock.mockReset();
   getPublicKeyMock.mockReset();
-  getDiscordConfigMock.mockReset();
+  getEffectiveDiscordConfigMock.mockReset();
   getPublicKeyMock.mockResolvedValue('0a'.repeat(32));
-  getDiscordConfigMock.mockResolvedValue({
+  getEffectiveDiscordConfigMock.mockResolvedValue({
     clientId: 'app-id',
     allowedGuilds: ['G1'],
     admins: { userIds: ['ADMIN'], roleIds: [] },
@@ -261,7 +261,7 @@ describe('InteractionsLambda: APPLICATION_COMMAND_AUTOCOMPLETE', () => {
   it('should cap autocomplete choices at 25 to satisfy the Discord limit', async () => {
     const manyGames = Array.from({ length: 50 }, (_, i) => `game${i}`);
     process.env['GAME_NAMES'] = manyGames.join(',');
-    getDiscordConfigMock.mockResolvedValueOnce({
+    getEffectiveDiscordConfigMock.mockResolvedValueOnce({
       clientId: 'app-id',
       allowedGuilds: ['G1'],
       admins: { userIds: ['U1'], roleIds: [] },

--- a/app/packages/lambda/interactions/src/handler.ts
+++ b/app/packages/lambda/interactions/src/handler.ts
@@ -17,7 +17,7 @@
 import { verifyAsync } from '@noble/ed25519';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
 import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
-import { canRun, getDiscordConfig, getPublicKey } from '@gsd/shared';
+import { canRun, getEffectiveDiscordConfig, getPublicKey } from '@gsd/shared';
 import type { DiscordAction, DiscordConfig } from '@gsd/shared';
 
 /** Discord interaction types we care about. Full list in discord-api-types. */
@@ -297,7 +297,7 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
   }
 
   const tableName = requireEnv('TABLE_NAME');
-  const cfg = await getDiscordConfig(tableName);
+  const cfg = await getEffectiveDiscordConfig(tableName);
 
   if (interaction.type === INTERACTION_APPLICATION_COMMAND_AUTOCOMPLETE) {
     return handleAutocomplete(interaction, cfg);

--- a/app/packages/server/src/controllers/discord.controller.ts
+++ b/app/packages/server/src/controllers/discord.controller.ts
@@ -90,13 +90,17 @@ export class DiscordController {
     };
   }
 
-  /** Returns the list of allowlisted guild IDs. The interactions Lambda rejects any command from a guild not in this list. */
+  /**
+   * Returns the dynamic allowlisted guild IDs and the Terraform-managed base guild IDs.
+   * The UI should render base guilds as locked (non-removable).
+   */
   @Get('guilds')
   async listGuilds() {
-    return { guilds: (await this.discord.getConfig()).allowedGuilds };
+    const [cfg, base] = await Promise.all([this.discord.getConfig(), this.discord.getBaseConfig()]);
+    return { guilds: cfg.allowedGuilds, baseGuilds: base.allowedGuilds };
   }
 
-  /** Adds a guild ID to the allowlist persisted in DynamoDB. Takes effect on the next interaction (Lambda re-reads per invocation). */
+  /** Adds a guild ID to the dynamic allowlist persisted in DynamoDB. Takes effect on the next interaction (Lambda re-reads per invocation). */
   @Post('guilds')
   async addGuild(@Body() body: { guildId?: unknown } = {}) {
     if (typeof body.guildId !== 'string') {
@@ -105,16 +109,25 @@ export class DiscordController {
     const guildId = body.guildId.trim();
     if (!guildId) throw new BadRequestException({ success: false, error: 'guildId required' });
     await this.discord.addAllowedGuild(guildId);
-    return { success: true, guilds: (await this.discord.getConfig()).allowedGuilds };
+    const [cfg, base] = await Promise.all([this.discord.getConfig(), this.discord.getBaseConfig()]);
+    return { success: true, guilds: cfg.allowedGuilds, baseGuilds: base.allowedGuilds };
   }
 
-  /** Removes a guild ID from the allowlist. Already-registered slash commands remain in Discord until manually cleaned up. */
+  /**
+   * Removes a guild ID from the dynamic allowlist. Returns 400 if the guild is
+   * in the Terraform base config — those entries require a tfvars edit + re-apply.
+   * Already-registered slash commands remain in Discord until manually cleaned up.
+   */
   @Delete('guilds/:guildId')
   async removeGuild(@Param('guildId') guildIdRaw: string) {
     const guildId = (guildIdRaw ?? '').trim();
     if (!guildId) throw new BadRequestException({ success: false, error: 'guildId required' });
-    await this.discord.removeAllowedGuild(guildId);
-    return { success: true, guilds: (await this.discord.getConfig()).allowedGuilds };
+    const result = await this.discord.removeAllowedGuild(guildId);
+    if (!result.ok) {
+      throw new BadRequestException({ success: false, error: result.reason });
+    }
+    const [cfg, base] = await Promise.all([this.discord.getConfig(), this.discord.getBaseConfig()]);
+    return { success: true, guilds: cfg.allowedGuilds, baseGuilds: base.allowedGuilds };
   }
 
   /**
@@ -130,19 +143,27 @@ export class DiscordController {
     return this.registrar.registerForGuild(guildId);
   }
 
-  /** Returns the global admin user/role lists. Admins bypass per-game permission gates in `canRun()`. */
+  /**
+   * Returns the dynamic admin user/role lists and the Terraform-managed base admin lists.
+   * The UI should render base admins as locked (non-removable).
+   */
   @Get('admins')
   async getAdmins() {
-    return (await this.discord.getConfig()).admins;
+    const [cfg, base] = await Promise.all([this.discord.getConfig(), this.discord.getBaseConfig()]);
+    return { ...cfg.admins, baseAdmins: base.admins };
   }
 
-  /** Replaces the admin user/role lists atomically. Omitted fields are treated as empty arrays (not "leave alone"). */
+  /**
+   * Replaces the dynamic admin user/role lists atomically. Omitted fields are treated as empty arrays
+   * (not "leave alone"). Base admins set via Terraform are unaffected by this endpoint.
+   */
   @Put('admins')
   async putAdmins(@Body() body: { userIds?: unknown; roleIds?: unknown } = {}) {
     const userIds = requireStringArray('userIds', body.userIds);
     const roleIds = requireStringArray('roleIds', body.roleIds);
     await this.discord.setAdmins({ userIds, roleIds });
-    return { success: true, admins: (await this.discord.getConfig()).admins };
+    const [cfg, base] = await Promise.all([this.discord.getConfig(), this.discord.getBaseConfig()]);
+    return { success: true, admins: cfg.admins, baseAdmins: base.admins };
   }
 
   /** Returns the per-game permission map (user/role IDs allowed to run specific actions on each game). */

--- a/app/packages/server/src/services/DiscordConfigService.test.ts
+++ b/app/packages/server/src/services/DiscordConfigService.test.ts
@@ -13,6 +13,7 @@ import { DiscordConfigService } from './DiscordConfigService.js';
 import { ConfigService, type TfOutputs } from './ConfigService.js';
 
 const getDiscordConfigMock = vi.fn();
+const getBaseDiscordConfigMock = vi.fn();
 const putDiscordConfigMock = vi.fn();
 const getBotTokenMock = vi.fn();
 const getPublicKeyMock = vi.fn();
@@ -25,6 +26,7 @@ vi.mock('@gsd/shared', async () => {
   return {
     ...actual,
     getDiscordConfig: (...args: unknown[]) => getDiscordConfigMock(...args),
+    getBaseDiscordConfig: (...args: unknown[]) => getBaseDiscordConfigMock(...args),
     putDiscordConfig: (...args: unknown[]) => putDiscordConfigMock(...args),
     getBotToken: (...args: unknown[]) => getBotTokenMock(...args),
     getPublicKey: (...args: unknown[]) => getPublicKeyMock(...args),
@@ -61,6 +63,7 @@ function makeService(outputs: TfOutputs | null = TF): DiscordConfigService {
 
 beforeEach(() => {
   getDiscordConfigMock.mockReset();
+  getBaseDiscordConfigMock.mockReset();
   putDiscordConfigMock.mockReset();
   getBotTokenMock.mockReset();
   getPublicKeyMock.mockReset();
@@ -72,6 +75,10 @@ beforeEach(() => {
     allowedGuilds: [],
     admins: { userIds: [], roleIds: [] },
     gamePermissions: {},
+  });
+  getBaseDiscordConfigMock.mockResolvedValue({
+    allowedGuilds: [],
+    admins: { userIds: [], roleIds: [] },
   });
   putDiscordConfigMock.mockResolvedValue(undefined);
   getBotTokenMock.mockResolvedValue(null);
@@ -126,6 +133,23 @@ describe('DiscordConfigService.getRedacted', () => {
     const redacted = await makeService().getRedacted();
     expect(redacted.botTokenSet).toBe(false);
     expect(redacted.publicKeySet).toBe(false);
+  });
+
+  it('should include base guild and admin lists from the BASE#discord row', async () => {
+    getBaseDiscordConfigMock.mockResolvedValue({
+      allowedGuilds: ['G-base'],
+      admins: { userIds: ['U-base'], roleIds: ['R-base'] },
+    });
+    const redacted = await makeService().getRedacted();
+    expect(redacted.baseAllowedGuilds).toEqual(['G-base']);
+    expect(redacted.baseAdmins).toEqual({ userIds: ['U-base'], roleIds: ['R-base'] });
+  });
+
+  it('should return empty base lists when no BASE#discord row exists', async () => {
+    getBaseDiscordConfigMock.mockResolvedValue({ allowedGuilds: [], admins: { userIds: [], roleIds: [] } });
+    const redacted = await makeService().getRedacted();
+    expect(redacted.baseAllowedGuilds).toEqual([]);
+    expect(redacted.baseAdmins).toEqual({ userIds: [], roleIds: [] });
   });
 });
 
@@ -188,7 +212,7 @@ describe('DiscordConfigService.allowedGuilds mutations', () => {
     );
   });
 
-  it('should remove a guild from the allowlist', async () => {
+  it('should remove a guild from the dynamic allowlist and return ok', async () => {
     getDiscordConfigMock.mockResolvedValue({
       clientId: '',
       allowedGuilds: ['G1', 'G2'],
@@ -196,11 +220,23 @@ describe('DiscordConfigService.allowedGuilds mutations', () => {
       gamePermissions: {},
     });
     const svc = makeService();
-    await svc.removeAllowedGuild('G1');
+    const result = await svc.removeAllowedGuild('G1');
+    expect(result).toEqual({ ok: true });
     expect(putDiscordConfigMock).toHaveBeenCalledWith(
       'test-discord',
       expect.objectContaining({ allowedGuilds: ['G2'] }),
     );
+  });
+
+  it('should refuse to remove a guild that is in the Terraform base config', async () => {
+    getBaseDiscordConfigMock.mockResolvedValue({
+      allowedGuilds: ['G-base'],
+      admins: { userIds: [], roleIds: [] },
+    });
+    const svc = makeService();
+    const result = await svc.removeAllowedGuild('G-base');
+    expect(result).toMatchObject({ ok: false });
+    expect(putDiscordConfigMock).not.toHaveBeenCalled();
   });
 
   it('should dedupe and drop empty strings when setAllowedGuilds is called', async () => {

--- a/app/packages/server/src/services/DiscordConfigService.ts
+++ b/app/packages/server/src/services/DiscordConfigService.ts
@@ -18,6 +18,7 @@ import { ConfigService } from './ConfigService.js';
 import {
   asStringArray,
   getBotToken,
+  getBaseDiscordConfig,
   getDiscordConfig,
   getPublicKey,
   invalidateSecretsCache,
@@ -25,6 +26,7 @@ import {
   putBotToken,
   putDiscordConfig,
   putPublicKey,
+  type BaseDiscordConfig,
   type DiscordAction,
   type DiscordConfig,
   type RedactedDiscordConfig,
@@ -58,6 +60,9 @@ export class DiscordConfigService {
   private cache: DiscordConfig | null = null;
   /** Promise of an in-flight load — coalesces concurrent reads into one DDB call. */
   private inflight: Promise<DiscordConfig> | null = null;
+
+  private baseCache: BaseDiscordConfig | null = null;
+  private baseInflight: Promise<BaseDiscordConfig> | null = null;
 
   constructor(private readonly config: ConfigService) {}
 
@@ -101,6 +106,31 @@ export class DiscordConfigService {
     return this.inflight;
   }
 
+  /**
+   * Read the Terraform-managed BASE#discord row. Empty base returned when the
+   * row is absent (i.e. no base Terraform variables were set). Result is cached
+   * until `invalidateCache()` is called, same as the dynamic config cache.
+   */
+  private async loadBase(): Promise<BaseDiscordConfig> {
+    if (this.baseCache) return this.baseCache;
+    if (this.baseInflight) return this.baseInflight;
+    this.baseInflight = (async () => {
+      try {
+        const tableName = this.config.getTfOutputs()?.discord_table_name;
+        if (!tableName) return { allowedGuilds: [], admins: { userIds: [], roleIds: [] } };
+        const base = await getBaseDiscordConfig(tableName);
+        this.baseCache = base;
+        return base;
+      } catch (err) {
+        logger.error('Failed to load base Discord config from DynamoDB', { err });
+        return { allowedGuilds: [], admins: { userIds: [], roleIds: [] } };
+      } finally {
+        this.baseInflight = null;
+      }
+    })();
+    return this.baseInflight;
+  }
+
   private async save(cfg: DiscordConfig): Promise<void> {
     await putDiscordConfig(this.tableName(), cfg);
     this.cache = cfg;
@@ -110,9 +140,14 @@ export class DiscordConfigService {
     });
   }
 
-  /** Full (unredacted) config — only call this server-side. */
+  /** Full (unredacted) dynamic config — only call this server-side. */
   async getConfig(): Promise<DiscordConfig> {
     return this.load();
+  }
+
+  /** The Terraform-managed base allowlist and admins — read-only from the app's perspective. */
+  async getBaseConfig(): Promise<BaseDiscordConfig> {
+    return this.loadBase();
   }
 
   /** Bot token from Secrets Manager (used by the slash-command registrar). `null` if unset. */
@@ -120,10 +155,11 @@ export class DiscordConfigService {
     return getBotToken(this.botTokenSecretArn());
   }
 
-  /** Redacted view safe to return to the web client. Includes `*Set` flags for both secrets. */
+  /** Redacted view safe to return to the web client. Includes `*Set` flags for both secrets and the Terraform base lists. */
   async getRedacted(): Promise<RedactedDiscordConfig> {
-    const cfg = await this.load();
-    const [botToken, publicKey] = await Promise.all([
+    const [cfg, base, botToken, publicKey] = await Promise.all([
+      this.load(),
+      this.loadBase(),
       getBotToken(this.botTokenSecretArn()).catch(() => null),
       getPublicKey(this.publicKeySecretArn()).catch(() => null),
     ]);
@@ -132,6 +168,8 @@ export class DiscordConfigService {
       allowedGuilds: cfg.allowedGuilds,
       admins: cfg.admins,
       gamePermissions: cfg.gamePermissions,
+      baseAllowedGuilds: base.allowedGuilds,
+      baseAdmins: base.admins,
       botTokenSet: Boolean(botToken),
       publicKeySet: Boolean(publicKey),
     };
@@ -186,11 +224,23 @@ export class DiscordConfigService {
     }
   }
 
-  /** Remove a guild from the allowlist; no-op if it wasn't there. */
-  async removeAllowedGuild(guildId: string): Promise<void> {
+  /**
+   * Remove a guild from the dynamic allowlist. Returns `{ ok: false }` when the
+   * guild is in the Terraform base config — those entries can only be removed by
+   * editing tfvars and re-applying Terraform.
+   */
+  async removeAllowedGuild(guildId: string): Promise<{ ok: true } | { ok: false; reason: string }> {
+    const base = await this.loadBase();
+    if (base.allowedGuilds.includes(guildId)) {
+      return {
+        ok: false,
+        reason: `Guild ${guildId} is in the Terraform base config and cannot be removed via the UI. Edit base_allowed_guilds in tfvars and re-apply Terraform.`,
+      };
+    }
     const cfg = await this.load();
     cfg.allowedGuilds = cfg.allowedGuilds.filter((g) => g !== guildId);
     await this.save(cfg);
+    return { ok: true };
   }
 
   /**
@@ -254,6 +304,7 @@ export class DiscordConfigService {
   /** Drop the in-memory cache so the next read sees fresh values from DDB. */
   invalidateCache(): void {
     this.cache = null;
+    this.baseCache = null;
   }
 }
 

--- a/app/packages/shared/src/ddb/configStore.test.ts
+++ b/app/packages/shared/src/ddb/configStore.test.ts
@@ -5,7 +5,7 @@ import {
   GetCommand,
   PutCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { getDiscordConfig, putDiscordConfig } from './configStore.js';
+import { getBaseDiscordConfig, getDiscordConfig, getEffectiveDiscordConfig, putDiscordConfig } from './configStore.js';
 import { __resetDocClient } from './client.js';
 
 const ddb = mockClient(DynamoDBDocumentClient);
@@ -102,6 +102,114 @@ describe('getDiscordConfig', () => {
     const calls = ddb.commandCalls(GetCommand);
     expect(calls).toHaveLength(1);
     expect(calls[0]!.args[0]!.input.ConsistentRead).toBe(true);
+  });
+});
+
+describe('getBaseDiscordConfig', () => {
+  beforeEach(() => {
+    ddb.reset();
+    __resetDocClient();
+  });
+
+  it('should return an empty base when the BASE#discord row is absent', async () => {
+    ddb.on(GetCommand).resolves({});
+    const base = await getBaseDiscordConfig(TABLE);
+    expect(base).toEqual({ allowedGuilds: [], admins: { userIds: [], roleIds: [] } });
+  });
+
+  it('should parse allowedGuilds and admins from a stored base row', async () => {
+    ddb.on(GetCommand).resolves({
+      Item: {
+        pk: 'BASE#discord',
+        sk: 'BASE',
+        data: {
+          allowedGuilds: ['G-base'],
+          admins: { userIds: ['U-base'], roleIds: ['R-base'] },
+        },
+      },
+    });
+    const base = await getBaseDiscordConfig(TABLE);
+    expect(base.allowedGuilds).toEqual(['G-base']);
+    expect(base.admins).toEqual({ userIds: ['U-base'], roleIds: ['R-base'] });
+  });
+
+  it('should sanitize malformed base data without throwing', async () => {
+    ddb.on(GetCommand).resolves({
+      Item: {
+        pk: 'BASE#discord',
+        sk: 'BASE',
+        data: { allowedGuilds: 'not-an-array', admins: null },
+      },
+    });
+    const base = await getBaseDiscordConfig(TABLE);
+    expect(base.allowedGuilds).toEqual([]);
+    expect(base.admins).toEqual({ userIds: [], roleIds: [] });
+  });
+
+  it('should issue a strongly consistent read for the base row', async () => {
+    ddb.on(GetCommand).resolves({});
+    await getBaseDiscordConfig(TABLE);
+    const calls = ddb.commandCalls(GetCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0]!.input.ConsistentRead).toBe(true);
+  });
+});
+
+describe('getEffectiveDiscordConfig', () => {
+  beforeEach(() => {
+    ddb.reset();
+    __resetDocClient();
+  });
+
+  it('should merge base and dynamic guild lists without duplicates', async () => {
+    ddb
+      .on(GetCommand, { Key: { pk: 'CONFIG#discord', sk: 'CONFIG' } })
+      .resolves({
+        Item: { data: { clientId: 'c1', allowedGuilds: ['G1', 'G-shared'], admins: { userIds: [], roleIds: [] }, gamePermissions: {} } },
+      })
+      .on(GetCommand, { Key: { pk: 'BASE#discord', sk: 'BASE' } })
+      .resolves({
+        Item: { data: { allowedGuilds: ['G-base', 'G-shared'], admins: { userIds: [], roleIds: [] } } },
+      });
+    const cfg = await getEffectiveDiscordConfig(TABLE);
+    expect(cfg.allowedGuilds).toEqual(expect.arrayContaining(['G1', 'G-base', 'G-shared']));
+    expect(cfg.allowedGuilds).toHaveLength(3);
+  });
+
+  it('should merge base and dynamic admin lists without duplicates', async () => {
+    ddb
+      .on(GetCommand, { Key: { pk: 'CONFIG#discord', sk: 'CONFIG' } })
+      .resolves({
+        Item: { data: { clientId: '', allowedGuilds: [], admins: { userIds: ['U1'], roleIds: ['R-shared'] }, gamePermissions: {} } },
+      })
+      .on(GetCommand, { Key: { pk: 'BASE#discord', sk: 'BASE' } })
+      .resolves({
+        Item: { data: { allowedGuilds: [], admins: { userIds: ['U-base'], roleIds: ['R-shared'] } } },
+      });
+    const cfg = await getEffectiveDiscordConfig(TABLE);
+    expect(cfg.admins.userIds).toEqual(expect.arrayContaining(['U1', 'U-base']));
+    expect(cfg.admins.userIds).toHaveLength(2);
+    expect(cfg.admins.roleIds).toEqual(['R-shared']);
+  });
+
+  it('should preserve dynamic gamePermissions and clientId in the effective config', async () => {
+    ddb
+      .on(GetCommand, { Key: { pk: 'CONFIG#discord', sk: 'CONFIG' } })
+      .resolves({
+        Item: {
+          data: {
+            clientId: 'my-client',
+            allowedGuilds: [],
+            admins: { userIds: [], roleIds: [] },
+            gamePermissions: { palworld: { userIds: ['U1'], roleIds: [], actions: ['start'] } },
+          },
+        },
+      })
+      .on(GetCommand, { Key: { pk: 'BASE#discord', sk: 'BASE' } })
+      .resolves({});
+    const cfg = await getEffectiveDiscordConfig(TABLE);
+    expect(cfg.clientId).toBe('my-client');
+    expect(cfg.gamePermissions).toEqual({ palworld: { userIds: ['U1'], roleIds: [], actions: ['start'] } });
   });
 });
 

--- a/app/packages/shared/src/ddb/configStore.ts
+++ b/app/packages/shared/src/ddb/configStore.ts
@@ -1,10 +1,13 @@
 import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
-import type { DiscordConfig } from '../types.js';
+import type { BaseDiscordConfig, DiscordConfig } from '../types.js';
 import { asString, asStringArray, isSafeGameKey, sanitizeGamePermission } from '../sanitize.js';
 import { getDocClient } from './client.js';
 
 const CONFIG_PK = 'CONFIG#discord';
 const CONFIG_SK = 'CONFIG';
+
+const BASE_PK = 'BASE#discord';
+const BASE_SK = 'BASE';
 
 /** Empty, mutable DiscordConfig used when no item exists yet. */
 function emptyConfig(): DiscordConfig {
@@ -38,6 +41,66 @@ function parseConfigData(raw: unknown): DiscordConfig {
       roleIds: asStringArray(rawAdmins['roleIds']),
     },
     gamePermissions,
+  };
+}
+
+/** Empty base returned when no BASE#discord row exists (all lists default empty). */
+function emptyBase(): BaseDiscordConfig {
+  return { allowedGuilds: [], admins: { userIds: [], roleIds: [] } };
+}
+
+/**
+ * Coerce the stored BASE#discord `data` payload into a valid BaseDiscordConfig.
+ * Applies the same defensive sanitization as parseConfigData so hand-edited
+ * items or a missing row don't crash callers.
+ */
+function parseBaseData(raw: unknown): BaseDiscordConfig {
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  const rawAdmins = (obj['admins'] ?? {}) as Record<string, unknown>;
+  return {
+    allowedGuilds: asStringArray(obj['allowedGuilds']),
+    admins: {
+      userIds: asStringArray(rawAdmins['userIds']),
+      roleIds: asStringArray(rawAdmins['roleIds']),
+    },
+  };
+}
+
+/**
+ * Read the Terraform-managed BASE#discord row. Returns an empty base when the
+ * row is absent (i.e. all three base Terraform variables are unset).
+ */
+export async function getBaseDiscordConfig(tableName: string): Promise<BaseDiscordConfig> {
+  const resp = await getDocClient().send(
+    new GetCommand({
+      TableName: tableName,
+      Key: { pk: BASE_PK, sk: BASE_SK },
+      ConsistentRead: true,
+    }),
+  );
+  if (!resp.Item) return emptyBase();
+  return parseBaseData(resp.Item['data']);
+}
+
+/**
+ * Read both the Terraform base row and the app-managed dynamic row, then return
+ * their union as the effective config. This is what `canRun()` and the Lambdas
+ * should use — it ensures base entries are always enforced even when the dynamic
+ * row doesn't list them.
+ */
+export async function getEffectiveDiscordConfig(tableName: string): Promise<DiscordConfig> {
+  const [dynamic, base] = await Promise.all([
+    getDiscordConfig(tableName),
+    getBaseDiscordConfig(tableName),
+  ]);
+  return {
+    clientId: dynamic.clientId,
+    allowedGuilds: [...new Set([...base.allowedGuilds, ...dynamic.allowedGuilds])],
+    admins: {
+      userIds: [...new Set([...base.admins.userIds, ...dynamic.admins.userIds])],
+      roleIds: [...new Set([...base.admins.roleIds, ...dynamic.admins.roleIds])],
+    },
+    gamePermissions: dynamic.gamePermissions,
   };
 }
 

--- a/app/packages/shared/src/types.ts
+++ b/app/packages/shared/src/types.ts
@@ -31,12 +31,28 @@ export interface DiscordConfig {
   gamePermissions: Record<string, DiscordGamePermission>;
 }
 
+/**
+ * Terraform-managed baseline stored in the BASE#discord DynamoDB row.
+ *
+ * These entries form a read-only floor: the management UI can never remove
+ * them (only `terraform apply` can). The effective config seen by `canRun()`
+ * and the Lambdas is the union of this base and the dynamic CONFIG#discord row.
+ */
+export interface BaseDiscordConfig {
+  allowedGuilds: string[];
+  admins: DiscordAdmins;
+}
+
 /** Config shape returned to the web client — includes secret-presence flags, never the secret values. */
 export interface RedactedDiscordConfig {
   clientId: string;
   allowedGuilds: string[];
   admins: DiscordAdmins;
   gamePermissions: Record<string, DiscordGamePermission>;
+  /** Guild IDs locked in by Terraform — shown as non-removable in the UI. */
+  baseAllowedGuilds: string[];
+  /** Admin user/role IDs locked in by Terraform — shown as non-removable in the UI. */
+  baseAdmins: DiscordAdmins;
   botTokenSet: boolean;
   publicKeySet: boolean;
 }

--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -19,7 +19,7 @@ step 3 of the [setup guide](/setup) for details.
 | `watchdog.tf` | `watchdog` Lambda with its IAM, EventBridge schedule at `rate(${watchdog_interval_minutes} minute(s))`. |
 | `interactions.tf` | `interactions` Lambda with IAM + Function URL (`auth_type = NONE`, CORS for `https://discord.com`). Exposes `interactions_invoke_url`. |
 | `followup.tf` | `followup` Lambda with IAM (`ecs:RunTask`, `StopTask`, `DescribeTasks`, `iam:PassRole`, `dynamodb:GetItem`/`PutItem`, `ec2:DescribeNetworkInterfaces`). Async-invoked by interactions. |
-| `discord_store.tf` | DynamoDB table (pk+sk, TTL on `expiresAt`), two Secrets Manager secrets (`${project_name}/discord/bot-token`, `/discord/public-key`) with `recovery_window_in_days = 0` and `lifecycle.ignore_changes` on seeded secret values. Optional `CONFIG#discord` DynamoDB item seeded from tfvars. |
+| `discord_store.tf` | DynamoDB table (pk+sk, TTL on `expiresAt`), two Secrets Manager secrets (`${project_name}/discord/bot-token`, `/discord/public-key`) with `recovery_window_in_days = 0` and `lifecycle.ignore_changes` on seeded secret values. Optional `CONFIG#discord` DynamoDB item seeded from tfvars. Optional `BASE#discord` item holding the Terraform-managed base allowlist/admins (see `base_allowed_guilds` / `base_admin_*` variables). |
 | `variables.tf` | Every configurable input. See the table below. |
 | `outputs.tf` | Every value the management app (and humans) consume. |
 | `terraform.tfvars.example` | Starting point for your `terraform.tfvars`. |
@@ -41,6 +41,9 @@ step 3 of the [setup guide](/setup) for details.
 | `discord_application_id` | `string` | `""` | Seeds `CONFIG#discord` in DynamoDB on first apply. Skipped if empty. |
 | `discord_bot_token` | `string` (sensitive) | `""` | Seeds `${project_name}/discord/bot-token`. Empty → Terraform writes `"placeholder"`. |
 | `discord_public_key` | `string` (sensitive) | `""` | Seeds `${project_name}/discord/public-key`. Same placeholder behaviour. |
+| `base_allowed_guilds` | `list(string)` | `[]` | Guild IDs written to the `BASE#discord` row on every apply. The management UI shows these as locked; they cannot be removed via the UI. Update in tfvars + re-apply to change. |
+| `base_admin_user_ids` | `list(string)` | `[]` | Discord user IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
+| `base_admin_role_ids` | `list(string)` | `[]` | Discord role IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
 | `tags` | `map(string)` | defaults | Merged into `default_tags` for cost allocation (`Project`). |
 
 ## Outputs

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -321,6 +321,18 @@ connect it to a Discord application.
      paste and Save. The dashboard writes directly to DynamoDB and Secrets
      Manager.
 
+   Optionally set a **base allowlist and admins** in `terraform.tfvars`.
+   These are written to a separate `BASE#discord` DynamoDB row on every
+   `terraform apply` and cannot be removed via the dashboard UI — only a
+   tfvars edit + re-apply can change them. Useful for locking in your own
+   guild and user ID before handing the dashboard to others:
+
+   ```hcl
+   base_allowed_guilds = ["123456789012345678"]
+   base_admin_user_ids = ["987654321098765432"]
+   base_admin_role_ids = []
+   ```
+
 3. **Copy the interactions endpoint URL** (the `interactions_invoke_url`
    Terraform output, also shown in the dashboard Credentials tab) into the
    Discord Developer Portal under **General Information → Interactions

--- a/terraform/discord_store.tf
+++ b/terraform/discord_store.tf
@@ -100,6 +100,40 @@ resource "aws_secretsmanager_secret_version" "discord_public_key" {
 # the UI creates the row on first save — avoids a stray empty row on UI-only
 # deployments.
 
+# ─ Discord base config row ────────────────────────────────────────────────────
+# Written on every `terraform apply` when any base list is non-empty. Unlike the
+# config seed below, there is NO `ignore_changes` — re-applying after editing
+# the variables always updates this row. The management app merges this row with
+# the dynamic CONFIG#discord row; entries here can never be removed via the UI.
+#
+# The resource is skipped entirely when all three lists are empty so a
+# UI-only deployment doesn't end up with a stray empty row.
+
+resource "aws_dynamodb_table_item" "discord_base_config" {
+  count = (length(var.base_allowed_guilds) + length(var.base_admin_user_ids) + length(var.base_admin_role_ids)) > 0 ? 1 : 0
+
+  table_name = aws_dynamodb_table.discord.name
+  hash_key   = aws_dynamodb_table.discord.hash_key
+  range_key  = aws_dynamodb_table.discord.range_key
+
+  item = jsonencode({
+    pk = { S = "BASE#discord" }
+    sk = { S = "BASE" }
+    data = {
+      M = {
+        allowedGuilds = { L = [for g in var.base_allowed_guilds : { S = g }] }
+        admins = {
+          M = {
+            userIds = { L = [for u in var.base_admin_user_ids : { S = u }] }
+            roleIds = { L = [for r in var.base_admin_role_ids : { S = r }] }
+          }
+        }
+      }
+    }
+    updatedAt = { N = "0" }
+  })
+}
+
 resource "aws_dynamodb_table_item" "discord_config_seed" {
   count = var.discord_application_id != "" ? 1 : 0
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -29,6 +29,15 @@ watchdog_min_packets      = 100
 # discord_bot_token      = "MTIz...xyz"
 # discord_public_key     = "0123abc..."
 
+# Base allowlist / admins (optional — permanent floor managed by Terraform).
+# Guilds and admin user/role IDs listed here are written to a separate
+# BASE#discord DynamoDB row on every `terraform apply`. The management UI
+# shows them as locked and cannot remove them; only editing these lists and
+# re-applying Terraform can change the base set.
+# base_allowed_guilds  = ["123456789012345678"]
+# base_admin_user_ids  = ["987654321098765432"]
+# base_admin_role_ids  = []
+
 # Override game server settings (optional — defaults are set in variables.tf)
 game_servers = {
   palworld = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -135,6 +135,33 @@ variable "dns_ttl" {
   default     = 30
 }
 
+# ── Discord base allowlist / admins (optional) ───────────────────────────────
+# These lists are Terraform-managed and written to a separate DynamoDB row
+# (BASE#discord) on every `terraform apply`. They form an immutable floor that
+# the management UI can never remove — operators can only add/remove entries
+# they themselves added via the UI.
+#
+# Leave all three empty (the default) to manage everything through the UI.
+# Edit the lists in terraform.tfvars and re-apply to change the base set.
+
+variable "base_allowed_guilds" {
+  description = "Guild IDs permanently allowlisted by Terraform. Cannot be removed via the management UI."
+  type        = list(string)
+  default     = []
+}
+
+variable "base_admin_user_ids" {
+  description = "Discord user IDs with permanent server-wide admin privileges. Cannot be removed via the management UI."
+  type        = list(string)
+  default     = []
+}
+
+variable "base_admin_role_ids" {
+  description = "Discord role IDs with permanent server-wide admin privileges. Cannot be removed via the management UI."
+  type        = list(string)
+  default     = []
+}
+
 # ── Discord bot credentials (optional) ───────────────────────────────────────
 # If set, these seed the AWS Secrets Manager secrets on first `terraform apply`
 # so the bot is fully configured without touching the web UI. Leave empty to


### PR DESCRIPTION
## Summary
Introduces a Terraform-managed baseline for Discord allowlists and admin lists that cannot be removed via the management UI. This allows operators to enforce a permanent floor of allowed guilds and admins while still permitting the UI to manage additional entries.

## Key Changes

- **New `BaseDiscordConfig` type** in shared types representing the read-only Terraform baseline (allowedGuilds and admins)

- **New DynamoDB row `BASE#discord`** written by Terraform on every apply when any base list is non-empty, with three new Terraform variables:
  - `base_allowed_guilds`: Guild IDs permanently allowlisted
  - `base_admin_user_ids`: User IDs with permanent admin privileges
  - `base_admin_role_ids`: Role IDs with permanent admin privileges

- **New `getBaseDiscordConfig()` function** reads the BASE#discord row with strongly consistent reads, returning an empty base when absent

- **New `getEffectiveDiscordConfig()` function** merges the Terraform base and dynamic CONFIG#discord rows, deduplicating entries. This is now used by both Lambda handlers for permission checks

- **Updated `DiscordConfigService`** to:
  - Cache and load the base config separately with coalesced concurrent reads
  - Expose `getBaseConfig()` method for retrieving the base config
  - Prevent removal of guilds/admins that exist in the Terraform base (returns error with explanation)
  - Include base lists in the redacted config sent to the web client

- **Updated REST API endpoints** to return both dynamic and base lists:
  - `GET /discord/guilds` and `GET /discord/admins` now include `baseGuilds` and `baseAdmins`
  - `DELETE /discord/guilds/:guildId` returns 400 if the guild is in the base config
  - All mutation endpoints return the updated base lists alongside dynamic lists

- **Updated Lambda handlers** (interactions and followup) to use `getEffectiveDiscordConfig()` instead of `getDiscordConfig()` for permission checks, ensuring base entries are always enforced

## Implementation Details

- Base config is cached in `DiscordConfigService` and invalidated alongside the dynamic config
- Terraform resource uses `count` to skip creation when all base lists are empty (UI-only deployments)
- Defensive parsing sanitizes malformed base data without throwing
- Web client can render base entries as locked/non-removable based on the new `baseAllowedGuilds` and `baseAdmins` fields in the redacted config

https://claude.ai/code/session_01GxkgH9sABMbHDCQqXehHP1