### PR TITLE
feat(web): sonner toast notifications with 5-second stop undo

### DIFF
--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -16,7 +16,7 @@ import {
   CONFIGURED_DISCORD_CONFIG,
   makeActualCosts,
 } from './game-data.js';
-import { AppLayout, AuthGatePage, DashboardPage, CostsPage, LogsPage } from '../pages/index.js';
+import { AppLayout, AuthGatePage, DashboardPage, CostsPage, LogsPage, SettingsPage } from '../pages/index.js';
 
 export type {
   GameStatus,
@@ -43,7 +43,7 @@ export {
   VALID_USER_ID,
   SAMPLE_LOG_LINES,
 } from './game-data.js';
-export { AppLayout, AuthGatePage, DashboardPage, CostsPage, LogsPage } from '../pages/index.js';
+export { AppLayout, AuthGatePage, DashboardPage, CostsPage, LogsPage, SettingsPage } from '../pages/index.js';
 
 /** Per-spec overrides for the default `/api/*` stubs registered by `stubApis`. */
 export interface StubOptions {
@@ -202,6 +202,8 @@ type E2EFixtures = {
   costs: CostsPage;
   /** Page object for the `/logs` route — use in any authed-logs spec. */
   logs: LogsPage;
+  /** Page object for the `/settings` route — use in any authed-settings spec. */
+  settings: SettingsPage;
   /** Page object for the persistent nav shell (sidebar + top bar). */
   layout: AppLayout;
   /** Page object for the API-token modal — use in auth-gate specs. */
@@ -227,6 +229,9 @@ export const test = base.extend<E2EFixtures>({
   },
   logs: async ({ authedPage }, use) => {
     await use(new LogsPage(authedPage));
+  },
+  settings: async ({ authedPage }, use) => {
+    await use(new SettingsPage(authedPage));
   },
   layout: async ({ page }, use) => {
     await use(new AppLayout(page));

--- a/app/packages/web/e2e/pages/AppLayout.ts
+++ b/app/packages/web/e2e/pages/AppLayout.ts
@@ -23,4 +23,14 @@ export class AppLayout {
     await this.sidebarLink(label).click();
     await this.page.waitForURL(expectedPath);
   }
+
+  /** A visible Sonner toast matched by its message text. */
+  toastMessage(text: string | RegExp): import('@playwright/test').Locator {
+    return this.page.locator('[data-sonner-toast]').filter({ hasText: text });
+  }
+
+  /** The Undo action button inside a Sonner toast. */
+  toastUndoButton(): import('@playwright/test').Locator {
+    return this.page.locator('[data-sonner-toast]').getByRole('button', { name: 'Undo' });
+  }
 }

--- a/app/packages/web/e2e/pages/SettingsPage.ts
+++ b/app/packages/web/e2e/pages/SettingsPage.ts
@@ -1,0 +1,19 @@
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Page object for the settings route (`/settings`). Wraps the Watchdog
+ * Configuration panel and any other controls on the page.
+ */
+export class SettingsPage {
+  constructor(public readonly page: Page) {}
+
+  /** Navigate to the settings route. */
+  async goto(): Promise<void> {
+    await this.page.goto('/settings');
+  }
+
+  /** Save button in the Watchdog Configuration panel. */
+  saveWatchdogButton(): Locator {
+    return this.page.getByRole('button', { name: 'Save' });
+  }
+}

--- a/app/packages/web/e2e/pages/index.ts
+++ b/app/packages/web/e2e/pages/index.ts
@@ -3,3 +3,4 @@ export { AuthGatePage } from './AuthGatePage.js';
 export { DashboardPage, type ServerStateLabel } from './DashboardPage.js';
 export { CostsPage, type CostsRangeLabel } from './CostsPage.js';
 export { LogsPage, type LogLevelLabel } from './LogsPage.js';
+export { SettingsPage } from './SettingsPage.js';

--- a/app/packages/web/e2e/specs/dashboard.spec.ts
+++ b/app/packages/web/e2e/specs/dashboard.spec.ts
@@ -7,6 +7,7 @@ import {
   MULTI_GAME_STATUSES,
 } from '../fixtures/index.js';
 
+
 test.describe('dashboard', () => {
   test('should render a game card for a stopped game', async ({ dashboard }) => {
     await stubApis(dashboard.page, { statuses: [STOPPED_GAME] });
@@ -119,5 +120,27 @@ test.describe('dashboard', () => {
     await dashboard.goto();
 
     await layout.navigateTo('Settings', '/settings');
+  });
+
+  test('should show a success toast after starting a game', async ({ dashboard, layout }) => {
+    await stubApis(dashboard.page, { statuses: [STOPPED_GAME] });
+    await dashboard.goto();
+
+    await dashboard.startButton().click();
+
+    await expect(layout.toastMessage('minecraft is starting')).toBeVisible();
+  });
+
+  test('should show a stop toast with an Undo button after stopping a game', async ({ dashboard, layout }) => {
+    await stubApis(dashboard.page, { statuses: [RUNNING_GAME] });
+    await dashboard.goto();
+
+    await dashboard.stopButton().click();
+
+    // ConfirmDialog appears — confirm the stop.
+    await dashboard.page.getByRole('button', { name: /stop server/i }).click();
+
+    await expect(layout.toastMessage('minecraft stopped')).toBeVisible();
+    await expect(layout.toastUndoButton()).toBeVisible();
   });
 });

--- a/app/packages/web/e2e/specs/discord.spec.ts
+++ b/app/packages/web/e2e/specs/discord.spec.ts
@@ -9,6 +9,7 @@ import {
   VALID_GUILD_ID,
   VALID_GUILD_ID_2,
   VALID_USER_ID,
+  AppLayout,
   type DiscordConfigRedacted,
 } from '../fixtures/index.js';
 
@@ -288,5 +289,17 @@ test.describe('discord settings', () => {
 
     await page.goto('/discord');
     await expect(page.getByText(/infrastructure not deployed yet/i)).toBeVisible();
+  });
+
+  test('should show a success toast after saving credentials', async ({ authedPage: page }) => {
+    await stubApis(page, { discord: CONFIGURED_DISCORD_CONFIG });
+    await page.goto('/discord');
+
+    // Credentials tab is the default — wait for the form to be ready.
+    await expect(page.getByRole('button', { name: 'Save credentials' })).toBeVisible();
+    await page.getByRole('button', { name: 'Save credentials' }).click();
+
+    const layout = new AppLayout(page);
+    await expect(layout.toastMessage('Credentials saved')).toBeVisible();
   });
 });

--- a/app/packages/web/e2e/specs/settings.spec.ts
+++ b/app/packages/web/e2e/specs/settings.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect, stubApis } from '../fixtures/index.js';
+
+test.describe('settings', () => {
+  test('should show a success toast after saving watchdog settings', async ({
+    settings,
+    layout,
+  }) => {
+    await stubApis(settings.page, {});
+    await settings.goto();
+
+    await expect(settings.saveWatchdogButton()).toBeVisible();
+    await settings.saveWatchdogButton().click();
+
+    await expect(layout.toastMessage('Watchdog settings saved')).toBeVisible();
+  });
+});

--- a/app/packages/web/src/app.component.tsx
+++ b/app/packages/web/src/app.component.tsx
@@ -10,6 +10,7 @@ import { LogsPage } from './pages/logs.page.js';
 import { SettingsPage } from './pages/settings.page.js';
 import { PollingProvider } from './polling/polling-provider.component.js';
 import { GameStatusProvider } from './polling/game-status-provider.component.js';
+import { Toaster } from './components/ui/sonner.component.js';
 
 /**
  * Root component. Wires up the 401 handler on `api.ts` and renders the routed
@@ -36,6 +37,7 @@ export default function App() {
     <PollingProvider>
       <GameStatusProvider>
         <BrowserRouter>
+          <Toaster position="bottom-right" />
           <ApiTokenModal open={needsToken} onSuccess={() => setNeedsToken(false)} />
           <AppLayout>
             <Routes>

--- a/app/packages/web/src/components/game-card.component.test.tsx
+++ b/app/packages/web/src/components/game-card.component.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import type { GameStatus } from '../api.service.js';
 import { GameCard } from './game-card.component.js';
 
 const apiMock = vi.hoisted(() => ({
@@ -16,17 +17,28 @@ vi.mock('../lib/confirm-skip.utils.js', () => ({
   suppress: vi.fn(),
 }));
 
+const toastMock = vi.hoisted(() =>
+  Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+);
+vi.mock('sonner', () => ({ toast: toastMock }));
+
 /** A minimal running-server status fixture. */
-const runningStatus = {
+const runningStatus: GameStatus = {
   game: 'minecraft',
-  state: 'running' as const,
+  state: 'running',
 };
 
-function renderCard() {
+/** A minimal stopped-server status fixture. */
+const stoppedStatus: GameStatus = {
+  game: 'minecraft',
+  state: 'stopped',
+};
+
+function renderCard(status: GameStatus = runningStatus) {
   return render(
     <MemoryRouter>
       <GameCard
-        status={runningStatus}
+        status={status}
         onRefresh={vi.fn()}
         onOpenFiles={vi.fn()}
       />
@@ -35,6 +47,14 @@ function renderCard() {
 }
 
 describe('GameCard — Stop confirmation', () => {
+  beforeEach(() => {
+    apiMock.stop.mockResolvedValue(undefined);
+    apiMock.start.mockResolvedValue(undefined);
+    toastMock.mockClear();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
   it('should show the confirmation dialog when Stop is clicked and the action is not suppressed', async () => {
     mockIsSuppressed.mockReturnValue(false);
     renderCard();
@@ -73,5 +93,74 @@ describe('GameCard — Stop confirmation', () => {
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
 
     expect(apiMock.stop).not.toHaveBeenCalled();
+  });
+});
+
+describe('GameCard — Start/Stop toasts', () => {
+  beforeEach(() => {
+    apiMock.stop.mockResolvedValue(undefined);
+    apiMock.start.mockResolvedValue(undefined);
+    toastMock.mockClear();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  it('should show a success toast when Start succeeds', async () => {
+    renderCard(stoppedStatus);
+
+    await userEvent.click(screen.getByRole('button', { name: /start/i }));
+
+    expect(toastMock.success).toHaveBeenCalledWith('minecraft is starting');
+  });
+
+  it('should show an error toast with the error message when Start fails', async () => {
+    apiMock.start.mockRejectedValueOnce(new Error('capacity exceeded'));
+    renderCard(stoppedStatus);
+
+    await userEvent.click(screen.getByRole('button', { name: /start/i }));
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Failed to start minecraft',
+      expect.objectContaining({ description: 'capacity exceeded' }),
+    );
+  });
+
+  it('should show an error toast with the fallback description when Start fails with an unknown error', async () => {
+    apiMock.start.mockRejectedValueOnce('not an Error');
+    renderCard(stoppedStatus);
+
+    await userEvent.click(screen.getByRole('button', { name: /start/i }));
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Failed to start minecraft',
+      expect.objectContaining({ description: 'An unknown error occurred' }),
+    );
+  });
+
+  it('should show a stop toast with an Undo action when Stop succeeds', async () => {
+    mockIsSuppressed.mockReturnValue(true);
+    renderCard(runningStatus);
+
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    expect(toastMock).toHaveBeenCalledWith(
+      'minecraft stopped',
+      expect.objectContaining({
+        action: expect.objectContaining({ label: 'Undo' }),
+      }),
+    );
+  });
+
+  it('should show an error toast with the error message when Stop fails', async () => {
+    mockIsSuppressed.mockReturnValue(true);
+    apiMock.stop.mockRejectedValueOnce(new Error('task not found'));
+    renderCard(runningStatus);
+
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Failed to stop minecraft',
+      expect.objectContaining({ description: 'task not found' }),
+    );
   });
 });

--- a/app/packages/web/src/components/game-card.component.tsx
+++ b/app/packages/web/src/components/game-card.component.tsx
@@ -166,7 +166,7 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
           label: 'Undo',
           onClick: () => {
             void api.start(game)
-              .then(() => onRefresh(game))
+              .then(() => setTimeout(() => onRefresh(game), 3000))
               .catch((err: unknown) => {
                 toast.error(`Failed to undo stop of ${game}`, {
                   description: err instanceof Error ? err.message : undefined,

--- a/app/packages/web/src/components/game-card.component.tsx
+++ b/app/packages/web/src/components/game-card.component.tsx
@@ -147,7 +147,7 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
       toast.success(`${game} is starting`);
     } catch (err) {
       toast.error(`Failed to start ${game}`, {
-        description: err instanceof Error ? err.message : undefined,
+        description: err instanceof Error ? err.message : 'An unknown error occurred',
       });
     } finally {
       // Always schedule a refresh even on error — transient failures shouldn't
@@ -169,7 +169,7 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
               .then(() => setTimeout(() => onRefresh(game), 3000))
               .catch((err: unknown) => {
                 toast.error(`Failed to undo stop of ${game}`, {
-                  description: err instanceof Error ? err.message : undefined,
+                  description: err instanceof Error ? err.message : 'An unknown error occurred',
                 });
               });
           },
@@ -177,7 +177,7 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
       });
     } catch (err) {
       toast.error(`Failed to stop ${game}`, {
-        description: err instanceof Error ? err.message : undefined,
+        description: err instanceof Error ? err.message : 'An unknown error occurred',
       });
     } finally {
       setTimeout(() => { void onRefresh(game); setBusy(false); }, 3000);

--- a/app/packages/web/src/components/game-card.component.tsx
+++ b/app/packages/web/src/components/game-card.component.tsx
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
   PowerOff,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { api, type GameStatus, type GameEstimate } from '../api.service.js';
 import { Card } from '@/components/ui/card.component';
 import { Button } from '@/components/ui/button.component';
@@ -143,9 +144,14 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
     setBusy(true);
     try {
       await api.start(game);
+      toast.success(`${game} is starting`);
+    } catch (err) {
+      toast.error(`Failed to start ${game}`, {
+        description: err instanceof Error ? err.message : undefined,
+      });
     } finally {
-      // Always release the busy flag, even if the request threw — otherwise a
-      // transient API failure would leave the card disabled until reload.
+      // Always schedule a refresh even on error — transient failures shouldn't
+      // leave the card disabled until reload.
       setTimeout(() => { void onRefresh(game); setBusy(false); }, 3000);
     }
   }
@@ -154,6 +160,17 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
     setBusy(true);
     try {
       await api.stop(game);
+      toast(`${game} stopped`, {
+        duration: 5000,
+        action: {
+          label: 'Undo',
+          onClick: () => { void api.start(game).then(() => onRefresh(game)); },
+        },
+      });
+    } catch (err) {
+      toast.error(`Failed to stop ${game}`, {
+        description: err instanceof Error ? err.message : undefined,
+      });
     } finally {
       setTimeout(() => { void onRefresh(game); setBusy(false); }, 3000);
     }

--- a/app/packages/web/src/components/game-card.component.tsx
+++ b/app/packages/web/src/components/game-card.component.tsx
@@ -164,7 +164,15 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
         duration: 5000,
         action: {
           label: 'Undo',
-          onClick: () => { void api.start(game).then(() => onRefresh(game)); },
+          onClick: () => {
+            void api.start(game)
+              .then(() => onRefresh(game))
+              .catch((err: unknown) => {
+                toast.error(`Failed to undo stop of ${game}`, {
+                  description: err instanceof Error ? err.message : undefined,
+                });
+              });
+          },
         },
       });
     } catch (err) {

--- a/app/packages/web/src/components/watchdog-panel.component.test.tsx
+++ b/app/packages/web/src/components/watchdog-panel.component.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WatchdogPanel } from './watchdog-panel.component.js';
+
+const apiMock = vi.hoisted(() => ({
+  config: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+const toastMock = vi.hoisted(() =>
+  Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+);
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+/** Default config returned by the mocked `api.config()`. */
+const DEFAULT_CONFIG = {
+  watchdog_interval_minutes: 15,
+  watchdog_idle_checks: 4,
+  watchdog_min_packets: 100,
+};
+
+describe('WatchdogPanel', () => {
+  beforeEach(() => {
+    apiMock.config.mockResolvedValue(DEFAULT_CONFIG);
+    apiMock.saveConfig.mockResolvedValue(undefined);
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  it('should render the Watchdog Settings heading', () => {
+    render(<WatchdogPanel />);
+
+    expect(screen.getByText('Watchdog Settings')).toBeInTheDocument();
+  });
+
+  it('should render the Save button', () => {
+    render(<WatchdogPanel />);
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('should show a success toast after saving settings', async () => {
+    render(<WatchdogPanel />);
+
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(toastMock.success).toHaveBeenCalledWith('Watchdog settings saved');
+  });
+
+  it('should show an error toast with the error message when saving fails', async () => {
+    apiMock.saveConfig.mockRejectedValueOnce(new Error('network timeout'));
+    render(<WatchdogPanel />);
+
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Failed to save watchdog settings',
+      expect.objectContaining({ description: 'network timeout' }),
+    );
+  });
+
+  it('should show the fallback description when saving fails with an unknown error', async () => {
+    apiMock.saveConfig.mockRejectedValueOnce('not an Error object');
+    render(<WatchdogPanel />);
+
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Failed to save watchdog settings',
+      expect.objectContaining({ description: 'An unknown error occurred' }),
+    );
+  });
+});

--- a/app/packages/web/src/components/watchdog-panel.component.tsx
+++ b/app/packages/web/src/components/watchdog-panel.component.tsx
@@ -25,7 +25,7 @@ export function WatchdogPanel() {
       toast.success('Watchdog settings saved');
     } catch (err) {
       toast.error('Failed to save watchdog settings', {
-        description: err instanceof Error ? err.message : undefined,
+        description: err instanceof Error ? err.message : 'An unknown error occurred',
       });
     }
   }

--- a/app/packages/web/src/components/watchdog-panel.component.tsx
+++ b/app/packages/web/src/components/watchdog-panel.component.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
 import { api, type WatchdogConfig } from '../api.service.js';
 
 /**
@@ -12,8 +13,6 @@ export function WatchdogPanel() {
     watchdog_idle_checks: 4,
     watchdog_min_packets: 100,
   });
-  const [saved, setSaved] = useState(false);
-
   useEffect(() => {
     void api.config().then(setCfg);
   }, []);
@@ -21,9 +20,14 @@ export function WatchdogPanel() {
   const idleMinutes = cfg.watchdog_interval_minutes * cfg.watchdog_idle_checks;
 
   async function handleSave() {
-    await api.saveConfig(cfg);
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    try {
+      await api.saveConfig(cfg);
+      toast.success('Watchdog settings saved');
+    } catch (err) {
+      toast.error('Failed to save watchdog settings', {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    }
   }
 
   return (
@@ -45,7 +49,7 @@ export function WatchdogPanel() {
       </p>
       <div style={{ marginTop: '0.75rem' }}>
         <button className="btn-secondary btn-sm" onClick={() => void handleSave()}>
-          {saved ? 'Saved ✓' : 'Save'}
+          Save
         </button>
       </div>
     </div>

--- a/app/packages/web/src/pages/discord.page.test.tsx
+++ b/app/packages/web/src/pages/discord.page.test.tsx
@@ -10,8 +10,14 @@ const apiMock = vi.hoisted(() => ({
   discordRemoveGuild: vi.fn().mockResolvedValue(undefined),
   discordDeletePermission: vi.fn().mockResolvedValue(undefined),
   discordSaveAdmins: vi.fn().mockResolvedValue(undefined),
+  discordSaveCredentials: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+const toastMock = vi.hoisted(() =>
+  Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+);
+vi.mock('sonner', () => ({ toast: toastMock }));
 
 import { DiscordPage } from './discord.page.js';
 import { renderPage } from '../test-utils/render-page.utils.js';
@@ -34,6 +40,9 @@ describe('DiscordPage', () => {
     apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
     apiMock.games.mockResolvedValue({ games: ['minecraft'] });
     apiMock.discordConfig.mockResolvedValue(REDACTED_CONFIG);
+    apiMock.discordSaveCredentials.mockResolvedValue(undefined);
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
   });
 
   it('should render the Discord heading and the polling indicator wired to the status poll', async () => {
@@ -137,6 +146,43 @@ describe('DiscordPage', () => {
       await userEvent.click(screen.getByRole('button', { name: /remove guild/i }));
 
       expect(apiMock.discordRemoveGuild).toHaveBeenCalledWith('111111111111111111');
+    });
+  });
+
+  describe('Credentials tab — Save', () => {
+    it('should show a success toast after saving credentials', async () => {
+      renderPage(<DiscordPage />, { initialEntries: ['/discord'] });
+
+      await screen.findByRole('tab', { name: 'Credentials' });
+      await userEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      expect(toastMock.success).toHaveBeenCalledWith('Credentials saved');
+    });
+
+    it('should show an error toast when saving credentials fails', async () => {
+      apiMock.discordSaveCredentials.mockRejectedValueOnce(new Error('unauthorized'));
+      renderPage(<DiscordPage />, { initialEntries: ['/discord'] });
+
+      await screen.findByRole('tab', { name: 'Credentials' });
+      await userEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'Action failed',
+        expect.objectContaining({ description: 'unauthorized' }),
+      );
+    });
+
+    it('should show the fallback description when saving credentials fails with an unknown error', async () => {
+      apiMock.discordSaveCredentials.mockRejectedValueOnce('not an Error');
+      renderPage(<DiscordPage />, { initialEntries: ['/discord'] });
+
+      await screen.findByRole('tab', { name: 'Credentials' });
+      await userEvent.click(screen.getByRole('button', { name: 'Save credentials' }));
+
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'Action failed',
+        expect.objectContaining({ description: 'An unknown error occurred' }),
+      );
     });
   });
 

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -122,7 +122,7 @@ export function DiscordPage() {
       if (successMsg) toast.success(successMsg);
     } catch (err) {
       toast.error('Action failed', {
-        description: err instanceof Error ? err.message : undefined,
+        description: err instanceof Error ? err.message : 'An unknown error occurred',
       });
       throw err;
     } finally {

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -124,6 +124,7 @@ export function DiscordPage() {
       toast.error('Action failed', {
         description: err instanceof Error ? err.message : undefined,
       });
+      throw err;
     } finally {
       setBusy(false);
     }

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 import {
   Eye,
   EyeOff,
@@ -113,11 +114,16 @@ export function DiscordPage() {
    * Guard a mutating API call with the `busy` flag and refresh config after
    * it resolves so the UI reflects the server-side change.
    */
-  async function wrap<T>(fn: () => Promise<T>): Promise<void> {
+  async function wrap<T>(fn: () => Promise<T>, successMsg?: string): Promise<void> {
     setBusy(true);
     try {
       await fn();
       await refresh();
+      if (successMsg) toast.success(successMsg);
+    } catch (err) {
+      toast.error('Action failed', {
+        description: err instanceof Error ? err.message : undefined,
+      });
     } finally {
       setBusy(false);
     }
@@ -173,7 +179,7 @@ export function DiscordPage() {
           <CredentialsSection
             cfg={cfg}
             busy={busy}
-            onSave={(body) => wrap(() => api.discordSaveCredentials(body))}
+            onSave={(body) => wrap(() => api.discordSaveCredentials(body), 'Credentials saved')}
           />
         </TabsContent>
 
@@ -181,9 +187,9 @@ export function DiscordPage() {
           <GuildsSection
             cfg={cfg}
             busy={busy}
-            onAdd={(g) => wrap(() => api.discordAddGuild(g))}
-            onRemove={(g) => wrap(() => api.discordRemoveGuild(g))}
-            onRegister={(g) => wrap(() => api.discordRegisterCommands(g))}
+            onAdd={(g) => wrap(() => api.discordAddGuild(g), 'Guild added')}
+            onRemove={(g) => wrap(() => api.discordRemoveGuild(g), 'Guild removed')}
+            onRegister={(g) => wrap(() => api.discordRegisterCommands(g), 'Commands registered')}
           />
         </TabsContent>
 
@@ -191,7 +197,7 @@ export function DiscordPage() {
           <AdminsSection
             cfg={cfg}
             busy={busy}
-            onSave={(a) => wrap(() => api.discordSaveAdmins(a))}
+            onSave={(a) => wrap(() => api.discordSaveAdmins(a), 'Admins saved')}
           />
         </TabsContent>
 
@@ -200,8 +206,8 @@ export function DiscordPage() {
             cfg={cfg}
             games={games}
             busy={busy}
-            onSave={(game, perm) => wrap(() => api.discordSavePermission(game, perm))}
-            onDelete={(game) => wrap(() => api.discordDeletePermission(game))}
+            onSave={(game, perm) => wrap(() => api.discordSavePermission(game, perm), 'Permissions saved')}
+            onDelete={(game) => wrap(() => api.discordDeletePermission(game), 'Permissions cleared')}
           />
         </TabsContent>
       </Tabs>

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -180,7 +180,7 @@ export function DiscordPage() {
           <CredentialsSection
             cfg={cfg}
             busy={busy}
-            onSave={(body) => wrap(() => api.discordSaveCredentials(body), 'Credentials saved')}
+            onSave={(body) => { void wrap(() => api.discordSaveCredentials(body), 'Credentials saved').catch(() => undefined); }}
           />
         </TabsContent>
 
@@ -188,8 +188,8 @@ export function DiscordPage() {
           <GuildsSection
             cfg={cfg}
             busy={busy}
-            onAdd={(g) => wrap(() => api.discordAddGuild(g), 'Guild added')}
-            onRemove={(g) => wrap(() => api.discordRemoveGuild(g), 'Guild removed')}
+            onAdd={(g) => { void wrap(() => api.discordAddGuild(g), 'Guild added').catch(() => undefined); }}
+            onRemove={(g) => { void wrap(() => api.discordRemoveGuild(g), 'Guild removed').catch(() => undefined); }}
             onRegister={(g) => wrap(() => api.discordRegisterCommands(g), 'Commands registered')}
           />
         </TabsContent>
@@ -198,7 +198,7 @@ export function DiscordPage() {
           <AdminsSection
             cfg={cfg}
             busy={busy}
-            onSave={(a) => wrap(() => api.discordSaveAdmins(a), 'Admins saved')}
+            onSave={(a) => { void wrap(() => api.discordSaveAdmins(a), 'Admins saved').catch(() => undefined); }}
           />
         </TabsContent>
 
@@ -207,8 +207,8 @@ export function DiscordPage() {
             cfg={cfg}
             games={games}
             busy={busy}
-            onSave={(game, perm) => wrap(() => api.discordSavePermission(game, perm), 'Permissions saved')}
-            onDelete={(game) => wrap(() => api.discordDeletePermission(game), 'Permissions cleared')}
+            onSave={(game, perm) => { void wrap(() => api.discordSavePermission(game, perm), 'Permissions saved').catch(() => undefined); }}
+            onDelete={(game) => { void wrap(() => api.discordDeletePermission(game), 'Permissions cleared').catch(() => undefined); }}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
Closes #66

## Summary
- Mounts `<Toaster position="bottom-right" />` once in the root `<App>` component — single source of toast rendering across all routes
- Game start/stop: `toast.success` on start, undo-action toast (5 s window) on stop that calls `api.start(game)` to reverse the action
- Watchdog settings: replaces the 2-second "Saved ✓" badge with `toast.success` / `toast.error`
- Discord mutations: `wrap()` now catches errors and shows `toast.error`; all 7 call sites pass a `successMsg` string

## Test plan
- [ ] Start a game → "minecraft is starting" success toast appears bottom-right
- [ ] Stop a game → toast with **Undo** button appears for 5 seconds; clicking Undo restarts the server
- [ ] Stop a game and let the toast expire → no restart occurs
- [ ] Watchdog save → "Watchdog settings saved" toast replaces the old "Saved ✓" badge
- [ ] Discord credentials save → "Credentials saved" toast
- [ ] Simulate an API failure (e.g. revoke API token) → error toast with description shown
- [ ] `npm run app:test` — 335 tests pass, no regressions
- [ ] `npm run app:build` — vite build completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)