### PR TITLE
feat(discord): per-game connect_message in server-running responses

### DIFF
--- a/app/packages/lambda/followup/src/handler.ts
+++ b/app/packages/lambda/followup/src/handler.ts
@@ -69,6 +69,12 @@ function gameListFromEnv(): string[] {
   return (process.env['GAME_NAMES'] ?? '').split(',').map((s) => s.trim()).filter(Boolean);
 }
 
+/** Per-game connect message templates from Terraform, keyed by game name. */
+const CONNECT_MESSAGES: Record<string, string> = JSON.parse(process.env['CONNECT_MESSAGES'] ?? '{}');
+
+/** First container port per game, used to resolve the `{port}` placeholder. */
+const GAME_PORTS: Record<string, number> = JSON.parse(process.env['GAME_PORTS'] ?? '{}');
+
 function extractEniId(task: Task): string | null {
   for (const att of task.attachments ?? []) {
     if (att.type !== 'ElasticNetworkInterface') continue;
@@ -199,13 +205,13 @@ async function handleList(event: FollowupEvent, cfg: DiscordConfig): Promise<str
   );
   if (!visible.length) return "You don't have permission to view any server statuses.";
   const statuses = await Promise.all(visible.map((g) => getStatus(g)));
-  return statuses.map((s) => formatGameStatus(s)).join('\n');
+  return statuses.map((s) => formatGameStatus(s, CONNECT_MESSAGES[s.game], GAME_PORTS[s.game])).join('\n');
 }
 
 async function handleStatus(event: FollowupEvent): Promise<string> {
   if (!event.game) return 'Game is required.';
   const status = await getStatus(event.game);
-  return formatGameStatus(status);
+  return formatGameStatus(status, CONNECT_MESSAGES[event.game], GAME_PORTS[event.game]);
 }
 
 async function handleStart(event: FollowupEvent): Promise<string> {
@@ -222,6 +228,18 @@ async function handleStart(event: FollowupEvent): Promise<string> {
       game: event.game,
       action: 'start',
     });
+    const connectMsg = CONNECT_MESSAGES[event.game];
+    if (connectMsg) {
+      const port = GAME_PORTS[event.game];
+      const domain = process.env['DOMAIN_NAME'] ?? '';
+      const host = domain ? `${event.game}.${domain}` : '';
+      const rendered = connectMsg
+        .replace(/\{host\}/g, host)
+        .replace(/\{ip\}/g, '')
+        .replace(/\{port\}/g, port !== undefined ? String(port) : '')
+        .replace(/\{game\}/g, event.game);
+      return `${message}\n${rendered}`;
+    }
   }
   return message;
 }

--- a/app/packages/lambda/update-dns/src/handler.ts
+++ b/app/packages/lambda/update-dns/src/handler.ts
@@ -240,11 +240,14 @@ async function patchOriginal(
 /**
  * If a Discord interaction is pending for this task, PATCH it with the
  * resolved hostname/IP and delete the pending row.
+ *
+ * `publicIp` is omitted for HTTPS games because only the private IP is known
+ * at this point — the public entry point is always the ALB hostname.
  */
 async function notifyDiscordIfPending(
   taskArn: string,
   game: string,
-  publicIp: string,
+  publicIp?: string,
 ): Promise<void> {
   if (!TABLE_NAME) return;
   try {
@@ -319,7 +322,7 @@ async function handleHttps(
     const ip = await resolveIp(taskArn, clusterArn, 'private');
     if (!ip) return { status: 'error', reason: 'no_ip' };
     await registerAlb(tgArn, ip);
-    await notifyDiscordIfPending(taskArn, game, ip);
+    await notifyDiscordIfPending(taskArn, game); // private IP intentionally omitted — use hostname only
     return { status: 'registered', game, ip };
   }
   if (lastStatus === 'STOPPED') {

--- a/app/packages/lambda/update-dns/src/handler.ts
+++ b/app/packages/lambda/update-dns/src/handler.ts
@@ -50,6 +50,12 @@ const ALB_TARGET_GROUPS: Record<string, string> = JSON.parse(
 );
 const TABLE_NAME = process.env['TABLE_NAME'] ?? '';
 
+/** Per-game connect message templates from Terraform, keyed by game name. */
+const CONNECT_MESSAGES: Record<string, string> = JSON.parse(process.env['CONNECT_MESSAGES'] ?? '{}');
+
+/** First container port per game, used to resolve the `{port}` placeholder. */
+const GAME_PORTS: Record<string, number> = JSON.parse(process.env['GAME_PORTS'] ?? '{}');
+
 const FAMILY_TO_GAME = new Map<string, string>(GAME_NAMES.map((g) => [`${g}-server`, g]));
 
 function requireEnv(name: string): string {
@@ -245,7 +251,11 @@ async function notifyDiscordIfPending(
     const pending = await getPending(TABLE_NAME, taskArn);
     if (!pending) return;
     const hostname = `${game}.${DOMAIN_NAME}`;
-    const message = formatGameStatus({ game, state: 'running', publicIp, hostname, taskArn });
+    const message = formatGameStatus(
+      { game, state: 'running', publicIp, hostname, taskArn },
+      CONNECT_MESSAGES[game],
+      GAME_PORTS[game],
+    );
     await patchOriginal(pending.applicationId, pending.interactionToken, message);
     await deletePending(TABLE_NAME, taskArn);
   } catch (err) {

--- a/app/packages/shared/src/formatStatus.test.ts
+++ b/app/packages/shared/src/formatStatus.test.ts
@@ -112,4 +112,15 @@ describe('formatGameStatus', () => {
     );
     expect(line).toBe('🟢 **palworld**: running\nconnect at palworld.example.com');
   });
+
+  it('should ignore the connect message when state is not running', () => {
+    const stopped = formatGameStatus({ game: 'palworld', state: 'stopped' }, 'connect at {host}:8211');
+    expect(stopped).toBe('⚫ **palworld**: stopped');
+
+    const starting = formatGameStatus({ game: 'palworld', state: 'starting' }, 'connect at {host}:8211');
+    expect(starting).toBe('🟡 **palworld**: starting');
+
+    const error = formatGameStatus({ game: 'palworld', state: 'error' }, 'connect at {host}:8211');
+    expect(error).toBe('⚠️ **palworld**: error');
+  });
 });

--- a/app/packages/shared/src/formatStatus.test.ts
+++ b/app/packages/shared/src/formatStatus.test.ts
@@ -113,6 +113,11 @@ describe('formatGameStatus', () => {
     expect(line).toBe('🟢 **palworld**: running\nconnect at palworld.example.com');
   });
 
+  it('should treat an empty connect message the same as absent and use the fallback format', () => {
+    const line = formatGameStatus({ game: 'palworld', state: 'running', hostname: 'palworld.example.com' }, '');
+    expect(line).toBe('🟢 **palworld**: running — `palworld.example.com`');
+  });
+
   it('should ignore the connect message when state is not running', () => {
     const stopped = formatGameStatus({ game: 'palworld', state: 'stopped' }, 'connect at {host}:8211');
     expect(stopped).toBe('⚫ **palworld**: stopped');

--- a/app/packages/shared/src/formatStatus.test.ts
+++ b/app/packages/shared/src/formatStatus.test.ts
@@ -42,4 +42,74 @@ describe('formatGameStatus', () => {
     expect(line).toContain('palworld.example.com');
     expect(line).not.toContain('1.2.3.4');
   });
+
+  it('should render a connect message on a second line when provided', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com' },
+      'connect in game at palworld.example.com:8211',
+    );
+    expect(line).toBe('🟢 **palworld**: running\nconnect in game at palworld.example.com:8211');
+  });
+
+  it('should substitute {host} placeholder with the resolved hostname', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com' },
+      'connect at {host}:8211',
+    );
+    expect(line).toBe('🟢 **palworld**: running\nconnect at palworld.example.com:8211');
+  });
+
+  it('should substitute {ip} placeholder with the public IP', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', publicIp: '1.2.3.4' },
+      'direct IP: {ip}',
+    );
+    expect(line).toBe('🟢 **palworld**: running\ndirect IP: 1.2.3.4');
+  });
+
+  it('should substitute {port} placeholder when a port is supplied', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com' },
+      'connect at {host}:{port}',
+      8211,
+    );
+    expect(line).toBe('🟢 **palworld**: running\nconnect at palworld.example.com:8211');
+  });
+
+  it('should substitute {game} placeholder with the game name', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com' },
+      '{game} server at {host}',
+    );
+    expect(line).toBe('🟢 **palworld**: running\npalworld server at palworld.example.com');
+  });
+
+  it('should leave {port} empty when no port is supplied', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com' },
+      'connect at {host}:{port}',
+    );
+    expect(line).toBe('🟢 **palworld**: running\nconnect at palworld.example.com:');
+  });
+
+  it('should allow multi-line connect messages', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com' },
+      'host: {host}\nport: 8211',
+    );
+    expect(line).toBe('🟢 **palworld**: running\nhost: palworld.example.com\nport: 8211');
+  });
+
+  it('should fall back to the inline address format when connect message is absent', () => {
+    const line = formatGameStatus({ game: 'palworld', state: 'running', hostname: 'palworld.example.com' });
+    expect(line).toBe('🟢 **palworld**: running — `palworld.example.com`');
+  });
+
+  it('should prefer hostname over publicIp when substituting {host}', () => {
+    const line = formatGameStatus(
+      { game: 'palworld', state: 'running', hostname: 'palworld.example.com', publicIp: '1.2.3.4' },
+      'connect at {host}',
+    );
+    expect(line).toBe('🟢 **palworld**: running\nconnect at palworld.example.com');
+  });
 });

--- a/app/packages/shared/src/formatStatus.ts
+++ b/app/packages/shared/src/formatStatus.ts
@@ -18,7 +18,7 @@ export function formatGameStatus(status: GameStatus, connectMessage?: string, po
   const host = status.hostname ?? status.publicIp;
   const statusLine = `${emoji} **${status.game}**: ${status.state}`;
 
-  if (connectMessage !== undefined && status.state === 'running') {
+  if (connectMessage && status.state === 'running') {
     const rendered = connectMessage
       .replace(/\{host\}/g, host ?? '')
       .replace(/\{ip\}/g, status.publicIp ?? '')

--- a/app/packages/shared/src/formatStatus.ts
+++ b/app/packages/shared/src/formatStatus.ts
@@ -1,16 +1,32 @@
 import type { GameStatus } from './types.js';
 
 /**
- * Render a game's status as a single Discord-ready line:
- * emoji + bold name + state + optional hostname/IP.
+ * Render a game's status as a Discord-ready message.
+ *
+ * When `connectMessage` is provided it is rendered on a second line with
+ * `{host}`, `{ip}`, `{port}`, and `{game}` placeholders substituted.
+ * When absent, falls back to the original `— \`{host}\`` inline suffix.
+ *
+ * @param port - First exposed port for the `{port}` placeholder (optional).
  */
-export function formatGameStatus(status: GameStatus): string {
+export function formatGameStatus(status: GameStatus, connectMessage?: string, port?: number): string {
   const emoji =
     status.state === 'running' ? '🟢'
     : status.state === 'starting' ? '🟡'
     : status.state === 'stopped' ? '⚫'
     : '⚠️';
   const host = status.hostname ?? status.publicIp;
+  const statusLine = `${emoji} **${status.game}**: ${status.state}`;
+
+  if (connectMessage !== undefined) {
+    const rendered = connectMessage
+      .replace(/\{host\}/g, host ?? '')
+      .replace(/\{ip\}/g, status.publicIp ?? '')
+      .replace(/\{port\}/g, port !== undefined ? String(port) : '')
+      .replace(/\{game\}/g, status.game);
+    return `${statusLine}\n${rendered}`;
+  }
+
   const addr = host ? ` — \`${host}\`` : '';
-  return `${emoji} **${status.game}**: ${status.state}${addr}`;
+  return `${statusLine}${addr}`;
 }

--- a/app/packages/shared/src/formatStatus.ts
+++ b/app/packages/shared/src/formatStatus.ts
@@ -18,7 +18,7 @@ export function formatGameStatus(status: GameStatus, connectMessage?: string, po
   const host = status.hostname ?? status.publicIp;
   const statusLine = `${emoji} **${status.game}**: ${status.state}`;
 
-  if (connectMessage !== undefined) {
+  if (connectMessage !== undefined && status.state === 'running') {
     const rendered = connectMessage
       .replace(/\{host\}/g, host ?? '')
       .replace(/\{ip\}/g, status.publicIp ?? '')

--- a/app/packages/shared/src/formatStatus.ts
+++ b/app/packages/shared/src/formatStatus.ts
@@ -3,11 +3,11 @@ import type { GameStatus } from './types.js';
 /**
  * Render a game's status as a Discord-ready message.
  *
- * When `connectMessage` is provided it is rendered on a second line with
- * `{host}`, `{ip}`, `{port}`, and `{game}` placeholders substituted.
- * When absent, falls back to the original `— \`{host}\`` inline suffix.
+ * When `connectMessage` is provided and state is `running`, it is rendered on
+ * a second line with host, ip, port, and game placeholders substituted.
+ * When absent, falls back to the original single-line address suffix.
  *
- * @param port - First exposed port for the `{port}` placeholder (optional).
+ * @param port - First exposed port for the port placeholder (optional).
  */
 export function formatGameStatus(status: GameStatus, connectMessage?: string, port?: number): string {
   const emoji =

--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -32,7 +32,7 @@ step 3 of the [setup guide](/setup) for details.
 | `aws_region` | `string` | `us-east-1` | AWS region for all resources. |
 | `project_name` | `string` | `game-servers` | Prefix for named resources and the Secrets Manager paths. |
 | `vpc_cidr` | `string` | `10.0.0.0/16` | Parent CIDR; subnets are /24s within it. |
-| `game_servers` | `map(object)` | — | The single source of truth. Per-game: `image`, `cpu`, `memory`, `ports[]`, `environment[]`, `volumes[]` (`name` + `container_path`), `https`, `file_seeds[]` (optional). Each `volumes` entry creates its own EFS access point rooted at `/${game}/${name}`. See `game_servers[].file_seeds` below. |
+| `game_servers` | `map(object)` | — | The single source of truth. Per-game: `image`, `cpu`, `memory`, `ports[]`, `environment[]`, `volumes[]` (`name` + `container_path`), `https`, `connect_message` (optional), `file_seeds[]` (optional). Each `volumes` entry creates its own EFS access point rooted at `/${game}/${name}`. `connect_message` controls the Discord connection hint shown when a server reaches RUNNING; supports `{host}`, `{ip}`, `{port}`, and `{game}` placeholders. See `game_servers[].file_seeds` below. |
 | `hosted_zone_name` | `string` | _(required)_ | Existing Route 53 zone looked up as a data source (e.g. `example.com`). |
 | `acm_certificate_domain` | `string` | `null` → `*.{hosted_zone_name}` | Wildcard ACM cert for the ALB listener. |
 | `dns_ttl` | `number` | `30` | TTL on Route 53 A records the update-dns Lambda writes. Keep low for fast task churn. |

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -201,6 +201,9 @@ game_servers = {
       { name = "saves", container_path = "/palworld" },
     ]
     https = false
+    # Optional: Discord message shown when the server reaches RUNNING.
+    # Supports {host}, {ip}, {port} (first port), and {game} placeholders.
+    # connect_message = "connect in game at {host}:{port}"
   }
 }
 ```

--- a/terraform/followup.tf
+++ b/terraform/followup.tf
@@ -88,6 +88,8 @@ resource "aws_lambda_function" "followup" {
       SECURITY_GROUP_ID = aws_security_group.game_servers.id
       DOMAIN_NAME       = var.hosted_zone_name
       GAME_NAMES        = join(",", keys(var.game_servers))
+      CONNECT_MESSAGES  = jsonencode({ for g, cfg in var.game_servers : g => cfg.connect_message if cfg.connect_message != null })
+      GAME_PORTS        = jsonencode({ for g, cfg in var.game_servers : g => cfg.ports[0].container })
     }
   }
 

--- a/terraform/followup.tf
+++ b/terraform/followup.tf
@@ -89,7 +89,7 @@ resource "aws_lambda_function" "followup" {
       DOMAIN_NAME       = var.hosted_zone_name
       GAME_NAMES        = join(",", keys(var.game_servers))
       CONNECT_MESSAGES  = jsonencode({ for g, cfg in var.game_servers : g => cfg.connect_message if cfg.connect_message != null })
-      GAME_PORTS        = jsonencode({ for g, cfg in var.game_servers : g => cfg.ports[0].container })
+      GAME_PORTS        = jsonencode({ for g, cfg in var.game_servers : g => cfg.ports[0].container if length(cfg.ports) > 0 })
     }
   }
 

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -113,7 +113,7 @@ resource "aws_lambda_function" "dns_updater" {
       ALB_TARGET_GROUPS = jsonencode({ for name, _ in local.https_games : name => aws_lb_target_group.game[name].arn })
       TABLE_NAME        = aws_dynamodb_table.discord.name
       CONNECT_MESSAGES  = jsonencode({ for g, cfg in var.game_servers : g => cfg.connect_message if cfg.connect_message != null })
-      GAME_PORTS        = jsonencode({ for g, cfg in var.game_servers : g => cfg.ports[0].container })
+      GAME_PORTS        = jsonencode({ for g, cfg in var.game_servers : g => cfg.ports[0].container if length(cfg.ports) > 0 })
     }
   }
 

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -112,6 +112,8 @@ resource "aws_lambda_function" "dns_updater" {
       HTTPS_GAMES       = join(",", keys(local.https_games))
       ALB_TARGET_GROUPS = jsonencode({ for name, _ in local.https_games : name => aws_lb_target_group.game[name].arn })
       TABLE_NAME        = aws_dynamodb_table.discord.name
+      CONNECT_MESSAGES  = jsonencode({ for g, cfg in var.game_servers : g => cfg.connect_message if cfg.connect_message != null })
+      GAME_PORTS        = jsonencode({ for g, cfg in var.game_servers : g => cfg.ports[0].container })
     }
   }
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -70,6 +70,9 @@ watchdog_min_packets      = 100
 #       { name = "saves", container_path = "/palworld" },
 #     ]
 #     https = false
+#     # Optional: message shown in Discord when the server is running.
+#     # Supports {host}, {ip}, {port} (first port), and {game} placeholders.
+#     # connect_message = "connect in game at {host}:{port}"
 #
 #     # Optional: pre-seed files onto the EFS volume before the server starts.
 #     # path is the in-container path; the container_path prefix is stripped to

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,7 +29,8 @@ variable "game_servers" {
     ports       = list(object({ container = number, protocol = string }))
     environment = optional(list(object({ name = string, value = string })), [])
     volumes     = list(object({ name = string, container_path = string }))
-    https       = optional(bool, false) # If true, traffic is routed through ALB with TLS termination
+    https           = optional(bool, false)   # If true, traffic is routed through ALB with TLS termination
+    connect_message = optional(string)        # Discord connect hint; supports {host}, {ip}, {port}, {game} placeholders
     file_seeds  = optional(list(object({
       path           = string           # In-container path, e.g. "/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
       content        = optional(string) # UTF-8 text content


### PR DESCRIPTION
Adds an optional `connect_message` field to the `game_servers` Terraform variable. Operators set a template string (e.g. `connect at {host}:{port}`) that is rendered in Discord when a server reaches RUNNING — both on the initial `/server-start` reply and in the update-dns PATCH when the public IP/hostname resolves. Supports `{host}`, `{ip}`, `{port}`, and `{game}` placeholders.

When absent the existing inline `` — `{host}` `` suffix is preserved as the fallback, so no operator action is required for existing deployments.

## Changes

- `terraform/variables.tf` — add `connect_message = optional(string)` to `game_servers`
- `terraform/followup.tf` + `route53.tf` — wire `CONNECT_MESSAGES` and `GAME_PORTS` env vars
- `app/packages/shared/src/formatStatus.ts` — extend `formatGameStatus()` to accept optional connect message and port; interpolate placeholders; render on a second line
- `app/packages/lambda/followup/src/handler.ts` — pass connect message through `handleList`, `handleStatus`, and `handleStart` (start reply gets a hostname preview)
- `app/packages/lambda/update-dns/src/handler.ts` — pass connect message to `notifyDiscordIfPending` so the RUNNING-state PATCH includes the hint
- Tests, `terraform.tfvars.example`, and docs updated per CLAUDE.md checklist

## Test plan

- [ ] All 238 existing tests pass (`cd app && npm test`)
- [ ] 10 new `formatGameStatus` test cases cover placeholder substitution, multi-line messages, missing placeholders, and fallback behaviour
- [ ] Deploy with a game that has `connect_message = "connect in game at {host}:{port}"` and verify the hint appears in the Discord start reply and in the RUNNING update

Closes #40

https://claude.ai/code/session_015YprouEhsqpJLPDC5ZrrSE