### PR TITLE
chore: rebrand to Hyveon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Game Server Manager
+# Hyveon
 
 A cost-efficient multi-game dedicated server platform on **AWS Fargate** with a
-local web UI and a fully serverless Discord bot. Servers only run — and only
-cost money — while someone is playing.
+local management UI and a fully serverless Discord bot. Servers only run — and
+only cost money — while someone is playing.
 
-> 📚 Full documentation lives at **[codercoco.github.io/game-server-deploy](https://codercoco.github.io/game-server-deploy/)**
+> 📚 Full documentation lives at **[codercoco.github.io/Hyveon](https://codercoco.github.io/Hyveon/)**
 > (built from [`docs/`](./docs) by GitHub Pages). The rest of this README is a
 > quick tour; deep-dives, setup steps, and architecture diagrams are on the
 > site.
@@ -31,22 +31,22 @@ cost money — while someone is playing.
 
 ## Documentation
 
-The [docs site](https://codercoco.github.io/game-server-deploy/) is
+The [docs site](https://codercoco.github.io/Hyveon/) is
 organised around three roles. Pick the one that matches what you need to do.
 
 | Guide | You are… |
 |---|---|
-| [**Setup guide**](https://codercoco.github.io/game-server-deploy/setup/) | Going from a blank AWS account to a running Fargate task. |
-| [**User guide**](https://codercoco.github.io/game-server-deploy/guides/user/) | Driving an already-provisioned deployment — the dashboard, Discord commands, day-to-day ops. |
-| [**Maintainer guide**](https://codercoco.github.io/game-server-deploy/guides/maintainer/) | Working on this codebase. |
-| [**Private parent + submodule guide**](https://codercoco.github.io/game-server-deploy/guides/submodule/) | Wrapping this repo in a private repo that holds `terraform.tfvars` and tfstate. Includes an interactive scaffolder ([`scripts/init-parent.ts`](./scripts/init-parent.ts)) that generates the wrapper Makefile, tfvars, and `.env`. |
+| [**Setup guide**](https://codercoco.github.io/Hyveon/setup/) | Going from a blank AWS account to a running Fargate task. |
+| [**User guide**](https://codercoco.github.io/Hyveon/guides/user/) | Driving an already-provisioned deployment — the dashboard, Discord commands, day-to-day ops. |
+| [**Maintainer guide**](https://codercoco.github.io/Hyveon/guides/maintainer/) | Working on this codebase. |
+| [**Private parent + submodule guide**](https://codercoco.github.io/Hyveon/guides/submodule/) | Wrapping this repo in a private repo that holds `terraform.tfvars` and tfstate. Includes an interactive scaffolder ([`scripts/init-parent.ts`](./scripts/init-parent.ts)) that generates the wrapper Makefile, tfvars, and `.env`. |
 
 Component deep-dives:
 
-- [**Architecture**](https://codercoco.github.io/game-server-deploy/architecture/) — full diagram + `/server-start` sequence.
-- [**Terraform**](https://codercoco.github.io/game-server-deploy/components/terraform/) — every `.tf` file, variables, outputs, gotchas.
-- [**Management app**](https://codercoco.github.io/game-server-deploy/components/management-app/) — Nest.js API, React dashboard, `@gsd/shared`.
-- [**Lambdas**](https://codercoco.github.io/game-server-deploy/components/lambdas/) — interactions, followup, update-dns, watchdog.
+- [**Architecture**](https://codercoco.github.io/Hyveon/architecture/) — full diagram + `/server-start` sequence.
+- [**Terraform**](https://codercoco.github.io/Hyveon/components/terraform/) — every `.tf` file, variables, outputs, gotchas.
+- [**Management app**](https://codercoco.github.io/Hyveon/components/management-app/) — Nest.js API, React dashboard, `@gsd/shared`.
+- [**Lambdas**](https://codercoco.github.io/Hyveon/components/lambdas/) — interactions, followup, update-dns, watchdog.
 
 ## Quick start
 
@@ -73,7 +73,7 @@ docker compose up --build
 #     http://localhost:5000  (dashboard prompts for $API_TOKEN)
 ```
 
-See the [setup guide](https://codercoco.github.io/game-server-deploy/setup/)
+See the [setup guide](https://codercoco.github.io/Hyveon/setup/)
 for the full walkthrough, including the IAM policy, Discord bot setup, and
 troubleshooting.
 
@@ -114,7 +114,7 @@ pennies/month. Playing 4 hours/day, 5 days/week ≈ **$10–12/month**, vs.
 ## Repository structure
 
 ```text
-game-server-deploy/
+Hyveon/
 ├── app/                       # Nest.js + React monorepo (npm workspaces)
 │   └── packages/
 │       ├── shared/            # @gsd/shared

--- a/app/packages/server/src/main.ts
+++ b/app/packages/server/src/main.ts
@@ -50,7 +50,7 @@ async function bootstrap(): Promise<void> {
   }
 
   await app.listen(PORT);
-  logger.info(`Game Server Manager API running on http://localhost:${PORT}`, {
+  logger.info(`Hyveon API running on http://localhost:${PORT}`, {
     mode: isDev ? 'development' : 'production',
     port: PORT,
   });

--- a/app/packages/web/e2e/pages/AppLayout.ts
+++ b/app/packages/web/e2e/pages/AppLayout.ts
@@ -10,7 +10,7 @@ export class AppLayout {
 
   /** Top-bar product heading — used as a "the dashboard mounted" smoke check. */
   brandHeading(): Locator {
-    return this.page.getByRole('heading', { name: 'Game Server Manager' });
+    return this.page.getByRole('heading', { name: 'Hyveon' });
   }
 
   /** Sidebar nav link by visible label (e.g. "Logs", "Discord", "Settings"). */

--- a/app/packages/web/e2e/pages/CostsPage.ts
+++ b/app/packages/web/e2e/pages/CostsPage.ts
@@ -4,7 +4,7 @@ import type { Page, Locator } from '@playwright/test';
 export type CostsRangeLabel = '7d' | '30d';
 
 /**
- * Page object for the `/costs` route added in CoderCoco/game-server-deploy#61.
+ * Page object for the `/costs` route added in CoderCoco/Hyveon#61.
  * Wraps the headline KPI, the stacked bar chart, the per-game estimates
  * table, and the time-range selector so spec files read as test logic
  * rather than locator soup.

--- a/app/packages/web/e2e/pages/LogsPage.ts
+++ b/app/packages/web/e2e/pages/LogsPage.ts
@@ -4,7 +4,7 @@ import type { Page, Locator } from '@playwright/test';
 export type LogLevelLabel = 'INFO' | 'WARN' | 'ERROR' | 'DEBUG';
 
 /**
- * Page object for the `/logs` route added in CoderCoco/game-server-deploy#63.
+ * Page object for the `/logs` route added in CoderCoco/Hyveon#63.
  * Wraps the LIVE/PAUSED pill, the searchable game combobox, the in-stream
  * search input, the Levels multi-select, the autoscroll toggle, the
  * Pause/Resume button, the log box, and the footer line-count summary so

--- a/app/packages/web/e2e/specs/costs.spec.ts
+++ b/app/packages/web/e2e/specs/costs.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, stubApis, MULTI_GAME_COST_DATA } from '../fixtures/index.js';
 
 /**
- * Specs for the `/costs` route added in CoderCoco/game-server-deploy#61.
+ * Specs for the `/costs` route added in CoderCoco/Hyveon#61.
  * Filter / sort exercises pass `MULTI_GAME_COST_DATA` so the table has more
  * than one row to interact with; the default `COST_DATA` only contains
  * `minecraft`.

--- a/app/packages/web/src/components/api-token-modal.component.tsx
+++ b/app/packages/web/src/components/api-token-modal.component.tsx
@@ -15,7 +15,7 @@ import { Button } from './ui/button.component';
 
 const MIN_TOKEN_LENGTH = 16;
 const DOCS_URL =
-  'https://codercoco.github.io/game-server-deploy/setup#api-token';
+  'https://codercoco.github.io/Hyveon/setup#api-token';
 
 /**
  * Blocking dialog shown when the API rejects a request with 401. The operator

--- a/app/packages/web/src/components/app-layout.component.tsx
+++ b/app/packages/web/src/components/app-layout.component.tsx
@@ -198,7 +198,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
               <Menu className="w-5 h-5" aria-hidden="true" />
             </button>
 
-            <h1 className="hidden sm:block text-lg font-semibold text-foreground shrink-0">Game Server Manager</h1>
+            <h1 className="hidden sm:block text-lg font-semibold text-foreground shrink-0">Hyveon</h1>
             <span className="inline-flex shrink-0 items-center px-2.5 py-0.5 rounded text-xs font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
               {envLabel}
             </span>

--- a/app/packages/web/src/pages/costs.page.tsx
+++ b/app/packages/web/src/pages/costs.page.tsx
@@ -178,7 +178,7 @@ function useCostsData(days: number): {
  * with a delta-vs-prior pill, and a time-range selector.
  *
  * Per-game split for the historical chart is currently a uniform fallback
- * because `/api/costs/actual` only returns daily totals — see CoderCoco/game-server-deploy#61.
+ * because `/api/costs/actual` only returns daily totals — see CoderCoco/Hyveon#61.
  */
 export function CostsPage() {
   const [range, setRange] = useState<RangeKey>('7d');
@@ -272,7 +272,7 @@ export function CostsPage() {
             {games.length > 0 && (
               <p className="mt-3 text-[0.7rem] text-[var(--color-muted-foreground)]">
                 Per-game split is a uniform approximation — Cost Explorer returns
-                daily totals only. See CoderCoco/game-server-deploy#61.
+                daily totals only. See CoderCoco/Hyveon#61.
               </p>
             )}
           </CardContent>

--- a/app/packages/web/src/pages/dashboard.page.tsx
+++ b/app/packages/web/src/pages/dashboard.page.tsx
@@ -123,7 +123,7 @@ function NoGamesCard() {
       </CardHeader>
       <CardContent className="flex flex-wrap gap-4">
         <a
-          href="https://codercoco.github.io/game-server-deploy/setup"
+          href="https://codercoco.github.io/Hyveon/setup"
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center gap-1.5 text-sm text-[var(--color-primary-light)] underline-offset-4 hover:underline"
@@ -132,7 +132,7 @@ function NoGamesCard() {
           <ExternalLink className="size-3.5" />
         </a>
         <a
-          href="https://github.com/CoderCoco/game-server-deploy/blob/main/terraform/terraform.tfvars.example"
+          href="https://github.com/CoderCoco/Hyveon/blob/main/terraform/terraform.tfvars.example"
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center gap-1.5 text-sm text-[var(--color-primary-light)] underline-offset-4 hover:underline"

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -339,7 +339,7 @@ function SetupWizard({ cfg }: { cfg: DiscordConfigRedacted }) {
         <p className="text-xs text-[var(--color-muted-foreground)] border-t border-[var(--color-border)] mt-4 pt-4">
           Full walkthrough:{' '}
           <a
-            href="https://codercoco.github.io/game-server-deploy/setup"
+            href="https://codercoco.github.io/Hyveon/setup"
             target="_blank"
             rel="noreferrer"
             className="text-[var(--color-primary-light)] underline-offset-4 hover:underline"

--- a/docs/docs/guides/maintainer.md
+++ b/docs/docs/guides/maintainer.md
@@ -9,15 +9,15 @@ You're here to change the code. This page is the shortest path from "clean
 clone" to "PR merged" plus the invariants that are load-bearing enough that
 CI can't always catch you breaking them.
 
-Read [`CLAUDE.md`](https://github.com/codercoco/game-server-deploy/blob/main/CLAUDE.md)
-and [`CONTRIBUTING.md`](https://github.com/codercoco/game-server-deploy/blob/main/CONTRIBUTING.md)
+Read [`CLAUDE.md`](https://github.com/CoderCoco/Hyveon/blob/main/CLAUDE.md)
+and [`CONTRIBUTING.md`](https://github.com/CoderCoco/Hyveon/blob/main/CONTRIBUTING.md)
 first. They are the source of truth for test/lint conventions and PR titles.
 This page is documentation over the top of them, not a replacement.
 
 ## Repository layout
 
 ```text
-game-server-deploy/
+Hyveon/
 ├── app/                                 # npm-workspaces monorepo
 │   ├── package.json                     # workspaces root; `npm run` scripts fan out
 │   ├── eslint.config.js                 # flat config; recommended TS + React presets
@@ -277,9 +277,9 @@ pattern we recommend for anyone running this for real — see the
 
 ## Useful references
 
-- [`CLAUDE.md`](https://github.com/codercoco/game-server-deploy/blob/main/CLAUDE.md) —
+- [`CLAUDE.md`](https://github.com/CoderCoco/Hyveon/blob/main/CLAUDE.md) —
   project instructions in full, including the "why" for every invariant.
-- [`CONTRIBUTING.md`](https://github.com/codercoco/game-server-deploy/blob/main/CONTRIBUTING.md) —
+- [`CONTRIBUTING.md`](https://github.com/CoderCoco/Hyveon/blob/main/CONTRIBUTING.md) —
   PR rules, review policy, local-check commands.
 - [Architecture](/architecture) —
   component and sequence diagrams.

--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -35,10 +35,10 @@ flowchart LR
     PTF["terraform.tfvars"]:::priv
     PENV[".env<br/>API_TOKEN=…"]:::priv
     PSTAMP[".make/<br/>setup.stamp, tfstate.json"]:::priv
-    PSUB["game-server-deploy/<br/>→ submodule"]:::priv
+    PSUB["Hyveon/<br/>→ submodule"]:::priv
   end
 
-  subgraph Upstream["game-server-deploy (public)"]
+  subgraph Upstream["Hyveon (public)"]
     direction TB
     UAPP["app/"]:::public
     UTF["terraform/*.tf"]:::public
@@ -66,7 +66,7 @@ your-private-games/                 # private repo you own
 ├── Makefile                        # wrapper — see "What the wrapper does" below
 ├── terraform.tfvars                # YOUR copy; checked in (private repo)
 ├── .make/                          # stamp dir (sha of submodule setup.sh, cached tfstate)
-└── game-server-deploy/             # submodule → CoderCoco/game-server-deploy
+└── Hyveon/             # submodule → CoderCoco/Hyveon
 ```
 
 That's the whole shape. No `config/` directory, no symlinks, no
@@ -84,11 +84,11 @@ git clone git@github.com:you/your-private-games.git
 cd your-private-games
 
 # 2. Add the submodule.
-git submodule add https://github.com/CoderCoco/game-server-deploy.git
+git submodule add https://github.com/CoderCoco/Hyveon.git
 
 # 3. Install all deps and run the scaffolder.
-(cd game-server-deploy && npm install)
-(cd game-server-deploy && npm run scripts:init-parent)
+(cd Hyveon && npm install)
+(cd Hyveon && npm run scripts:init-parent)
 ```
 
 The script prompts for project name, AWS region, hosted zone, and
@@ -112,11 +112,11 @@ Five targets, no surprises:
 
 | Target | What it does |
 |---|---|
-| `make setup` | One-time bootstrap. Runs `git submodule update --init --recursive`, executes `game-server-deploy/setup.sh` (installs Node/Terraform/AWS CLI on Debian/Ubuntu, npm-installs all workspaces, builds Lambda bundles, runs `terraform init` and bootstraps the S3 backend), then records the sha256 of `setup.sh` in `.make/setup.stamp`. |
-| `make plan` | Copies `terraform.tfvars` into `game-server-deploy/terraform/terraform.tfvars`, then runs `make -C game-server-deploy tf-plan` — which itself rebuilds the Lambda bundles before `terraform plan`. |
+| `make setup` | One-time bootstrap. Runs `git submodule update --init --recursive`, executes `Hyveon/setup.sh` (installs Node/Terraform/AWS CLI on Debian/Ubuntu, npm-installs all workspaces, builds Lambda bundles, runs `terraform init` and bootstraps the S3 backend), then records the sha256 of `setup.sh` in `.make/setup.stamp`. |
+| `make plan` | Copies `terraform.tfvars` into `Hyveon/terraform/terraform.tfvars`, then runs `make -C Hyveon tf-plan` — which itself rebuilds the Lambda bundles before `terraform plan`. |
 | `make apply` | Same as `plan`, but delegates to `tf-apply`. The submodule's `tf-apply` recipe prints a post-deploy checklist with the Discord interactions URL when it finishes. |
 | `make update` | Bumps the submodule to the tip of `main` (`git submodule update --remote --merge`). If the new `setup.sh` differs from the recorded sha, clears `.terraform/` and re-runs `setup.sh` automatically; otherwise leaves it alone. Reminds you to commit the new submodule pointer. |
-| `make dev` | Pulls live tfstate into `.make/tfstate.json` (so the embed step has something to read), wipes stale TS build info under the submodule's `app/packages/*/`, then runs `make -C game-server-deploy dev`, exporting `API_TOKEN` and `TF_STATE_PATH` to the child make. |
+| `make dev` | Pulls live tfstate into `.make/tfstate.json` (so the embed step has something to read), wipes stale TS build info under the submodule's `app/packages/*/`, then runs `make -C Hyveon dev`, exporting `API_TOKEN` and `TF_STATE_PATH` to the child make. |
 
 The `tfvars` copy is **always fresh** on plan/apply — the recipe `cp`s
 unconditionally, not just when the file is older than the destination. This
@@ -125,7 +125,7 @@ parent's `terraform.tfvars` between runs.
 
 ## Submodule update with idempotent setup.sh re-run
 
-`make update` records `sha256sum game-server-deploy/setup.sh` in
+`make update` records `sha256sum Hyveon/setup.sh` in
 `.make/setup.stamp` after each successful setup. On every subsequent
 `update`, it compares the new file's sha against the stamp:
 
@@ -133,7 +133,7 @@ parent's `terraform.tfvars` between runs.
   npm dependencies are still valid.
 - **Changed** → upstream tweaked the bootstrap (new tool version, S3 backend
   config change, Lambda build step, …). The recipe wipes
-  `game-server-deploy/terraform/.terraform/` and re-runs `setup.sh`, then
+  `Hyveon/terraform/.terraform/` and re-runs `setup.sh`, then
   records the new sha.
 
 You don't have to remember whether the bootstrap moved. The stamp file is
@@ -159,7 +159,7 @@ to keep the same token across rebuilds.
 
 ## tfstate lives in S3 by default
 
-`game-server-deploy/setup.sh` provisions an S3 bucket
+`Hyveon/setup.sh` provisions an S3 bucket
 (`{project_name}-tf-state`) and a DynamoDB lock table
 (`{project_name}-tf-locks`) on first run, then `terraform init`s with the
 S3 backend pointing at them. The parent repo never holds `terraform.tfstate`
@@ -198,8 +198,8 @@ make apply
 
 ```bash
 make update
-git add game-server-deploy
-git commit -m "chore: bump game-server-deploy to $(git -C game-server-deploy rev-parse --short HEAD)"
+git add Hyveon
+git commit -m "chore: bump Hyveon to $(git -C Hyveon rev-parse --short HEAD)"
 make plan        # eyeball the diff
 make apply       # if it looks right
 ```
@@ -212,7 +212,7 @@ Things that tend to need attention after a bump:
 
 - New or renamed Terraform variables → add them to your
   `terraform.tfvars`. Compare against
-  `game-server-deploy/terraform/terraform.tfvars.example`.
+  `Hyveon/terraform/terraform.tfvars.example`.
 - New environment variables on the Lambdas → typically Terraform handles
   this automatically, but verify in the plan output.
 - Changes to the four slash-command descriptors → re-click **Register
@@ -276,7 +276,7 @@ than stashing long-lived keys. The role's policy is the same
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `make plan` says "No such file or directory" pointing at `game-server-deploy/` | Submodule wasn't initialised | `make setup` (or `git submodule update --init --recursive`). |
+| `make plan` says "No such file or directory" pointing at `Hyveon/` | Submodule wasn't initialised | `make setup` (or `git submodule update --init --recursive`). |
 | `make apply` runs against an old `terraform.tfvars` | You edited the parent's tfvars but ran terraform inside the submodule directly | Always run `make apply` from the parent — the `copy-tfvars` recipe forces a fresh copy. |
 | `make update` silently pulls main and breaks apply | Upstream changed something incompatible | The stamp file's job is to flag setup.sh changes; for non-bootstrap breakage, run `make plan` and read the diff. Pin to a SHA in `.gitmodules` if you want stricter control. |
 | After bumping upstream, Discord commands have wrong arguments | Descriptors in `@gsd/shared/commands.ts` changed | Click **Register commands** for each guild in the dashboard. |

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 slug: /
 ---
 
-# Game Server Deploy
+# Hyveon
 
 A cost-efficient, multi-game dedicated server platform on **AWS Fargate** with a
 local management UI and a fully serverless Discord bot. Servers only run — and
@@ -70,7 +70,7 @@ the `/server-start` sequence) see the
 ## Repository map
 
 ```text
-game-server-deploy/
+Hyveon/
 ├── app/                       # Nest.js + React monorepo (npm workspaces)
 │   └── packages/
 │       ├── shared/            # @gsd/shared

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -38,7 +38,7 @@ On the AWS side you need:
 ## 1. Create and authorise an IAM user
 
 1. In the **[AWS IAM console](https://console.aws.amazon.com/iam/)** →
-   **Users → Create user**, give it a name like `game-server-deploy`.
+   **Users → Create user**, give it a name like `hyveon`.
 2. On the permissions step, choose **Attach policies directly** and skip
    through without selecting any managed policy. Create the user.
 3. Open the new user → **Permissions → Add permissions → Create inline
@@ -127,8 +127,8 @@ instead — the management app will pick them up too.
 **Linux / macOS:**
 
 ```bash
-git clone https://github.com/codercoco/game-server-deploy.git
-cd game-server-deploy
+git clone https://github.com/CoderCoco/Hyveon.git
+cd Hyveon
 chmod +x setup.sh
 ./setup.sh
 ```
@@ -136,8 +136,8 @@ chmod +x setup.sh
 **Windows (PowerShell 5.1+):**
 
 ```powershell
-git clone https://github.com/codercoco/game-server-deploy.git
-cd game-server-deploy
+git clone https://github.com/CoderCoco/Hyveon.git
+cd Hyveon
 .\setup.ps1
 ```
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -3,13 +3,13 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'Game Server Deploy',
+  title: 'Hyveon',
   tagline: 'Cost-efficient multi-game dedicated server platform on AWS Fargate',
   url: 'https://codercoco.github.io',
-  baseUrl: '/game-server-deploy/',
+  baseUrl: '/Hyveon/',
 
-  organizationName: 'codercoco',
-  projectName: 'game-server-deploy',
+  organizationName: 'CoderCoco',
+  projectName: 'Hyveon',
 
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
@@ -33,7 +33,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           routeBasePath: '/',
           editUrl:
-            'https://github.com/codercoco/game-server-deploy/tree/main/docs/',
+            'https://github.com/CoderCoco/Hyveon/tree/main/docs/',
         },
         blog: false,
         theme: {
@@ -51,7 +51,7 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: 'Game Server Deploy',
+      title: 'Hyveon',
       items: [
         {
           type: 'docSidebar',
@@ -60,7 +60,7 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: 'https://github.com/codercoco/game-server-deploy',
+          href: 'https://github.com/CoderCoco/Hyveon',
           label: 'GitHub',
           position: 'right',
         },
@@ -83,12 +83,12 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/codercoco/game-server-deploy',
+              href: 'https://github.com/CoderCoco/Hyveon',
             },
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Game Server Deploy. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Hyveon. Built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "game-server-deploy-docs",
+  "name": "hyveon-docs",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "game-server-deploy-docs",
+      "name": "hyveon-docs",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.6.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "game-server-deploy-docs",
+  "name": "hyveon-docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Custom CSS overrides for the Game Server Deploy documentation site.
+ * Custom CSS overrides for the Hyveon documentation site.
  * Docusaurus applies the correct set of variables automatically based on the
  * user's OS colour-scheme preference (light/dark), controlled by
  * `respectPrefersColorScheme: true` in docusaurus.config.ts.

--- a/docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Convert game-server-deploy from a Nest+React web app (operator runs Docker, hand-runs `terraform apply`) into a single-binary cross-platform Electron desktop application that owns the full deploy lifecycle — config editing, plan/apply/destroy, log streaming — while keeping the existing AWS infrastructure intact and leaving room for non-AWS clouds in the future.
+Convert Hyveon from a Nest+React web app (operator runs Docker, hand-runs `terraform apply`) into a single-binary cross-platform Electron desktop application that owns the full deploy lifecycle — config editing, plan/apply/destroy, log streaming — while keeping the existing AWS infrastructure intact and leaving room for non-AWS clouds in the future.
 
 ## Non-goals
 
@@ -292,7 +292,7 @@ npm run desktop:package    # electron-builder → release/{*.exe, *.dmg, *.AppIm
 
 ```yaml
 appId: dev.gsd.desktop
-productName: Game Server Deploy
+productName: Hyveon
 asar: true
 extraResources:
   # placed in process.resourcesPath at runtime, OUTSIDE app.asar.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "game-server-deploy",
+  "name": "hyveon",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "game-server-deploy",
+      "name": "hyveon",
       "workspaces": [
         "app",
         "app/packages/*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "game-server-deploy",
+  "name": "hyveon",
   "private": true,
   "workspaces": [
     "app",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,14 +1,14 @@
 # scripts/
 
-Helper scripts for `game-server-deploy`. These are intentionally **not** part
+Helper scripts for `Hyveon`. These are intentionally **not** part
 of the `app/` workspace — they exist to be run from a *parent* repo that
-vendors `game-server-deploy` as a git submodule, before any of the app's
+vendors `Hyveon` as a git submodule, before any of the app's
 dependencies have been installed.
 
 ## `init-parent.ts`
 
 Interactive scaffolder for the [private parent + submodule deployment
-pattern](https://codercoco.github.io/game-server-deploy/guides/submodule/). It
+pattern](https://codercoco.github.io/Hyveon/guides/submodule/). It
 generates a `Makefile`, `terraform.tfvars`, `.env`, and `.gitignore` in your
 parent repo, all wired to the wrapper Make targets (`setup`, `plan`, `apply`,
 `update`, `dev`) so you can drive the whole stack from the parent repo root.
@@ -18,11 +18,11 @@ parent repo, all wired to the wrapper Make targets (`setup`, `plan`, `apply`,
 From the parent (private) repo root, after adding the submodule:
 
 ```bash
-git submodule add https://github.com/CoderCoco/game-server-deploy.git
-(cd game-server-deploy/scripts && npm install)
-node --import tsx game-server-deploy/scripts/init-parent.ts
+git submodule add https://github.com/CoderCoco/Hyveon.git
+(cd Hyveon/scripts && npm install)
+node --import tsx Hyveon/scripts/init-parent.ts
 # or, equivalently:
-npx --prefix game-server-deploy/scripts tsx game-server-deploy/scripts/init-parent.ts
+npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts
 ```
 
 Flags:

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -10,8 +10,8 @@ import { renderMakefile, renderTfvars, renderEnv, renderGitignore } from './init
 
 const a = {
   parentDir: '/tmp/parent',
-  submoduleDir: 'game-server-deploy',
-  submoduleName: 'game-server-deploy',
+  submoduleDir: 'Hyveon',
+  submoduleName: 'Hyveon',
   projectName: 'mygames',
   awsRegion: 'us-west-2',
   hostedZone: 'example.com',
@@ -25,7 +25,7 @@ const expect = (label: string, ok: boolean): void => {
 };
 
 const mk = renderMakefile(a);
-expect('Makefile sets SUBMODULE', mk.includes('SUBMODULE   := $(REPO_ROOT)/game-server-deploy'));
+expect('Makefile sets SUBMODULE', mk.includes('SUBMODULE   := $(REPO_ROOT)/Hyveon'));
 expect('Makefile reads .env', mk.includes('include $(REPO_ROOT)/.env'));
 expect('Makefile delegates plan', mk.includes('$(MAKE) -C $(SUBMODULE) tf-plan'));
 expect('Makefile delegates apply', mk.includes('$(MAKE) -C $(SUBMODULE) tf-apply'));

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -2,16 +2,16 @@
 /**
  * init-parent.ts
  *
- * Interactive scaffolder for the "private parent repo + game-server-deploy
+ * Interactive scaffolder for the "private parent repo + Hyveon
  * submodule" deployment pattern documented at
- * https://codercoco.github.io/game-server-deploy/guides/submodule/.
+ * https://codercoco.github.io/Hyveon/guides/submodule/.
  *
  * Run from the parent (private) repo root:
  *
  *   cd your-private-games
- *   git submodule add https://github.com/CoderCoco/game-server-deploy.git
- *   (cd game-server-deploy/scripts && npm install)
- *   npx --prefix game-server-deploy/scripts tsx game-server-deploy/scripts/init-parent.ts
+ *   git submodule add https://github.com/CoderCoco/Hyveon.git
+ *   (cd Hyveon/scripts && npm install)
+ *   npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts
  *
  * The script writes (or refuses to overwrite without --force):
  *   - Makefile           wrapper around the submodule's Makefile
@@ -74,7 +74,7 @@ function detectSubmodulePath(parentDir: string, scriptDir: string): string {
     const m = readFileSync(gm, 'utf8').match(/path\s*=\s*(\S+)/);
     if (m) return m[1];
   }
-  return 'game-server-deploy';
+  return 'Hyveon';
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -345,7 +345,7 @@ async function main(): Promise<void> {
   const guessedParent = findParentRepoRoot(cwd()) ?? findParentRepoRoot(scriptDir) ?? cwd();
 
   output.write('\n');
-  output.write('  game-server-deploy — submodule deployment scaffolder\n');
+  output.write('  Hyveon — submodule deployment scaffolder\n');
   output.write('  ────────────────────────────────────────────────────\n');
   output.write('\n');
   output.write(`  Parent repo:  ${guessedParent}\n`);
@@ -369,7 +369,7 @@ async function main(): Promise<void> {
       'Submodule path (relative to parent repo)',
       detectSubmodulePath(parentDir, scriptDir),
     );
-    const submoduleName = submoduleDir.split('/').pop() || 'game-server-deploy';
+    const submoduleName = submoduleDir.split('/').pop() || 'Hyveon';
 
     let projectName = '';
     while (!isValidProjectName(projectName)) {
@@ -435,11 +435,11 @@ async function main(): Promise<void> {
       const gm = readFileSync(join(parentDir, '.gitmodules'), 'utf8');
       if (!gm.includes(submoduleDir)) {
         output.write(`  Note: ${submoduleDir} is not in .gitmodules. Add it with:\n`);
-        output.write(`    git submodule add https://github.com/CoderCoco/game-server-deploy.git ${submoduleDir}\n\n`);
+        output.write(`    git submodule add https://github.com/CoderCoco/Hyveon.git ${submoduleDir}\n\n`);
       }
     } else {
       output.write(`  Note: no .gitmodules found. Add the submodule with:\n`);
-      output.write(`    git submodule add https://github.com/CoderCoco/game-server-deploy.git ${submoduleDir}\n\n`);
+      output.write(`    git submodule add https://github.com/CoderCoco/Hyveon.git ${submoduleDir}\n\n`);
     }
   } finally {
     rl.close();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,7 +2,7 @@
   "name": "@gsd/scripts",
   "private": true,
   "version": "0.0.0",
-  "description": "Helper scripts for game-server-deploy. Not part of the app workspace — install from this directory.",
+  "description": "Helper scripts for Hyveon. Not part of the app workspace — install from this directory.",
   "type": "module",
   "scripts": {
     "init-parent": "tsx init-parent.ts",

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'EOF'
-Game Server Manager — setup helper
+Hyveon — setup helper
 
 Usage:
   ./setup.sh              First-time bootstrap (default).
@@ -30,7 +30,7 @@ EOF
 
 bootstrap() {
   echo ""
-  echo "  🎮  Game Server Manager — Setup"
+  echo "  🎮  Hyveon — Setup"
   echo "  ──────────────────────────────────────"
   echo ""
 


### PR DESCRIPTION
## Summary

Repository was renamed from `game-server-deploy` to `Hyveon` on GitHub. This PR updates the visible brand and URL references throughout the codebase to match.

**Updated:**
- README.md (title, docs URLs, repo tree label)
- Docusaurus site config (title, baseUrl, projectName, organizationName, edit URLs, navbar, footer, copyright)
- Docs pages (intro, setup, architecture, guides, submodule wrapper guide)
- App source (header `<h1>`, page docs hrefs, e2e brand assertions, JSDoc repo refs)
- `setup.sh` bootstrap banner
- `scripts/` (init-parent banner, README, test fixtures)
- Design spec (`docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md`)
- Root `package.json#name` → `hyveon`
- `docs/package.json#name` → `hyveon-docs`
- `package-lock.json` (root name field, auto-regenerated)

**Intentionally NOT changed in this PR:**
- `@gsd/*` npm workspace scope — separate refactor; renaming touches every TS import. The desktop pivot's Epic B already plans the `@gsd/server` → `@gsd/desktop-main` migration; broader scope rename should happen alongside.
- Terraform `project_name` default `"game-servers-poc"` — changing it re-tags every AWS resource and invalidates Cost Explorer's existing Project-tag activation. Needs a planned migration with a `terraform plan` review.
- CLAUDE.md's reference to the existing AWS tag value.

**Issue bodies on GitHub:** 82 of 112 open issues had their bodies updated to use `github.com/CoderCoco/Hyveon` URLs (handled out-of-band via `gh issue edit`).

## Test plan

- [ ] `npm install` succeeds at the new root name
- [ ] `npm run app:dev` boots
- [ ] Browser shows "Hyveon" in the app header
- [ ] `cd docs && npm run start` renders the docs site with the new title
- [ ] No broken internal links in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)