### PR TITLE
feat(app): stream live server logs to the management UI via SSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ Any time you add or remove Terraform variables, update **all four** of these in 
 - **Always use `/pr` to create pull requests.** The `.claude/commands/pr.md` skill validates the title format before calling the API. Never call `mcp__github__create_pull_request` directly without running this check first.
 - **PR titles MUST use Conventional Commits.** We squash-merge, so the PR title becomes the commit subject on `main` verbatim — a badly-formed title produces a badly-formed commit that can't be fixed after merge. Format: `<type>(<optional-scope>): <imperative summary>`, where `<type>` is one of `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `build`, `ci`, `style`. Keep the subject under ~70 characters; put details in the PR body. Examples: `refactor(app): migrate server from Express+tsyringe to Nest.js`, `docs: reflect Nest.js migration in CLAUDE.md`, `fix(watchdog): stop leaking tags on failed runs`, `chore: add ESLint flat config`.
 - **Pre-flight check (mandatory):** before any `create_pull_request` call, verify the title matches `^(feat|fix|refactor|docs|test|chore|perf|build|ci|style)(\([^)]+\))?: .+$`. If it doesn't, fix it first. `Add ESLint configuration` fails (no type prefix); `chore: add ESLint configuration` passes.
+- **Always include `Closes #N`** in the PR body when the PR resolves a GitHub issue. Place it as the first line so GitHub auto-closes the issue on merge.
 
 ## PR Review Workflow
 

--- a/app/packages/server/src/controllers/logs.controller.ts
+++ b/app/packages/server/src/controllers/logs.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, MessageEvent, Param, Query, Sse } from '@nestjs/common';
+import { Observable } from 'rxjs';
 import { LogsService } from '../services/LogsService.js';
 
 /** Tails CloudWatch logs from the `/ecs/{game}-server` log group. */
@@ -12,5 +13,36 @@ export class LogsController {
     const limit = parseInt(String(limitRaw ?? '50'), 10);
     const lines = await this.logs.getRecentLogs(game, limit);
     return { game, lines };
+  }
+
+  /**
+   * SSE stream of new log lines for a game, delivered as they arrive from
+   * `FilterLogEvents`. The client receives `{ data: { line: "..." } }` events.
+   * Auth: `Authorization: Bearer` header OR `?token=` query param (the latter
+   * is required because the browser's native `EventSource` cannot set headers).
+   */
+  @Sse(':game/stream')
+  streamLogs(@Param('game') game: string): Observable<MessageEvent> {
+    const ac = new AbortController();
+
+    return new Observable<MessageEvent>((subscriber) => {
+      const run = async () => {
+        try {
+          for await (const line of this.logs.streamLogs(game, ac.signal)) {
+            subscriber.next({ data: { line } } as MessageEvent);
+          }
+          subscriber.complete();
+        } catch (err) {
+          if ((err as Error).name === 'AbortError') {
+            subscriber.complete();
+          } else {
+            subscriber.error(err);
+          }
+        }
+      };
+      void run();
+
+      return () => ac.abort();
+    });
   }
 }

--- a/app/packages/server/src/guards/api-token.guard.ts
+++ b/app/packages/server/src/guards/api-token.guard.ts
@@ -66,6 +66,9 @@ export class ApiTokenGuard implements CanActivate {
       if (typeof queryToken !== 'string') {
         throw new UnauthorizedException({ error: 'missing bearer token' });
       }
+      // Remove the token from req.query so RequestLoggerMiddleware doesn't
+      // log it — the finish handler fires after this guard runs.
+      delete (req.query as Record<string, unknown>)['token'];
       presented = queryToken;
     }
     if (presented !== configured) {

--- a/app/packages/server/src/guards/api-token.guard.ts
+++ b/app/packages/server/src/guards/api-token.guard.ts
@@ -55,11 +55,19 @@ export class ApiTokenGuard implements CanActivate {
       return true;
     }
 
+    // Prefer the Authorization header; fall back to ?token= query param for
+    // SSE endpoints where the browser's native EventSource cannot set headers.
     const header = req.headers['authorization'];
-    if (typeof header !== 'string' || !header.startsWith('Bearer ')) {
-      throw new UnauthorizedException({ error: 'missing bearer token' });
+    let presented: string;
+    if (typeof header === 'string' && header.startsWith('Bearer ')) {
+      presented = header.slice('Bearer '.length).trim();
+    } else {
+      const queryToken = (req.query as Record<string, unknown> | undefined)?.['token'];
+      if (typeof queryToken !== 'string') {
+        throw new UnauthorizedException({ error: 'missing bearer token' });
+      }
+      presented = queryToken;
     }
-    const presented = header.slice('Bearer '.length).trim();
     if (presented !== configured) {
       logger.warn('Rejected /api request with bad bearer token', {
         path: req.path,

--- a/app/packages/server/src/services/LogsService.test.ts
+++ b/app/packages/server/src/services/LogsService.test.ts
@@ -4,6 +4,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import {
   CloudWatchLogsClient,
   DescribeLogStreamsCommand,
+  FilterLogEventsCommand,
   GetLogEventsCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 
@@ -102,5 +103,139 @@ describe('LogsService', () => {
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/error fetching logs for minecraft/i);
     expect(lines[0]).toContain('denied');
+  });
+});
+
+describe('LogsService.streamLogs', () => {
+  /** Service under test, freshly constructed per test. */
+  let service: LogsService;
+
+  beforeEach(() => {
+    cwMock.reset();
+    service = new LogsService(makeConfig());
+  });
+
+  it('should terminate immediately when signal is already aborted before the first poll', async () => {
+    const ac = new AbortController();
+    ac.abort();
+
+    const lines: string[] = [];
+    for await (const line of service.streamLogs('minecraft', ac.signal, 0)) {
+      lines.push(line);
+    }
+
+    expect(lines).toEqual([]);
+    expect(cwMock.commandCalls(FilterLogEventsCommand)).toHaveLength(0);
+  });
+
+  it('should yield log lines from the first poll and terminate on abort', async () => {
+    cwMock.on(FilterLogEventsCommand).resolves({
+      events: [
+        { eventId: 'e1', timestamp: 1000, message: 'line1' },
+        { eventId: 'e2', timestamp: 2000, message: 'line2' },
+      ],
+    });
+
+    const ac = new AbortController();
+    const gen = service.streamLogs('minecraft', ac.signal, 0);
+
+    const { value: l1 } = await gen.next();
+    const { value: l2 } = await gen.next();
+    ac.abort();
+    const { done } = await gen.next();
+
+    expect(l1).toBe('line1');
+    expect(l2).toBe('line2');
+    expect(done).toBe(true);
+  });
+
+  it('should yield new events from successive polls', async () => {
+    cwMock
+      .on(FilterLogEventsCommand)
+      .resolvesOnce({ events: [{ eventId: 'e1', timestamp: 1000, message: 'first' }] })
+      .resolves({ events: [{ eventId: 'e2', timestamp: 2000, message: 'second' }] });
+
+    const ac = new AbortController();
+    const gen = service.streamLogs('minecraft', ac.signal, 0);
+
+    const { value: l1 } = await gen.next();
+    const { value: l2 } = await gen.next();
+    ac.abort();
+    await gen.return(undefined);
+
+    expect(l1).toBe('first');
+    expect(l2).toBe('second');
+  });
+
+  it('should de-duplicate events with the same eventId across polls', async () => {
+    cwMock
+      .on(FilterLogEventsCommand)
+      .resolvesOnce({ events: [{ eventId: 'e1', timestamp: 1000, message: 'line1' }] })
+      .resolvesOnce({
+        events: [
+          { eventId: 'e1', timestamp: 1000, message: 'line1' }, // already seen
+          { eventId: 'e2', timestamp: 2000, message: 'line2' }, // new
+        ],
+      });
+
+    const ac = new AbortController();
+    const gen = service.streamLogs('minecraft', ac.signal, 0);
+
+    const { value: l1 } = await gen.next(); // first poll yields 'line1'
+    const { value: l2 } = await gen.next(); // second poll skips duplicate, yields 'line2'
+    ac.abort();
+    await gen.return(undefined);
+
+    expect(l1).toBe('line1');
+    expect(l2).toBe('line2');
+  });
+
+  it('should query the /ecs/{game}-server log group', async () => {
+    cwMock.on(FilterLogEventsCommand).resolves({
+      events: [{ eventId: 'e1', timestamp: 1000, message: 'hello' }],
+    });
+
+    const ac = new AbortController();
+    const gen = service.streamLogs('valheim', ac.signal, 0);
+
+    await gen.next(); // first poll runs and yields 'hello'
+    ac.abort();
+    await gen.return(undefined);
+
+    const calls = cwMock.commandCalls(FilterLogEventsCommand);
+    expect(calls[0]!.args[0].input.logGroupName).toBe('/ecs/valheim-server');
+  });
+
+  it('should yield a stream-error sentinel and continue when a poll throws', async () => {
+    cwMock
+      .on(FilterLogEventsCommand)
+      .rejectsOnce(new Error('throttled'))
+      .resolves({ events: [{ eventId: 'e1', timestamp: 1000, message: 'recovered' }] });
+
+    const ac = new AbortController();
+    const gen = service.streamLogs('minecraft', ac.signal, 0);
+
+    const { value: errLine } = await gen.next(); // first poll throws
+    const { value: okLine } = await gen.next(); // second poll succeeds
+    ac.abort();
+    await gen.return(undefined);
+
+    expect(errLine).toMatch(/\[stream error\].*throttled/);
+    expect(okLine).toBe('recovered');
+  });
+
+  it('should map a missing event.message to an empty string', async () => {
+    cwMock.on(FilterLogEventsCommand).resolves({
+      events: [{ eventId: 'e1', timestamp: 1000 }], // no message field
+    });
+
+    const ac = new AbortController();
+    const gen = service.streamLogs('minecraft', ac.signal, 0);
+
+    const { value: line } = await gen.next();
+    ac.abort();
+    await gen.return(undefined);
+
+    expect(line).toBe('');
   });
 });

--- a/app/packages/server/src/services/LogsService.ts
+++ b/app/packages/server/src/services/LogsService.ts
@@ -18,12 +18,16 @@ function sleepInterruptible(ms: number, signal: AbortSignal): Promise<void> {
       reject(new DOMException('Aborted', 'AbortError'));
       return;
     }
-    const timer = setTimeout(resolve, ms);
     const onAbort = () => {
       clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
       reject(new DOMException('Aborted', 'AbortError'));
     };
-    signal.addEventListener('abort', onAbort, { once: true });
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort);
   });
 }
 
@@ -68,6 +72,7 @@ export class LogsService {
       try {
         const resp = await this.getClient().send(
           new FilterLogEventsCommand({ logGroupName: logGroup, startTime, limit: 100 }),
+          { abortSignal: signal },
         );
         for (const e of resp.events ?? []) {
           const id = e.eventId ?? `${e.timestamp}-${e.message}`;

--- a/app/packages/server/src/services/LogsService.ts
+++ b/app/packages/server/src/services/LogsService.ts
@@ -2,10 +2,30 @@ import { Injectable } from '@nestjs/common';
 import {
   CloudWatchLogsClient,
   DescribeLogStreamsCommand,
+  FilterLogEventsCommand,
   GetLogEventsCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { logger } from '../logger.js';
 import { ConfigService } from './ConfigService.js';
+
+/**
+ * Sleep for `ms` milliseconds, but reject immediately if `signal` is aborted.
+ * Used by `streamLogs` so the poll loop exits promptly when the SSE client disconnects.
+ */
+function sleepInterruptible(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
 
 /**
  * Fetches recent CloudWatch Logs lines for a game's ECS task so the UI can
@@ -23,6 +43,54 @@ export class LogsService {
       this.client = new CloudWatchLogsClient({ region: this.config.getRegion() });
     }
     return this.client;
+  }
+
+  /**
+   * Async generator that polls `FilterLogEvents` every `pollInterval` ms and
+   * yields new log lines as they arrive. De-duplicates by `eventId` so lines
+   * are never emitted twice even when `startTime` windows overlap at the
+   * boundary. The generator exits cleanly when `signal` is aborted (i.e.
+   * when the SSE client disconnects).
+   *
+   * Queries the whole log group so that a stop+start of the ECS task
+   * (which creates a new stream) is handled automatically without reconnecting.
+   */
+  async *streamLogs(
+    game: string,
+    signal: AbortSignal,
+    pollInterval = 2000,
+  ): AsyncGenerator<string> {
+    const logGroup = `/ecs/${game}-server`;
+    let startTime = Date.now();
+    const seen = new Set<string>();
+
+    while (!signal.aborted) {
+      try {
+        const resp = await this.getClient().send(
+          new FilterLogEventsCommand({ logGroupName: logGroup, startTime, limit: 100 }),
+        );
+        for (const e of resp.events ?? []) {
+          const id = e.eventId ?? `${e.timestamp}-${e.message}`;
+          if (!seen.has(id)) {
+            seen.add(id);
+            yield e.message ?? '';
+          }
+          if ((e.timestamp ?? 0) >= startTime) {
+            startTime = (e.timestamp ?? startTime) + 1;
+          }
+        }
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') break;
+        logger.error('Log stream poll error', { err, game, logGroup });
+        yield `[stream error] ${String(err)}`;
+      }
+
+      try {
+        await sleepInterruptible(pollInterval, signal);
+      } catch {
+        break;
+      }
+    }
   }
 
   /**

--- a/app/packages/web/src/components/LogsPanel.tsx
+++ b/app/packages/web/src/components/LogsPanel.tsx
@@ -91,10 +91,16 @@ export function LogsPanel({ games }: Props) {
     setPaused(false);
 
     let cancelled = false;
-    void api.logs(selectedGame).then((data) => {
-      if (!cancelled) setLines(data.lines);
-    });
-    startStream(selectedGame);
+    void (async () => {
+      try {
+        const data = await api.logs(selectedGame);
+        if (cancelled) return;
+        setLines(data.lines);
+        startStream(selectedGame);
+      } catch {
+        if (!cancelled) startStream(selectedGame);
+      }
+    })();
 
     return () => {
       cancelled = true;

--- a/app/packages/web/src/components/LogsPanel.tsx
+++ b/app/packages/web/src/components/LogsPanel.tsx
@@ -1,37 +1,113 @@
-import { useState, useEffect, useRef } from 'react';
-import { api } from '../api.js';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { api, getStoredApiToken } from '../api.js';
+
+const MAX_LINES = 1000;
 
 interface Props {
   games: string[];
 }
 
 /**
- * Bottom-of-dashboard panel that tails CloudWatch logs for the currently-selected
- * game. Fetches a fixed number of recent lines from `/api/logs/:game` on game
- * change and on explicit refresh; auto-scrolls to the newest entry.
+ * Bottom-of-dashboard panel that tails CloudWatch logs for the selected game.
+ * On game change it fetches a snapshot of recent lines, then opens an SSE
+ * stream (`/api/logs/:game/stream`) to append new events as they arrive.
+ * The auth token is passed as `?token=` because the browser's native
+ * `EventSource` cannot set custom headers.
+ *
+ * Pause buffers incoming lines without scrolling; Resume flushes the buffer.
+ * Lines are capped at MAX_LINES to keep the DOM light.
  */
 export function LogsPanel({ games }: Props) {
   const [selectedGame, setSelectedGame] = useState<string>('');
   const [lines, setLines] = useState<string[]>([]);
+  const [paused, setPaused] = useState(false);
   const boxRef = useRef<HTMLDivElement>(null);
+  const esRef = useRef<EventSource | null>(null);
+  const pausedRef = useRef(false);
+  const bufferRef = useRef<string[]>([]);
 
-  const fetchLogs = async (game: string) => {
-    if (!game) return;
-    const data = await api.logs(game);
-    setLines(data.lines);
-  };
+  const appendLine = useCallback((line: string) => {
+    if (pausedRef.current) {
+      bufferRef.current.push(line);
+      return;
+    }
+    setLines((prev) => {
+      const next = [...prev, line];
+      return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
+    });
+  }, []);
+
+  const stopStream = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+  }, []);
+
+  const startStream = useCallback(
+    (game: string) => {
+      stopStream();
+      const token = getStoredApiToken();
+      const url = `/api/logs/${game}/stream${token ? `?token=${encodeURIComponent(token)}` : ''}`;
+      const es = new EventSource(url);
+
+      es.onmessage = (e: MessageEvent) => {
+        try {
+          const data = JSON.parse(e.data as string) as { line: string };
+          appendLine(data.line);
+        } catch {
+          // ignore malformed events
+        }
+      };
+
+      esRef.current = es;
+    },
+    [stopStream, appendLine],
+  );
+
+  const handlePauseToggle = useCallback(() => {
+    const nowPaused = !pausedRef.current;
+    pausedRef.current = nowPaused;
+    setPaused(nowPaused);
+    if (!nowPaused && bufferRef.current.length > 0) {
+      const buffered = bufferRef.current;
+      bufferRef.current = [];
+      setLines((prev) => {
+        const next = [...prev, ...buffered];
+        return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next;
+      });
+    }
+  }, []);
 
   useEffect(() => {
     if (games.length && !selectedGame) setSelectedGame(games[0]!);
   }, [games, selectedGame]);
 
   useEffect(() => {
-    if (selectedGame) void fetchLogs(selectedGame);
-  }, [selectedGame]);
+    if (!selectedGame) return;
+    setLines([]);
+    bufferRef.current = [];
+    pausedRef.current = false;
+    setPaused(false);
 
+    let cancelled = false;
+    void api.logs(selectedGame).then((data) => {
+      if (!cancelled) setLines(data.lines);
+    });
+    startStream(selectedGame);
+
+    return () => {
+      cancelled = true;
+      stopStream();
+    };
+  }, [selectedGame, startStream, stopStream]);
+
+  // Auto-scroll to bottom when new lines arrive and not paused
   useEffect(() => {
-    if (boxRef.current) boxRef.current.scrollTop = boxRef.current.scrollHeight;
-  }, [lines]);
+    if (!paused && boxRef.current) {
+      boxRef.current.scrollTop = boxRef.current.scrollHeight;
+    }
+  }, [lines, paused]);
 
   return (
     <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: '12px', padding: '1.25rem' }}>
@@ -57,8 +133,8 @@ export function LogsPanel({ games }: Props) {
         }
       </div>
       <div style={{ marginTop: '0.6rem' }}>
-        <button className="btn-secondary btn-sm" onClick={() => void fetchLogs(selectedGame)}>
-          Refresh Logs
+        <button className="btn-secondary btn-sm" onClick={handlePauseToggle}>
+          {paused ? 'Resume' : 'Pause'}
         </button>
       </div>
     </div>

--- a/docs/docs/components/management-app.md
+++ b/docs/docs/components/management-app.md
@@ -74,7 +74,7 @@ Every route is under `/api/*` and gated by `ApiTokenGuard`.
 | `GamesController` | `GET /api/games`, `GET /api/status`, `GET /api/status/:game`, `POST /api/start/:game`, `POST /api/stop/:game` | List/read status, trigger RunTask/StopTask. Invalidates ConfigService's tfstate cache on list/status reads so fresh applies are picked up without restarting. |
 | `ConfigController` | `GET /api/config`, `POST /api/config` | Read/write watchdog knobs in `server_config.json`. Takes effect on next `terraform apply` (the values are baked into Lambda env). |
 | `CostsController` | `GET /api/costs/estimate`, `GET /api/costs/actual?days=N` | Per-game Fargate estimates; Cost Explorer actuals grouped by the `Project` tag. |
-| `LogsController` | `GET /api/logs/:game?limit=50` | Last N log events from `/ecs/{game}-server` on the most recent task. |
+| `LogsController` | `GET /api/logs/:game?limit=50`, `GET /api/logs/:game/stream` | Snapshot of last N log events; SSE stream of new events as they arrive (polls `FilterLogEvents` every 2 s). |
 | `FilesController` | `GET /api/files/:game`, `POST /api/files/:game/start`, `POST /api/files/:game/stop` | Ad-hoc FileBrowser task against the game's EFS access point. |
 | `DiscordController` | `GET/PUT /api/discord/config`, `POST /api/discord/guilds`, `DELETE /api/discord/guilds/:id`, `POST /api/discord/guilds/:id/register-commands`, `PUT /api/discord/admins`, `PUT /api/discord/permissions/:game`, `DELETE /api/discord/permissions/:game` | Read-redacted config, save credentials, manage guild allowlist + commands, admins, per-game permissions. |
 
@@ -105,6 +105,8 @@ Every route is under `/api/*` and gated by `ApiTokenGuard`.
   (no path traversal, no SSRF).
 - **`EcsService` / `Ec2Service` / `LogsService` / `CostService` /
   `FileManagerService`** — thin wrappers over the AWS SDK v3 clients.
+  `LogsService.streamLogs(game, signal)` is an `AsyncGenerator` that polls
+  `FilterLogEvents` every 2 s; `getRecentLogs` remains the snapshot path.
 
 ### Auth
 
@@ -113,7 +115,9 @@ Every route is under `/api/*` and gated by `ApiTokenGuard`.
 
 - Reads the configured token from `ConfigService` (not cached — rotation
   takes effect immediately).
-- Matches `Authorization: Bearer <token>` exactly.
+- Matches `Authorization: Bearer <token>` exactly; falls back to
+  `?token=<token>` query param when the header is absent (needed for the
+  SSE stream endpoint because `EventSource` cannot set headers).
 - In dev mode, if no token is configured: logs once and allows the
   request.
 - In production, boot is refused if no token is configured, so the
@@ -157,8 +161,13 @@ everywhere, not `console.log`.
 4. **Discord Bot** — four tabs: Credentials, Guilds, Admins, Per-Game
    Permissions. See the [user guide](/guides/user)
    for the day-to-day workflow.
-5. **Live Logs** — tails the last N events from
-   `/ecs/{game}-server` for the most recent task.
+5. **Live Logs** — fetches a snapshot of the last 50 events on game change,
+   then opens an SSE stream (`/api/logs/:game/stream`) that appends new
+   lines as they arrive (capped at 1 000 lines in the DOM). Pause/Resume
+   toggle buffers incoming lines without scrolling. The token is sent as
+   `?token=` because `EventSource` cannot set custom headers. Log streaming
+   is SSE, not WebSocket — if interactive features ever require
+   bidirectional comms, revisit then.
 6. **File Manager modal** — spawns a FileBrowser Fargate task against the
    game's EFS access point so you can inspect/upload saves without
    starting the game itself.


### PR DESCRIPTION
Closes #43

Adds a real-time log tail to the Logs panel:

- LogsService.streamLogs(game, signal) – AsyncGenerator that polls
  FilterLogEvents every 2 s, de-duplicates by eventId, advances
  startTime on each tick, and exits cleanly when the AbortSignal fires.
  Queries the whole log group so task stop+start (new stream) is handled
  automatically.

- GET /api/logs/:game/stream – @Sse() endpoint wrapping the generator
  in an RxJS Observable. Teardown aborts the generator when the client
  disconnects.

- ApiTokenGuard – falls back to ?token= query param when the
  Authorization header is absent, which is necessary because the
  browser's native EventSource cannot set custom headers.

- LogsPanel.tsx – fetches a snapshot on game change then opens an
  EventSource stream that appends new lines (capped at 1 000). Pause
  buffers incoming lines; Resume flushes the buffer. Replaces the old
  manual Refresh button.

- LogsService.test.ts – seven new streamLogs cases covering clean
  termination, multi-poll delivery, de-duplication, log-group naming,
  error recovery, and missing message fields.

- docs/components/management-app.md – updated endpoint table, Live Logs
  description, auth notes, and LogsService blurb.

IAM: logs:* already covers FilterLogEvents (docs/setup.md unchanged).

https://claude.ai/code/session_01THkoGDYjJhojhtnUEYi4w9