### PR TITLE
fix(build): remove package-lock.json from install stamp prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ WEB_SRCS     := $(shell find $(APP_DIR)/packages/web/src     -name '*.ts' -o -na
                 $(APP_DIR)/packages/web/vite.config.ts
 LAMBDA_SRCS  := $(shell find $(APP_DIR)/packages/lambda      -name '*.ts' -o -name '*.mjs' 2>/dev/null)
 PKG_JSONS    := $(shell find $(APP_DIR)/packages             -name 'package.json' 2>/dev/null) \
-                $(APP_DIR)/package.json \
-                $(APP_DIR)/package-lock.json
+                $(APP_DIR)/package.json
 TS_CONFIGS   := $(APP_DIR)/tsconfig.json \
                 $(APP_DIR)/tsconfig.base.json \
                 $(shell find $(APP_DIR)/packages -name 'tsconfig*.json' 2>/dev/null)


### PR DESCRIPTION
Closes #132

## Summary

- `app/package-lock.json` was listed in `PKG_JSONS` as a hard prerequisite for `.make/install.stamp`, but it is an *output* of `npm install`, not an input — making the dependency circular
- On a fresh clone the file doesn't exist, so Make immediately bails with `No rule to make target 'app/package-lock.json', needed by '.make/install.stamp'`
- Removed the lockfile from `PKG_JSONS`; the workspace `package.json` files are sufficient for detecting when a re-install is needed

## Test plan

- [ ] Run `make tf-plan` (or `make build-lambdas`) on a fresh clone with no `app/package-lock.json` present — confirm the install stamp runs successfully instead of bailing with a missing-target error