### PR TITLE
feat(web): accessibility pass over the new dashboard

### DIFF
--- a/app/packages/web/src/components/app-layout.component.test.tsx
+++ b/app/packages/web/src/components/app-layout.component.test.tsx
@@ -2,8 +2,13 @@ import { useEffect } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { LiveIndicator, RefreshAllButton } from './app-layout.component.js';
+import { MemoryRouter } from 'react-router-dom';
+import { AppLayout, LiveIndicator, RefreshAllButton } from './app-layout.component.js';
 import { PollingProvider, usePollingActions } from '../polling/polling-provider.component.js';
+
+vi.mock('../api.service.js', () => ({
+  api: { env: () => Promise.resolve(null) },
+}));
 
 /**
  * Mounts a child component that registers a poller in `useEffect` so the
@@ -59,6 +64,35 @@ describe('AppLayout — RefreshAllButton', () => {
       await Promise.resolve();
     });
     expect(fn.mock.calls.length).toBeGreaterThan(before);
+  });
+});
+
+describe('AppLayout — skip link and nav landmarks', () => {
+  it('should render a skip-to-main-content link as the first focusable element', () => {
+    render(
+      <PollingProvider>
+        <MemoryRouter>
+          <AppLayout>content</AppLayout>
+        </MemoryRouter>
+      </PollingProvider>,
+    );
+
+    const skipLink = screen.getByRole('link', { name: 'Skip to main content' });
+    expect(skipLink).toBeInTheDocument();
+    expect(skipLink).toHaveAttribute('href', '#main');
+  });
+
+  it('should mark the active route link with aria-current="page"', () => {
+    render(
+      <PollingProvider>
+        <MemoryRouter initialEntries={['/logs']}>
+          <AppLayout>content</AppLayout>
+        </MemoryRouter>
+      </PollingProvider>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Logs' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Dashboard' })).not.toHaveAttribute('aria-current');
   });
 });
 

--- a/app/packages/web/src/components/app-layout.component.tsx
+++ b/app/packages/web/src/components/app-layout.component.tsx
@@ -144,7 +144,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
         </header>
 
         {/* Page content */}
-        <main id="main" className="flex-1 overflow-auto p-8">
+        <main id="main" tabIndex={-1} className="flex-1 overflow-auto p-8">
           {children}
         </main>
       </div>

--- a/app/packages/web/src/components/app-layout.component.tsx
+++ b/app/packages/web/src/components/app-layout.component.tsx
@@ -55,12 +55,20 @@ export function AppLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex h-screen bg-background">
+      {/* Skip-to-content link — first focusable element, revealed on focus */}
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-card focus:text-foreground focus:rounded-[var(--radius-md)] focus:ring-2 focus:ring-[var(--color-primary)] focus:outline-none"
+      >
+        Skip to main content
+      </a>
+
       {/* Sidebar */}
       <aside className="w-60 border-r border-border bg-card flex flex-col">
         {/* Brand */}
         <div className="px-4 py-5 border-b border-border">
           <div className="flex items-center gap-2">
-            <div className="w-8 h-8 rounded bg-gradient-to-br from-purple-500 to-purple-700 flex items-center justify-center">
+            <div className="w-8 h-8 rounded bg-gradient-to-br from-purple-500 to-purple-700 flex items-center justify-center" aria-hidden="true">
               <Server className="w-5 h-5 text-white" />
             </div>
             <span className="font-semibold text-foreground">Game Servers</span>
@@ -68,29 +76,33 @@ export function AppLayout({ children }: { children: ReactNode }) {
         </div>
 
         {/* Nav sections */}
-        <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-6">
+        <nav aria-label="Main navigation" className="flex-1 overflow-y-auto px-3 py-4 space-y-6">
           {/* Monitoring */}
           <div>
-            <div className="px-3 mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            <p id="nav-monitoring" className="px-3 mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
               Monitoring
-            </div>
-            <div className="space-y-1">
+            </p>
+            <ul aria-labelledby="nav-monitoring" className="space-y-1 list-none">
               {monitoringItems.map((item) => (
-                <NavLink key={item.to + item.label} item={item} active={location.pathname === item.to} />
+                <li key={item.to + item.label}>
+                  <NavLink item={item} active={location.pathname === item.to} />
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
 
           {/* Configuration */}
           <div>
-            <div className="px-3 mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            <p id="nav-configuration" className="px-3 mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
               Configuration
-            </div>
-            <div className="space-y-1">
+            </p>
+            <ul aria-labelledby="nav-configuration" className="space-y-1 list-none">
               {configItems.map((item) => (
-                <NavLink key={item.to + item.label} item={item} active={location.pathname === item.to} />
+                <li key={item.to + item.label}>
+                  <NavLink item={item} active={location.pathname === item.to} />
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
         </nav>
       </aside>
@@ -107,28 +119,32 @@ export function AppLayout({ children }: { children: ReactNode }) {
           </div>
 
           <div className="flex items-center gap-4">
-            {/* Search placeholder */}
-            <div className="relative">
+            {/* Search placeholder — not yet functional; hidden from keyboard/screen readers */}
+            <div className="relative" aria-hidden="true">
               <input
                 type="text"
                 placeholder="Search... ⌘K"
                 className="w-64 px-3 py-1.5 text-sm bg-muted border border-border rounded focus:outline-none focus:ring-2 focus:ring-purple-500/50"
                 readOnly
+                tabIndex={-1}
               />
             </div>
 
             <RefreshAllButton />
             <LiveIndicator />
 
-            {/* Avatar placeholder */}
-            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-purple-700 flex items-center justify-center">
+            {/* Avatar placeholder — decorative */}
+            <div
+              className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-purple-700 flex items-center justify-center"
+              aria-hidden="true"
+            >
               <span className="text-xs font-medium text-white">OP</span>
             </div>
           </div>
         </header>
 
         {/* Page content */}
-        <main className="flex-1 overflow-auto p-8">
+        <main id="main" className="flex-1 overflow-auto p-8">
           {children}
         </main>
       </div>
@@ -151,9 +167,10 @@ export function RefreshAllButton() {
       size="sm"
       onClick={() => void refreshAll()}
       aria-label="Refresh all"
+      aria-busy={anyLoading}
       disabled={Object.keys(pollers).length === 0}
     >
-      <RefreshCw className={cn('size-3.5', anyLoading && 'animate-spin')} />
+      <RefreshCw className={cn('size-3.5', anyLoading && 'motion-safe:animate-spin')} aria-hidden="true" />
       Refresh
     </Button>
   );
@@ -172,17 +189,22 @@ export function LiveIndicator() {
   const anyFresh = entries.some((p) => p.lastSuccessAt !== null && !isStale(p, now));
   const allStale = entries.length > 0 && entries.every((p) => isStale(p, now));
   const dotClass = anyFresh
-    ? 'bg-[var(--color-cyan)] animate-pulse'
+    ? 'bg-[var(--color-cyan)] motion-safe:animate-pulse'
     : allStale
       ? 'bg-[var(--color-muted-foreground)]/60'
       : 'bg-[var(--color-muted-foreground)]/40';
   const labelClass = allStale
     ? 'text-[var(--color-muted-foreground)]/60'
     : 'text-muted-foreground';
+  const statusLabel = anyFresh ? 'Live — data is current' : allStale ? 'Stale — data may be out of date' : 'Connecting';
   return (
-    <div className="flex items-center gap-2 px-3 py-1.5 bg-muted rounded border border-border">
-      <div className={cn('w-2 h-2 rounded-full', dotClass)} />
-      <span className={cn('text-xs font-medium', labelClass)}>LIVE</span>
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 bg-muted rounded border border-border"
+      role="status"
+      aria-label={statusLabel}
+    >
+      <div className={cn('w-2 h-2 rounded-full', dotClass)} aria-hidden="true" />
+      <span className={cn('text-xs font-medium', labelClass)} aria-hidden="true">LIVE</span>
     </div>
   );
 }
@@ -197,15 +219,15 @@ function NavLink({ item, active }: { item: NavItem; active: boolean }) {
   );
   if (item.disabled) {
     return (
-      <span className={className}>
-        <Icon className="w-4 h-4" />
+      <span className={className} aria-disabled="true">
+        <Icon className="w-4 h-4" aria-hidden="true" />
         {item.label}
       </span>
     );
   }
   return (
-    <Link to={item.to} className={className}>
-      <Icon className="w-4 h-4" />
+    <Link to={item.to} className={className} aria-current={active ? 'page' : undefined}>
+      <Icon className="w-4 h-4" aria-hidden="true" />
       {item.label}
     </Link>
   );

--- a/app/packages/web/src/components/game-card.component.tsx
+++ b/app/packages/web/src/components/game-card.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Copy,
@@ -47,15 +47,15 @@ function badgeVariant(state: ServerState): 'success' | 'warning' | 'destructive'
   }
 }
 
-/** Map a server state to the icon shown next to the badge text. */
+/** Map a server state to the icon shown next to the badge text. Always aria-hidden — the text label already conveys the state. */
 function StateIcon({ state, className }: { state: ServerState; className?: string }) {
   const cls = cn('size-3', className);
   switch (state) {
-    case 'running':      return <CircleCheck     className={cls} />;
-    case 'starting':     return <Loader2         className={cn(cls, 'animate-spin')} />;
-    case 'stopped':      return <PowerOff        className={cls} />;
-    case 'not_deployed': return <CircleX         className={cls} />;
-    case 'error':        return <AlertTriangle   className={cls} />;
+    case 'running':      return <CircleCheck     className={cls} aria-hidden="true" />;
+    case 'starting':     return <Loader2         className={cn(cls, 'motion-safe:animate-spin')} aria-hidden="true" />;
+    case 'stopped':      return <PowerOff        className={cls} aria-hidden="true" />;
+    case 'not_deployed': return <CircleX         className={cls} aria-hidden="true" />;
+    case 'error':        return <AlertTriangle   className={cls} aria-hidden="true" />;
   }
 }
 
@@ -136,6 +136,15 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
   const { game, state } = status;
   const [busy, setBusy] = useState(false);
   const [stopDialogOpen, setStopDialogOpen] = useState(false);
+  const [stateAnnouncement, setStateAnnouncement] = useState('');
+  const prevStateRef = useRef(state);
+
+  useEffect(() => {
+    if (prevStateRef.current !== state) {
+      setStateAnnouncement(`${game} server is now ${STATE_LABELS[state].toLowerCase()}`);
+      prevStateRef.current = state;
+    }
+  }, [state, game]);
 
   const canStart = state === 'stopped' || state === 'not_deployed';
   const canStop  = state === 'running'  || state === 'starting';
@@ -200,8 +209,11 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
         onConfirm={() => { void handleStop(); }}
       />
       <Card className="relative overflow-hidden p-0 flex flex-col">
+        {/* Screen-reader announcement for state transitions */}
+        <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">{stateAnnouncement}</span>
+
         {/* Top gradient accent rule */}
-        <div className={cn('h-0.5 w-full', accentRuleClass(state))} />
+        <div className={cn('h-0.5 w-full', accentRuleClass(state))} aria-hidden="true" />
 
         {/* Header */}
         <div className="px-5 pt-4 pb-4 flex items-start justify-between gap-3">
@@ -259,6 +271,8 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
               size="sm"
               onClick={() => void handleStart()}
               disabled={!canStart || busy}
+              aria-busy={busy}
+              aria-label={`Start ${game} server`}
               className="flex-1 min-w-[6rem] bg-gradient-to-r from-[var(--color-green)] to-[var(--color-cyan)] hover:brightness-110"
             >
               Start
@@ -275,6 +289,8 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
                 }
               }}
               disabled={!canStop || busy}
+              aria-busy={busy}
+              aria-label={`Stop ${game} server`}
               className="flex-1 min-w-[6rem] bg-gradient-to-r from-[var(--color-red)] to-[var(--color-pink)] hover:brightness-110"
             >
               Stop

--- a/app/packages/web/src/components/game-card.component.tsx
+++ b/app/packages/web/src/components/game-card.component.tsx
@@ -218,9 +218,9 @@ export function GameCard({ status, estimate, onRefresh, onOpenFiles }: Props) {
         {/* Header */}
         <div className="px-5 pt-4 pb-4 flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <h3 className="font-[var(--font-ui)] text-[17px] font-bold capitalize leading-tight text-[var(--color-foreground)]">
+            <h2 className="font-[var(--font-ui)] text-[17px] font-bold capitalize leading-tight text-[var(--color-foreground)]">
               {game}
-            </h3>
+            </h2>
             <div className="mt-1 flex items-center gap-1.5 min-w-0">
               <span
                 className={cn(

--- a/app/packages/web/src/components/kpi-strip.component.tsx
+++ b/app/packages/web/src/components/kpi-strip.component.tsx
@@ -173,7 +173,7 @@ function KpiTile({ accent, label, Icon, value, delta, spark }: TileSpec) {
         <span className="text-[0.7rem] font-medium uppercase tracking-wider text-[var(--color-muted-foreground)]">
           {label}
         </span>
-        <Icon className={cn('size-4', ACCENT.icon[accent])} />
+        <Icon className={cn('size-4', ACCENT.icon[accent])} aria-hidden="true" />
       </div>
 
       <div className="font-[var(--font-ui)] text-2xl font-bold leading-none mb-2 text-[var(--color-foreground)]">

--- a/app/packages/web/src/components/watchdog-panel.component.tsx
+++ b/app/packages/web/src/components/watchdog-panel.component.tsx
@@ -40,9 +40,9 @@ export function WatchdogPanel() {
   return (
     <TooltipProvider delayDuration={150}>
       <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: '12px', padding: '1.25rem' }}>
-        <h2 style={{ fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-dim)', marginBottom: '1rem' }}>
+        <p style={{ fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-dim)', marginBottom: '1rem' }}>
           Watchdog Settings
-        </h2>
+        </p>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.6rem' }}>
           <Field
             label="Check interval (min)"

--- a/app/packages/web/src/index.css
+++ b/app/packages/web/src/index.css
@@ -62,6 +62,15 @@ body {
   font-feature-settings: 'tnum';
 }
 
+/* ── Motion accessibility ───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 /* ── Legacy button classes (used by unmigrated components only) ─────── */
 button {
   border: none;

--- a/app/packages/web/src/index.css
+++ b/app/packages/web/src/index.css
@@ -11,7 +11,7 @@
 
   /* Foreground */
   --color-foreground:     #e1e4ed;
-  --color-muted-foreground: #8b90a5;
+  --color-muted-foreground: #9398ad;
 
   /* Accent palette */
   --color-primary:       #7c3aed;
@@ -43,7 +43,7 @@
   --surface2: #252a40;
   --border:   #2e3350;
   --text:     #e1e4ed;
-  --text-dim: #8b90a5;
+  --text-dim: #9398ad;
   --accent:   #7c3aed;
   --accent-h: #a78bfa;
   --green:    #4ade80;

--- a/app/packages/web/src/pages/costs.page.tsx
+++ b/app/packages/web/src/pages/costs.page.tsx
@@ -334,7 +334,7 @@ function DeltaPill({
   const ArrowIcon = decreased ? ArrowDown : ArrowUp;
   return (
     <Badge variant={decreased ? 'success' : 'destructive'} className="font-[var(--font-mono)] gap-1">
-      <ArrowIcon className="size-3" />
+      <ArrowIcon className="size-3" aria-hidden="true" />
       {formatUsd(Math.abs(delta))}
       {deltaPct !== null && ` (${Math.abs(deltaPct).toFixed(1)}%)`}
       <span className="opacity-80 ml-1">vs prior</span>
@@ -404,6 +404,7 @@ function StackedBarChart({
                     <Tooltip key={g}>
                       <TooltipTrigger asChild>
                         <div
+                          role="img"
                           className="w-full transition-opacity hover:opacity-80"
                           style={{
                             height: `${segmentPct}%`,
@@ -496,7 +497,7 @@ function EstimatesTable({
           Per-game estimates
         </CardTitle>
         <div className="relative w-64">
-          <Search className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-[var(--color-muted-foreground)]" />
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-[var(--color-muted-foreground)]" aria-hidden="true" />
           <Input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
@@ -590,7 +591,7 @@ function SortableHeader({
         )}
       >
         {label}
-        <Icon className="size-3" />
+        <Icon className="size-3" aria-hidden="true" />
       </Button>
     </TableHead>
   );

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -525,7 +525,7 @@ function SecretField({
           type="button"
           onClick={() => setReveal((r) => !r)}
           aria-label={reveal ? 'Hide value' : 'Show value'}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
         >
           {reveal ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
         </button>

--- a/app/packages/web/src/polling/polling-indicator.component.test.tsx
+++ b/app/packages/web/src/polling/polling-indicator.component.test.tsx
@@ -91,6 +91,19 @@ describe('PollingIndicator', () => {
     expect(screen.getByText('Not polling')).toBeInTheDocument();
   });
 
+  it('should have role="status" so screen readers announce updates', async () => {
+    render(
+      <PollingProvider>
+        <PollerSeed name="status" intervalMs={20_000} />
+        <PollingIndicator />
+      </PollingProvider>,
+    );
+
+    await flushPolls();
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
   it('should expose the next-poll countdown via the tooltip on hover', async () => {
     const user = userEvent.setup();
     render(

--- a/app/packages/web/src/polling/polling-indicator.component.tsx
+++ b/app/packages/web/src/polling/polling-indicator.component.tsx
@@ -44,8 +44,12 @@ export function PollingIndicator({ name = 'status', className }: Props) {
           className,
         )}
       >
+        {/* Stable text for AT — only changes on stale transition, not every tick */}
+        <span className="sr-only">
+          {`Polling data is stale${state.lastSuccessAt ? ` — last updated at ${new Date(state.lastSuccessAt).toLocaleTimeString()}` : ''}`}
+        </span>
         <span className="size-1.5 rounded-full bg-[var(--color-red)]" aria-hidden="true" />
-        Stale · last updated {formatAgo(state.lastSuccessAt, now)}
+        <span aria-hidden="true">Stale · last updated {formatAgo(state.lastSuccessAt, now)}</span>
       </div>
     );
   }
@@ -62,6 +66,12 @@ export function PollingIndicator({ name = 'status', className }: Props) {
               className,
             )}
           >
+            {/* Stable text for AT — only changes when lastSuccessAt changes, not every tick */}
+            <span className="sr-only">
+              {state.lastSuccessAt
+                ? `Data updated at ${new Date(state.lastSuccessAt).toLocaleTimeString()}`
+                : 'Awaiting first poll'}
+            </span>
             <RefreshCw
               className={cn(
                 'size-3 text-[var(--color-cyan)]',
@@ -69,7 +79,7 @@ export function PollingIndicator({ name = 'status', className }: Props) {
               )}
               aria-hidden="true"
             />
-            <span>Updated {formatAgo(state.lastSuccessAt, now)}</span>
+            <span aria-hidden="true">Updated {formatAgo(state.lastSuccessAt, now)}</span>
           </div>
         </TooltipTrigger>
         <TooltipContent side="bottom">

--- a/app/packages/web/src/polling/polling-indicator.component.tsx
+++ b/app/packages/web/src/polling/polling-indicator.component.tsx
@@ -37,12 +37,14 @@ export function PollingIndicator({ name = 'status', className }: Props) {
   if (stale) {
     return (
       <div
+        role="status"
+        aria-live="polite"
         className={cn(
           'inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] border border-[var(--color-red)]/40 bg-[var(--color-red)]/10 px-2 py-0.5 text-xs font-medium text-[var(--color-red)]',
           className,
         )}
       >
-        <span className="size-1.5 rounded-full bg-[var(--color-red)]" />
+        <span className="size-1.5 rounded-full bg-[var(--color-red)]" aria-hidden="true" />
         Stale · last updated {formatAgo(state.lastSuccessAt, now)}
       </div>
     );
@@ -53,6 +55,8 @@ export function PollingIndicator({ name = 'status', className }: Props) {
       <Tooltip>
         <TooltipTrigger asChild>
           <div
+            role="status"
+            aria-live="polite"
             className={cn(
               'inline-flex items-center gap-1.5 text-xs text-[var(--color-muted-foreground)]',
               className,
@@ -61,8 +65,9 @@ export function PollingIndicator({ name = 'status', className }: Props) {
             <RefreshCw
               className={cn(
                 'size-3 text-[var(--color-cyan)]',
-                state.loading && 'animate-spin',
+                state.loading && 'motion-safe:animate-spin',
               )}
+              aria-hidden="true"
             />
             <span>Updated {formatAgo(state.lastSuccessAt, now)}</span>
           </div>


### PR DESCRIPTION
Closes #69

## Summary

- **Skip-to-content link** (`sr-only`/`focus:not-sr-only`) added as the first focusable element in `AppLayout`; `<main id="main">` is the target
- **Semantic nav landmarks**: `<nav aria-label="Main navigation">` with `<ul>/<li>` groups labelled by `aria-labelledby`; `aria-current="page"` on active links; `aria-disabled="true"` on disabled items
- **ARIA live regions**: `role="status" aria-live="polite"` on `PollingIndicator` and `LiveIndicator`; per-card `<span aria-live="polite">` announces server state transitions (stopped → starting → running)
- **Decorative elements hidden**: all icon-only lucide icons get `aria-hidden="true"`; spinner uses `motion-safe:animate-spin`; search placeholder and avatar div get `aria-hidden + tabIndex={-1}`
- **Buttons enriched**: Start/Stop buttons add `aria-busy` and game-specific `aria-label`; RefreshAllButton adds `aria-busy`; SecretField toggle gets a visible focus ring
- **Heading order fixed**: game card heading promoted `h3 → h2` to eliminate the `h1 → h3` skip flagged by Lighthouse
- **Contrast token bumped**: `--color-muted-foreground` / `--text-dim` raised from `#8b90a5` (4.46:1) to `#9398ad` (4.94:1) to clear WCAG AA on `surface-2` backgrounds
- **`prefers-reduced-motion`** global block added to `index.css` to zero out all animation durations for users who prefer it
- **`role="img"`** on stacked-bar chart segments in `CostsPage` (fixes `aria-prohibited-attr` on `<div aria-label>`)
- **Tests**: 2 new suites — skip-link/`aria-current` in `AppLayout`, `role="status"` assertion in `PollingIndicator` (477 unit tests, all passing)

## Lighthouse a11y scores (desktop, Lighthouse 13.2)

| Route | Score |
|-------|-------|
| `/` | **100** ✅ |
| `/costs` | **100** ✅ |
| `/discord` | **100** ✅ |
| `/logs` | **100** ✅ |
| `/settings` | **96** ✅ |

> `/settings` scores 96 due to small help-icon touch targets (11px) in `WatchdogPanel` — below the 24px minimum. These buttons are labelled and keyboard-accessible; the touch-target gap is deferred to a follow-up.

## Test plan

- [ ] Tab from the URL bar on `/` — confirm skip link appears visually and pressing Enter jumps focus to main content
- [ ] Navigate to `/logs` — confirm "Logs" nav link has `aria-current="page"` and "Dashboard" does not
- [ ] Start a game server — confirm screen reader (or live-region spy) announces state transitions
- [ ] Check `/discord` inactive tabs render legibly in a grayscale or colorblindness filter
- [ ] Run `npm run app:test` — all 477 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)