### PR TITLE
test: add full-stack integration test suite (real Nest + mocked AWS SDK)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,36 @@
+name: Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: app/packages/web
+
+      - run: npm run app:test:integration
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: integration-playwright-report
+          path: app/packages/web/playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ app/packages/server/src/generated/tfstate.ts
 app/packages/web/test-results/
 app/packages/web/playwright-report/
 app/packages/web/playwright/.cache/
+app/packages/web/dist-integration/
 
 .make

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ When working in a specific area, read the relevant doc rather than relying on wh
 | AWS IAM deploy policy | `docs/docs/setup.md` |
 | Terraform variables reference | `docs/docs/components/terraform.md` |
 | Full setup walkthrough | `docs/docs/setup.md` |
+| Integration test architecture | `docs/docs/components/integration-tests.md` |
 | Copilot review tuning | `.github/copilot-instructions.md` |
 | PR creation command | `.claude/commands/pr.md` |
 
@@ -161,14 +162,13 @@ Any time you add or remove Terraform variables, update **all four** of these in 
 
 ### Two-tier browser testing strategy
 
-The test suite has two complementary tiers:
+The test suite has three complementary tiers:
 
 | Tier | Command | What runs | When to add specs |
 |------|---------|-----------|-------------------|
 | **Unit / integration** | `npm run app:test` | Vitest. Server-side logic, hooks, helpers run under the `node` environment; React component specs in `@gsd/web` run under `jsdom` via `environmentMatchGlobs`. No real network — AWS SDK mocked via `aws-sdk-client-mock`; the `@gsd/web` API client is stubbed via `vi.mock`. | Pure logic, hook behaviour, server controllers, **per-component React behaviour** (rendering, callbacks, internal state transitions). |
 | **E2E (tier 1 — #74)** | `npm run app:test:e2e` | Playwright against `vite build` + `vite preview`. Nest server never runs; every `/api/*` call is stubbed at the network layer via `page.route()`. | User-visible flows: routing, auth gate, button interactions, status-badge rendering, optimistic updates. |
-
-A planned **tier 2** (#75) will add full-stack specs (real Nest + mocked AWS SDK) for scenarios that require real HTTP contract validation between the client and server. Until that lands, all browser-facing specs belong in tier 1.
+| **Integration (tier 2 — #75)** | `npm run app:test:integration` | Playwright against `vite build (integration config)` + `vite preview` + real Nest server on `:3002`. AWS SDK intercepted by `aws-sdk-client-mock`. Mock state pushed via `ServerMocks` fixture to `/api/test/mocks/*`. | Real HTTP contract validation, `ApiTokenGuard` behaviour, `ConfigService` tfstate parsing, start/stop flows end-to-end, error propagation from ECS through the API response. |
 
 **React component unit tests (`@gsd/web`):**
 - Use **Vitest + jsdom + `@testing-library/react` + `@testing-library/user-event`**. `@testing-library/jest-dom` matchers (`toBeInTheDocument`, `toHaveTextContent`, etc.) are auto-loaded via `app/vitest.setup.ts`.
@@ -180,7 +180,7 @@ A planned **tier 2** (#75) will add full-stack specs (real Nest + mocked AWS SDK
 - Each routed page (`DashboardPage`, `CostsPage`, `DiscordPage`, `LogsPage`, `SettingsPage`) gets a co-located `*.test.tsx` that mounts the page through `renderPage()` (`app/packages/web/src/test-utils/renderPage.tsx`). The helper wraps children in `PollingProvider → GameStatusProvider → MemoryRouter` so the same provider stack the production app uses is exercised; pass `initialEntries` when the page reads `useLocation`.
 - Mock `../api.js` with `vi.mock` + `vi.hoisted` so the page drives off canned data instead of real fetches. Stub every method the page (and the GameStatusProvider above it) calls — at minimum `api.status` and `api.costsEstimate` — or the test will hang waiting for the polling registry to settle.
 - These tests are intentionally **complementary** to the e2e tier, not a replacement: the e2e specs prove the indicator + chrome render at the route level under a real Vite preview build; the unit tests pin the page's own provider wiring (e.g. that `<PollingIndicator />` resolves to "Updated …" once the mocked status poll resolves) and let us iterate on the page layout without spinning up Playwright.
-- Keep page-test scope tight: smoke-render each header section, exercise interactive controls that aren't already covered by a child component's unit test, and verify the polling indicator wiring. Anything that requires real HTTP belongs in the planned tier-2 specs (#75).
+- Keep page-test scope tight: smoke-render each header section, exercise interactive controls that aren't already covered by a child component's unit test, and verify the polling indicator wiring. Anything that requires real HTTP belongs in tier-2 integration specs (`e2e/integration-specs/`).
 
 **Playwright conventions:**
 - Specs live under `app/packages/web/e2e/specs/`.
@@ -190,6 +190,13 @@ A planned **tier 2** (#75) will add full-stack specs (real Nest + mocked AWS SDK
 - Import `{ test, expect, stubApis }` plus the page-object fixture you need (`logs`, `dashboard`, `costs`, `layout`, `authGate`) from `../fixtures/index.js` for authenticated specs; use `@playwright/test` directly for auth-gate specs.
 - Use the `authedPage` fixture (token pre-seeded in localStorage) only when a spec needs raw `Page` access (e.g. to call `stubApis` or `addInitScript`); otherwise prefer the higher-level page-object fixtures.
 - Stubs must cover every `/api/*` endpoint the page hits, or the catch-all returns 404 and the test will surface the missing stub quickly.
+
+**Integration test conventions (tier 2):**
+- Specs live under `app/packages/web/e2e/integration-specs/`. Import `{ test, expect }` from `./index.js` (NOT from `@playwright/test`) — the extended `test` includes the `serverMocks`, `authedPage`, and `dashboard` fixtures.
+- `serverMocks` (`ServerMocks` from `e2e/fixtures/server-mocks.ts`) pushes queued responses to the test server via `POST /api/test/mocks/*`. Always include it in test parameters — it resets the MockStore before and after each spec automatically.
+- The test Nest server (`test-main.ts`) runs on `:3002`; the Vite integration preview (port 4174) proxies `/api` to it. Pure HTTP tests call `http://localhost:3002/api/...` directly (bypasses the proxy). Browser tests navigate to the `baseURL` (port 4174) and the proxy routes API calls.
+- `workers: 1` and `fullyParallel: false` in `playwright.integration.config.ts` are intentional — the shared in-process `MockStore` cannot be used concurrently.
+- The integration Vite build sets `VITE_STATUS_POLL_MS=3000` so pollers fire every 3 s instead of 20 s, keeping status-polling specs fast without busy-looping.
 
 ## Git & Branch Workflow
 

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -28,6 +28,11 @@ export default tseslint.config(
       tsdoc,
     },
     rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
       'tsdoc/syntax': 'error',
       'jsdoc/require-jsdoc': ['error', {
         publicOnly: true,

--- a/app/packages/server/src/services/ConfigService.ts
+++ b/app/packages/server/src/services/ConfigService.ts
@@ -26,10 +26,11 @@ function resolveRuntimePath(...relativeCandidates: string[]): string {
   return join(__dirname, relativeCandidates[0]);
 }
 
-const TF_STATE_PATH = resolveRuntimePath(
-  '../../../../../terraform/terraform.tfstate',
-  '../../../../terraform/terraform.tfstate',
-);
+const TF_STATE_PATH = process.env['TF_STATE_PATH'] ??
+  resolveRuntimePath(
+    '../../../../../terraform/terraform.tfstate',
+    '../../../../terraform/terraform.tfstate',
+  );
 const CONFIG_PATH = resolveRuntimePath(
   '../../../../../app/server_config.json',
   '../../../../server_config.json',

--- a/app/packages/server/src/services/ConfigService.ts
+++ b/app/packages/server/src/services/ConfigService.ts
@@ -7,34 +7,17 @@ import { EMBEDDED_TFSTATE } from '../generated/tfstate.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-/**
- * Probes candidate relative paths from __dirname in order and returns the
- * first that exists on disk.  Falls back to the first candidate when none
- * exist so callers get a deterministic (missing-file) path rather than
- * undefined behaviour.
- *
- * Needed because the depth from __dirname to the repo/workspace root differs
- * between environments:
- *   - local source tree  (src/services or dist/services inside repo): 5 levels up → repo root
- *   - Docker image       (dist/services inside /app):                  4 levels up → /app
- */
-function resolveRuntimePath(...relativeCandidates: string[]): string {
-  for (const rel of relativeCandidates) {
-    const resolved = join(__dirname, rel);
-    if (existsSync(resolved)) return resolved;
-  }
-  return join(__dirname, relativeCandidates[0]);
-}
+// dist/services/ → 4 hops up = app root (repo: app/, Docker: /workspace/app/)
+// 5 hops up = repo/workspace root, where terraform/ lives
+const APP_ROOT = join(__dirname, '..', '..', '..', '..');
 
-const TF_STATE_PATH = process.env['TF_STATE_PATH'] ??
-  resolveRuntimePath(
-    '../../../../../terraform/terraform.tfstate',
-    '../../../../terraform/terraform.tfstate',
-  );
-const CONFIG_PATH = resolveRuntimePath(
-  '../../../../../app/server_config.json',
-  '../../../../server_config.json',
-);
+const TF_STATE_PATH =
+  process.env['TF_STATE_PATH'] ??
+  join(APP_ROOT, '..', 'terraform', 'terraform.tfstate');
+
+const SERVER_CONFIG_PATH =
+  process.env['SERVER_CONFIG_PATH'] ??
+  join(APP_ROOT, 'server_config.json');
 
 /**
  * Shape of the subset of Terraform root outputs the management app consumes.
@@ -83,7 +66,8 @@ const DEFAULT_CONFIG: WatchdogConfig = {
  *    lazily and cached in-memory until {@link ConfigService.invalidateCache}
  *    is called.
  *  - `server_config.json` — the user-editable file holding the watchdog
- *    tunables and the optional API bearer token.
+ *    tunables and the optional API bearer token. Path resolved via
+ *    `SERVER_CONFIG_PATH` env var, defaulting to `<app-root>/server_config.json`.
  *  - A handful of process env vars (`AWS_DEFAULT_REGION`, `API_TOKEN`).
  *
  * Every other service injects this one instead of touching `process.env` or
@@ -197,9 +181,9 @@ export class ConfigService {
     if (env !== undefined) {
       return env.length > 0 ? env : null;
     }
-    if (!existsSync(CONFIG_PATH)) return null;
+    if (!existsSync(SERVER_CONFIG_PATH)) return null;
     try {
-      const raw = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8')) as { api_token?: unknown };
+      const raw = JSON.parse(readFileSync(SERVER_CONFIG_PATH, 'utf-8')) as { api_token?: unknown };
       return typeof raw.api_token === 'string' && raw.api_token.length > 0 ? raw.api_token : null;
     } catch (err) {
       logger.warn('Could not read api_token from config file', { err });
@@ -226,9 +210,9 @@ export class ConfigService {
    * fresh object on every call — safe for callers to mutate.
    */
   getConfig(): WatchdogConfig {
-    if (!existsSync(CONFIG_PATH)) return { ...DEFAULT_CONFIG };
+    if (!existsSync(SERVER_CONFIG_PATH)) return { ...DEFAULT_CONFIG };
     try {
-      const saved = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8')) as Partial<WatchdogConfig>;
+      const saved = JSON.parse(readFileSync(SERVER_CONFIG_PATH, 'utf-8')) as Partial<WatchdogConfig>;
       return { ...DEFAULT_CONFIG, ...saved };
     } catch (err) {
       logger.warn('Could not read config file, using defaults', { err });
@@ -242,7 +226,7 @@ export class ConfigService {
    * save here is not effective until the next `terraform apply`.
    */
   saveConfig(config: WatchdogConfig): void {
-    writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+    writeFileSync(SERVER_CONFIG_PATH, JSON.stringify(config, null, 2));
     logger.info('Config saved', config);
   }
 }

--- a/app/packages/server/src/test-main.ts
+++ b/app/packages/server/src/test-main.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration-test entry point for the Nest server.
+ *
+ * Sets up aws-sdk-client-mock interceptors BEFORE creating the Nest
+ * application. EcsService creates its ECSClient lazily (on first request),
+ * so patching the prototype here is sufficient — all subsequent send() calls
+ * on any ECSClient instance will hit the mock.
+ *
+ * Run via: PORT=3002 NODE_ENV=test API_TOKEN=test-token
+ *           TF_STATE_PATH=<path> node dist/test-main.js
+ */
+import 'reflect-metadata';
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  ECSClient,
+  ListTasksCommand,
+  DescribeTasksCommand,
+  RunTaskCommand,
+  StopTaskCommand,
+} from '@aws-sdk/client-ecs';
+import { AppModule } from './app.module.js';
+import { TestMocksModule } from './test-mocks/test-mocks.module.js';
+import { mockStore } from './test-mocks/mock-store.js';
+import { logger } from './logger.js';
+
+// ── Patch ECSClient prototype before DI container creates any instances ──
+
+const ecsMock = mockClient(ECSClient);
+
+ecsMock.on(ListTasksCommand).callsFake(async () => {
+  const next = mockStore.dequeueListTasks();
+  if (next?.type === 'error') {
+    throw Object.assign(new Error(next.message ?? 'Mock ListTasks error'), {
+      name: next.code ?? 'ServiceException',
+    });
+  }
+  return (next?.data as object | undefined) ?? { taskArns: [] };
+});
+
+ecsMock.on(DescribeTasksCommand).callsFake(async () => {
+  const next = mockStore.dequeueDescribeTasks();
+  if (next?.type === 'error') {
+    throw Object.assign(new Error(next.message ?? 'Mock DescribeTasks error'), {
+      name: next.code ?? 'ServiceException',
+    });
+  }
+  return (next?.data as object | undefined) ?? { tasks: [] };
+});
+
+ecsMock.on(RunTaskCommand).callsFake(async () => {
+  const next = mockStore.dequeueRunTask();
+  if (next?.type === 'error') {
+    throw Object.assign(new Error(next.message ?? 'Mock RunTask error'), {
+      name: next.code ?? 'ServiceException',
+    });
+  }
+  return (next?.data as object | undefined) ?? {
+    tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:123456789012:task/test-cluster/test-task-id' }],
+    failures: [],
+  };
+});
+
+ecsMock.on(StopTaskCommand).callsFake(async () => {
+  const next = mockStore.dequeueStopTask();
+  if (next?.type === 'error') {
+    throw Object.assign(new Error(next.message ?? 'Mock StopTask error'), {
+      name: next.code ?? 'ServiceException',
+    });
+  }
+  return (next?.data as object | undefined) ?? {};
+});
+
+// ── Boot the Nest application ──
+
+/** Wraps AppModule (real providers + global guard) and adds TestMocksModule. */
+@Module({ imports: [AppModule, TestMocksModule] })
+class TestAppModule {}
+
+const PORT = parseInt(process.env['PORT'] ?? '3002', 10);
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create<NestExpressApplication>(TestAppModule, {
+    logger: ['error', 'warn'],
+  });
+  app.setGlobalPrefix('api');
+  await app.listen(PORT);
+  logger.info(`Integration test server running on http://localhost:${PORT}`, { port: PORT });
+}
+
+void bootstrap();

--- a/app/packages/server/src/test-mocks/mock-store.ts
+++ b/app/packages/server/src/test-mocks/mock-store.ts
@@ -1,0 +1,47 @@
+/** Shape of a single queued mock response. */
+export interface MockResponse {
+  /** 'success' returns `data`; 'error' throws an error with `code` and `message`. */
+  type: 'success' | 'error';
+  data?: unknown;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Singleton in-process store of queued AWS SDK mock responses.
+ * `test-main.ts` sets up `aws-sdk-client-mock` interceptors that read from
+ * this store via `dequeue*()`. Playwright tests push responses via the
+ * `TestMocksController` HTTP endpoints before exercising each flow.
+ *
+ * Default (empty queue) behaviour per command:
+ *  - ListTasks    → { taskArns: [] }   (no running tasks)
+ *  - DescribeTasks → { tasks: [] }
+ *  - RunTask      → { tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:123:task/test-cluster/test-task-id' }] }
+ *  - StopTask     → {}
+ */
+class MockStore {
+  private listTasksQueue: MockResponse[] = [];
+  private describeTasksQueue: MockResponse[] = [];
+  private runTaskQueue: MockResponse[] = [];
+  private stopTaskQueue: MockResponse[] = [];
+
+  pushListTasks(r: MockResponse): void     { this.listTasksQueue.push(r); }
+  pushDescribeTasks(r: MockResponse): void { this.describeTasksQueue.push(r); }
+  pushRunTask(r: MockResponse): void       { this.runTaskQueue.push(r); }
+  pushStopTask(r: MockResponse): void      { this.stopTaskQueue.push(r); }
+
+  dequeueListTasks(): MockResponse | null     { return this.listTasksQueue.shift() ?? null; }
+  dequeueDescribeTasks(): MockResponse | null { return this.describeTasksQueue.shift() ?? null; }
+  dequeueRunTask(): MockResponse | null       { return this.runTaskQueue.shift() ?? null; }
+  dequeueStopTask(): MockResponse | null      { return this.stopTaskQueue.shift() ?? null; }
+
+  /** Clear all queues — called between tests via `POST /api/test/mocks/reset`. */
+  reset(): void {
+    this.listTasksQueue = [];
+    this.describeTasksQueue = [];
+    this.runTaskQueue = [];
+    this.stopTaskQueue = [];
+  }
+}
+
+export const mockStore = new MockStore();

--- a/app/packages/server/src/test-mocks/mock-store.ts
+++ b/app/packages/server/src/test-mocks/mock-store.ts
@@ -14,10 +14,10 @@ export interface MockResponse {
  * `TestMocksController` HTTP endpoints before exercising each flow.
  *
  * Default (empty queue) behaviour per command:
- *  - ListTasks    → { taskArns: [] }   (no running tasks)
- *  - DescribeTasks → { tasks: [] }
- *  - RunTask      → { tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:123:task/test-cluster/test-task-id' }] }
- *  - StopTask     → {}
+ *  - ListTasks    → \{ taskArns: [] \}   (no running tasks)
+ *  - DescribeTasks → \{ tasks: [] \}
+ *  - RunTask      → \{ tasks: [\{ taskArn: 'arn:aws:ecs:us-east-1:123:task/test-cluster/test-task-id' \}] \}
+ *  - StopTask     → \{\}
  */
 class MockStore {
   private listTasksQueue: MockResponse[] = [];

--- a/app/packages/server/src/test-mocks/test-mocks.controller.ts
+++ b/app/packages/server/src/test-mocks/test-mocks.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { mockStore, type MockResponse } from './mock-store.js';
+
+/**
+ * HTTP endpoints for Playwright integration tests to control mock AWS SDK
+ * responses. Only registered in the test binary — never imported by AppModule.
+ *
+ * Protected by ApiTokenGuard (the global guard from AppModule applies to all
+ * routes) — callers must send `Authorization: Bearer test-token`.
+ */
+@Controller('test/mocks')
+export class TestMocksController {
+  /** Reset all queues between test scenarios. */
+  @Post('reset')
+  reset(): { ok: true } {
+    mockStore.reset();
+    return { ok: true };
+  }
+
+  /** Push a response for the next `ListTasksCommand` call. */
+  @Post('ecs/list-tasks')
+  pushListTasks(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushListTasks(body);
+    return { ok: true };
+  }
+
+  /** Push a response for the next `DescribeTasksCommand` call. */
+  @Post('ecs/describe-tasks')
+  pushDescribeTasks(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushDescribeTasks(body);
+    return { ok: true };
+  }
+
+  /** Push a response for the next `RunTaskCommand` call. */
+  @Post('ecs/run-task')
+  pushRunTask(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushRunTask(body);
+    return { ok: true };
+  }
+
+  /** Push a response for the next `StopTaskCommand` call. */
+  @Post('ecs/stop-task')
+  pushStopTask(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushStopTask(body);
+    return { ok: true };
+  }
+}

--- a/app/packages/server/src/test-mocks/test-mocks.module.ts
+++ b/app/packages/server/src/test-mocks/test-mocks.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TestMocksController } from './test-mocks.controller.js';
+
+/** Nest module exposing mock-control endpoints. Only imported by TestAppModule in test-main.ts. */
+@Module({
+  controllers: [TestMocksController],
+})
+export class TestMocksModule {}

--- a/app/packages/web/e2e/fixtures/server-mocks.ts
+++ b/app/packages/web/e2e/fixtures/server-mocks.ts
@@ -1,0 +1,82 @@
+import { test as base } from '@playwright/test';
+import type { APIRequestContext, Page } from '@playwright/test';
+import { DashboardPage } from '../pages/DashboardPage.js';
+
+const SERVER_BASE = 'http://localhost:3002';
+const AUTH_HEADERS = { Authorization: 'Bearer test-token' };
+
+/** Shape matching the server-side MockResponse — one queued ECS command reply. */
+export interface MockResponse {
+  type: 'success' | 'error';
+  data?: unknown;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Playwright-side helper that pushes queued responses into the test server's
+ * MockStore via its HTTP control endpoints at `/api/test/mocks/*`. Each method
+ * maps to one ECS command type. Construct via the `serverMocks` fixture — it
+ * resets the store automatically before and after every test.
+ */
+export class ServerMocks {
+  constructor(private readonly request: APIRequestContext) {}
+
+  private async post(path: string, body?: unknown): Promise<void> {
+    const res = await this.request.post(`${SERVER_BASE}${path}`, {
+      headers: AUTH_HEADERS,
+      ...(body !== undefined ? { data: body } : {}),
+    });
+    if (!res.ok()) throw new Error(`Mock control call failed ${res.status()} ${path}`);
+  }
+
+  /** Clear all ECS command queues — called automatically before and after each test. */
+  async reset(): Promise<void> { await this.post('/api/test/mocks/reset'); }
+
+  /** Queue a response for the next ListTasksCommand call. */
+  async pushListTasks(r: MockResponse): Promise<void> { await this.post('/api/test/mocks/ecs/list-tasks', r); }
+
+  /** Queue a response for the next DescribeTasksCommand call. */
+  async pushDescribeTasks(r: MockResponse): Promise<void> { await this.post('/api/test/mocks/ecs/describe-tasks', r); }
+
+  /** Queue a response for the next RunTaskCommand call. */
+  async pushRunTask(r: MockResponse): Promise<void> { await this.post('/api/test/mocks/ecs/run-task', r); }
+
+  /** Queue a response for the next StopTaskCommand call. */
+  async pushStopTask(r: MockResponse): Promise<void> { await this.post('/api/test/mocks/ecs/stop-task', r); }
+}
+
+type IntegrationFixtures = {
+  /**
+   * Pre-seeded mock controller — resets the MockStore before and after each
+   * test so no queued responses leak between specs.
+   */
+  serverMocks: ServerMocks;
+  /**
+   * Page with `apiToken = 'test-token'` pre-seeded in localStorage so every
+   * navigation to the Vite preview starts authenticated.
+   */
+  authedPage: Page;
+  /** Dashboard page object backed by `authedPage`. */
+  dashboard: DashboardPage;
+};
+
+export const test = base.extend<IntegrationFixtures>({
+  serverMocks: async ({ request }, use) => {
+    const mocks = new ServerMocks(request);
+    await mocks.reset();
+    await use(mocks);
+    await mocks.reset();
+  },
+
+  authedPage: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('apiToken', 'test-token');
+    });
+    await use(page);
+  },
+
+  dashboard: async ({ authedPage }, use) => {
+    await use(new DashboardPage(authedPage));
+  },
+});

--- a/app/packages/web/e2e/fixtures/tfstate.fixture.json
+++ b/app/packages/web/e2e/fixtures/tfstate.fixture.json
@@ -1,0 +1,25 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.0",
+  "outputs": {
+    "aws_region":                     { "value": "us-east-1",          "type": "string" },
+    "ecs_cluster_name":               { "value": "test-cluster",        "type": "string" },
+    "ecs_cluster_arn":                { "value": "arn:aws:ecs:us-east-1:123456789012:cluster/test-cluster", "type": "string" },
+    "subnet_ids":                     { "value": "subnet-test1234",     "type": "string" },
+    "security_group_id":              { "value": "sg-test1234",         "type": "string" },
+    "file_manager_security_group_id": { "value": "sg-fm-test1234",      "type": "string" },
+    "efs_file_system_id":             { "value": "fs-test1234",         "type": "string" },
+    "efs_access_points": {
+      "value": { "minecraft": "fsap-mc1234", "valheim": "fsap-vh1234" },
+      "type": ["object", { "minecraft": "string", "valheim": "string" }]
+    },
+    "domain_name":                    { "value": "test.example.com",   "type": "string" },
+    "game_names":                     { "value": ["minecraft", "valheim"], "type": ["tuple", ["string", "string"]] },
+    "alb_dns_name":                   { "value": null,                  "type": "string" },
+    "acm_certificate_arn":            { "value": null,                  "type": "string" },
+    "discord_table_name":             { "value": "test-discord-table",  "type": "string" },
+    "discord_bot_token_secret_arn":   { "value": "arn:aws:secretsmanager:us-east-1:123456789012:secret/test/discord/bot-token",   "type": "string" },
+    "discord_public_key_secret_arn":  { "value": "arn:aws:secretsmanager:us-east-1:123456789012:secret/test/discord/public-key",  "type": "string" },
+    "interactions_invoke_url":        { "value": null,                  "type": "string" }
+  }
+}

--- a/app/packages/web/e2e/integration-specs/api-token-guard.spec.ts
+++ b/app/packages/web/e2e/integration-specs/api-token-guard.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from './index.js';
+
+/** Base URL for direct calls to the Nest test server (bypasses the Vite proxy). */
+const ENV_URL = 'http://localhost:3002/api/env';
+
+test.describe('ApiTokenGuard', () => {
+  test('should reject requests with no Authorization header with 401', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(ENV_URL);
+    expect(resp.status()).toBe(401);
+  });
+
+  test('should reject requests with wrong token with 401', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(ENV_URL, {
+      headers: { Authorization: 'Bearer wrong-token' },
+    });
+    expect(resp.status()).toBe(401);
+    const body = await resp.json() as { error?: string };
+    expect(body.error).toBe('invalid bearer token');
+  });
+
+  test('should allow requests with valid Authorization: Bearer header', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(ENV_URL, {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json() as { region: string };
+    expect(body.region).toBe('us-east-1');
+  });
+
+  test('should allow requests with valid ?token= query param (SSE fallback)', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(`${ENV_URL}?token=test-token`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json() as { region: string };
+    expect(body.region).toBe('us-east-1');
+  });
+});

--- a/app/packages/web/e2e/integration-specs/api-token-guard.spec.ts
+++ b/app/packages/web/e2e/integration-specs/api-token-guard.spec.ts
@@ -4,14 +4,14 @@ import { test, expect } from './index.js';
 const ENV_URL = 'http://localhost:3002/api/env';
 
 test.describe('ApiTokenGuard', () => {
-  test('should reject requests with no Authorization header with 401', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should reject requests with no Authorization header with 401', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(ENV_URL);
     expect(resp.status()).toBe(401);
   });
 
-  test('should reject requests with wrong token with 401', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should reject requests with wrong token with 401', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(ENV_URL, {
       headers: { Authorization: 'Bearer wrong-token' },
     });
@@ -20,8 +20,8 @@ test.describe('ApiTokenGuard', () => {
     expect(body.error).toBe('invalid bearer token');
   });
 
-  test('should allow requests with valid Authorization: Bearer header', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should allow requests with valid Authorization: Bearer header', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(ENV_URL, {
       headers: { Authorization: 'Bearer test-token' },
     });
@@ -30,8 +30,8 @@ test.describe('ApiTokenGuard', () => {
     expect(body.region).toBe('us-east-1');
   });
 
-  test('should allow requests with valid ?token= query param (SSE fallback)', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should allow requests with valid ?token= query param (SSE fallback)', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(`${ENV_URL}?token=test-token`);
     expect(resp.status()).toBe(200);
     const body = await resp.json() as { region: string };

--- a/app/packages/web/e2e/integration-specs/can-run.spec.ts
+++ b/app/packages/web/e2e/integration-specs/can-run.spec.ts
@@ -1,0 +1,13 @@
+import { test } from './index.js';
+
+/**
+ * Placeholder for canRun() permission enforcement tests.
+ *
+ * TODO(#75): Add integration specs once the Discord module is wired into the
+ * test server. Each spec should verify that a guild not in `allowedGuilds`, a
+ * non-admin user, or a user without the required per-game action permission is
+ * rejected with the appropriate HTTP error.
+ */
+test.skip('canRun() permission enforcement — pending Discord integration', () => {
+  // placeholder
+});

--- a/app/packages/web/e2e/integration-specs/config-service.spec.ts
+++ b/app/packages/web/e2e/integration-specs/config-service.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from './index.js';
+
+const BASE = 'http://localhost:3002';
+const HEADERS = { Authorization: 'Bearer test-token' };
+
+/**
+ * Verifies that ConfigService correctly reads from the synthetic tfstate fixture
+ * (`e2e/fixtures/tfstate.fixture.json`) injected via `TF_STATE_PATH` at
+ * test-server startup.
+ */
+test.describe('ConfigService — tfstate fixture', () => {
+  test('should return aws_region and domain from tfstate fixture', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(`${BASE}/api/env`, { headers: HEADERS });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json() as { region: string; domain: string; environment: string };
+    expect(body.region).toBe('us-east-1');
+    expect(body.domain).toBe('test.example.com');
+    // 'PROD' is derived when domain_name is non-empty
+    expect(body.environment).toBe('PROD');
+  });
+
+  test('should return game names from tfstate fixture', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(`${BASE}/api/games`, { headers: HEADERS });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json() as { games: string[] };
+    expect(body.games).toEqual(['minecraft', 'valheim']);
+  });
+
+  test('should return status entries for all games in tfstate fixture', async ({ request, serverMocks: _ }) => {
+    void _;
+    const resp = await request.get(`${BASE}/api/status`, { headers: HEADERS });
+    expect(resp.status()).toBe(200);
+    const statuses = await resp.json() as Array<{ game: string; state: string }>;
+    // Default mock state — no queued ListTasks responses → empty taskArns → stopped
+    expect(statuses.map((s) => s.game).sort()).toEqual(['minecraft', 'valheim']);
+    statuses.forEach((s) => expect(s.state).toBe('stopped'));
+  });
+});

--- a/app/packages/web/e2e/integration-specs/config-service.spec.ts
+++ b/app/packages/web/e2e/integration-specs/config-service.spec.ts
@@ -9,8 +9,8 @@ const HEADERS = { Authorization: 'Bearer test-token' };
  * test-server startup.
  */
 test.describe('ConfigService — tfstate fixture', () => {
-  test('should return aws_region and domain from tfstate fixture', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should return aws_region and domain from tfstate fixture', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(`${BASE}/api/env`, { headers: HEADERS });
     expect(resp.status()).toBe(200);
     const body = await resp.json() as { region: string; domain: string; environment: string };
@@ -20,16 +20,16 @@ test.describe('ConfigService — tfstate fixture', () => {
     expect(body.environment).toBe('PROD');
   });
 
-  test('should return game names from tfstate fixture', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should return game names from tfstate fixture', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(`${BASE}/api/games`, { headers: HEADERS });
     expect(resp.status()).toBe(200);
     const body = await resp.json() as { games: string[] };
     expect(body.games).toEqual(['minecraft', 'valheim']);
   });
 
-  test('should return status entries for all games in tfstate fixture', async ({ request, serverMocks: _ }) => {
-    void _;
+  test('should return status entries for all games in tfstate fixture', async ({ request, serverMocks: _reset }) => {
+
     const resp = await request.get(`${BASE}/api/status`, { headers: HEADERS });
     expect(resp.status()).toBe(200);
     const statuses = await resp.json() as Array<{ game: string; state: string }>;

--- a/app/packages/web/e2e/integration-specs/error-propagation.spec.ts
+++ b/app/packages/web/e2e/integration-specs/error-propagation.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from './index.js';
+
+const BASE = 'http://localhost:3002';
+const HEADERS = { Authorization: 'Bearer test-token' };
+
+/**
+ * Verifies that AWS SDK errors surfaced by the mock store propagate through
+ * the Nest server as structured `{ success: false, message }` responses rather
+ * than crashing the server or returning an HTTP error status.
+ *
+ * The mock interceptor in `test-main.ts` throws an Error with the `name` field
+ * set to the `code` value, mirroring the real AWS SDK exception shape. Nest's
+ * `EcsService.start()` catch block converts that to the message string via
+ * `String(err)` → `"<name>: <message>"`.
+ */
+test.describe('Error propagation', () => {
+  test('should surface RunTask AccessDeniedException as a failed start response', async ({
+    request,
+    serverMocks,
+  }) => {
+    await serverMocks.pushRunTask({
+      type: 'error',
+      code: 'AccessDeniedException',
+      message: 'User is not authorized to perform ecs:RunTask',
+    });
+
+    // findRunningTask() uses the default empty-queue ListTasks response (no
+    // existing task), so start() proceeds to RunTask where the error fires.
+    const resp = await request.post(`${BASE}/api/start/minecraft`, { headers: HEADERS });
+
+    // Nest POST routes return 201 by default — the error is encoded in the body.
+    expect(resp.status()).toBe(201);
+    const body = await resp.json() as { success: boolean; message: string };
+    expect(body.success).toBe(false);
+    expect(body.message).toContain('AccessDeniedException');
+  });
+});

--- a/app/packages/web/e2e/integration-specs/index.ts
+++ b/app/packages/web/e2e/integration-specs/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-exports for integration specs. Import `test` and `expect` from here
+ * rather than from `@playwright/test` directly — `test` includes the
+ * `serverMocks`, `authedPage`, and `dashboard` fixtures that every integration
+ * spec needs.
+ */
+export { test, type MockResponse, ServerMocks } from '../fixtures/server-mocks.js';
+export { expect } from '@playwright/test';

--- a/app/packages/web/e2e/integration-specs/start-stop.spec.ts
+++ b/app/packages/web/e2e/integration-specs/start-stop.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from './index.js';
+
+/**
+ * ECS task ARN used as the mock "running task" across start/stop tests.
+ * The value itself doesn't matter — just needs to be a non-empty string.
+ */
+const TASK_ARN = 'arn:aws:ecs:us-east-1:123456789012:task/test-cluster/abc12345';
+
+test.describe('Start / Stop game server (browser)', () => {
+  /**
+   * Golden path: the dashboard loads, polls the real Nest server, and renders
+   * both games from the tfstate fixture as STOPPED (default mock behaviour —
+   * empty ListTasks queue → taskArns [] → stopped).
+   */
+  test('should display game cards from tfstate and show STOPPED status on initial load', async ({
+    dashboard,
+    serverMocks: _,
+  }) => {
+    void _;
+    await dashboard.goto();
+    await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
+    await expect(dashboard.gameCardHeading('valheim')).toBeVisible();
+    // At least one STOPPED badge must be visible (both games are stopped)
+    await expect(dashboard.statusBadge('STOPPED').first()).toBeVisible();
+  });
+
+  /**
+   * Seeds one game as RUNNING (one ListTasks response consumed by whichever
+   * game's status call executes first), then verifies that exactly one Stop
+   * button is rendered and that clicking it opens the confirm dialog.
+   *
+   * Two games call ListTasksCommand concurrently; the first dequeues the
+   * RUNNING ARN and the second falls through to the default (no task → stopped).
+   * The result is always one RUNNING + one STOPPED card, with exactly one Stop
+   * button visible.
+   */
+  test('should show confirm dialog when Stop is clicked on a running game', async ({
+    dashboard,
+    serverMocks,
+  }) => {
+    await serverMocks.pushListTasks({
+      type: 'success',
+      data: { taskArns: [TASK_ARN] },
+    });
+    await serverMocks.pushDescribeTasks({
+      type: 'success',
+      data: { tasks: [{ taskArn: TASK_ARN, lastStatus: 'RUNNING' }] },
+    });
+
+    await dashboard.goto();
+
+    // One game is running — its Stop button is the only one on the page
+    await expect(dashboard.stopButton()).toBeVisible();
+    await dashboard.stopButton().click();
+
+    // Confirmation dialog must appear with the game name in the heading.
+    // Radix AlertDialog renders with role="alertdialog", not "dialog".
+    await expect(dashboard.page.getByRole('alertdialog')).toBeVisible();
+    await expect(dashboard.page.getByRole('heading', { name: /Stop .+\?/ })).toBeVisible();
+  });
+});

--- a/app/packages/web/e2e/integration-specs/start-stop.spec.ts
+++ b/app/packages/web/e2e/integration-specs/start-stop.spec.ts
@@ -14,9 +14,8 @@ test.describe('Start / Stop game server (browser)', () => {
    */
   test('should display game cards from tfstate and show STOPPED status on initial load', async ({
     dashboard,
-    serverMocks: _,
+    serverMocks: _reset,
   }) => {
-    void _;
     await dashboard.goto();
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
     await expect(dashboard.gameCardHeading('valheim')).toBeVisible();

--- a/app/packages/web/e2e/integration-specs/status-polling.spec.ts
+++ b/app/packages/web/e2e/integration-specs/status-polling.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './index.js';
+
+const TASK_ARN = 'arn:aws:ecs:us-east-1:123456789012:task/test-cluster/abc12345';
+
+/**
+ * Verifies that the dashboard's status poller picks up AWS state changes
+ * without a page reload. The integration build sets VITE_STATUS_POLL_MS=3000
+ * so the test can push new mock responses after the initial load and observe
+ * the badge transition within a generous timeout.
+ */
+test.describe('Status polling', () => {
+  test('should update game badge from STOPPED to RUNNING after mock state changes', async ({
+    dashboard,
+    serverMocks,
+  }) => {
+    // Navigate — initial poll fires immediately on mount (default: no tasks → stopped)
+    await dashboard.goto();
+    await expect(dashboard.statusBadge('STOPPED').first()).toBeVisible();
+
+    // Push 2 RUNNING responses — one per game in the next concurrent poll
+    for (let i = 0; i < 2; i++) {
+      await serverMocks.pushListTasks({
+        type: 'success',
+        data: { taskArns: [TASK_ARN] },
+      });
+      await serverMocks.pushDescribeTasks({
+        type: 'success',
+        data: { tasks: [{ taskArn: TASK_ARN, lastStatus: 'RUNNING' }] },
+      });
+    }
+
+    // The next poll (≤3 s) consumes the RUNNING responses and updates the badges
+    await expect(dashboard.statusBadge('RUNNING').first()).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/app/packages/web/package.json
+++ b/app/packages/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:integration": "playwright test --config playwright.integration.config.ts"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/app/packages/web/playwright.integration.config.ts
+++ b/app/packages/web/playwright.integration.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const fixtureDir = fileURLToPath(new URL('e2e/fixtures', import.meta.url));
+const tfstatePath = join(fixtureDir, 'tfstate.fixture.json');
+const serverDist = fileURLToPath(new URL('../../packages/server/dist', import.meta.url));
+
+export default defineConfig({
+  testDir: './e2e/integration-specs',
+  /** Serial execution prevents mock-state races between specs. */
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:4174',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: [
+    {
+      command: `node ${join(serverDist, 'test-main.js')}`,
+      url: 'http://localhost:3002/api/env?token=test-token',
+      timeout: 30_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        PORT: '3002',
+        NODE_ENV: 'test',
+        API_TOKEN: 'test-token',
+        TF_STATE_PATH: tfstatePath,
+      },
+    },
+    {
+      command: 'npx vite build --config vite.integration.config.ts && npx vite preview --config vite.integration.config.ts',
+      url: 'http://localhost:4174',
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/app/packages/web/playwright.integration.config.ts
+++ b/app/packages/web/playwright.integration.config.ts
@@ -28,7 +28,8 @@ export default defineConfig({
     {
       command: `node ${join(serverDist, 'test-main.js')}`,
       url: 'http://localhost:3002/api/env?token=test-token',
-      timeout: 30_000,
+      // ESM module loading from Windows/DrvFs in WSL2 is slow — allow up to 2 min.
+      timeout: 120_000,
       reuseExistingServer: !process.env.CI,
       env: {
         PORT: '3002',

--- a/app/packages/web/vite.integration.config.ts
+++ b/app/packages/web/vite.integration.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     outDir: 'dist-integration',
     emptyOutDir: true,
   },
+  define: {
+    // Speed up the status poller so browser integration tests don't wait 20 s per cycle.
+    'import.meta.env.VITE_STATUS_POLL_MS': '"3000"',
+  },
   preview: {
     port: 4174,
     strictPort: true,

--- a/app/packages/web/vite.integration.config.ts
+++ b/app/packages/web/vite.integration.config.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+/**
+ * Vite config for integration tests. Differences from vite.config.ts:
+ *  - outDir → dist-integration (avoids clobbering the regular e2e build)
+ *  - preview runs on port 4174 (4173 is the tier-1 e2e port)
+ *  - preview.proxy routes /api to the test Nest server on :3002
+ */
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  build: {
+    outDir: 'dist-integration',
+    emptyOutDir: true,
+  },
+  preview: {
+    port: 4174,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3002',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/docs/docs/components/integration-tests.md
+++ b/docs/docs/components/integration-tests.md
@@ -1,0 +1,97 @@
+# Integration Test Suite (Tier 2)
+
+Full-stack Playwright tests that run a **real Nest.js server** with **mocked AWS SDK** calls, wired to a **Vite preview build** that proxies `/api` requests to it. The goal is to validate the HTTP contract between the frontend and the server without spinning up real AWS infrastructure.
+
+## How to Run
+
+```bash
+# Build the server, then run the integration Playwright suite
+npm run app:test:integration
+```
+
+This command (from the repo root):
+1. Builds `@gsd/server` via `tsc`.
+2. Builds the `@gsd/web` integration bundle (port 4174, `dist-integration/`).
+3. Starts the test Nest server on `:3002` and the Vite preview on `:4174`.
+4. Runs `playwright test --config playwright.integration.config.ts`.
+
+## Architecture
+
+```
+Playwright test process
+  ├── request (APIRequestContext) ─────────────── HTTP directly to :3002
+  └── page (Browser)
+        └── http://localhost:4174 (Vite preview)
+              └── /api/* proxy ────────────────── http://localhost:3002
+                    └── Nest test server (test-main.js)
+                          ├── AppModule (real controllers, services, guards)
+                          ├── TestMocksModule   (POST /api/test/mocks/*)
+                          └── aws-sdk-client-mock (ECSClient prototype patched)
+                                └── MockStore  (per-command FIFO queues)
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `app/packages/server/src/test-main.ts` | Integration server entry point. Patches `ECSClient` via `mockClient()` before `NestFactory.create()`, then boots `TestAppModule`. |
+| `app/packages/server/src/test-mocks/mock-store.ts` | In-process `MockStore` singleton with per-command FIFO queues. |
+| `app/packages/server/src/test-mocks/test-mocks.controller.ts` | `POST /api/test/mocks/{reset,ecs/list-tasks,...}` — Playwright uses these to seed responses. |
+| `app/packages/web/vite.integration.config.ts` | Vite build config for integration tests (port 4174, `/api` proxy, `VITE_STATUS_POLL_MS=3000`). |
+| `app/packages/web/playwright.integration.config.ts` | Playwright config: `testDir: e2e/integration-specs`, `workers: 1`, two `webServer` entries. |
+| `app/packages/web/e2e/fixtures/server-mocks.ts` | `ServerMocks` class + extended `test` with `serverMocks`, `authedPage`, `dashboard` fixtures. |
+| `app/packages/web/e2e/fixtures/tfstate.fixture.json` | Synthetic Terraform state (`minecraft` + `valheim`, `us-east-1`, `test.example.com`). |
+| `app/packages/web/e2e/integration-specs/` | All integration specs. |
+
+## How Mock Responses Work
+
+The test server's `MockStore` holds separate FIFO queues for `ListTasks`, `DescribeTasks`, `RunTask`, and `StopTask`. When a queue is empty, the corresponding interceptor returns a safe default:
+
+| Command | Default (empty queue) |
+|---------|-----------------------|
+| `ListTasksCommand` | `{ taskArns: [] }` → game is stopped |
+| `DescribeTasksCommand` | `{ tasks: [] }` |
+| `RunTaskCommand` | `{ tasks: [{ taskArn: 'arn:…/test-task-id' }], failures: [] }` |
+| `StopTaskCommand` | `{}` |
+
+Push a response before navigating or clicking:
+
+```ts
+await serverMocks.pushListTasks({
+  type: 'success',
+  data: { taskArns: ['arn:aws:ecs:us-east-1:123:task/test-cluster/abc'] },
+});
+await serverMocks.pushDescribeTasks({
+  type: 'success',
+  data: { tasks: [{ taskArn: '…', lastStatus: 'RUNNING' }] },
+});
+```
+
+Push an error to test propagation:
+
+```ts
+await serverMocks.pushRunTask({
+  type: 'error',
+  code: 'AccessDeniedException',
+  message: 'User is not authorized to perform ecs:RunTask',
+});
+```
+
+## Spec Inventory
+
+| Spec | What it tests |
+|------|---------------|
+| `api-token-guard.spec.ts` | 401 on missing/wrong token; 200 with valid Bearer; 200 with `?token=` query param. |
+| `config-service.spec.ts` | `GET /api/env` returns region + domain from the fixture; `GET /api/games` returns the fixture game list. |
+| `start-stop.spec.ts` | Dashboard renders STOPPED games on load; confirm dialog appears when Stop is clicked on a RUNNING game. |
+| `status-polling.spec.ts` | Pushing RUNNING mock responses causes the dashboard badge to update within the 3 s poll cycle. |
+| `error-propagation.spec.ts` | `AccessDeniedException` from `RunTaskCommand` surfaces as `{ success: false, message: '…' }` in the start response. |
+| `can-run.spec.ts` | Placeholder — skipped until Discord module is wired into the test server. |
+
+## Design Constraints
+
+- **`workers: 1`, `fullyParallel: false`** — the `MockStore` is an in-process singleton; concurrent tests would corrupt each other's queues.
+- **`serverMocks` resets before and after every test** — the fixture calls `POST /api/test/mocks/reset` in setup and teardown.
+- **`VITE_STATUS_POLL_MS=3000`** — the integration Vite build shortens the poller interval from 20 s to 3 s so status-change assertions complete in < 10 s.
+- **`TestMocksModule` is never imported by `AppModule`** — it only exists in `TestAppModule` (defined inline in `test-main.ts`), so it cannot accidentally reach the production server.
+- **`TF_STATE_PATH`** — the integration Playwright config injects `e2e/fixtures/tfstate.fixture.json` via this env var so `ConfigService` reads the fixture instead of requiring a real Terraform state file.

--- a/docs/superpowers/plans/2026-05-07-full-stack-integration-tests.md
+++ b/docs/superpowers/plans/2026-05-07-full-stack-integration-tests.md
@@ -1,0 +1,1288 @@
+# Full-Stack Integration Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Playwright integration test suite where a real Nest server runs on port 3002 (with AWS SDK calls mocked via `aws-sdk-client-mock`) and Vite preview proxies `/api` to it, covering the guard, config, start/stop flows, status polling, and error propagation.
+
+**Architecture:** The test Nest server boots from `test-main.ts` which calls `mockClient()` on every AWS SDK client class before `NestFactory.create()` runs. A `TestMocksModule` (only registered in the test binary) exposes `POST /api/test/mocks/*` endpoints so Playwright tests can queue per-test mock responses at runtime. Playwright's `webServer` config starts both the test Nest server and a Vite preview (built with a separate config) that proxies `/api` to port 3002.
+
+**Tech Stack:** `@playwright/test`, `aws-sdk-client-mock` (already in devDependencies), `@nestjs/common`, Vite 5, TypeScript ESM.
+
+---
+
+## File Map
+
+### New files — server package (`app/packages/server/src/`)
+
+| File | Responsibility |
+|------|---------------|
+| `test-main.ts` | Test entry point: mocks all AWS clients, boots `TestAppModule` on port 3002 |
+| `test-mocks/mock-store.ts` | In-memory queue of per-command mock responses; singleton in the server process |
+| `test-mocks/test-mocks.module.ts` | Nest module that exports `TestMocksController` |
+| `test-mocks/test-mocks.controller.ts` | `POST /api/test/mocks/reset` and `POST /api/test/mocks/ecs/*` — lets Playwright configure mock behavior |
+
+### Modified files — server package
+
+| File | Change |
+|------|--------|
+| `src/services/ConfigService.ts` | Check `process.env.TF_STATE_PATH` first in `getTfOutputs()` so the test binary can point at a fixture |
+
+### New files — web package (`app/packages/web/`)
+
+| File | Responsibility |
+|------|---------------|
+| `vite.integration.config.ts` | Vite config for integration build: `outDir: dist-integration`, `preview.port: 4174`, `preview.proxy → :3002` |
+| `playwright.integration.config.ts` | Playwright config: `testDir: e2e/integration-specs`, two `webServer` entries (test Nest + Vite preview) |
+| `e2e/fixtures/tfstate.fixture.json` | Synthetic Terraform state with two games (`minecraft`, `valheim`) |
+| `e2e/fixtures/server-mocks.ts` | Playwright `serverMocks` fixture — makes HTTP calls to `/api/test/mocks/*` with Bearer token |
+| `e2e/integration-specs/index.ts` | Re-exports `test`, `expect`, `serverMocks` for all integration specs |
+| `e2e/integration-specs/api-token-guard.spec.ts` | 401 without token; 200 with valid token |
+| `e2e/integration-specs/config-service.spec.ts` | tfstate fixture parsed → games endpoint lists minecraft + valheim |
+| `e2e/integration-specs/start-stop.spec.ts` | Start flow (RunTask mock → 200 → UI STARTING), Stop flow |
+| `e2e/integration-specs/status-polling.spec.ts` | DescribeTasks mock sequence: RUNNING → STOPPED; badge transitions |
+| `e2e/integration-specs/error-propagation.spec.ts` | RunTask throws AccessDeniedException → 500 → UI error toast |
+| `e2e/integration-specs/can-run.spec.ts` | Skipped placeholder; see note in task |
+
+### Modified files — web package
+
+| File | Change |
+|------|--------|
+| `package.json` | Add `test:integration` script |
+
+### Root changes
+
+| File | Change |
+|------|--------|
+| Root `package.json` | Add `app:test:integration` script |
+| `.github/workflows/integration.yml` | New CI workflow running integration suite |
+| `CLAUDE.md` | Update "two-tier browser testing strategy" table with tier descriptions |
+| `docs/docs/components/integration-tests.md` | New: "Running integration tests" section |
+
+---
+
+## Task 1: Add `TF_STATE_PATH` env-var override to ConfigService
+
+**Files:**
+- Modify: `app/packages/server/src/services/ConfigService.ts:29-32`
+
+- [ ] **Step 1: Open ConfigService and locate `TF_STATE_PATH`**
+
+The constant is at line 29:
+```ts
+const TF_STATE_PATH = resolveRuntimePath(
+  '../../../../../terraform/terraform.tfstate',
+  '../../../../terraform/terraform.tfstate',
+);
+```
+
+- [ ] **Step 2: Replace with env-var-aware version**
+
+Replace those four lines with:
+```ts
+const TF_STATE_PATH = process.env['TF_STATE_PATH'] ??
+  resolveRuntimePath(
+    '../../../../../terraform/terraform.tfstate',
+    '../../../../terraform/terraform.tfstate',
+  );
+```
+
+- [ ] **Step 3: Run existing unit tests to verify no regression**
+
+```bash
+npm run app:test
+```
+
+Expected: all tests pass (the change is backwards-compatible — env var absent → same behaviour as before).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/packages/server/src/services/ConfigService.ts
+git commit -m "fix(server): honour TF_STATE_PATH env var in ConfigService"
+```
+
+---
+
+## Task 2: Create the synthetic tfstate fixture
+
+**Files:**
+- Create: `app/packages/web/e2e/fixtures/tfstate.fixture.json`
+
+- [ ] **Step 1: Create the fixture file**
+
+```json
+{
+  "version": 4,
+  "terraform_version": "1.9.0",
+  "outputs": {
+    "aws_region":                     { "value": "us-east-1",          "type": "string" },
+    "ecs_cluster_name":               { "value": "test-cluster",        "type": "string" },
+    "ecs_cluster_arn":                { "value": "arn:aws:ecs:us-east-1:123456789012:cluster/test-cluster", "type": "string" },
+    "subnet_ids":                     { "value": "subnet-test1234",     "type": "string" },
+    "security_group_id":              { "value": "sg-test1234",         "type": "string" },
+    "file_manager_security_group_id": { "value": "sg-fm-test1234",      "type": "string" },
+    "efs_file_system_id":             { "value": "fs-test1234",         "type": "string" },
+    "efs_access_points": {
+      "value": { "minecraft": "fsap-mc1234", "valheim": "fsap-vh1234" },
+      "type": ["object", { "minecraft": "string", "valheim": "string" }]
+    },
+    "domain_name":                    { "value": "test.example.com",   "type": "string" },
+    "game_names":                     { "value": ["minecraft", "valheim"], "type": ["tuple", ["string", "string"]] },
+    "alb_dns_name":                   { "value": null,                  "type": "string" },
+    "acm_certificate_arn":            { "value": null,                  "type": "string" },
+    "discord_table_name":             { "value": "test-discord-table",  "type": "string" },
+    "discord_bot_token_secret_arn":   { "value": "arn:aws:secretsmanager:us-east-1:123456789012:secret/test/discord/bot-token",   "type": "string" },
+    "discord_public_key_secret_arn":  { "value": "arn:aws:secretsmanager:us-east-1:123456789012:secret/test/discord/public-key",  "type": "string" },
+    "interactions_invoke_url":        { "value": null,                  "type": "string" }
+  }
+}
+```
+
+- [ ] **Step 2: Verify ConfigService parses it correctly (manual smoke test)**
+
+```bash
+TF_STATE_PATH=app/packages/web/e2e/fixtures/tfstate.fixture.json node -e "
+import('./app/packages/server/dist/services/ConfigService.js').then(m => {
+  const svc = new m.ConfigService();
+  console.log(JSON.stringify(svc.getTfOutputs(), null, 2));
+});
+"
+```
+
+Expected: JSON with `game_names: ['minecraft', 'valheim']`, `aws_region: 'us-east-1'`. (Skip this step if the server isn't compiled yet — it will be validated when the test server starts in Task 5.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/fixtures/tfstate.fixture.json
+git commit -m "test: add synthetic tfstate fixture for integration tests"
+```
+
+---
+
+## Task 3: Create the mock-store (server-side in-process mock state)
+
+**Files:**
+- Create: `app/packages/server/src/test-mocks/mock-store.ts`
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p app/packages/server/src/test-mocks
+```
+
+- [ ] **Step 2: Create `mock-store.ts`**
+
+```ts
+/** Shape of a single queued mock response. */
+export interface MockResponse {
+  /** 'success' returns `data`; 'error' throws an error with `code` and `message`. */
+  type: 'success' | 'error';
+  data?: unknown;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Singleton in-process store of queued AWS SDK mock responses.
+ * `test-main.ts` sets up `aws-sdk-client-mock` interceptors that read from
+ * this store via `dequeue*()`. Playwright tests push responses via the
+ * `TestMocksController` HTTP endpoints before exercising each flow.
+ *
+ * Default (empty queue) behaviour per command:
+ *  - ListTasks   → { taskArns: [] }   (no running tasks)
+ *  - DescribeTasks → { tasks: [] }
+ *  - RunTask     → { tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:123:task/test-task-id' }] }
+ *  - StopTask    → {}
+ */
+class MockStore {
+  private listTasksQueue: MockResponse[] = [];
+  private describeTasksQueue: MockResponse[] = [];
+  private runTaskQueue: MockResponse[] = [];
+  private stopTaskQueue: MockResponse[] = [];
+
+  pushListTasks(r: MockResponse): void    { this.listTasksQueue.push(r); }
+  pushDescribeTasks(r: MockResponse): void{ this.describeTasksQueue.push(r); }
+  pushRunTask(r: MockResponse): void      { this.runTaskQueue.push(r); }
+  pushStopTask(r: MockResponse): void     { this.stopTaskQueue.push(r); }
+
+  dequeueListTasks(): MockResponse | null    { return this.listTasksQueue.shift() ?? null; }
+  dequeueDescribeTasks(): MockResponse | null{ return this.describeTasksQueue.shift() ?? null; }
+  dequeueRunTask(): MockResponse | null      { return this.runTaskQueue.shift() ?? null; }
+  dequeueStopTask(): MockResponse | null     { return this.stopTaskQueue.shift() ?? null; }
+
+  /** Clear all queues — called between tests via `POST /api/test/mocks/reset`. */
+  reset(): void {
+    this.listTasksQueue = [];
+    this.describeTasksQueue = [];
+    this.runTaskQueue = [];
+    this.stopTaskQueue = [];
+  }
+}
+
+export const mockStore = new MockStore();
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/server/src/test-mocks/mock-store.ts
+git commit -m "test(server): add in-process MockStore for integration test mock control"
+```
+
+---
+
+## Task 4: Create TestMocksController and TestMocksModule
+
+**Files:**
+- Create: `app/packages/server/src/test-mocks/test-mocks.controller.ts`
+- Create: `app/packages/server/src/test-mocks/test-mocks.module.ts`
+
+- [ ] **Step 1: Create `test-mocks.controller.ts`**
+
+```ts
+import { Body, Controller, Post } from '@nestjs/common';
+import { mockStore, type MockResponse } from './mock-store.js';
+
+/**
+ * HTTP endpoints for Playwright integration tests to control mock AWS SDK
+ * responses. Only registered in the test binary — never imported by AppModule.
+ *
+ * Protected by ApiTokenGuard (the global guard from AppModule applies to all
+ * routes) — callers must send `Authorization: Bearer test-token`.
+ */
+@Controller('test/mocks')
+export class TestMocksController {
+  /** Reset all queues between test scenarios. */
+  @Post('reset')
+  reset(): { ok: true } {
+    mockStore.reset();
+    return { ok: true };
+  }
+
+  /** Push a response for the next `ListTasksCommand` call. */
+  @Post('ecs/list-tasks')
+  pushListTasks(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushListTasks(body);
+    return { ok: true };
+  }
+
+  /** Push a response for the next `DescribeTasksCommand` call. */
+  @Post('ecs/describe-tasks')
+  pushDescribeTasks(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushDescribeTasks(body);
+    return { ok: true };
+  }
+
+  /** Push a response for the next `RunTaskCommand` call. */
+  @Post('ecs/run-task')
+  pushRunTask(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushRunTask(body);
+    return { ok: true };
+  }
+
+  /** Push a response for the next `StopTaskCommand` call. */
+  @Post('ecs/stop-task')
+  pushStopTask(@Body() body: MockResponse): { ok: true } {
+    mockStore.pushStopTask(body);
+    return { ok: true };
+  }
+}
+```
+
+- [ ] **Step 2: Create `test-mocks.module.ts`**
+
+```ts
+import { Module } from '@nestjs/common';
+import { TestMocksController } from './test-mocks.controller.js';
+
+/** Nest module exposing mock-control endpoints. Only imported by TestAppModule in test-main.ts. */
+@Module({
+  controllers: [TestMocksController],
+})
+export class TestMocksModule {}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/server/src/test-mocks/
+git commit -m "test(server): add TestMocksModule for per-test mock control via HTTP"
+```
+
+---
+
+## Task 5: Create the test Nest server entry point
+
+**Files:**
+- Create: `app/packages/server/src/test-main.ts`
+
+The key constraint is that `mockClient(ECSClient)` must be called **before** `NestFactory.create()` so the prototype mock is in place when EcsService's lazy `getClient()` first creates an `ECSClient` instance.
+
+- [ ] **Step 1: Create `test-main.ts`**
+
+```ts
+/**
+ * Integration-test entry point for the Nest server.
+ *
+ * Sets up aws-sdk-client-mock interceptors BEFORE creating the Nest
+ * application so that any ECSClient instances created by DI providers
+ * (EcsService's lazy getClient()) hit the mock rather than real AWS.
+ *
+ * Run via: PORT=3002 NODE_ENV=test API_TOKEN=test-token
+ *           TF_STATE_PATH=<path> node dist/test-main.js
+ */
+import 'reflect-metadata';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  ECSClient,
+  ListTasksCommand,
+  DescribeTasksCommand,
+  RunTaskCommand,
+  StopTaskCommand,
+} from '@aws-sdk/client-ecs';
+import { mockStore } from './test-mocks/mock-store.js';
+
+// ── Patch ECSClient prototype before the DI container creates any instances ──
+
+const ecsMock = mockClient(ECSClient);
+
+ecsMock.on(ListTasksCommand).callsFake(async () => {
+  const next = mockStore.dequeueListTasks();
+  if (next?.type === 'error') {
+    const err = Object.assign(new Error(next.message ?? 'Mock ListTasks error'), { name: next.code ?? 'ServiceException' });
+    throw err;
+  }
+  return (next?.data as object | undefined) ?? { taskArns: [] };
+});
+
+ecsMock.on(DescribeTasksCommand).callsFake(async () => {
+  const next = mockStore.dequeueDescribeTasks();
+  if (next?.type === 'error') {
+    const err = Object.assign(new Error(next.message ?? 'Mock DescribeTasks error'), { name: next.code ?? 'ServiceException' });
+    throw err;
+  }
+  return (next?.data as object | undefined) ?? { tasks: [] };
+});
+
+ecsMock.on(RunTaskCommand).callsFake(async () => {
+  const next = mockStore.dequeueRunTask();
+  if (next?.type === 'error') {
+    const err = Object.assign(new Error(next.message ?? 'Mock RunTask error'), { name: next.code ?? 'ServiceException' });
+    throw err;
+  }
+  return (next?.data as object | undefined) ?? {
+    tasks: [{ taskArn: 'arn:aws:ecs:us-east-1:123456789012:task/test-cluster/test-task-id' }],
+    failures: [],
+  };
+});
+
+ecsMock.on(StopTaskCommand).callsFake(async () => {
+  const next = mockStore.dequeueStopTask();
+  if (next?.type === 'error') {
+    const err = Object.assign(new Error(next.message ?? 'Mock StopTask error'), { name: next.code ?? 'ServiceException' });
+    throw err;
+  }
+  return (next?.data as object | undefined) ?? {};
+});
+
+// ── Now boot the Nest application ──
+
+import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { Module } from '@nestjs/common';
+import { AppModule } from './app.module.js';
+import { TestMocksModule } from './test-mocks/test-mocks.module.js';
+import { logger } from './logger.js';
+
+/** Wraps AppModule (all real providers + global guard) and adds TestMocksModule. */
+@Module({ imports: [AppModule, TestMocksModule] })
+class TestAppModule {}
+
+const PORT = parseInt(process.env['PORT'] ?? '3002', 10);
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create<NestExpressApplication>(TestAppModule, {
+    logger: ['error', 'warn'],
+  });
+  app.setGlobalPrefix('api');
+  await app.listen(PORT);
+  logger.info(`Integration test server running on http://localhost:${PORT}`, { port: PORT });
+}
+
+void bootstrap();
+```
+
+> **Note on ESM imports:** With TypeScript ESM, static `import` statements at the top of the file are hoisted and evaluated before the module body executes. The `mockClient(ECSClient)` calls run in the module body — after the import of `ECSClient`, but before `NestFactory.create()`. Since `aws-sdk-client-mock` patches `ECSClient.prototype.send`, all subsequent client instances (including those EcsService creates lazily on first request) will hit the mock.
+
+- [ ] **Step 2: Compile the server to verify `test-main.ts` type-checks**
+
+```bash
+npm run build -w @gsd/server
+```
+
+Expected: no TypeScript errors. The `dist/test-main.js` file is produced.
+
+- [ ] **Step 3: Smoke-test the server starts**
+
+```bash
+TF_STATE_PATH=$(pwd)/app/packages/web/e2e/fixtures/tfstate.fixture.json \
+  API_TOKEN=test-token \
+  NODE_ENV=test \
+  PORT=3002 \
+  node app/packages/server/dist/test-main.js &
+
+sleep 3
+curl -s "http://localhost:3002/api/env?token=test-token" | grep region
+kill %1
+```
+
+Expected: JSON containing `"aws_region":"us-east-1"` printed, then the background job is killed cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/packages/server/src/test-main.ts
+git commit -m "test(server): add integration test entry point with aws-sdk-client-mock setup"
+```
+
+---
+
+## Task 6: Create Vite integration config
+
+**Files:**
+- Create: `app/packages/web/vite.integration.config.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+/**
+ * Vite config for integration tests. Differences from vite.config.ts:
+ *  - outDir → dist-integration (avoids clobbering the regular e2e build)
+ *  - preview runs on port 4174 (4173 is the tier-1 e2e port)
+ *  - preview.proxy routes /api to the test Nest server on :3002
+ */
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  build: {
+    outDir: 'dist-integration',
+    emptyOutDir: true,
+  },
+  preview: {
+    port: 4174,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3002',
+        changeOrigin: true,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 2: Verify the build works with this config**
+
+```bash
+cd app/packages/web && npx vite build --config vite.integration.config.ts
+```
+
+Expected: `dist-integration/` produced with `index.html`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/vite.integration.config.ts
+git commit -m "test(web): add Vite integration config (port 4174, proxy → :3002)"
+```
+
+---
+
+## Task 7: Create Playwright integration config
+
+**Files:**
+- Create: `app/packages/web/playwright.integration.config.ts`
+
+- [ ] **Step 1: Create the file**
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const fixtureDir = fileURLToPath(new URL('e2e/fixtures', import.meta.url));
+const tfstatePath = join(fixtureDir, 'tfstate.fixture.json');
+const serverDist = fileURLToPath(new URL('../../packages/server/dist', import.meta.url));
+
+export default defineConfig({
+  testDir: './e2e/integration-specs',
+  /** Single worker prevents mock-state races between specs running in parallel. */
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:4174',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    extraHTTPHeaders: { Authorization: 'Bearer test-token' },
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: [
+    {
+      /**
+       * The real Nest server with mocked AWS clients. Built by the
+       * `app:test:integration` npm script before Playwright is invoked.
+       */
+      command: `node ${join(serverDist, 'test-main.js')}`,
+      url: 'http://localhost:3002/api/env?token=test-token',
+      timeout: 30_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        PORT: '3002',
+        NODE_ENV: 'test',
+        API_TOKEN: 'test-token',
+        TF_STATE_PATH: tfstatePath,
+      },
+    },
+    {
+      /** Vite preview serving the integration build, proxying /api → :3002. */
+      command: 'npx vite build --config vite.integration.config.ts && npx vite preview --config vite.integration.config.ts',
+      url: 'http://localhost:4174',
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});
+```
+
+- [ ] **Step 2: Verify Playwright can parse the config**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts --list 2>&1 | head -20
+```
+
+Expected: Playwright lists 0 tests (no specs yet) without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/playwright.integration.config.ts
+git commit -m "test(web): add Playwright integration config (real Nest :3002 + Vite preview :4174)"
+```
+
+---
+
+## Task 8: Add npm scripts and CI workflow
+
+**Files:**
+- Modify: `app/packages/web/package.json`
+- Modify: Root `package.json`
+- Create: `.github/workflows/integration.yml`
+
+- [ ] **Step 1: Add `test:integration` to `app/packages/web/package.json`**
+
+In the `scripts` block, add after `test:e2e`:
+```json
+"test:integration": "playwright test --config playwright.integration.config.ts"
+```
+
+- [ ] **Step 2: Add scripts to root `package.json`**
+
+In the `scripts` block, add after `app:test:e2e` (or near it):
+```json
+"app:test:integration": "npm run build -w @gsd/server && npm run test:integration -w @gsd/web"
+```
+
+The `npm run build -w @gsd/server` ensures `dist/test-main.js` exists before Playwright starts the webServer.
+
+- [ ] **Step 3: Create `.github/workflows/integration.yml`**
+
+```yaml
+name: Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: app/packages/web
+
+      - run: npm run app:test:integration
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: integration-playwright-report
+          path: app/packages/web/playwright-report/
+          retention-days: 30
+```
+
+- [ ] **Step 4: Verify scripts run (will fail on missing specs — expected)**
+
+```bash
+npm run app:test:integration 2>&1 | head -30
+```
+
+Expected: Server compiles and starts, Vite builds and starts, Playwright reports "0 tests" or similar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/packages/web/package.json package.json .github/workflows/integration.yml
+git commit -m "chore: add app:test:integration script and CI workflow"
+```
+
+---
+
+## Task 9: Create the Playwright-side server-mocks fixture
+
+**Files:**
+- Create: `app/packages/web/e2e/fixtures/server-mocks.ts`
+
+This runs in Playwright's Node.js test runner (not the browser). It wraps the `POST /api/test/mocks/*` endpoints with typed helper methods.
+
+- [ ] **Step 1: Create `server-mocks.ts`**
+
+```ts
+import { test as base } from '@playwright/test';
+
+const SERVER = 'http://localhost:3002';
+const TOKEN  = 'test-token';
+
+async function post(path: string, body: object = {}): Promise<void> {
+  const res = await fetch(`${SERVER}/api/test/mocks${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${TOKEN}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Mock endpoint ${path} returned ${res.status}`);
+}
+
+/**
+ * Helper for configuring the real Nest server's AWS mock responses from
+ * within Playwright specs. Call `serverMocks.reset()` at the start of each
+ * spec to clear leftover state from the previous test.
+ */
+export type ServerMocks = {
+  /** Clear all mock queues. Call this in `beforeEach`. */
+  reset(): Promise<void>;
+
+  /**
+   * Queue a `ListTasksCommand` response.
+   * Default when queue is empty: `{ taskArns: [] }` (no running tasks).
+   */
+  listTasks(response: { taskArns: string[] }): Promise<void>;
+
+  /**
+   * Queue a `DescribeTasksCommand` response.
+   * Default when queue is empty: `{ tasks: [] }`.
+   */
+  describeTasks(response: {
+    tasks: Array<{
+      taskArn: string;
+      lastStatus: string;
+      attachments?: Array<{ type: string; details: Array<{ name: string; value: string }> }>;
+    }>;
+  }): Promise<void>;
+
+  /** Queue a successful `RunTaskCommand` response. */
+  runTaskSuccess(taskArn?: string): Promise<void>;
+
+  /** Queue an error for the next `RunTaskCommand`. */
+  runTaskError(code: string, message: string): Promise<void>;
+
+  /** Queue a successful `StopTaskCommand` response. */
+  stopTaskSuccess(): Promise<void>;
+};
+
+type Fixtures = { serverMocks: ServerMocks };
+
+export const test = base.extend<Fixtures>({
+  serverMocks: async ({}, use) => {
+    const mocks: ServerMocks = {
+      reset: () => post('/reset'),
+
+      listTasks: (data) => post('/ecs/list-tasks', { type: 'success', data }),
+
+      describeTasks: (data) => post('/ecs/describe-tasks', { type: 'success', data }),
+
+      runTaskSuccess: (taskArn = 'arn:aws:ecs:us-east-1:123:task/test-cluster/test-id') =>
+        post('/ecs/run-task', {
+          type: 'success',
+          data: { tasks: [{ taskArn }], failures: [] },
+        }),
+
+      runTaskError: (code, message) =>
+        post('/ecs/run-task', { type: 'error', code, message }),
+
+      stopTaskSuccess: () => post('/ecs/stop-task', { type: 'success', data: {} }),
+    };
+    await use(mocks);
+  },
+});
+
+export { expect } from '@playwright/test';
+```
+
+- [ ] **Step 2: Create `e2e/integration-specs/index.ts`**
+
+```ts
+/** Unified test/expect/fixtures export for all integration specs. */
+export { test, expect, type ServerMocks } from '../fixtures/server-mocks.js';
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/fixtures/server-mocks.ts \
+        app/packages/web/e2e/integration-specs/index.ts
+git commit -m "test(web): add Playwright serverMocks fixture for integration test mock control"
+```
+
+---
+
+## Task 10: Write ApiTokenGuard spec
+
+**Files:**
+- Create: `app/packages/web/e2e/integration-specs/api-token-guard.spec.ts`
+
+- [ ] **Step 1: Create the spec**
+
+```ts
+import { test, expect } from './index.js';
+
+test.describe('ApiTokenGuard', () => {
+  test('should return 401 when Authorization header is missing', async ({ request }) => {
+    const res = await request.get('http://localhost:3002/api/env');
+    expect(res.status()).toBe(401);
+  });
+
+  test('should return 401 when bearer token is wrong', async ({ request }) => {
+    const res = await request.get('http://localhost:3002/api/env', {
+      headers: { Authorization: 'Bearer wrong-token' },
+    });
+    expect(res.status()).toBe(401);
+  });
+
+  test('should return 200 when bearer token is correct', async ({ request }) => {
+    const res = await request.get('http://localhost:3002/api/env', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json() as { aws_region?: string };
+    expect(body.aws_region).toBe('us-east-1');
+  });
+
+  test('should return 200 when token is passed as ?token= query param', async ({ request }) => {
+    const res = await request.get('http://localhost:3002/api/env?token=test-token');
+    expect(res.status()).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run this spec in isolation**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts api-token-guard.spec.ts
+```
+
+Expected: 4 tests pass (server must be running — start it manually if `reuseExistingServer` is enabled).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/integration-specs/api-token-guard.spec.ts
+git commit -m "test(integration): ApiTokenGuard — 401 without token, 200 with valid token"
+```
+
+---
+
+## Task 11: Write ConfigService spec
+
+**Files:**
+- Create: `app/packages/web/e2e/integration-specs/config-service.spec.ts`
+
+- [ ] **Step 1: Create the spec**
+
+```ts
+import { test, expect } from './index.js';
+
+test.describe('ConfigService tfstate integration', () => {
+  test('should list games from the fixture tfstate', async ({ request }) => {
+    const res = await request.get('http://localhost:3002/api/games', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json() as { games: string[] };
+    expect(body.games).toEqual(expect.arrayContaining(['minecraft', 'valheim']));
+    expect(body.games).toHaveLength(2);
+  });
+
+  test('should return aws_region from the fixture tfstate', async ({ request }) => {
+    const res = await request.get('http://localhost:3002/api/env', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    const body = await res.json() as { aws_region: string };
+    expect(body.aws_region).toBe('us-east-1');
+  });
+
+  test('should reload tfstate after cache invalidation', async ({ request }) => {
+    // /api/games calls invalidateCache() internally — calling it twice should
+    // still return the same fixture-file data (the file hasn't changed).
+    const res1 = await request.get('http://localhost:3002/api/games', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    const res2 = await request.get('http://localhost:3002/api/games', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    const body1 = await res1.json() as { games: string[] };
+    const body2 = await res2.json() as { games: string[] };
+    expect(body1.games).toEqual(body2.games);
+  });
+});
+```
+
+- [ ] **Step 2: Run this spec**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts config-service.spec.ts
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/integration-specs/config-service.spec.ts
+git commit -m "test(integration): ConfigService — tfstate parsed from fixture, games listed correctly"
+```
+
+---
+
+## Task 12: Write start/stop flow specs
+
+**Files:**
+- Create: `app/packages/web/e2e/integration-specs/start-stop.spec.ts`
+
+These specs navigate the actual UI (via the Vite preview at port 4174) and interact with buttons. They need `serverMocks` to queue ECS responses.
+
+The UI shows a "Start" button when a game is stopped and a "Stop" button + confirm dialog when running.
+
+- [ ] **Step 1: Create the spec**
+
+```ts
+import { test, expect } from './index.js';
+import { DashboardPage } from '../pages/index.js';
+
+test.describe('Start/Stop flow (full stack)', () => {
+  test.beforeEach(async ({ serverMocks, page }) => {
+    // Pre-seed token so the UI doesn't show the auth gate
+    await page.addInitScript(() => { localStorage.setItem('apiToken', 'test-token'); });
+    await serverMocks.reset();
+  });
+
+  test('should show STARTING after clicking Start when game is stopped', async ({ page, serverMocks }) => {
+    // Status poll: ListTasks returns empty → game is stopped
+    // (default mock returns empty, no push needed for this first poll)
+    
+    // RunTask will succeed
+    await serverMocks.runTaskSuccess();
+
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto();
+
+    // Wait for the stopped state to render
+    await expect(dashboard.statusBadge('stopped')).toBeVisible({ timeout: 10_000 });
+
+    // Click Start — the real Nest server calls ECS.runTask() on the mock
+    await dashboard.startButton().click();
+
+    // The API returns { success: true } → UI transitions to optimistic STARTING
+    await expect(
+      page.getByText(/starting/i).or(dashboard.statusBadge('starting')),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('should call StopTask and show stopped after confirm dialog', async ({ page, serverMocks }) => {
+    // Queue: ListTasks → running task exists, DescribeTasks → RUNNING state
+    const taskArn = 'arn:aws:ecs:us-east-1:123:task/test-cluster/running-task';
+    await serverMocks.listTasks({ taskArns: [taskArn] });
+    await serverMocks.describeTasks({
+      tasks: [{ taskArn, lastStatus: 'RUNNING' }],
+    });
+    await serverMocks.stopTaskSuccess();
+
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto();
+
+    await expect(dashboard.statusBadge('running')).toBeVisible({ timeout: 10_000 });
+
+    // Click Stop — triggers confirmation dialog
+    await dashboard.stopButton().click();
+    // Confirm the dialog
+    await page.getByRole('button', { name: /confirm|stop|yes/i }).click();
+
+    // The real Nest server calls ECS.stopTask() on the mock → success response
+    await expect(
+      page.getByText(/stopping|stopped/i),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});
+```
+
+> **Note:** The locator for "stopped" / "running" badges and "Start" / "Stop" buttons assumes the DashboardPage conventions established in `e2e/pages/DashboardPage.ts`. If the exact locators don't match, check `DashboardPage.statusBadge()` and `DashboardPage.startButton()` / `stopButton()` and adjust the assertions above accordingly.
+
+- [ ] **Step 2: Run this spec**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts start-stop.spec.ts
+```
+
+Expected: 2 tests pass. If a test fails, examine the HTML snapshot / trace to check the actual badge/button text and update the locators.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/integration-specs/start-stop.spec.ts
+git commit -m "test(integration): start/stop full-stack flow — RunTask/StopTask mock → UI transitions"
+```
+
+---
+
+## Task 13: Write status-polling spec
+
+**Files:**
+- Create: `app/packages/web/e2e/integration-specs/status-polling.spec.ts`
+
+This spec pushes two different `ListTasks` responses — the first poll returns RUNNING, the second returns empty (STOPPED). It verifies the dashboard badge transitions.
+
+- [ ] **Step 1: Create the spec**
+
+```ts
+import { test, expect } from './index.js';
+import { DashboardPage } from '../pages/index.js';
+
+test.describe('Status polling (full stack)', () => {
+  test.beforeEach(async ({ serverMocks, page }) => {
+    await page.addInitScript(() => { localStorage.setItem('apiToken', 'test-token'); });
+    await serverMocks.reset();
+  });
+
+  test('should transition badge from running to stopped as mock queue is consumed', async ({ page, serverMocks }) => {
+    const taskArn = 'arn:aws:ecs:us-east-1:123:task/test-cluster/poll-task';
+
+    // First poll: task is RUNNING
+    await serverMocks.listTasks({ taskArns: [taskArn] });
+    await serverMocks.describeTasks({ tasks: [{ taskArn, lastStatus: 'RUNNING' }] });
+
+    // Second poll: no running tasks (task stopped)
+    // (dequeue returns null → default empty response for both list and describe)
+
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto();
+
+    // Initial render should show running
+    await expect(dashboard.statusBadge('running')).toBeVisible({ timeout: 10_000 });
+
+    // After the queued running response is consumed, next poll gets the default
+    // (empty tasks) → status becomes stopped. The UI polls every few seconds;
+    // wait up to 20s for the transition.
+    await expect(dashboard.statusBadge('stopped')).toBeVisible({ timeout: 20_000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts status-polling.spec.ts
+```
+
+Expected: 1 test passes. The test may need the dashboard poll interval to elapse — if it takes too long, check the dashboard's polling interval and set a matching timeout.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/integration-specs/status-polling.spec.ts
+git commit -m "test(integration): status polling — RUNNING→STOPPED badge transition via mock queue"
+```
+
+---
+
+## Task 14: Write error-propagation spec
+
+**Files:**
+- Create: `app/packages/web/e2e/integration-specs/error-propagation.spec.ts`
+
+This spec queues a `RunTask` error and verifies the UI shows an error toast.
+
+- [ ] **Step 1: Create the spec**
+
+```ts
+import { test, expect } from './index.js';
+import { DashboardPage } from '../pages/index.js';
+
+test.describe('Error propagation (full stack)', () => {
+  test.beforeEach(async ({ serverMocks, page }) => {
+    await page.addInitScript(() => { localStorage.setItem('apiToken', 'test-token'); });
+    await serverMocks.reset();
+  });
+
+  test('should show error toast when ECS RunTask throws AccessDeniedException', async ({ page, serverMocks }) => {
+    // Game is stopped (default mock: empty ListTasks)
+    // RunTask will throw an AWS error
+    await serverMocks.runTaskError('AccessDeniedException', 'User is not authorized to perform ecs:RunTask');
+
+    const dashboard = new DashboardPage(page);
+    await dashboard.goto();
+
+    await expect(dashboard.statusBadge('stopped')).toBeVisible({ timeout: 10_000 });
+    await dashboard.startButton().click();
+
+    // The real Nest server catches the exception and returns { success: false, message: '...' }
+    // (EcsService.start wraps the thrown error and returns { success: false, message: String(err) })
+    // The UI reads this and shows an error toast or inline error
+    await expect(
+      page.getByText(/failed|error|denied/i).or(page.getByRole('alert')),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts error-propagation.spec.ts
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/packages/web/e2e/integration-specs/error-propagation.spec.ts
+git commit -m "test(integration): error propagation — AccessDeniedException from RunTask → UI error toast"
+```
+
+---
+
+## Task 15: Write canRun() enforcement spec (placeholder)
+
+**Files:**
+- Create: `app/packages/web/e2e/integration-specs/can-run.spec.ts`
+
+> **Design note:** The management web app authenticates via API token, not Discord guild/user permissions. `canRun()` enforcement in the Nest routes is not currently implemented — `GamesController.start()` does not call `canRun()`. This spec is a placeholder. Once per-game permission enforcement is added to the management API (separate issue), remove the `test.skip` annotation.
+
+- [ ] **Step 1: Create the placeholder**
+
+```ts
+import { test, expect } from './index.js';
+
+test.describe('canRun() enforcement', () => {
+  test.skip(
+    true,
+    'canRun() is not yet enforced on the management API routes. ' +
+    'GamesController.start/stop authenticate via API token only. ' +
+    'Add enforcement and enable this spec when per-game permission gates are added to the Nest controllers.',
+  );
+
+  test('should return 403 when game action is disallowed by canRun()', async ({ request }) => {
+    // When implemented: configure the fixture Discord config with a restricted
+    // game, then attempt start/stop and expect HTTP 403.
+    const res = await request.post('http://localhost:3002/api/start/restricted-game', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+    expect(res.status()).toBe(403);
+  });
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/packages/web/e2e/integration-specs/can-run.spec.ts
+git commit -m "test(integration): canRun() spec placeholder (skipped — enforcement not yet in Nest API)"
+```
+
+---
+
+## Task 16: Update docs and CLAUDE.md
+
+**Files:**
+- Create: `docs/docs/components/integration-tests.md`
+- Modify: `CLAUDE.md` — "Code & Test Conventions" → "Two-tier browser testing strategy"
+
+- [ ] **Step 1: Create `docs/docs/components/integration-tests.md`**
+
+```markdown
+# Running integration tests
+
+The project has two complementary browser-test tiers. This page covers **Tier 2** — the full-stack integration suite. For Tier 1 (route-stubbed Playwright tests), see the README at `app/packages/web/e2e/`.
+
+## Tier overview
+
+| Tier | Command | Backend | When to add |
+|------|---------|---------|-------------|
+| **1 — E2E (#74)** | `npm run app:test:e2e` | Playwright route stubs — no Nest server | UI behaviour, routing, auth gate, component interactions |
+| **2 — Integration (#75)** | `npm run app:test:integration` | Real Nest server (port 3002) + mocked AWS SDK | Guard logic, ConfigService parsing, ECS orchestration, error propagation |
+
+## Running locally
+
+```bash
+# First run: install Playwright browsers if you haven't already
+cd app/packages/web && npx playwright install chromium --with-deps
+
+# Run the integration suite
+npm run app:test:integration
+```
+
+The script compiles `@gsd/server`, then Playwright starts:
+1. The test Nest server on `http://localhost:3002` (using `aws-sdk-client-mock`)
+2. A Vite preview on `http://localhost:4174` that proxies `/api → :3002`
+
+## Architecture
+
+```
+Playwright browser
+  └─► Vite preview :4174 (dist-integration/ build)
+          └─► Real Nest server :3002 (test-main.ts)
+                  ├─► aws-sdk-client-mock  (ECS — ListTasks, DescribeTasks, RunTask, StopTask)
+                  └─► Fixture tfstate.json (e2e/fixtures/tfstate.fixture.json)
+```
+
+## Controlling mock responses from specs
+
+`serverMocks` is a Playwright fixture that sends HTTP requests to the test server's `POST /api/test/mocks/*` endpoints. Use it to queue per-test AWS responses:
+
+```ts
+import { test, expect } from '../fixtures/server-mocks.js';
+
+test('should start a game', async ({ page, serverMocks }) => {
+  await serverMocks.reset();         // clear queues from previous test
+  await serverMocks.runTaskSuccess(); // next RunTask returns success
+  // ... navigate and click Start ...
+});
+```
+
+## Fixture tfstate
+
+`e2e/fixtures/tfstate.fixture.json` is a synthetic Terraform state with two games (`minecraft`, `valheim`) and realistic output shapes. The Nest server reads it via the `TF_STATE_PATH` environment variable set in `playwright.integration.config.ts`.
+
+## CI
+
+Integration tests run on every PR via `.github/workflows/integration.yml`. Playwright traces and videos are uploaded as artifacts on failure.
+```
+
+- [ ] **Step 2: Update `CLAUDE.md` "Two-tier browser testing strategy" table**
+
+Locate the table under "Two-tier browser testing strategy" and replace just the `| **E2E (tier 1 — #74)** |` row and the paragraph that follows with:
+
+```markdown
+| **Unit / integration** | `npm run app:test` | Vitest. Server-side logic, hooks, helpers run under the `node` environment; React component specs in `@gsd/web` run under `jsdom` via `environmentMatchGlobs`. No real network — AWS SDK mocked via `aws-sdk-client-mock`; the `@gsd/web` API client is stubbed via `vi.mock`. | Pure logic, hook behaviour, server controllers, **per-component React behaviour** (rendering, callbacks, internal state transitions). |
+| **E2E (tier 1 — #74)** | `npm run app:test:e2e` | Playwright against `vite build` + `vite preview`. Nest server never runs; every `/api/*` call is stubbed at the network layer via `page.route()`. | User-visible flows: routing, auth gate, button interactions, status-badge rendering, optimistic updates. |
+| **Integration (tier 2 — #75)** | `npm run app:test:integration` | Playwright against a real Nest server (port 3002, AWS SDK mocked) + Vite preview (port 4174, proxies `/api`). | Guard logic (`ApiTokenGuard`), `ConfigService` tfstate parsing, ECS orchestration, error propagation from real controller code. |
+```
+
+Also update the paragraph after the table to read:
+
+```markdown
+A **tier 2** integration suite (#75) runs Playwright against a real Nest server in test mode (`NODE_ENV=test`, `API_TOKEN=test-token`, AWS SDK clients replaced by `aws-sdk-client-mock`). Use it for any scenario that requires real HTTP contract validation between the browser and server — especially when a regression could only be caught by exercising the actual guard, service, or controller code.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/docs/components/integration-tests.md CLAUDE.md
+git commit -m "docs: add integration-tests.md and update CLAUDE.md two-tier strategy table"
+```
+
+---
+
+## Task 17: Full suite smoke run and verify no regressions
+
+- [ ] **Step 1: Run all three test tiers**
+
+```bash
+npm run app:test
+npm run app:test:e2e
+npm run app:test:integration
+```
+
+Expected: all pass. Fix any failures before marking the issue done.
+
+- [ ] **Step 2: Confirm integration test count matches spec coverage**
+
+```bash
+cd app/packages/web && npx playwright test --config playwright.integration.config.ts --list
+```
+
+Expected: at least 9 named tests across 5 spec files (api-token-guard: 4, config-service: 3, start-stop: 2, status-polling: 1, error-propagation: 1), plus 1 skipped test in can-run.spec.ts.
+
+- [ ] **Step 3: Final commit (none needed if previous tasks committed cleanly)**
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+| Acceptance criterion | Covered by |
+|---------------------|-----------|
+| `playwright.integration.config.ts` with webServer entries | Task 7 |
+| `aws-sdk-client-mock` fixture module | Tasks 3–5, 9 |
+| `tfstate.fixture.json` with two games | Task 2 |
+| `app:test:integration` script + CI job | Task 8 |
+| `ApiTokenGuard` 401/200 tests | Task 10 |
+| `ConfigService.getTfOutputs()` + cache invalidation | Task 11 |
+| Start flow full-stack | Task 12 |
+| Stop flow full-stack | Task 12 |
+| Status polling RUNNING→STOPPED | Task 13 |
+| Error propagation (AccessDeniedException) | Task 14 |
+| `canRun()` enforcement | Task 15 (skipped with note — not yet in Nest API) |
+| "Running integration tests" docs section | Task 16 |
+| `CLAUDE.md` two-tier strategy updated | Task 16 |
+| Unit + e2e tests unaffected | Task 17 |
+
+### Known gaps / follow-ups
+
+1. **EC2 mock not included.** `EcsService.getStatus()` calls `ec2.getPublicIp(eniId)` for RUNNING tasks. The status-polling spec works around this by relying on the task having no ENI attachments (so `extractEniId` returns null and the IP lookup is skipped). If specs need a running task with an IP, add `Ec2Client` to the mock setup in `test-main.ts` and a `mockPublicIp()` helper in `server-mocks.ts`.
+2. **canRun() enforcement** is not yet in the Nest API (Task 15 placeholder).
+3. **Other AWS clients** (DynamoDB, SecretsManager, CloudWatch, CostExplorer) are not mocked in `test-main.ts`. Add them if specs need to exercise `DiscordConfigService`, `LogsService`, or `CostService` paths through the full stack.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "app:lint": "npm run lint           -w game-server-manager",
     "app:lint:fix": "npm run lint:fix       -w game-server-manager",
     "app:test:e2e": "npm run test:e2e       -w @gsd/web",
-    "app:test:integration": "npm run build -w @gsd/server && npm run test:integration -w @gsd/web",
+    "app:test:integration": "node app/scripts/embed-tfstate.mjs && npm run build -w @gsd/server && npm run test:integration -w @gsd/web",
     "scripts:init-parent": "npm run init-parent  -w @gsd/scripts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "app:lint": "npm run lint           -w game-server-manager",
     "app:lint:fix": "npm run lint:fix       -w game-server-manager",
     "app:test:e2e": "npm run test:e2e       -w @gsd/web",
+    "app:test:integration": "npm run build -w @gsd/server && npm run test:integration -w @gsd/web",
     "scripts:init-parent": "npm run init-parent  -w @gsd/scripts"
   }
 }


### PR DESCRIPTION
Closes #75

## Summary

- Adds a **tier-2 integration test suite** (`npm run app:test:integration`) where a real Nest server runs on `:3002`, AWS SDK calls are intercepted by `aws-sdk-client-mock`, and the Vite preview on `:4174` proxies `/api` to it — no real AWS required
- New `ServerMocks` Playwright fixture class + extended `test` object that resets `MockStore` before/after each spec; mock responses pushed to the server via `POST /api/test/mocks/*`
- 6 spec files covering API token guard (401/200 auth), ConfigService tfstate parsing, start/stop browser flows, status-badge polling transitions, and ECS error propagation; `canRun()` spec stubbed pending Discord integration
- Integration Vite config injects `VITE_STATUS_POLL_MS=3000` so poll-based assertions complete in < 10 s; Nest server startup timeout raised to 120 s for WSL2/DrvFs ESM loading latency
- `CLAUDE.md` two-tier strategy table updated to three-tier; integration conventions section added; reference docs table updated
- `docs/docs/components/integration-tests.md` added: architecture diagram, key-file table, mock response reference, spec inventory, design constraints

## Test plan

- [ ] `npm run app:test:integration` — 11 pass, 1 skip (`canRun.spec.ts` placeholder)
- [ ] `npm run app:test` (unit) — all pass, unaffected
- [ ] `npm run app:test:e2e` (tier-1) — all pass, unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)