### PR TITLE
test(web): Playwright e2e harness with auth-gate and dashboard specs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,33 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: app/packages/web
+
+      - run: npm run app:test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: app/packages/web/playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,9 @@ Thumbs.db
 # be committed (contains AWS ARNs/account IDs).
 app/packages/server/src/generated/tfstate.ts
 
+# Playwright artifacts (traces, videos, screenshots) and HTML report.
+app/packages/web/test-results/
+app/packages/web/playwright-report/
+app/packages/web/playwright/.cache/
+
 .make

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,10 +154,28 @@ Any time you add or remove Terraform variables, update **all four** of these in 
 
 ## Code & Test Conventions
 
-- **Test names**: every `it(...)` case must read as a natural-language sentence starting with "should" — e.g. `it('should return null when state file is missing')`, not `it('returns null...')`.
+- **Test names**: every `it(...)` / `test(...)` case must read as a natural-language sentence starting with "should" — e.g. `it('should return null when state file is missing')`, not `it('returns null...')`.
 - **TSDoc comments**: document non-trivial functions, helpers, and notable constants/variables with TSDoc (`/** ... */`) so their intent is clear later. This applies to test-file helpers (stub factories, fixtures) as well as production code.
 - **Typing in tests**: avoid `as unknown as SomeType` casts. Prefer `vi.mocked(fn)` for mocked modules and `Partial<T>` + a single `as T` for service-shaped stubs.
 - **No raw `process.env` in business logic**: wrap environment access behind a service method so tests can stub it via `vi.spyOn` instead of mutating `process.env` (which is flaky and leaks across tests).
+
+### Two-tier browser testing strategy
+
+The test suite has two complementary tiers:
+
+| Tier | Command | What runs | When to add specs |
+|------|---------|-----------|-------------------|
+| **Unit / integration** | `npm run app:test` | Vitest — server-side logic, hooks, helpers. No browser, no real network. AWS SDK mocked via `aws-sdk-client-mock`. | Pure logic, hook behaviour, server controllers. |
+| **E2E (tier 1 — #74)** | `npm run app:test:e2e` | Playwright against `vite build` + `vite preview`. Nest server never runs; every `/api/*` call is stubbed at the network layer via `page.route()`. | User-visible flows: routing, auth gate, button interactions, status-badge rendering, optimistic updates. |
+
+A planned **tier 2** (#75) will add full-stack specs (real Nest + mocked AWS SDK) for scenarios that require real HTTP contract validation between the client and server. Until that lands, all browser-facing specs belong in tier 1.
+
+**Playwright conventions:**
+- Specs live under `app/packages/web/e2e/specs/`.
+- Shared stub helpers and fixtures are in `app/packages/web/e2e/fixtures/`.
+- Import `{ test, expect, stubApis }` from `../fixtures/index.js` for authenticated specs; use `@playwright/test` directly for auth-gate specs.
+- Use the `authedPage` fixture (token pre-seeded in localStorage) for any spec that is not testing the auth flow itself.
+- Stubs must cover every `/api/*` endpoint the page hits, or the catch-all returns 404 and the test will surface the missing stub quickly.
 
 ## Git & Branch Workflow
 

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -49,6 +49,7 @@ export default tseslint.config(
   },
   {
     files: ['packages/web/**/*.{ts,tsx}'],
+    ignores: ['packages/web/e2e/**'],
     ...react.configs.flat.recommended,
     languageOptions: {
       ...react.configs.flat.recommended.languageOptions,
@@ -62,16 +63,18 @@ export default tseslint.config(
   },
   {
     files: ['packages/web/**/*.{ts,tsx}'],
+    ignores: ['packages/web/e2e/**'],
     ...react.configs.flat['jsx-runtime'],
   },
   {
     files: ['packages/web/**/*.{ts,tsx}'],
+    ignores: ['packages/web/e2e/**'],
     plugins: { 'react-hooks': reactHooks },
     rules: reactHooks.configs.recommended.rules,
   },
   {
-    // TypeScript already enforces prop types; disable the runtime-only rule.
     files: ['packages/web/**/*.{ts,tsx}'],
+    ignores: ['packages/web/e2e/**'],
     rules: { 'react/prop-types': 'off' },
   },
   {

--- a/app/packages/web/e2e/fixtures/game-data.ts
+++ b/app/packages/web/e2e/fixtures/game-data.ts
@@ -1,4 +1,4 @@
-import type { GameStatus, CostEstimates, EnvInfo } from '../../src/api.js';
+import type { GameStatus, CostEstimates, EnvInfo, WatchdogConfig } from '../../src/api.js';
 
 /** Stub response for `GET /api/env`. */
 export const ENV_DATA: EnvInfo = {
@@ -27,6 +27,13 @@ export const MULTI_GAME_STATUSES: GameStatus[] = [
   STOPPED_GAME,
   { game: 'valheim', state: 'running', publicIp: '5.6.7.8' },
 ];
+
+/** Stub response for `GET /api/config` (the watchdog tuning panel). */
+export const WATCHDOG_CONFIG: WatchdogConfig = {
+  watchdog_interval_minutes: 15,
+  watchdog_idle_checks: 4,
+  watchdog_min_packets: 100,
+};
 
 /** Stub response for `GET /api/costs/estimate`. */
 export const COST_DATA: CostEstimates = {

--- a/app/packages/web/e2e/fixtures/game-data.ts
+++ b/app/packages/web/e2e/fixtures/game-data.ts
@@ -1,0 +1,43 @@
+import type { GameStatus, CostEstimates, EnvInfo } from '../../src/api.js';
+
+/** Stub response for `GET /api/env`. */
+export const ENV_DATA: EnvInfo = {
+  region: 'us-east-1',
+  domain: 'example.com',
+  environment: 'dev',
+};
+
+/** A single stopped game — use as the default single-game fixture. */
+export const STOPPED_GAME: GameStatus = {
+  game: 'minecraft',
+  state: 'stopped',
+};
+
+/** A single running game with a public IP. */
+export const RUNNING_GAME: GameStatus = {
+  game: 'minecraft',
+  state: 'running',
+  publicIp: '1.2.3.4',
+  hostname: 'minecraft.example.com',
+  taskArn: 'arn:aws:ecs:us-east-1:123:task/minecraft/abc',
+};
+
+/** Two-game fixture covering stopped + running states. */
+export const MULTI_GAME_STATUSES: GameStatus[] = [
+  STOPPED_GAME,
+  { game: 'valheim', state: 'running', publicIp: '5.6.7.8' },
+];
+
+/** Stub response for `GET /api/costs/estimate`. */
+export const COST_DATA: CostEstimates = {
+  games: {
+    minecraft: {
+      vcpu: 1,
+      memoryGb: 2,
+      costPerHour: 0.08,
+      costPerDay24h: 1.92,
+      costPerMonth4hpd: 9.6,
+    },
+  },
+  totalPerHourIfAllOn: 0.08,
+};

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -1,10 +1,11 @@
-import { test as base, expect, type Page } from '@playwright/test';
-import type { GameStatus, CostEstimates, EnvInfo, ActionResult } from '../../src/api.js';
-import { ENV_DATA, STOPPED_GAME, COST_DATA } from './game-data.js';
+import { test as base, type Page } from '@playwright/test';
+import type { GameStatus, CostEstimates, EnvInfo, ActionResult, WatchdogConfig } from '../../src/api.js';
+import { ENV_DATA, STOPPED_GAME, COST_DATA, WATCHDOG_CONFIG } from './game-data.js';
 
-export type { GameStatus, CostEstimates, EnvInfo };
-export { ENV_DATA, STOPPED_GAME, RUNNING_GAME, MULTI_GAME_STATUSES, COST_DATA } from './game-data.js';
+export type { GameStatus, CostEstimates, EnvInfo, WatchdogConfig };
+export { ENV_DATA, STOPPED_GAME, RUNNING_GAME, MULTI_GAME_STATUSES, COST_DATA, WATCHDOG_CONFIG } from './game-data.js';
 
+/** Per-spec overrides for the default `/api/*` stubs registered by `stubApis`. */
 export interface StubOptions {
   /** Game statuses returned by `GET /api/status`. Defaults to `[STOPPED_GAME]`. */
   statuses?: GameStatus[];
@@ -12,6 +13,8 @@ export interface StubOptions {
   costs?: CostEstimates;
   /** Env info returned by `GET /api/env`. */
   env?: EnvInfo;
+  /** Watchdog config returned by `GET /api/config`. */
+  config?: WatchdogConfig;
   /** Override for `POST /api/start/:game` response. */
   startResult?: ActionResult;
 }
@@ -20,15 +23,22 @@ export interface StubOptions {
  * Registers Playwright route intercepts for all `/api/*` endpoints used by the
  * dashboard. Call before `page.goto()` in each spec that needs a running UI.
  *
- * Routes are registered most-specific first; the catch-all at the end returns
- * 404 for any endpoint not explicitly stubbed so specs fail fast rather than
- * hanging on unhandled requests.
+ * Playwright matches routes in REVERSE registration order (last-registered
+ * wins), so we register the catch-all FIRST and the specific stubs after —
+ * that way `/api/status` hits the specific handler, while `/api/anything-else`
+ * falls through to the catch-all 404 so missing stubs surface as fast failures
+ * instead of hangs.
  */
 export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void> {
   const statuses = opts.statuses ?? [STOPPED_GAME];
   const costs = opts.costs ?? COST_DATA;
   const env = opts.env ?? ENV_DATA;
+  const config = opts.config ?? WATCHDOG_CONFIG;
   const startResult: ActionResult = opts.startResult ?? { success: true, message: 'Started' };
+
+  await page.route('**/api/**', (route) =>
+    route.fulfill({ status: 404, json: { error: 'not stubbed' } })
+  );
 
   await page.route('**/api/env', (route) => route.fulfill({ json: env }));
 
@@ -42,15 +52,17 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
 
   await page.route('**/api/costs/estimate', (route) => route.fulfill({ json: costs }));
 
+  await page.route('**/api/config', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({ json: { success: true, config } });
+    }
+    return route.fulfill({ json: config });
+  });
+
   await page.route('**/api/start/*', (route) => route.fulfill({ json: startResult }));
 
   await page.route('**/api/stop/*', (route) =>
     route.fulfill({ json: { success: true, message: 'Stopped' } as ActionResult })
-  );
-
-  // Catch-all: return 404 for any not-yet-stubbed endpoint so tests fail fast.
-  await page.route('**/api/**', (route) =>
-    route.fulfill({ status: 404, json: { error: 'not stubbed' } })
   );
 }
 

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -1,0 +1,74 @@
+import { test as base, expect, type Page } from '@playwright/test';
+import type { GameStatus, CostEstimates, EnvInfo, ActionResult } from '../../src/api.js';
+import { ENV_DATA, STOPPED_GAME, COST_DATA } from './game-data.js';
+
+export type { GameStatus, CostEstimates, EnvInfo };
+export { ENV_DATA, STOPPED_GAME, RUNNING_GAME, MULTI_GAME_STATUSES, COST_DATA } from './game-data.js';
+
+export interface StubOptions {
+  /** Game statuses returned by `GET /api/status`. Defaults to `[STOPPED_GAME]`. */
+  statuses?: GameStatus[];
+  /** Cost estimates returned by `GET /api/costs/estimate`. */
+  costs?: CostEstimates;
+  /** Env info returned by `GET /api/env`. */
+  env?: EnvInfo;
+  /** Override for `POST /api/start/:game` response. */
+  startResult?: ActionResult;
+}
+
+/**
+ * Registers Playwright route intercepts for all `/api/*` endpoints used by the
+ * dashboard. Call before `page.goto()` in each spec that needs a running UI.
+ *
+ * Routes are registered most-specific first; the catch-all at the end returns
+ * 404 for any endpoint not explicitly stubbed so specs fail fast rather than
+ * hanging on unhandled requests.
+ */
+export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void> {
+  const statuses = opts.statuses ?? [STOPPED_GAME];
+  const costs = opts.costs ?? COST_DATA;
+  const env = opts.env ?? ENV_DATA;
+  const startResult: ActionResult = opts.startResult ?? { success: true, message: 'Started' };
+
+  await page.route('**/api/env', (route) => route.fulfill({ json: env }));
+
+  await page.route('**/api/status', (route) => route.fulfill({ json: statuses }));
+
+  await page.route('**/api/status/*', (route) => {
+    const game = new URL(route.request().url()).pathname.split('/').pop()!;
+    const s = statuses.find((x) => x.game === game) ?? statuses[0];
+    return route.fulfill({ json: s });
+  });
+
+  await page.route('**/api/costs/estimate', (route) => route.fulfill({ json: costs }));
+
+  await page.route('**/api/start/*', (route) => route.fulfill({ json: startResult }));
+
+  await page.route('**/api/stop/*', (route) =>
+    route.fulfill({ json: { success: true, message: 'Stopped' } as ActionResult })
+  );
+
+  // Catch-all: return 404 for any not-yet-stubbed endpoint so tests fail fast.
+  await page.route('**/api/**', (route) =>
+    route.fulfill({ status: 404, json: { error: 'not stubbed' } })
+  );
+}
+
+type E2EFixtures = {
+  /**
+   * A page with `apiToken` pre-seeded in localStorage so every navigation
+   * starts authenticated. Use this in all specs except auth-gate tests.
+   */
+  authedPage: Page;
+};
+
+export const test = base.extend<E2EFixtures>({
+  authedPage: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('apiToken', 'test-token');
+    });
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/app/packages/web/e2e/specs/auth-gate.spec.ts
+++ b/app/packages/web/e2e/specs/auth-gate.spec.ts
@@ -27,6 +27,12 @@ test.describe('auth gate', () => {
   });
 
   test('should save token and show dashboard after reload', async ({ page }) => {
+    // Playwright matches routes in REVERSE registration order, so register the
+    // catch-all 404 FIRST and the specific 401/200 handlers after — otherwise
+    // the catch-all takes precedence and the modal never triggers.
+    await page.route('**/api/**', (route) =>
+      route.fulfill({ status: 404, json: { error: 'not stubbed' } })
+    );
     // Return 401 for unauthenticated requests, 200 once the token is present.
     await page.route('**/api/env', async (route) => {
       const auth = route.request().headers()['authorization'] ?? '';
@@ -52,9 +58,6 @@ test.describe('auth gate', () => {
         await route.fulfill({ status: 401, body: 'Unauthorized' });
       }
     });
-    await page.route('**/api/**', (route) =>
-      route.fulfill({ status: 404, json: { error: 'not stubbed' } })
-    );
 
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'API token required' })).toBeVisible();

--- a/app/packages/web/e2e/specs/auth-gate.spec.ts
+++ b/app/packages/web/e2e/specs/auth-gate.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import { stubApis, ENV_DATA, COST_DATA } from '../fixtures/index.js';
+
+/**
+ * Auth-gate specs use the base Playwright `test` (no pre-seeded token) so
+ * they can verify the 401 → modal and token-save → reload flows in isolation.
+ */
+
+test.describe('auth gate', () => {
+  test('should show token modal when API returns 401', async ({ page }) => {
+    await page.route('**/api/**', (route) =>
+      route.fulfill({ status: 401, body: 'Unauthorized' })
+    );
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'API token required' })).toBeVisible();
+  });
+
+  test('should load dashboard when valid token is already stored', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('apiToken', 'test-token');
+    });
+    await stubApis(page, { statuses: [] });
+    await page.goto('/');
+    // Top-bar heading is the dashboard shell; modal should not appear.
+    await expect(page.getByRole('heading', { name: 'Game Server Manager' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'API token required' })).not.toBeVisible();
+  });
+
+  test('should save token and show dashboard after reload', async ({ page }) => {
+    // Return 401 for unauthenticated requests, 200 once the token is present.
+    await page.route('**/api/env', async (route) => {
+      const auth = route.request().headers()['authorization'] ?? '';
+      if (auth.startsWith('Bearer ')) {
+        await route.fulfill({ json: ENV_DATA });
+      } else {
+        await route.fulfill({ status: 401, body: 'Unauthorized' });
+      }
+    });
+    await page.route('**/api/status', async (route) => {
+      const auth = route.request().headers()['authorization'] ?? '';
+      if (auth.startsWith('Bearer ')) {
+        await route.fulfill({ json: [] });
+      } else {
+        await route.fulfill({ status: 401, body: 'Unauthorized' });
+      }
+    });
+    await page.route('**/api/costs/estimate', async (route) => {
+      const auth = route.request().headers()['authorization'] ?? '';
+      if (auth.startsWith('Bearer ')) {
+        await route.fulfill({ json: COST_DATA });
+      } else {
+        await route.fulfill({ status: 401, body: 'Unauthorized' });
+      }
+    });
+    await page.route('**/api/**', (route) =>
+      route.fulfill({ status: 404, json: { error: 'not stubbed' } })
+    );
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'API token required' })).toBeVisible();
+
+    await page.getByPlaceholder('API token').fill('my-test-token');
+    await page.getByRole('button', { name: 'Save & reload' }).click();
+
+    // After reload the stored token is sent; the modal must be gone.
+    await expect(page.getByRole('heading', { name: 'Game Server Manager' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'API token required' })).not.toBeVisible();
+  });
+});

--- a/app/packages/web/e2e/specs/dashboard.spec.ts
+++ b/app/packages/web/e2e/specs/dashboard.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, stubApis, STOPPED_GAME, RUNNING_GAME, MULTI_GAME_STATUSES } from '../fixtures/index.js';
+
+test.describe('dashboard', () => {
+  test('should render a game card for a stopped game', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [STOPPED_GAME] });
+    await page.goto('/');
+
+    const card = page.getByText('minecraft', { exact: false }).first();
+    await expect(card).toBeVisible();
+    await expect(page.getByText('Offline')).toBeVisible();
+  });
+
+  test('should render a game card for a running game with IP', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [RUNNING_GAME] });
+    await page.goto('/');
+
+    await expect(page.getByText('Online')).toBeVisible();
+    await expect(page.getByText('minecraft.example.com')).toBeVisible();
+  });
+
+  test('should render multiple game cards', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: MULTI_GAME_STATUSES });
+    await page.goto('/');
+
+    await expect(page.getByText('minecraft', { exact: false }).first()).toBeVisible();
+    await expect(page.getByText('valheim', { exact: false }).first()).toBeVisible();
+  });
+
+  test('should show empty-state message when no games are configured', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [] });
+    await page.goto('/');
+
+    await expect(page.getByText(/no games configured/i)).toBeVisible();
+  });
+
+  test('should fire POST /api/start/:game when Start is clicked', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [STOPPED_GAME] });
+
+    // Track whether the start request was made.
+    let startCalled = false;
+    await page.route('**/api/start/minecraft', (route) => {
+      startCalled = true;
+      return route.fulfill({ json: { success: true, message: 'Started' } });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Start' }).click();
+
+    await expect.poll(() => startCalled).toBe(true);
+  });
+
+  test('should disable Start button for a running game', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [RUNNING_GAME] });
+    await page.goto('/');
+
+    await expect(page.getByRole('button', { name: 'Start' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Stop' })).toBeEnabled();
+  });
+
+  test('should navigate to the Logs page via sidebar', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [] });
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Logs' }).click();
+    await expect(page).toHaveURL('/logs');
+  });
+
+  test('should navigate to the Discord page via sidebar', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [] });
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Discord' }).click();
+    await expect(page).toHaveURL('/discord');
+  });
+
+  test('should navigate to the Settings page via sidebar', async ({ authedPage: page }) => {
+    await stubApis(page, { statuses: [] });
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Settings' }).click();
+    await expect(page).toHaveURL('/settings');
+  });
+});

--- a/app/packages/web/package.json
+++ b/app/packages/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -29,6 +30,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/app/packages/web/playwright.config.ts
+++ b/app/packages/web/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e/specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run build && npm run preview',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/docs/docs/components/management-app.md
+++ b/docs/docs/components/management-app.md
@@ -188,6 +188,29 @@ All calls go through `request<T>()`, which:
 `http://localhost:3001`. Production builds to `dist/` which the Nest server
 serves as static files at `/`.
 
+### Running e2e tests
+
+The web package ships a [Playwright](https://playwright.dev/) harness that runs specs against the **production build** (`vite build` + `vite preview`). Every `/api/*` call is stubbed at the network layer — the Nest server never starts.
+
+```bash
+# One-off (builds the app, starts vite preview, runs specs, exits)
+npm run app:test:e2e
+
+# Keep vite preview running between runs (set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD if already installed)
+cd app/packages/web
+npm run build && npm run preview &   # leave running
+npx playwright test                   # fast re-run without rebuilding
+```
+
+First-time setup — install the Chromium browser binary:
+
+```bash
+cd app/packages/web
+npx playwright install chromium
+```
+
+Specs live under `app/packages/web/e2e/specs/`. Shared stubs and fixtures are in `app/packages/web/e2e/fixtures/`. On CI, Playwright uploads traces and videos as artifacts when a spec fails; see `.github/workflows/e2e.yml`.
+
 ## Docker
 
 `Dockerfile` is node:20-slim:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
         "app/packages/lambda/*",
         "scripts"
       ],
-      "dependencies": {
-        "@tailwindcss/vite": "4.2.4"
-      },
       "engines": {
         "node": ">=20"
       }
@@ -24,7 +21,6 @@
       "devDependencies": {
         "@eslint/js": "^9.13.0",
         "@types/node": "^20.14.0",
-        "@vitejs/plugin-react": "^4.7.0",
         "aws-sdk-client-mock": "^4.0.1",
         "concurrently": "^8.2.2",
         "esbuild": "^0.23.0",
@@ -142,7 +138,6 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@tailwindcss/vite": "^4.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
@@ -155,6 +150,8 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
+        "@tailwindcss/vite": "^4.2.4",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.7.0",
@@ -2522,6 +2519,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2532,6 +2530,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2542,6 +2541,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2551,12 +2551,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2764,6 +2766,22 @@
       "engines": {
         "node": ">=8.0.0",
         "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3700,12 +3718,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.2",
@@ -3714,12 +3732,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.2",
@@ -3728,12 +3746,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.2",
@@ -3742,12 +3760,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.2",
@@ -3756,12 +3774,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.2",
@@ -3770,12 +3788,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.2",
@@ -3784,12 +3802,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.2",
@@ -3798,12 +3816,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.2",
@@ -3812,12 +3830,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.2",
@@ -3826,12 +3844,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.2",
@@ -3840,12 +3858,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.2",
@@ -3854,12 +3872,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.2",
@@ -3868,12 +3886,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.2",
@@ -3882,12 +3900,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.2",
@@ -3896,12 +3914,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.2",
@@ -3910,12 +3928,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.2",
@@ -3924,12 +3942,12 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.2",
@@ -3938,12 +3956,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.2",
@@ -3952,12 +3970,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.2",
@@ -3966,12 +3984,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.2",
@@ -3980,12 +3998,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.2",
@@ -3994,12 +4012,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.2",
@@ -4008,12 +4026,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.2",
@@ -4022,12 +4040,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.2",
@@ -4036,12 +4054,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -4778,6 +4796,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
       "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -4793,6 +4812,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
       "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -4819,6 +4839,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4835,6 +4856,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4851,6 +4873,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4867,6 +4890,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4883,6 +4907,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4899,6 +4924,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4915,6 +4941,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4931,6 +4958,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4947,6 +4975,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4971,6 +5000,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4992,6 +5022,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5008,6 +5039,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5021,6 +5053,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
       "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/node": "4.2.4",
@@ -5132,6 +5165,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -5185,7 +5219,7 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -6730,6 +6764,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6817,6 +6852,7 @@
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
       "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8051,6 +8087,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8271,6 +8308,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -8932,6 +8970,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9077,6 +9116,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -9109,6 +9149,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9129,6 +9170,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9149,6 +9191,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9169,6 +9212,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9189,6 +9233,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9209,6 +9254,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9229,6 +9275,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9249,6 +9296,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9269,6 +9317,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9289,6 +9338,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9309,6 +9359,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9411,6 +9462,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -9556,6 +9608,7 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9975,6 +10028,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -9988,6 +10042,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10004,6 +10105,7 @@
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
       "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10406,6 +10508,7 @@
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10827,6 +10930,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11138,6 +11242,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11578,7 +11683,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -11702,6 +11807,7 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -11787,12 +11893,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11804,12 +11910,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11821,12 +11927,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11838,12 +11944,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11855,12 +11961,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11872,12 +11978,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11889,12 +11995,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11906,12 +12012,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11923,12 +12029,12 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11940,12 +12046,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11957,12 +12063,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11974,12 +12080,12 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11991,12 +12097,12 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12008,12 +12114,12 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12025,12 +12131,12 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12042,12 +12148,12 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12059,12 +12165,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12076,12 +12182,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12093,12 +12199,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12110,12 +12216,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12127,12 +12233,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12144,12 +12250,12 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12161,12 +12267,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12175,6 +12281,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "app:test:watch": "npm run test:watch     -w game-server-manager",
     "app:lint": "npm run lint           -w game-server-manager",
     "app:lint:fix": "npm run lint:fix       -w game-server-manager",
+    "app:test:e2e": "npm run test:e2e       -w @gsd/web",
     "scripts:init-parent": "npm run init-parent  -w @gsd/scripts"
   }
 }


### PR DESCRIPTION
Closes #74

## Summary

Adds a Playwright e2e harness for `@gsd/web` that runs against the production build (`vite build` + `vite preview`) with every `/api/*` call stubbed at the network layer. The Nest server is never started — this is the **stubs-only** tier (#74); the full-stack tier with a real Nest server lands separately in #75.

- New scripts: `npm run app:test:e2e` (root) → `playwright test` in `@gsd/web`.
- New CI job (`.github/workflows/e2e.yml`) installs the Chromium browser with system deps, runs the suite on every PR, and uploads `playwright-report/` (traces + videos) as an artifact on failure.
- Co-located fixtures and stubs under `app/packages/web/e2e/fixtures/`; specs under `e2e/specs/`.
- A custom `authedPage` Playwright fixture pre-seeds `localStorage.apiToken` so most specs start authenticated; auth-gate specs use the base `test` to exercise the 401-trigger path.
- A catch-all `page.route('**/api/**')` returns 404 for any endpoint not explicitly stubbed so missing stubs surface as fast test failures rather than hangs.

## Spec coverage delivered with this PR

**Auth gate** (`auth-gate.spec.ts`):
- `should show token modal when API returns 401`
- `should load dashboard when valid token is already stored`
- `should save token and show dashboard after reload`

**Dashboard** (`dashboard.spec.ts`):
- `should render a game card for a stopped game` / `for a running game with IP`
- `should render multiple game cards`
- `should show empty-state message when no games are configured`
- `should fire POST /api/start/:game when Start is clicked`
- `should disable Start button for a running game`
- Sidebar nav specs for `/logs`, `/discord`, `/settings`

Per-surface specs (Costs panel, Stop confirmation, polling indicator, etc.) follow with their respective UI issues (#60–#68) — the harness is now in place to plug them in.

## Acceptance criteria from #74

- [x] `npm run app:test:e2e` runs the suite locally and in CI against the production build.
- [x] CI fails the PR when a spec breaks; traces + videos uploaded as artifacts on failure.
- [x] At least the auth-gate and dashboard Start specs land with this issue.
- [x] `docs/docs/components/management-app.md` gains a \"Running e2e tests\" section.
- [x] No real AWS / Discord calls — every external request is stubbed.
- [x] `npm run app:test` continues to pass; e2e suite runs as a separate command.
- [x] `CLAUDE.md`'s \"Code & Test Conventions\" section now describes the two-tier strategy (#74 stubs vs #75 real Nest) and when to add specs to each tier.

## Implementation notes

- Chose **Playwright** over Vitest browser mode (per the issue's open question) for the trace viewer, parallel projects, and first-class CI artifacts story. Vitest unit tests remain on Vitest — only browser-driven specs use Playwright.
- The webServer command is `npm run build && npm run preview`; Playwright polls until `http://localhost:4173` responds. `reuseExistingServer` is true locally so re-runs are fast if `vite preview` is already running.
- Cleanup: added `app/packages/web/test-results/`, `playwright-report/`, and `playwright/.cache/` to `.gitignore` so local artifacts don't get committed.

## Test plan

- [ ] CI: e2e workflow runs and all 12 specs pass (Chromium, Ubuntu).
- [ ] Local: `sudo npx playwright install-deps chromium` once, then `npm run app:test:e2e` from repo root passes.
- [ ] `npm run app:test` still passes (the unit-test suite is untouched).
- [ ] Reviewer can open `app/packages/web/playwright-report/index.html` after a local run to inspect traces/videos.