### PR TITLE
chore(claude): enable github and chrome-devtools-mcp plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,9 @@
 {
   "enabledPlugins": {
+    "github@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "terraform@claude-plugins-official": true
+    "terraform@claude-plugins-official": true,
+    "chrome-devtools-mcp@claude-plugins-official": true
   },
   "permissions": {
     "deny": [

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,6 @@
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"]
-    },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Enable `github@claude-plugins-official` and `chrome-devtools-mcp@claude-plugins-official` plugins in `.claude/settings.json`
- Remove the now-redundant manual `github` HTTP MCP entry from `.mcp.json` (superseded by the official plugin)

## Test plan

- [ ] Verify Claude Code loads the GitHub and Chrome DevTools MCP plugins on session start
- [ ] Confirm GitHub MCP tools (e.g. `create_pull_request`) are available without the manual `.mcp.json` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)