### PR TITLE
feat(shared): define CloudProvider interface

### DIFF
--- a/app/packages/shared/src/cloud.test.ts
+++ b/app/packages/shared/src/cloud.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import type {
+  CloudProvider,
+  CostBreakdown,
+  DateRange,
+  LogChunk,
+  StartOpts,
+  WorkloadHandle,
+  WorkloadStatus,
+} from './cloud.js';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+describe('cloud.ts interface file', () => {
+  it('should import nothing from @aws-sdk/*', () => {
+    const src = readFileSync(resolve(dir, 'cloud.ts'), 'utf8');
+    expect(src).not.toMatch(/from ['"]@aws-sdk\//);
+  });
+});
+
+describe('CloudProvider', () => {
+  it('should be implementable with a plain object satisfying all six methods', () => {
+    /**
+     * Compile-time check: this object must satisfy CloudProvider or tsc/vitest
+     * will fail. The runtime assertion just confirms the object is truthy.
+     */
+    const provider = {
+      async startWorkload(_game: string, _opts: StartOpts): Promise<WorkloadHandle> {
+        return { workloadId: 'test-id' };
+      },
+      async stopWorkload(_game: string): Promise<void> {},
+      async getWorkloadStatus(_game: string): Promise<WorkloadStatus> {
+        return { state: 'stopped' };
+      },
+      async *streamWorkloadLogs(_game: string, _signal: AbortSignal): AsyncIterable<LogChunk> {},
+      async getCostEstimate(): Promise<CostBreakdown> {
+        return { total: 0, currency: 'USD', breakdown: {} };
+      },
+      async getActualCosts(_range: DateRange): Promise<CostBreakdown> {
+        return { total: 0, currency: 'USD', breakdown: {} };
+      },
+    } satisfies CloudProvider;
+
+    expect(provider).toBeDefined();
+  });
+});

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -1,0 +1,57 @@
+/** Options for launching a game workload. Intentionally empty for v1; implementations may extend via intersection. */
+export interface StartOpts {
+  [key: string]: unknown;
+}
+
+/** Opaque handle returned by startWorkload — uniquely identifies the launched workload within the provider. */
+export interface WorkloadHandle {
+  workloadId: string;
+}
+
+/** Cloud-agnostic status of a game workload. */
+export interface WorkloadStatus {
+  state: 'running' | 'starting' | 'stopped' | 'not_deployed' | 'error';
+  /** Provider-assigned workload identifier (replaces cloud-specific IDs such as task ARNs). */
+  workloadId?: string;
+  publicIp?: string;
+  hostname?: string;
+  message?: string;
+}
+
+/** A single timestamped log entry streamed from a running workload. */
+export interface LogChunk {
+  message: string;
+  timestamp: Date;
+}
+
+/**
+ * Cloud-agnostic cost snapshot. Shared return type for both forward-looking
+ * estimates (getCostEstimate) and billed actuals (getActualCosts).
+ */
+export interface CostBreakdown {
+  /** Total cost across all items in the breakdown. */
+  total: number;
+  currency: string;
+  /** Per-game or per-service cost keyed by name. */
+  breakdown: Record<string, number>;
+}
+
+/** Closed date interval used by getActualCosts to scope the billing query. */
+export interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Cloud-provider abstraction. No `@aws-sdk/*` shapes appear in this interface
+ * or its parameter/return types. Concrete implementations live in provider
+ * packages (e.g. `@hyveon/cloud-aws`).
+ */
+export interface CloudProvider {
+  startWorkload(game: string, opts: StartOpts): Promise<WorkloadHandle>;
+  stopWorkload(game: string): Promise<void>;
+  getWorkloadStatus(game: string): Promise<WorkloadStatus>;
+  streamWorkloadLogs(game: string, signal: AbortSignal): AsyncIterable<LogChunk>;
+  getCostEstimate(): Promise<CostBreakdown>;
+  getActualCosts(range: DateRange): Promise<CostBreakdown>;
+}

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -1,4 +1,4 @@
-/** Options for launching a game workload. Intentionally empty for v1; implementations may extend via intersection. */
+/** Options for launching a game workload. Intentionally open/opaque for v1; implementations may accept provider-specific keys or refine this via intersection. */
 export interface StartOpts {
   [key: string]: unknown;
 }

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js';
+export * from './cloud.js';
 export * from './sanitize.js';
 export * from './canRun.js';
 export * from './formatStatus.js';


### PR DESCRIPTION
Closes #163

## Summary

- Adds `CloudProvider` interface to `@hyveon/shared/cloud.ts` with six methods: `startWorkload`, `stopWorkload`, `getWorkloadStatus`, `streamWorkloadLogs`, `getCostEstimate`, `getActualCosts`
- Defines supporting cloud-agnostic types: `StartOpts`, `WorkloadHandle`, `WorkloadStatus`, `LogChunk`, `CostBreakdown`, `DateRange` — no `@aws-sdk/*` shapes appear anywhere in the file
- Re-exports everything from `@hyveon/shared` so consumer packages can import without reaching into internals

## Implementation notes

- `WorkloadStatus` replaces the AWS-specific `taskArn` field from the existing `GameStatus` with a generic `workloadId?: string`
- `CostBreakdown` is a single shared return type for both `getCostEstimate()` (forward-looking) and `getActualCosts(range)` (billed actuals), avoiding a split type hierarchy before there are concrete impls to inform the design
- `StartOpts` is an open index signature (`[key: string]: unknown`) rather than a closed empty interface — implementations can intersect it with cloud-specific options without forcing callers to cast
- Concrete AWS implementations (`AwsCloudProvider`) are deferred to a follow-up issue in epic #137

## Test plan

- [ ] `npm run app:test` passes (482 tests, including the two new `cloud.test.ts` specs)
- [ ] `cloud.test.ts` — "should import nothing from @aws-sdk/*" — reads `cloud.ts` as source text and asserts no `from '@aws-sdk/` pattern
- [ ] `cloud.test.ts` — "should be implementable with a plain object satisfying all six methods" — `satisfies CloudProvider` causes a compile error if any method signature drifts

🤖 Generated with [Claude Code](https://claude.ai/code)