### PR TITLE
fix(ci): set minimal permissions for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CoderCoco/game-server-deploy/security/code-scanning/12](https://github.com/CoderCoco/game-server-deploy/security/code-scanning/12)

Add an explicit `permissions` block to `.github/workflows/test.yml` at the workflow root so it applies to all jobs (including `test`) unless overridden.  
For this workflow, the best minimal permission is:

- `contents: read`

This is sufficient for `actions/checkout` and typical test execution, and it documents least privilege without changing functionality.

Edit region: near the top-level keys (`name`, `on`, `jobs`) in `.github/workflows/test.yml`, inserting `permissions` between `on` and `jobs` (or anywhere at root level).

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
