### PR TITLE
chore(claude): enable typescript-lsp and terraform plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": true,
+    "terraform@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable the `typescript-lsp` Claude Code plugin at the project level via `.claude/settings.json` so anyone working in this repo gets TS language-server features automatically.
- Enable the `terraform` Claude Code plugin alongside it for parity with the Terraform-heavy half of the codebase.

## Test plan
- [ ] Reload plugins (`/reload-plugins`) and confirm both plugins activate without prompting.
- [ ] Open a `.ts` file and verify typescript-lsp diagnostics work.
- [ ] Open a `.tf` file and verify terraform plugin features are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)