### PR TITLE
feat(scripts): add init-parent scaffolder for submodule deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ organised around three roles. Pick the one that matches what you need to do.
 | [**Setup guide**](https://codercoco.github.io/game-server-deploy/setup/) | Going from a blank AWS account to a running Fargate task. |
 | [**User guide**](https://codercoco.github.io/game-server-deploy/guides/user/) | Driving an already-provisioned deployment — the dashboard, Discord commands, day-to-day ops. |
 | [**Maintainer guide**](https://codercoco.github.io/game-server-deploy/guides/maintainer/) | Working on this codebase. |
-| [**Private parent + submodule guide**](https://codercoco.github.io/game-server-deploy/guides/submodule/) | Wrapping this repo in a private repo that holds `terraform.tfvars`, `server_config.json`, and tfstate. |
+| [**Private parent + submodule guide**](https://codercoco.github.io/game-server-deploy/guides/submodule/) | Wrapping this repo in a private repo that holds `terraform.tfvars` and tfstate. Includes an interactive scaffolder ([`scripts/init-parent.ts`](./scripts/init-parent.ts)) that generates the wrapper Makefile, tfvars, and `.env`. |
 
 Component deep-dives:
 
@@ -130,6 +130,7 @@ game-server-deploy/
 ├── Dockerfile
 ├── docker-compose.yml
 ├── setup.sh                   # First-time bootstrap (node/terraform/aws)
+├── scripts/                   # Helper scripts (init-parent.ts scaffolder)
 ├── CLAUDE.md                  # Project instructions + invariants
 ├── CONTRIBUTING.md            # PR conventions, local checks
 └── README.md                  # this file

--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -16,7 +16,8 @@ Role-oriented walkthroughs for the three people most likely to open this site:
 - **[Submodule guide](/guides/submodule)** — the
   recommended layout for running the stack for real: wrap this repo as a git
   submodule inside a private parent repo that holds `terraform.tfvars`,
-  `server_config.json`, state, and anything else secret.
+  state, and anything else secret. Includes an interactive scaffolder that
+  generates the wrapper Makefile and config files for you.
 
 The [Setup guide](/setup) is still the first stop if
 none of the above has happened yet.

--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -8,8 +8,8 @@ sidebar_position: 4
 This is the pattern we recommend if you're running the stack for real: a
 **private parent repo** you own, with this repo vendored as a git submodule,
 plus all the per-deployment secrets sitting alongside. Nothing sensitive ever
-lives in a public fork, and pulling upstream changes is `git submodule update
---remote`.
+lives in a public fork, and pulling upstream changes is one `make update`
+away.
 
 If you're just kicking the tyres, the plain
 [setup guide](/setup) is fine. Come back to this
@@ -18,11 +18,11 @@ page when you're ready to commit your config to source control.
 ## Why this layout
 
 `terraform.tfvars` (with your hosted zone, and optionally Discord
-credentials), `server_config.json` (watchdog knobs and the bearer token),
-and `terraform.tfstate` (raw infrastructure state including IAM role
-names and the DNS zone ID) are **yours**. None of them belong in this
-public repo. A submodule keeps upstream code cleanly separated from your
-deployment-specific configuration without forking.
+credentials), `terraform.tfstate` (raw infrastructure state including IAM
+role names and the DNS zone ID), and `API_TOKEN` for the management app
+are **yours**. None of them belong in this public repo. A submodule keeps
+upstream code cleanly separated from your deployment-specific configuration
+without forking.
 
 ```mermaid
 flowchart LR
@@ -31,12 +31,11 @@ flowchart LR
 
   subgraph Parent["your-private-games (private)"]
     direction TB
+    PMK["Makefile"]:::priv
     PTF["terraform.tfvars"]:::priv
-    PCFG["server_config.json"]:::priv
-    PSTATE["state/<br/>terraform.tfstate<br/>(or S3 backend config)"]:::priv
     PENV[".env<br/>API_TOKEN=…"]:::priv
-    PSCRIPT["scripts/<br/>apply.sh, dev.sh, …"]:::priv
-    PSUB["gsd/<br/>→ submodule"]:::priv
+    PSTAMP[".make/<br/>setup.stamp, tfstate.json"]:::priv
+    PSUB["game-server-deploy/<br/>→ submodule"]:::priv
   end
 
   subgraph Upstream["game-server-deploy (public)"]
@@ -44,233 +43,133 @@ flowchart LR
     UAPP["app/"]:::public
     UTF["terraform/*.tf"]:::public
     USET["setup.sh"]:::public
+    UMK["Makefile"]:::public
   end
 
   PSUB -- "git submodule" --> Upstream
-  PTF -. "symlinked or copied into" .-> UTF
-  PCFG -. "symlinked or bind-mounted into" .-> UAPP
-  PSTATE -. "tfstate (or remote backend)" .-> UTF
+  PMK  -- "delegates via 'make -C'" --> UMK
+  PTF  -. "copied into" .-> UTF
 ```
 
-The secret-bearing files stay in the parent; the submodule stays
-upstream-clean.
+The parent's wrapper Makefile copies `terraform.tfvars` into the submodule on
+every plan/apply, then delegates Terraform/dev work to the submodule's own
+`Makefile` targets (`tf-plan`, `tf-apply`, `dev`, …). The submodule checkout
+stays clean — only files inside its own `.gitignore` get touched.
 
 ## Reference layout
 
 ```text
 your-private-games/                 # private repo you own
 ├── .gitmodules
-├── .gitignore                      # ignores state/, .env, secrets/
-├── .env                            # API_TOKEN, AWS_PROFILE, etc. — gitignored
-├── README.md                       # your personal runbook
-├── gsd/                            # submodule → codercoco/game-server-deploy
-├── config/
-│   ├── terraform.tfvars            # YOUR copy; checked in
-│   └── server_config.json          # checked in (minus api_token)
-├── state/                          # tfstate if using local backend
-│   └── terraform.tfstate           # gitignored
-├── docker-compose.override.yml     # optional — custom mounts
-└── scripts/
-    ├── setup.sh                    # wrapper around gsd/setup.sh
-    ├── apply.sh
-    └── dev.sh
+├── .gitignore                      # ignores .env, .make/, *.tfstate
+├── .env                            # API_TOKEN — gitignored
+├── Makefile                        # wrapper — see "What the wrapper does" below
+├── terraform.tfvars                # YOUR copy; checked in (private repo)
+├── .make/                          # stamp dir (sha of submodule setup.sh, cached tfstate)
+└── game-server-deploy/             # submodule → CoderCoco/game-server-deploy
 ```
 
-## Step by step
+That's the whole shape. No `config/` directory, no symlinks, no
+`docker-compose.override.yml`. Everything driven from one Makefile.
 
-### 1. Create the private repo
+## Quick start (interactive scaffolder)
+
+The public repo ships an interactive TypeScript script that writes the four
+files above for you. It only needs Node.js 20+, which you already need for
+the rest of the project.
 
 ```bash
-# On GitHub, create `your-private-games` (or whatever) as a private repo.
+# 1. Create a private repo on GitHub, then clone it.
 git clone git@github.com:you/your-private-games.git
 cd your-private-games
+
+# 2. Add the submodule.
+git submodule add https://github.com/CoderCoco/game-server-deploy.git
+
+# 3. Install scaffolder deps and run it from the parent repo root.
+(cd game-server-deploy/scripts && npm install)
+npx --prefix game-server-deploy/scripts tsx \
+    game-server-deploy/scripts/init-parent.ts
 ```
 
-### 2. Add the submodule
+The script prompts for project name, AWS region, hosted zone, and
+(optionally) Discord credentials, then writes `Makefile`,
+`terraform.tfvars`, `.env`, and `.gitignore`. Existing files are skipped
+unless you pass `--force`.
+
+After it finishes:
 
 ```bash
-git submodule add https://github.com/codercoco/game-server-deploy.git gsd
-
-# Pin to a known-good commit (recommended):
-cd gsd && git checkout <sha-or-tag> && cd ..
-git add .gitmodules gsd
-git commit -m "chore: pin gsd submodule"
+$EDITOR terraform.tfvars            # add at least one entry under game_servers
+make setup                          # init submodule, run setup.sh, terraform init
+make plan
+make apply
 ```
 
-Using a pinned SHA/tag means upstream changes don't silently affect your
-next apply; you update explicitly with:
+## What the wrapper Makefile does
 
-```bash
-cd gsd && git fetch && git checkout <new-sha> && cd ..
-git add gsd && git commit -m "chore: bump gsd to <new-sha>"
+The generated wrapper is a thin layer over the submodule's own Makefile.
+Five targets, no surprises:
+
+| Target | What it does |
+|---|---|
+| `make setup` | One-time bootstrap. Runs `git submodule update --init --recursive`, executes `game-server-deploy/setup.sh` (installs Node/Terraform/AWS CLI on Debian/Ubuntu, npm-installs all workspaces, builds Lambda bundles, runs `terraform init` and bootstraps the S3 backend), then records the sha256 of `setup.sh` in `.make/setup.stamp`. |
+| `make plan` | Copies `terraform.tfvars` into `game-server-deploy/terraform/terraform.tfvars`, then runs `make -C game-server-deploy tf-plan` — which itself rebuilds the Lambda bundles before `terraform plan`. |
+| `make apply` | Same as `plan`, but delegates to `tf-apply`. The submodule's `tf-apply` recipe prints a post-deploy checklist with the Discord interactions URL when it finishes. |
+| `make update` | Bumps the submodule to the tip of `main` (`git submodule update --remote --merge`). If the new `setup.sh` differs from the recorded sha, clears `.terraform/` and re-runs `setup.sh` automatically; otherwise leaves it alone. Reminds you to commit the new submodule pointer. |
+| `make dev` | Pulls live tfstate into `.make/tfstate.json` (so the embed step has something to read), wipes stale TS build info under the submodule's `app/packages/*/`, then runs `make -C game-server-deploy dev`, exporting `API_TOKEN` and `TF_STATE_PATH` to the child make. |
+
+The `tfvars` copy is **always fresh** on plan/apply — the recipe `cp`s
+unconditionally, not just when the file is older than the destination. This
+prevents stale variables from sneaking into a deploy when you've edited the
+parent's `terraform.tfvars` between runs.
+
+## Submodule update with idempotent setup.sh re-run
+
+`make update` records `sha256sum game-server-deploy/setup.sh` in
+`.make/setup.stamp` after each successful setup. On every subsequent
+`update`, it compares the new file's sha against the stamp:
+
+- **Unchanged** → nothing to do; the existing `.terraform/` and installed
+  npm dependencies are still valid.
+- **Changed** → upstream tweaked the bootstrap (new tool version, S3 backend
+  config change, Lambda build step, …). The recipe wipes
+  `game-server-deploy/terraform/.terraform/` and re-runs `setup.sh`, then
+  records the new sha.
+
+You don't have to remember whether the bootstrap moved. The stamp file is
+cheap and gitignored.
+
+## .env and the API_TOKEN
+
+`API_TOKEN` is the bearer token the management app's Nest server requires
+on every `/api/*` request. The wrapper Makefile loads it from `.env` via
+`include`, so it's available for `make dev` and any docker-compose target
+without ever being baked into the Makefile itself:
+
+```makefile
+ifneq (,$(wildcard $(REPO_ROOT)/.env))
+include $(REPO_ROOT)/.env
+export
+endif
 ```
 
-### 3. `.gitignore` the things that must never leak
+`.env` is in the parent's `.gitignore`. Generate a fresh token with
+`openssl rand -hex 32` (or just re-run `init-parent.ts`) — there's no need
+to keep the same token across rebuilds.
 
-```gitignore
-# Local tfstate (if you don't use a remote backend)
-state/*.tfstate
-state/*.tfstate.backup
-state/.terraform/
-state/.terraform.lock.hcl
+## tfstate lives in S3 by default
 
-# Shell env with the bearer token and sometimes AWS creds
-.env
+`game-server-deploy/setup.sh` provisions an S3 bucket
+(`{project_name}-tf-state`) and a DynamoDB lock table
+(`{project_name}-tf-locks`) on first run, then `terraform init`s with the
+S3 backend pointing at them. The parent repo never holds `terraform.tfstate`
+on disk — the wrapper's `make dev` pulls a fresh copy into
+`.make/tfstate.json` for the management app to read.
 
-# Anything you keep outside config/ that's sensitive
-secrets/
-
-# Editor / OS noise
-.DS_Store
-.vscode/
-```
-
-### 4. Put your tfvars and server config in `config/`
-
-```bash
-mkdir -p config state
-cp gsd/terraform/terraform.tfvars.example config/terraform.tfvars
-# edit config/terraform.tfvars with your real values
-
-cat > config/server_config.json <<'JSON'
-{
-  "watchdog_interval_minutes": 15,
-  "watchdog_idle_checks": 4,
-  "watchdog_min_packets": 100
-}
-JSON
-```
-
-Now wire those into the submodule's expected paths. Two options:
-
-- **Symlinks** (simplest, works on Linux + macOS):
-
-  ```bash
-  ln -sf "$(pwd)/config/terraform.tfvars" gsd/terraform/terraform.tfvars
-  ln -sf "$(pwd)/config/server_config.json" gsd/app/server_config.json
-  ```
-
-  Both paths are gitignored inside `gsd/`, so the symlinks won't pollute the
-  submodule's working tree.
-
-- **Script-driven copies** (works on Windows, or if you dislike symlinks):
-  have `scripts/apply.sh` copy `config/*` into `gsd/terraform/` and
-  `gsd/app/` at the start of every run. The copy target is already
-  gitignored inside the submodule.
-
-### 5. Decide where tfstate lives
-
-Two reasonable choices:
-
-- **Local state in the parent repo** — simplest, fine for a single
-  operator. Add a backend override file inside the symlinked tfvars or
-  point `terraform init` at an explicit `-chdir` pattern:
-
-  ```bash
-  terraform -chdir=gsd/terraform init \
-    -backend-config="path=$(pwd)/state/terraform.tfstate"
-  ```
-
-- **S3 + DynamoDB remote backend** — better for teams, CI, or "don't
-  lose your laptop". Add a `backend.tf` in `config/` with:
-
-  ```hcl
-  terraform {
-    backend "s3" {
-      bucket         = "your-tf-state-bucket"
-      key            = "gsd/terraform.tfstate"
-      region         = "us-east-1"
-      dynamodb_table = "tf-state-lock"
-      encrypt        = true
-    }
-  }
-  ```
-
-  and symlink it into `gsd/terraform/backend.tf`. The bucket and lock
-  table need to be created once, either by hand or by a tiny bootstrap
-  terraform in its own directory.
-
-### 6. Put the bearer token in `.env`
-
-`app/server_config.json` can hold an `api_token` field, but if your
-`server_config.json` is committed to the parent repo you don't want the
-token in there. Put it in `.env` instead (gitignored):
-
-```bash
-# .env
-export API_TOKEN="$(openssl rand -hex 32)"
-export AWS_PROFILE="games"    # if you use named profiles
-```
-
-Source it before running anything:
-
-```bash
-source .env
-cd gsd/app && npm run dev
-# or
-cd gsd && docker compose up --build
-```
-
-`server_config.json` stays token-free and public to whoever reads the
-private parent; the actual secret comes from the environment at runtime.
-
-### 7. Write a thin wrapper script
-
-A minimal `scripts/apply.sh`:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-
-# Ensure submodule is at the committed SHA
-git submodule update --init --recursive
-
-# (Re)link config into the submodule
-ln -sf "$(pwd)/config/terraform.tfvars" gsd/terraform/terraform.tfvars
-ln -sf "$(pwd)/config/server_config.json" gsd/app/server_config.json
-
-# Build Lambdas, then apply
-cd gsd/app && npm ci && npm run build:lambdas
-cd ../terraform && terraform init && terraform apply
-```
-
-Similar `dev.sh` for the management app:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(dirname "$0")/.."
-source .env
-cd gsd/app
-npm ci
-npm run dev
-```
-
-Run `chmod +x scripts/*.sh` and you're one command away from each action.
-
-### 8. Docker: override mounts, don't rewrite the compose file
-
-If you're using `docker compose`, create a `docker-compose.override.yml` in
-the parent. Compose merges it with `gsd/docker-compose.yml`:
-
-```yaml
-# docker-compose.override.yml — kept in the parent repo
-services:
-  app:
-    volumes:
-      - ./config/server_config.json:/app/server_config.json
-      - ./state:/app/terraform/state:ro   # if using local tfstate outside gsd/
-    env_file:
-      - .env
-```
-
-Run it from inside the submodule:
-
-```bash
-cd gsd
-docker compose -f docker-compose.yml -f ../docker-compose.override.yml up --build
-```
+If you don't want a remote backend (single-operator, throwaway deployment),
+delete the S3 bootstrap from your fork of `setup.sh`. We don't recommend
+this for anything you care about.
 
 ## Discord credentials: pick a home
 
@@ -283,9 +182,9 @@ Public Key. Trade-offs:
 | **Environment at apply time** (`TF_VAR_discord_bot_token=…`) | Never on disk. | Every operator needs the token in their shell to apply. |
 | **Dashboard only** | Token only exists in Secrets Manager. | You have to paste it once per fresh environment, and the DDB `CONFIG#discord` row is seeded manually. |
 
-The tfvars route is what most people pick. `.tfvars` is gitignored in the
-*submodule*, and your parent repo is private, so it ends up covered by the
-same "private-repo trust boundary" as everything else.
+The tfvars route is what most people pick, and it's what `init-parent.ts`
+will offer to seed. Your parent repo is private, so it ends up covered by
+the same "private-repo trust boundary" as everything else.
 
 Rotation after the first apply (tfvars route):
 
@@ -293,29 +192,28 @@ Rotation after the first apply (tfvars route):
 terraform taint aws_secretsmanager_secret_version.discord_bot_token
 # or: aws_secretsmanager_secret_version.discord_public_key
 # or: aws_dynamodb_table_item.discord_config_seed
-terraform apply
+make apply
 ```
 
 ## Keeping up with upstream
 
 ```bash
-cd gsd
-git fetch
-git log --oneline HEAD..origin/main           # preview
-git checkout origin/main                      # or a new tag
-cd ..
-git add gsd && git commit -m "chore: bump gsd to $(git -C gsd rev-parse --short HEAD)"
+make update
+git add game-server-deploy
+git commit -m "chore: bump game-server-deploy to $(git -C game-server-deploy rev-parse --short HEAD)"
+make plan        # eyeball the diff
+make apply       # if it looks right
 ```
 
-Always run `npm run build:lambdas` + `terraform plan` after a bump and
-eyeball the plan diff before applying. Breaking changes in the upstream
-Lambda env-var shape or IAM policies will show up as Lambda changes in the
-plan.
+`make update` always reminds you about the commit step at the end. If
+`setup.sh` changed upstream, it'll have already re-run by the time `make
+plan` starts, so the next plan picks up any new tooling cleanly.
 
 Things that tend to need attention after a bump:
 
 - New or renamed Terraform variables → add them to your
-  `config/terraform.tfvars`.
+  `terraform.tfvars`. Compare against
+  `game-server-deploy/terraform/terraform.tfvars.example`.
 - New environment variables on the Lambdas → typically Terraform handles
   this automatically, but verify in the plan output.
 - Changes to the four slash-command descriptors → re-click **Register
@@ -348,10 +246,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: cd gsd/app && npm ci && npm run build:lambdas
-      - run: |
-          ln -sf "$(pwd)/config/terraform.tfvars" gsd/terraform/terraform.tfvars
-          cd gsd/terraform && terraform init && terraform plan -no-color
+      - run: make setup
+      - run: make plan
 ```
 
 Use OIDC → an IAM role for `aws-actions/configure-aws-credentials` rather
@@ -362,24 +258,28 @@ than stashing long-lived keys. The role's policy is the same
 
 - **Don't fork the public repo and edit it.** The submodule pattern gives
   you every pinning benefit of a fork without the merge conflicts. If you
-  need a real code change, contribute upstream and bump your submodule to
-  the new commit.
+  need a real code change, contribute upstream and `make update` to bump
+  to the new commit.
 - **Don't commit `terraform.tfvars` inside the submodule.** Even a private
   parent doesn't save you if someone later runs `git submodule foreach git
-  push origin HEAD`. Keep your config in `config/` in the parent and
-  symlink it in.
-- **Don't commit `terraform.tfstate` anywhere in the public repo path.**
-  Keep it in `state/` (gitignored) or in a remote backend.
-- **Don't expose `API_TOKEN` in `server_config.json` if that file is
-  committed.** Environment variable only, or commit the file without the
-  `api_token` field.
+  push origin HEAD`. Keep your tfvars in the *parent* — the wrapper copies
+  it into the submodule at apply time, and the submodule's own
+  `.gitignore` excludes `terraform/*.tfvars`.
+- **Don't hardcode `API_TOKEN` in the wrapper Makefile.** Use `.env` and
+  the `include`/`export` pattern. The Makefile lives in your private repo,
+  but a leaked clone is one careless `git push` away.
+- **Don't run plan/apply directly in the submodule.** Always go through
+  the parent's `make plan`/`make apply` so the freshly-edited
+  `terraform.tfvars` is copied in first. A plan against stale vars is a
+  plan against the wrong universe.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `terraform apply` inside the submodule can't find `terraform.tfvars` | Symlink missing or broken | Re-run `scripts/apply.sh` which recreates them, or `ln -sf ../../config/terraform.tfvars gsd/terraform/terraform.tfvars`. |
-| `docker compose` ignores your override | Running from the wrong directory | From `gsd/`, pass both files explicitly: `-f docker-compose.yml -f ../docker-compose.override.yml`. |
-| `git submodule update --remote` silently pulls main and breaks apply | You hadn't pinned; `remote` moves to origin/HEAD | Either pin to a SHA (`git -C gsd checkout <sha>`) or add `branch = main` in `.gitmodules` and review diffs before every bump. |
+| `make plan` says "No such file or directory" pointing at `game-server-deploy/` | Submodule wasn't initialised | `make setup` (or `git submodule update --init --recursive`). |
+| `make apply` runs against an old `terraform.tfvars` | You edited the parent's tfvars but ran terraform inside the submodule directly | Always run `make apply` from the parent — the `copy-tfvars` recipe forces a fresh copy. |
+| `make update` silently pulls main and breaks apply | Upstream changed something incompatible | The stamp file's job is to flag setup.sh changes; for non-bootstrap breakage, run `make plan` and read the diff. Pin to a SHA in `.gitmodules` if you want stricter control. |
 | After bumping upstream, Discord commands have wrong arguments | Descriptors in `@gsd/shared/commands.ts` changed | Click **Register commands** for each guild in the dashboard. |
-| CI plan shows a Lambda recreating every run | Bundle hash changes between builds | Run `npm ci` (not `npm install`) in CI to pin dependencies; commit `app/package-lock.json` via the submodule bump. |
+| `make dev` complains it can't read tfstate | First-time run before `make apply` | Ignore — the recipe writes `null` and the app degrades gracefully until the first apply succeeds. |
+| CI plan shows a Lambda recreating every run | Bundle hash changes between builds | Run `npm ci` (not `npm install`) in CI to pin dependencies; `setup.sh` already does this. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,43 @@
+# scripts/
+
+Helper scripts for `game-server-deploy`. These are intentionally **not** part
+of the `app/` workspace — they exist to be run from a *parent* repo that
+vendors `game-server-deploy` as a git submodule, before any of the app's
+dependencies have been installed.
+
+## `init-parent.ts`
+
+Interactive scaffolder for the [private parent + submodule deployment
+pattern](https://codercoco.github.io/game-server-deploy/guides/submodule/). It
+generates a `Makefile`, `terraform.tfvars`, `.env`, and `.gitignore` in your
+parent repo, all wired to the wrapper Make targets (`setup`, `plan`, `apply`,
+`update`, `dev`) so you can drive the whole stack from the parent repo root.
+
+### Usage
+
+From the parent (private) repo root, after adding the submodule:
+
+```bash
+git submodule add https://github.com/CoderCoco/game-server-deploy.git
+(cd game-server-deploy/scripts && npm install)
+node --import tsx game-server-deploy/scripts/init-parent.ts
+# or, equivalently:
+npx --prefix game-server-deploy/scripts tsx game-server-deploy/scripts/init-parent.ts
+```
+
+Flags:
+
+- `--force` — overwrite existing files instead of skipping them.
+- `--non-interactive` (`-y`) — accept all defaults; useful for CI smoke tests.
+
+The script never reads or modifies anything inside the submodule. Safe to
+re-run; without `--force` it leaves existing files alone.
+
+### Requirements
+
+- Node.js 20+ (the same minimum the rest of the project enforces).
+- `git` on `$PATH` (used to detect `.gitmodules`).
+
+Windows users should run this under WSL or Git Bash — the generated
+`Makefile` uses `bash`, `sha256sum`, and `cp`, which mirrors the upstream
+Makefile's shell expectations.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,7 +28,6 @@ npx --prefix game-server-deploy/scripts tsx game-server-deploy/scripts/init-pare
 Flags:
 
 - `--force` — overwrite existing files instead of skipping them.
-- `--non-interactive` (`-y`) — accept all defaults; useful for CI smoke tests.
 
 The script never reads or modifies anything inside the submodule. Safe to
 re-run; without `--force` it leaves existing files alone.

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Render-function smoke test for init-parent.ts. Run with:
+ *   npx tsx init-parent.test.ts
+ *
+ * No assertion library — fails loudly via `process.exit(1)` if any check
+ * doesn't hold.
+ */
+
+import { renderMakefile, renderTfvars, renderEnv, renderGitignore } from './init-parent.ts';
+
+const a = {
+  parentDir: '/tmp/parent',
+  submoduleDir: 'game-server-deploy',
+  submoduleName: 'game-server-deploy',
+  projectName: 'mygames',
+  awsRegion: 'us-west-2',
+  hostedZone: 'example.com',
+  apiToken: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222',
+  configureDiscord: false,
+};
+
+const errors: string[] = [];
+const expect = (label: string, ok: boolean): void => {
+  if (!ok) errors.push(label);
+};
+
+const mk = renderMakefile(a);
+expect('Makefile sets SUBMODULE', mk.includes('SUBMODULE   := $(REPO_ROOT)/game-server-deploy'));
+expect('Makefile reads .env', mk.includes('include $(REPO_ROOT)/.env'));
+expect('Makefile delegates plan', mk.includes('$(MAKE) -C $(SUBMODULE) tf-plan'));
+expect('Makefile delegates apply', mk.includes('$(MAKE) -C $(SUBMODULE) tf-apply'));
+expect('Makefile has dev target with state pull', mk.includes('terraform -chdir=$(TF_DIR) state pull'));
+expect('Makefile has setup with stamp', mk.includes('SETUP_STAMP := $(STAMP_DIR)/setup.stamp'));
+expect('Makefile rerun-on-change in update', mk.includes('setup.sh changed'));
+expect('Makefile copy-tfvars uses cp', mk.includes('cp $(TFVARS) $(TF_DIR)/terraform.tfvars'));
+expect('Makefile uses bash shell', mk.startsWith('SHELL      := /usr/bin/env bash'));
+expect('Makefile does NOT inline API_TOKEN', !/API_TOKEN\s*:?=\s*[a-f0-9]{40,}/.test(mk));
+
+const tfv = renderTfvars(a);
+expect('tfvars sets project_name', tfv.includes('project_name = "mygames"'));
+expect('tfvars sets aws_region', tfv.includes('aws_region   = "us-west-2"'));
+expect('tfvars sets hosted_zone_name', tfv.includes('hosted_zone_name = "example.com"'));
+expect('tfvars has game_servers map', tfv.includes('game_servers = {'));
+expect('tfvars Discord left commented when not configured', tfv.includes('# discord_application_id'));
+
+const env = renderEnv(a);
+expect('env contains API_TOKEN line', env.includes(`API_TOKEN=${a.apiToken}`));
+
+const gi = renderGitignore(a);
+expect('gitignore covers .env', gi.includes('.env\n'));
+expect('gitignore covers .make/', gi.includes('.make/'));
+expect('gitignore covers tfstate', gi.includes('terraform.tfstate'));
+
+const aDiscord = { ...a, configureDiscord: true, discordApplicationId: '111', discordBotToken: 'btok', discordPublicKey: 'pkey' };
+const tfvD = renderTfvars(aDiscord);
+expect('tfvars writes Discord values when configured', tfvD.includes('discord_bot_token      = "btok"'));
+expect('tfvars writes Discord public key', tfvD.includes('discord_public_key     = "pkey"'));
+
+if (errors.length) {
+  process.stderr.write(`\n✗ ${errors.length} render check(s) failed:\n`);
+  for (const e of errors) process.stderr.write(`  - ${e}\n`);
+  process.exit(1);
+}
+process.stdout.write('✓ All render checks passed.\n');

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -215,8 +215,9 @@ discord_public_key     = "${a.discordPublicKey}"
 `;
 
   return `# ${a.projectName} — Terraform variables.
-# This file is gitignored at the parent-repo level; the Makefile copies it into
-# ${a.submoduleDir}/terraform/terraform.tfvars on every plan/apply.
+# Commit this file to your private parent repo. The wrapper Makefile copies it
+# into ${a.submoduleDir}/terraform/terraform.tfvars on every plan/apply, where
+# the submodule's own .gitignore prevents it from being committed back.
 
 aws_region   = "${a.awsRegion}"
 project_name = "${a.projectName}"

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -1,0 +1,462 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * init-parent.ts
+ *
+ * Interactive scaffolder for the "private parent repo + game-server-deploy
+ * submodule" deployment pattern documented at
+ * https://codercoco.github.io/game-server-deploy/guides/submodule/.
+ *
+ * Run from the parent (private) repo root:
+ *
+ *   cd your-private-games
+ *   git submodule add https://github.com/CoderCoco/game-server-deploy.git
+ *   (cd game-server-deploy/scripts && npm install)
+ *   npx --prefix game-server-deploy/scripts tsx game-server-deploy/scripts/init-parent.ts
+ *
+ * The script writes (or refuses to overwrite without --force):
+ *   - Makefile           wrapper around the submodule's Makefile
+ *   - terraform.tfvars   skeleton populated from your answers
+ *   - .env               API_TOKEN for the management app (gitignored)
+ *   - .gitignore         covers .env, .make/, terraform.tfstate*, etc.
+ *
+ * It NEVER reads or modifies anything inside the submodule.
+ */
+
+import { createInterface, type Interface } from 'node:readline/promises';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { stdin as input, stdout as output, argv, cwd, exit } from 'node:process';
+import { randomBytes } from 'node:crypto';
+
+interface Answers {
+  parentDir: string;
+  submoduleDir: string;
+  submoduleName: string;
+  projectName: string;
+  awsRegion: string;
+  hostedZone: string;
+  apiToken: string;
+  configureDiscord: boolean;
+  discordApplicationId?: string;
+  discordBotToken?: string;
+  discordPublicKey?: string;
+}
+
+const FORCE = argv.includes('--force');
+const NON_INTERACTIVE = argv.includes('--non-interactive') || argv.includes('-y');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Path detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Walk up from `start` until a directory containing `.gitmodules` is found. */
+function findParentRepoRoot(start: string): string | null {
+  let dir = resolve(start);
+  while (true) {
+    if (existsSync(join(dir, '.gitmodules'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** Best-effort guess of the submodule path inside the parent repo. */
+function detectSubmodulePath(parentDir: string, scriptDir: string): string {
+  // If the script lives at <parent>/<submodule>/scripts/init-parent.ts,
+  // the submodule directory name is the immediate parent of `scripts/`.
+  const submoduleRoot = dirname(scriptDir);
+  const rel = relative(parentDir, submoduleRoot);
+  if (rel && !rel.startsWith('..') && !isAbsolute(rel)) return rel;
+
+  // Fall back to parsing .gitmodules.
+  const gm = join(parentDir, '.gitmodules');
+  if (existsSync(gm)) {
+    const m = readFileSync(gm, 'utf8').match(/path\s*=\s*(\S+)/);
+    if (m) return m[1];
+  }
+  return 'game-server-deploy';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prompting
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function ask(rl: Interface, label: string, def?: string): Promise<string> {
+  const suffix = def === undefined ? ': ' : ` [${def}]: `;
+  const raw = (await rl.question(label + suffix)).trim();
+  return raw || def || '';
+}
+
+async function askBool(rl: Interface, label: string, def: boolean): Promise<boolean> {
+  const hint = def ? 'Y/n' : 'y/N';
+  const raw = (await rl.question(`${label} (${hint}): `)).trim().toLowerCase();
+  if (!raw) return def;
+  return raw.startsWith('y');
+}
+
+async function askRequired(rl: Interface, label: string, def?: string): Promise<string> {
+  while (true) {
+    const v = await ask(rl, label, def);
+    if (v) return v;
+    output.write('  ↳ a value is required.\n');
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File generators
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mirrors the structure documented in the Makefile-driven submodule pattern:
+ *   setup → init submodule, run setup.sh, stamp its sha
+ *   plan  → copy tfvars in, delegate to submodule's `make tf-plan`
+ *   apply → same, delegate to `make tf-apply`
+ *   update → bump submodule, rerun setup.sh only if its sha changed
+ *   dev   → pull live tfstate into .make/, then `make dev` in submodule
+ *
+ * API_TOKEN is loaded from .env (gitignored) — never hardcoded.
+ */
+export function renderMakefile(a: Answers): string {
+  return `SHELL      := /usr/bin/env bash
+.SHELLFLAGS := -eu -o pipefail -c
+
+REPO_ROOT   := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SUBMODULE   := $(REPO_ROOT)/${a.submoduleDir}
+TF_DIR      := $(SUBMODULE)/terraform
+TFVARS      := $(REPO_ROOT)/terraform.tfvars
+STAMP_DIR   := $(REPO_ROOT)/.make
+SETUP_STAMP := $(STAMP_DIR)/setup.stamp
+
+# Load API_TOKEN (and any other K=V) from .env without leaking it into git.
+ifneq (,$(wildcard $(REPO_ROOT)/.env))
+include $(REPO_ROOT)/.env
+export
+endif
+
+.PHONY: help setup plan apply update dev copy-tfvars
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+help:
+\t@echo "${a.projectName} — submodule deployment wrapper"
+\t@echo ""
+\t@echo "  make setup    One-time bootstrap: init submodule, install deps, terraform init"
+\t@echo "  make plan     Copy tfvars into submodule then terraform plan"
+\t@echo "  make apply    Copy tfvars into submodule then terraform apply"
+\t@echo "  make update   Pull latest ${a.submoduleDir}/main; rerun setup.sh if changed"
+\t@echo "  make dev      Start dev servers (Nest :3001 + Vite :5173)"
+
+# ── Stamp dir ────────────────────────────────────────────────────────────────
+$(STAMP_DIR):
+\t@mkdir -p $@
+
+# ── One-time setup ───────────────────────────────────────────────────────────
+setup: | $(STAMP_DIR)
+\tgit submodule update --init --recursive
+\tbash $(SUBMODULE)/setup.sh
+\t@sha256sum $(SUBMODULE)/setup.sh | cut -d' ' -f1 > $(SETUP_STAMP)
+
+# ── Copy tfvars into the submodule terraform dir ─────────────────────────────
+$(TF_DIR)/terraform.tfvars: $(TFVARS)
+\tcp $(TFVARS) $@
+
+# Force a fresh copy on every plan/apply so stale vars can't slip through.
+copy-tfvars: $(TFVARS)
+\tcp $(TFVARS) $(TF_DIR)/terraform.tfvars
+
+# ── Terraform targets ────────────────────────────────────────────────────────
+plan: copy-tfvars
+\t$(MAKE) -C $(SUBMODULE) tf-plan
+
+apply: copy-tfvars
+\t$(MAKE) -C $(SUBMODULE) tf-apply
+
+# ── Submodule update with idempotent setup.sh re-run ─────────────────────────
+update: | $(STAMP_DIR)
+\tgit submodule update --remote --merge $(SUBMODULE)
+\t@CURRENT=$$(sha256sum $(SUBMODULE)/setup.sh | cut -d' ' -f1); \\
+\t PREVIOUS=$$(cat $(SETUP_STAMP) 2>/dev/null || echo ""); \\
+\t if [ "$$CURRENT" != "$$PREVIOUS" ]; then \\
+\t   echo "setup.sh changed — clearing .terraform/ and rerunning..."; \\
+\t   rm -rf $(TF_DIR)/.terraform; \\
+\t   bash $(SUBMODULE)/setup.sh; \\
+\t   echo "$$CURRENT" > $(SETUP_STAMP); \\
+\t else \\
+\t   echo "setup.sh unchanged — skipping."; \\
+\t fi
+\t@echo ""
+\t@echo "Submodule updated. Commit the new pointer when ready:"
+\t@echo "  git add ${a.submoduleDir} && git commit -m 'chore: bump ${a.submoduleDir}'"
+
+# ── Dev server ───────────────────────────────────────────────────────────────
+# Pull live tfstate so embed-tfstate has something to read; falls back to null
+# when the backend isn't reachable yet (e.g. before the first apply).
+dev: | $(STAMP_DIR)
+\tterraform -chdir=$(TF_DIR) state pull > $(STAMP_DIR)/tfstate.json 2>/dev/null || echo 'null' > $(STAMP_DIR)/tfstate.json
+\trm -f $(SUBMODULE)/app/packages/*/tsconfig*.tsbuildinfo
+\tTF_STATE_PATH=$(STAMP_DIR)/tfstate.json $(MAKE) -C $(SUBMODULE) dev
+`;
+}
+
+/**
+ * Skeleton tfvars derived from the public terraform.tfvars.example shape. We
+ * fill in the few things we just asked the user about and leave the rest as
+ * commented examples.
+ */
+export function renderTfvars(a: Answers): string {
+  const discordBlock =
+    a.configureDiscord && a.discordApplicationId && a.discordBotToken && a.discordPublicKey
+      ? `discord_application_id = "${a.discordApplicationId}"
+discord_bot_token      = "${a.discordBotToken}"
+discord_public_key     = "${a.discordPublicKey}"
+`
+      : `# discord_application_id = "1234567890"
+# discord_bot_token      = "MTIz...xyz"
+# discord_public_key     = "0123abc..."
+`;
+
+  return `# ${a.projectName} — Terraform variables.
+# This file is gitignored at the parent-repo level; the Makefile copies it into
+# ${a.submoduleDir}/terraform/terraform.tfvars on every plan/apply.
+
+aws_region   = "${a.awsRegion}"
+project_name = "${a.projectName}"
+
+# Hosted zone in Route 53. {game}.${a.hostedZone} records are managed by Lambda.
+hosted_zone_name = "${a.hostedZone}"
+
+# Watchdog: auto-shuts down idle servers after (interval × idle_checks) minutes.
+watchdog_interval_minutes = 15
+watchdog_idle_checks      = 4
+watchdog_min_packets      = 100
+
+# acm_certificate_domain = "*.${a.hostedZone}"
+
+# Discord bot credentials (optional — leave commented out to configure via the web UI).
+${discordBlock}
+# base_allowed_guilds  = ["123456789012345678"]
+# base_admin_user_ids  = ["987654321098765432"]
+# base_admin_role_ids  = []
+
+# Game server definitions. See ${a.submoduleDir}/terraform/terraform.tfvars.example
+# for the full schema.
+game_servers = {
+  # palworld = {
+  #   image  = "thijsvanloef/palworld-server-docker:latest"
+  #   cpu    = 2048
+  #   memory = 8192
+  #   ports = [
+  #     { container = 8211,  protocol = "udp" },
+  #     { container = 27015, protocol = "udp" },
+  #   ]
+  #   environment = [
+  #     { name = "PLAYERS",     value = "8" },
+  #     { name = "SERVER_NAME", value = "My Palworld Server" },
+  #   ]
+  #   volumes = [
+  #     { name = "saves", container_path = "/palworld" },
+  #   ]
+  #   https = false
+  # }
+}
+`;
+}
+
+export function renderEnv(a: Answers): string {
+  return `# Bearer token for the management app (also used by docker compose).
+# This file is gitignored — never commit it. Rotate by deleting and re-running
+# \`init-parent.ts\` (or just generate a new hex string).
+API_TOKEN=${a.apiToken}
+`;
+}
+
+export function renderGitignore(a: Answers): string {
+  return `# ${a.projectName} — parent repo .gitignore
+
+# Bearer token + any local environment overrides
+.env
+.env.*
+!.env.example
+
+# Make stamp dir (sha256 of submodule's setup.sh, cached tfstate.json, ...)
+.make/
+
+# Terraform local state, if you ever fall off the S3 backend
+terraform.tfstate
+terraform.tfstate.backup
+*.tfvars.local
+
+# Editor / OS noise
+.DS_Store
+.vscode/
+.idea/
+`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IO helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function writeIfSafe(path: string, contents: string): 'wrote' | 'skipped' | 'overwrote' {
+  if (existsSync(path) && !FORCE) {
+    return 'skipped';
+  }
+  const existed = existsSync(path);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+  return existed ? 'overwrote' : 'wrote';
+}
+
+function status(path: string, action: 'wrote' | 'skipped' | 'overwrote', parentDir: string): void {
+  const rel = relative(parentDir, path) || path;
+  const tag =
+    action === 'wrote'
+      ? '  +'
+      : action === 'overwrote'
+        ? '  ~'
+        : '  ·';
+  const note = action === 'skipped' ? '  (exists — use --force to overwrite)' : '';
+  output.write(`${tag} ${rel}${note}\n`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isValidProjectName(s: string): boolean {
+  // Used as part of S3 bucket names by setup.sh — keep it conservative.
+  return /^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/.test(s);
+}
+
+function isValidRegion(s: string): boolean {
+  return /^[a-z]{2,3}-[a-z]+-\d$/.test(s);
+}
+
+function isValidDomain(s: string): boolean {
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(s);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const guessedParent = findParentRepoRoot(cwd()) ?? findParentRepoRoot(scriptDir) ?? cwd();
+
+  output.write('\n');
+  output.write('  game-server-deploy — submodule deployment scaffolder\n');
+  output.write('  ────────────────────────────────────────────────────\n');
+  output.write('\n');
+  output.write(`  Parent repo:  ${guessedParent}\n`);
+  output.write(`  Script:       ${relative(guessedParent, fileURLToPath(import.meta.url)) || fileURLToPath(import.meta.url)}\n`);
+  output.write('\n');
+  output.write('  This will write Makefile, terraform.tfvars, .env, and .gitignore in\n');
+  output.write('  the parent repo. Existing files are skipped unless you pass --force.\n');
+  output.write('\n');
+
+  const rl = createInterface({ input, output });
+  try {
+    const parentDir = NON_INTERACTIVE
+      ? guessedParent
+      : await ask(rl, 'Parent repo path', guessedParent);
+
+    if (!existsSync(parentDir) || !statSync(parentDir).isDirectory()) {
+      output.write(`\n  ✗ ${parentDir} is not a directory.\n`);
+      exit(1);
+    }
+
+    const submoduleDir = await ask(
+      rl,
+      'Submodule path (relative to parent repo)',
+      detectSubmodulePath(parentDir, scriptDir),
+    );
+    const submoduleName = submoduleDir.split('/').pop() || 'game-server-deploy';
+
+    let projectName = '';
+    while (!isValidProjectName(projectName)) {
+      projectName = await askRequired(rl, 'Project name (S3 bucket prefix; lowercase, dashes ok)', 'game-servers');
+      if (!isValidProjectName(projectName)) output.write('  ↳ must be 3–32 chars, lowercase letters/numbers/dashes.\n');
+    }
+
+    let awsRegion = '';
+    while (!isValidRegion(awsRegion)) {
+      awsRegion = await askRequired(rl, 'AWS region', 'us-east-1');
+      if (!isValidRegion(awsRegion)) output.write('  ↳ must look like "us-east-1".\n');
+    }
+
+    let hostedZone = '';
+    while (!isValidDomain(hostedZone)) {
+      hostedZone = await askRequired(rl, 'Route 53 hosted zone (e.g. example.com)');
+      if (!isValidDomain(hostedZone)) output.write('  ↳ must be a valid domain.\n');
+    }
+
+    const generated = randomBytes(32).toString('hex');
+    const apiTokenChoice = NON_INTERACTIVE
+      ? generated
+      : await ask(rl, 'API_TOKEN for the management app (press Enter to generate)', generated);
+    const apiToken = apiTokenChoice || generated;
+
+    const configureDiscord = NON_INTERACTIVE
+      ? false
+      : await askBool(rl, 'Seed Discord credentials in tfvars now?', false);
+
+    let discordApplicationId: string | undefined;
+    let discordBotToken: string | undefined;
+    let discordPublicKey: string | undefined;
+    if (configureDiscord) {
+      discordApplicationId = await askRequired(rl, '  Discord Application ID');
+      discordBotToken = await askRequired(rl, '  Discord Bot Token');
+      discordPublicKey = await askRequired(rl, '  Discord Public Key');
+    }
+
+    const answers: Answers = {
+      parentDir,
+      submoduleDir,
+      submoduleName,
+      projectName,
+      awsRegion,
+      hostedZone,
+      apiToken,
+      configureDiscord,
+      discordApplicationId,
+      discordBotToken,
+      discordPublicKey,
+    };
+
+    output.write('\n  Writing files…\n');
+    status(join(parentDir, 'Makefile'), writeIfSafe(join(parentDir, 'Makefile'), renderMakefile(answers)), parentDir);
+    status(join(parentDir, 'terraform.tfvars'), writeIfSafe(join(parentDir, 'terraform.tfvars'), renderTfvars(answers)), parentDir);
+    status(join(parentDir, '.env'), writeIfSafe(join(parentDir, '.env'), renderEnv(answers)), parentDir);
+    status(join(parentDir, '.gitignore'), writeIfSafe(join(parentDir, '.gitignore'), renderGitignore(answers)), parentDir);
+
+    output.write('\n  ✓ Done.\n\n');
+    output.write('  Next steps:\n');
+    output.write(`    1. Review terraform.tfvars and add at least one entry under game_servers.\n`);
+    output.write(`    2. Run \`make setup\` to bootstrap the submodule and Terraform.\n`);
+    output.write(`    3. Run \`make plan\` then \`make apply\`.\n`);
+    output.write(`    4. \`make dev\` to launch the management app on :5173.\n\n`);
+
+    if (existsSync(join(parentDir, '.gitmodules'))) {
+      const gm = readFileSync(join(parentDir, '.gitmodules'), 'utf8');
+      if (!gm.includes(submoduleDir)) {
+        output.write(`  Note: ${submoduleDir} is not in .gitmodules. Add it with:\n`);
+        output.write(`    git submodule add https://github.com/CoderCoco/game-server-deploy.git ${submoduleDir}\n\n`);
+      }
+    } else {
+      output.write(`  Note: no .gitmodules found. Add the submodule with:\n`);
+      output.write(`    git submodule add https://github.com/CoderCoco/game-server-deploy.git ${submoduleDir}\n\n`);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+// Only run when this file is the entry point — keeps the renderers importable
+// from tests without auto-launching the prompt loop.
+if (import.meta.url === `file://${argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
+    exit(1);
+  });
+}

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -44,7 +44,6 @@ interface Answers {
 }
 
 const FORCE = argv.includes('--force');
-const NON_INTERACTIVE = argv.includes('--non-interactive') || argv.includes('-y');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Path detection
@@ -357,9 +356,7 @@ async function main(): Promise<void> {
 
   const rl = createInterface({ input, output });
   try {
-    const parentDir = NON_INTERACTIVE
-      ? guessedParent
-      : await ask(rl, 'Parent repo path', guessedParent);
+    const parentDir = await ask(rl, 'Parent repo path', guessedParent);
 
     if (!existsSync(parentDir) || !statSync(parentDir).isDirectory()) {
       output.write(`\n  ✗ ${parentDir} is not a directory.\n`);
@@ -392,14 +389,10 @@ async function main(): Promise<void> {
     }
 
     const generated = randomBytes(32).toString('hex');
-    const apiTokenChoice = NON_INTERACTIVE
-      ? generated
-      : await ask(rl, 'API_TOKEN for the management app (press Enter to generate)', generated);
+    const apiTokenChoice = await ask(rl, 'API_TOKEN for the management app (press Enter to generate)', generated);
     const apiToken = apiTokenChoice || generated;
 
-    const configureDiscord = NON_INTERACTIVE
-      ? false
-      : await askBool(rl, 'Seed Discord credentials in tfvars now?', false);
+    const configureDiscord = await askBool(rl, 'Seed Discord credentials in tfvars now?', false);
 
     let discordApplicationId: string | undefined;
     let discordBotToken: string | undefined;
@@ -453,8 +446,13 @@ async function main(): Promise<void> {
 }
 
 // Only run when this file is the entry point — keeps the renderers importable
-// from tests without auto-launching the prompt loop.
-if (import.meta.url === `file://${argv[1]}`) {
+// from tests without auto-launching the prompt loop. Compare normalized
+// absolute paths so relative invocations (e.g. `tsx init-parent.ts`) still
+// match.
+const isEntrypoint =
+  argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(argv[1]);
+
+if (isEntrypoint) {
   main().catch((err) => {
     process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
     exit(1);

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,593 @@
+{
+  "name": "@gsd/scripts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@gsd/scripts",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^20.16.10",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@gsd/scripts",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Helper scripts for game-server-deploy. Not part of the app workspace — install from this directory.",
+  "type": "module",
+  "scripts": {
+    "init-parent": "tsx init-parent.ts",
+    "test": "tsx init-parent.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "@types/node": "^20.16.10"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds an interactive TypeScript scaffolder (`init-parent.ts`) that automates setup of the recommended deployment pattern: a private parent repository with `game-server-deploy` vendored as a git submodule. The scaffolder generates four files in the parent repo—`Makefile`, `terraform.tfvars`, `.env`, and `.gitignore`—eliminating manual configuration steps.

## Key Changes

- **`scripts/init-parent.ts`** — interactive CLI that:
  - Detects the parent repo root by walking up the directory tree looking for `.gitmodules`
  - Prompts for project name, AWS region, Route 53 hosted zone, and optional Discord credentials
  - Generates a wrapper `Makefile` with five targets (`setup`, `plan`, `apply`, `update`, `dev`) that delegate to the submodule's own Makefile
  - Creates `terraform.tfvars` skeleton with user-provided values
  - Generates `.env` with a random 256-bit hex `API_TOKEN`
  - Writes `.gitignore` covering `.env`, `.make/`, and `terraform.tfstate*`
  - Supports `--force` to overwrite existing files
  - Never reads or modifies anything inside the submodule

- **`scripts/init-parent.test.ts`** — Smoke tests for the four render functions, verifying Makefile structure, tfvars content, env format, and gitignore coverage.

- **`scripts/package.json` & `tsconfig.json`** — Minimal Node.js 20+ workspace for running the scaffolder via `tsx` without installing the main app dependencies.

- **Updated documentation** (`docs/docs/guides/submodule.md`):
  - Replaced multi-step manual setup with quick-start using the scaffolder
  - Simplified reference layout (no `config/`, `state/`, or `scripts/` subdirectories in parent)
  - Documented the wrapper Makefile's five targets and their behavior
  - Explained idempotent `setup.sh` re-run via sha256 stamp file
  - Clarified `.env` and `API_TOKEN` handling
  - Updated CI example to use `make setup` and `make plan`
  - Kept Discord credential guidance and upstream update workflow

- **Updated `README.md`** — Minor link/wording adjustments to point to the new submodule guide.

## Notable Implementation Details

- **Path detection**: Walks up from script location or current directory to find `.gitmodules`, with fallback to parsing the file itself.
- **Validation**: Project names must be S3-bucket-safe (3–32 chars, lowercase/dashes); AWS regions and domains are regex-validated.
- **Safe writes**: Files are skipped if they exist unless `--force` is passed; uses `mkdirSync({ recursive: true })` for stamp directory.
- **Makefile design**: Copies `terraform.tfvars` unconditionally on every plan/apply (not just when stale) to prevent variable drift; loads `.env` via `include` without hardcoding secrets.
- **Stamp file**: Records `sha256sum` of `setup.sh` to detect upstream bootstrap changes and re-run only when needed.
- **Entrypoint detection**: Uses `fileURLToPath(import.meta.url) === resolve(argv[1])` so relative invocations (e.g. `tsx init-parent.ts`) still trigger `main()`.
- **Interactive by design**: no non-interactive/CI flag — drive `tsx` with a heredoc or `expect(1)` if you need to scaffold from a script.

https://claude.ai/code/session_01EiFVqDg4dqjvEGALR8d6T9