### PR TITLE
chore: disable terraform MCP plugin to fix /doctor TFE_TOKEN error

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "enabledPlugins": {
     "github@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "terraform@claude-plugins-official": true,
+    "terraform@claude-plugins-official": false,
     "chrome-devtools-mcp@claude-plugins-official": true
   },
   "permissions": {


### PR DESCRIPTION
## Summary

- Disables `terraform@claude-plugins-official` in `.claude/settings.json`
- This project uses Terraform locally against AWS; it does not use Terraform Cloud or HCP Terraform
- The plugin requires `TFE_TOKEN` to start, which causes a `/doctor` error in every session

## Test plan

- [ ] Run `/doctor` — the terraform plugin error should no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)