### PR TITLE
feat(shared): define SecretsStore interface

### DIFF
--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -1,0 +1,32 @@
+/**
+ * Cloud-agnostic interface for reading and writing secrets in a key-value store.
+ * Implementations may target AWS Secrets Manager, Azure Key Vault, GCP Secret Manager,
+ * or any other backend — callers depend only on this contract.
+ */
+export interface SecretsStore {
+  /**
+   * Retrieves the value of a secret by name.
+   *
+   * @param name - The name (identifier) of the secret to retrieve.
+   * @returns The secret value as a string, or `undefined` if no secret with
+   *   that name exists in the store.
+   */
+  get(name: string): Promise<string | undefined>;
+
+  /**
+   * Stores a secret value under the given name, creating or overwriting the
+   * secret as needed.
+   *
+   * @param name  - The name (identifier) to store the secret under.
+   * @param value - The plaintext value to store.
+   */
+  put(name: string, value: string): Promise<void>;
+
+  /**
+   * Checks whether a secret with the given name exists in the store.
+   *
+   * @param name - The name (identifier) to look up.
+   * @returns `true` if the secret exists, `false` otherwise.
+   */
+  exists(name: string): Promise<boolean>;
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -7,3 +7,4 @@ export * from './ddb/client.js';
 export * from './ddb/configStore.js';
 export * from './ddb/pendingStore.js';
 export * from './secrets/secretsStore.js';
+export * from './cloud.js';


### PR DESCRIPTION
Closes #165

## Summary

- Adds `SecretsStore` interface to `@hyveon/shared/src/cloud.ts` with three methods: `get(name)`, `put(name, value)`, `exists(name)`
- All method signatures return `Promise`-wrapped values and operate on `string` keys/values — no AWS-specific types anywhere in the file
- Re-exports `SecretsStore` from the `@hyveon/shared` barrel so consumers can import without reaching into internals

## Implementation notes

- The existing `app/packages/shared/src/secrets/secretsStore.ts` (concrete AWS Secrets Manager impl) is untouched — moving it to a future `@hyveon/cloud-aws` package is deferred to the parent epic (#137)
- The `@hyveon/cloud-aws` package does not exist yet; the acceptance criterion "implementations in `@hyveon/cloud-aws` can satisfy it without leaking AWS types" is a structural constraint on the interface shape, not a requirement to create that package here
- `cloud.ts` contains zero imports of any kind — it is a pure interface declaration

## Test plan

- [ ] `npm run app:test` passes
- [ ] No `@aws-sdk/` import appears in `cloud.ts` (`grep '@aws-sdk' app/packages/shared/src/cloud.ts` returns nothing)
- [ ] `SecretsStore` is importable from `@hyveon/shared` (re-export in `index.ts` confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)