### PR TITLE
chore(terraform): anonymize tfvars examples and remove game_servers default

### DIFF
--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -32,7 +32,7 @@ step 3 of the [setup guide](/setup) for details.
 | `project_name` | `string` | `game-servers` | Prefix for named resources and the Secrets Manager paths. |
 | `vpc_cidr` | `string` | `10.0.0.0/16` | Parent CIDR; subnets are /24s within it. |
 | `game_servers` | `map(object)` | — | The single source of truth. Per-game: `image`, `cpu`, `memory`, `ports[]`, `environment[]`, `volumes[]` (`name` + `container_path`), `https`. Each `volumes` entry creates its own EFS access point rooted at `/${game}/${name}`. |
-| `hosted_zone_name` | `string` | `codercoco.com` | Existing Route 53 zone looked up as a data source. |
+| `hosted_zone_name` | `string` | _(required)_ | Existing Route 53 zone looked up as a data source (e.g. `example.com`). |
 | `acm_certificate_domain` | `string` | `null` → `*.{hosted_zone_name}` | Wildcard ACM cert for the ALB listener. |
 | `dns_ttl` | `number` | `30` | TTL on Route 53 A records the update-dns Lambda writes. Keep low for fast task churn. |
 | `watchdog_interval_minutes` | `number` | `15` | How often the watchdog schedule fires. |

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -5,8 +5,8 @@ aws_region   = "us-east-1"
 project_name = "game-servers"
 
 # Domain for server DNS records (must have a hosted zone in Route 53)
-# Creates: palworld.codercoco.com, satisfactory.codercoco.com, etc.
-hosted_zone_name = "codercoco.com"
+# Creates: {game}.example.com for each entry in game_servers below.
+hosted_zone_name = "example.com"
 
 # Watchdog: auto-shuts down idle servers after (interval × idle_checks) minutes
 # Defaults: 15 min × 4 checks = 60 minutes of idle before shutdown
@@ -16,7 +16,7 @@ watchdog_idle_checks      = 4
 watchdog_min_packets      = 100
 
 # ACM certificate domain for HTTPS game servers (default: *.{hosted_zone_name})
-# acm_certificate_domain = "*.codercoco.com"
+# acm_certificate_domain = "*.example.com"
 
 # Discord bot credentials (optional — leave commented out to configure via the web UI).
 # If set here, they seed the backing stores on the first `terraform apply`.
@@ -38,58 +38,37 @@ watchdog_min_packets      = 100
 # base_admin_user_ids  = ["987654321098765432"]
 # base_admin_role_ids  = []
 
-# Override game server settings (optional — defaults are set in variables.tf)
-game_servers = {
-  palworld = {
-    image  = "thijsvanloef/palworld-server-docker:latest"
-    cpu    = 2048
-    memory = 8192
-    ports = [
-      { container = 8211,  protocol = "udp" },
-      { container = 27015, protocol = "udp" },
-    ]
-    environment = [
-      { name = "PLAYERS",        value = "8" },
-      { name = "MULTITHREADING", value = "true" },
-      { name = "RCON_ENABLED",   value = "true" },
-      { name = "RCON_PORT",      value = "25575" },
-      { name = "ADMIN_PASSWORD", value = "your_secure_password_here" },
-      { name = "SERVER_NAME",    value = "CoderCoco Palworld" },
-      { name = "UPDATE_ON_BOOT", value = "true" },
-      { name = "BACKUP_ENABLED", value = "true" },
-      { name = "BACKUP_CRON_EXPRESSION", value = "0 */6 * * *" },
-      { name = "DIFFICULTY",     value = "Normal" },
-    ]
-    # Each entry gets its own EFS access point rooted at /${game}/${name}.
-    # Add more entries if the image expects multiple mount paths.
-    volumes = [
-      { name = "saves", container_path = "/palworld" },
-    ]
-    https = false
-  }
-
-  # FoundryVTT — web-based virtual tabletop (requires HTTPS)
-  # The felddy/foundryvtt image needs FOUNDRY_USERNAME + FOUNDRY_PASSWORD
-  # to download the licensed FoundryVTT software on first run.
-  foundryvtt = {
-    image  = "felddy/foundryvtt:release"
-    cpu    = 1024
-    memory = 2048
-    ports = [
-      { container = 30000, protocol = "tcp" },
-    ]
-    environment = [
-      { name = "FOUNDRY_USERNAME",    value = "your_foundry_username" },
-      { name = "FOUNDRY_PASSWORD",    value = "your_foundry_password" },
-      { name = "FOUNDRY_ADMIN_KEY",   value = "your_admin_key" },
-      { name = "FOUNDRY_PROXY_SSL",   value = "true" },
-      { name = "FOUNDRY_PROXY_PORT",  value = "443" },
-      { name = "CONTAINER_VERBOSE",   value = "true" },
-      { name = "FOUNDRY_WORLD",       value = "my-world" },
-    ]
-    volumes = [
-      { name = "data", container_path = "/data" },
-    ]
-    https = true
-  }
-}
+# Game server definitions — required, no defaults are provided.
+# Each entry creates its own ECS task definition, EFS access point, log group,
+# and security group rules. Add as many games as you need.
+#
+# Example entry (Palworld):
+# game_servers = {
+#   palworld = {
+#     image  = "thijsvanloef/palworld-server-docker:latest"
+#     cpu    = 2048
+#     memory = 8192
+#     ports = [
+#       { container = 8211,  protocol = "udp" },
+#       { container = 27015, protocol = "udp" },
+#     ]
+#     environment = [
+#       { name = "PLAYERS",        value = "16" },
+#       { name = "MULTITHREADING", value = "true" },
+#       { name = "RCON_ENABLED",   value = "true" },
+#       { name = "RCON_PORT",      value = "25575" },
+#       { name = "ADMIN_PASSWORD", value = "your_secure_password_here" },
+#       { name = "SERVER_NAME",    value = "My Palworld Server" },
+#       { name = "UPDATE_ON_BOOT", value = "true" },
+#       { name = "BACKUP_ENABLED", value = "true" },
+#       { name = "BACKUP_CRON_EXPRESSION", value = "0 */6 * * *" },
+#       { name = "DIFFICULTY",     value = "Normal" },
+#     ]
+#     # Each entry gets its own EFS access point rooted at /${game}/${name}.
+#     # Add more entries if the image expects multiple mount paths.
+#     volumes = [
+#       { name = "saves", container_path = "/palworld" },
+#     ]
+#     https = false
+#   }
+# }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,78 +41,12 @@ variable "game_servers" {
     ])
     error_message = "Each game server must have at least one volume entry with non-empty name and container_path."
   }
-
-  default = {
-    palworld = {
-      image  = "thijsvanloef/palworld-server-docker:latest"
-      cpu    = 2048
-      memory = 8192
-      ports = [
-        { container = 8211,  protocol = "udp" },
-        { container = 27015, protocol = "udp" }, # Steam query port
-      ]
-      environment = [
-        { name = "PLAYERS",           value = "16" },
-        { name = "MULTITHREADING",    value = "true" },
-        { name = "RCON_ENABLED",      value = "true" },
-        { name = "RCON_PORT",         value = "25575" },
-        { name = "ADMIN_PASSWORD",    value = "changeme_please" },
-        { name = "SERVER_NAME",       value = "Palworld Server" },
-        { name = "UPDATE_ON_BOOT",    value = "true" },
-        { name = "BACKUP_ENABLED",    value = "true" },
-        { name = "BACKUP_CRON_EXPRESSION", value = "0 */6 * * *" },
-        { name = "DIFFICULTY",        value = "Normal" },
-      ]
-      volumes = [
-        { name = "saves", container_path = "/palworld" },
-      ]
-      https = false
-    }
-
-    satisfactory = {
-      image  = "wolveix/satisfactory-server:latest"
-      cpu    = 2048
-      memory = 8192
-      ports = [
-        { container = 7777,  protocol = "udp" },
-        { container = 15000, protocol = "udp" },
-        { container = 15777, protocol = "udp" },
-      ]
-      environment = [
-        { name = "MAXPLAYERS", value = "4" },
-        { name = "PGID",       value = "1000" },
-        { name = "PUID",       value = "1000" },
-      ]
-      volumes = [
-        { name = "config", container_path = "/config" },
-      ]
-      https = false
-    }
-
-    foundryvtt = {
-      image  = "felddy/foundryvtt:release"
-      cpu    = 1024
-      memory = 2048
-      ports = [
-        { container = 30000, protocol = "tcp" },
-      ]
-      environment = [
-        { name = "FOUNDRY_PROXY_SSL",  value = "true" },
-        { name = "FOUNDRY_PROXY_PORT", value = "443" },
-        { name = "CONTAINER_VERBOSE",  value = "true" },
-      ]
-      volumes = [
-        { name = "data", container_path = "/data" },
-      ]
-      https = true
-    }
-  }
 }
 
 # ── HTTPS / ALB ─────────────────────────────────────────────────────────────
 
 variable "acm_certificate_domain" {
-  description = "Domain for the ACM TLS certificate used by the ALB (e.g. *.codercoco.com)"
+  description = "Domain for the ACM TLS certificate used by the ALB (e.g. *.example.com). Defaults to *.{hosted_zone_name} when null."
   type        = string
   default     = null # When null, defaults to *.{hosted_zone_name}
 }
@@ -140,9 +74,8 @@ variable "watchdog_min_packets" {
 # ── DNS ──────────────────────────────────────────────────────────────────────
 
 variable "hosted_zone_name" {
-  description = "Route 53 hosted zone domain (must already exist)"
+  description = "Route 53 hosted zone domain (must already exist, e.g. example.com)"
   type        = string
-  default     = "codercoco.com"
 }
 
 variable "dns_ttl" {


### PR DESCRIPTION
## Summary
This PR removes hardcoded default game server configurations and makes the `game_servers` variable required, shifting to a more flexible example-driven approach. The example configuration is now generic and commented out, requiring users to explicitly define their own game servers.

## Key Changes

- **Removed default game server definitions** from `variables.tf`: Deleted pre-configured examples for Palworld, Satisfactory, and FoundryVTT that were provided as defaults
- **Made `game_servers` variable required**: Removed the `default` block, making this variable mandatory for all deployments
- **Updated `terraform.tfvars.example`**:
  - Changed `hosted_zone_name` from `"codercoco.com"` to generic `"example.com"`
  - Replaced concrete game server examples with a single commented-out Palworld example
  - Added comprehensive documentation explaining the game server structure and how to add custom entries
  - Updated ACM certificate domain example to use `example.com`
- **Updated variable descriptions**:
  - `hosted_zone_name`: Now explicitly states it must already exist and provides example format
  - `acm_certificate_domain`: Clarified default behavior when null
- **Updated documentation** in `terraform.md` to reflect the new required variable approach

## Implementation Details

The change encourages explicit configuration over implicit defaults, reducing the risk of users accidentally deploying unwanted services. Users must now copy the example configuration and customize it for their specific needs, making the deployment process more intentional and transparent.

https://claude.ai/code/session_011XwGyddBHntiQYnmtgePVw