### PR TITLE
feat(shared): define RemoteFileStore interface

### DIFF
--- a/app/packages/shared/src/cloud.test.ts
+++ b/app/packages/shared/src/cloud.test.ts
@@ -7,6 +7,8 @@ import type {
   CostBreakdown,
   DateRange,
   LogChunk,
+  RemoteFileStore,
+  SecretsStore,
   StartOpts,
   WorkloadHandle,
   WorkloadStatus,
@@ -45,5 +47,53 @@ describe('CloudProvider', () => {
     } satisfies CloudProvider;
 
     expect(provider).toBeDefined();
+  });
+});
+
+describe('SecretsStore', () => {
+  it('should be implementable with a plain object satisfying all three methods', () => {
+    /**
+     * Compile-time check: this object must satisfy SecretsStore or tsc/vitest
+     * will fail. The runtime assertion just confirms the object is truthy.
+     */
+    const store = {
+      async get(_name: string): Promise<string | undefined> {
+        return 'secret-value';
+      },
+      async put(_name: string, _value: string): Promise<void> {},
+      async exists(_name: string): Promise<boolean> {
+        return true;
+      },
+    } satisfies SecretsStore;
+
+    expect(store).toBeDefined();
+  });
+});
+
+describe('RemoteFileStore', () => {
+  it('should be implementable with a plain object satisfying all three methods', () => {
+    /**
+     * Compile-time check: this object must satisfy RemoteFileStore or tsc/vitest
+     * will fail. The runtime assertion just confirms the object is truthy.
+     */
+    const store = {
+      async get(_path: string): Promise<{ body: Uint8Array; etag: string } | undefined> {
+        return { body: new Uint8Array([1, 2, 3]), etag: 'abc123' };
+      },
+      async put(
+        _path: string,
+        _body: Uint8Array,
+        _opts?: { ifMatch?: string },
+      ): Promise<{ etag: string }> {
+        return { etag: 'def456' };
+      },
+      async listVersions(
+        _path: string,
+      ): Promise<Array<{ versionId: string; lastModified: Date }>> {
+        return [{ versionId: 'v1', lastModified: new Date('2026-01-01T00:00:00Z') }];
+      },
+    } satisfies RemoteFileStore;
+
+    expect(store).toBeDefined();
   });
 });

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -88,3 +88,46 @@ export interface SecretsStore {
    */
   exists(name: string): Promise<boolean>;
 }
+
+/**
+ * Cloud-agnostic interface for reading and writing versioned binary files in a
+ * remote object store. Implementations may target AWS S3, Azure Blob Storage,
+ * GCP Cloud Storage, or any other backend — callers depend only on this contract.
+ * No `@aws-sdk/*` shapes appear in this interface or its parameter/return types.
+ */
+export interface RemoteFileStore {
+  /**
+   * Retrieves the current version of a file by path.
+   *
+   * @param path - The store-relative path of the file to retrieve.
+   * @returns An object containing the raw file contents (`body`) and the
+   *   provider-assigned entity tag (`etag`), or `undefined` if no file
+   *   exists at the given path.
+   */
+  get(path: string): Promise<{ body: Uint8Array; etag: string } | undefined>;
+
+  /**
+   * Writes a file to the store at the given path, creating or overwriting it.
+   * Supports optimistic concurrency via an optional `ifMatch` etag guard — if
+   * provided, the write is rejected (provider throws) when the stored etag no
+   * longer matches, preventing lost-update races.
+   *
+   * @param path - The store-relative path to write the file to.
+   * @param body - The raw file contents to store.
+   * @param opts - Optional write options. When `opts.ifMatch` is set, the write
+   *   only succeeds when the current stored etag matches this value (optimistic
+   *   concurrency guard).
+   * @returns An object containing the provider-assigned etag for the newly
+   *   stored version.
+   */
+  put(path: string, body: Uint8Array, opts?: { ifMatch?: string }): Promise<{ etag: string }>;
+
+  /**
+   * Lists all available versions of a file in reverse-chronological order.
+   *
+   * @param path - The store-relative path of the file to query.
+   * @returns An array of version descriptors, each containing a provider-
+   *   assigned `versionId` and the `lastModified` timestamp for that version.
+   */
+  listVersions(path: string): Promise<Array<{ versionId: string; lastModified: Date }>>;
+}


### PR DESCRIPTION
Closes #166

## Summary

- Adds `RemoteFileStore` interface to `@hyveon/shared/src/cloud.ts` with three methods: `get(path)`, `put(path, body, opts?)`, `listVersions(path)`
- Supports optimistic locking via `opts.ifMatch` / etag round-trip — `put` only succeeds when the stored etag matches the provided value
- All method signatures use only built-in types (`Uint8Array`, `Date`, `string`) — no `@aws-sdk/*` imports anywhere in the file
- Adds compile-time `satisfies` tests for `RemoteFileStore` in `cloud.test.ts`, following the same pattern established for `CloudProvider`
- Backfills a missing `satisfies` test for `SecretsStore` (landed in #218 without coverage)

## Implementation notes

- `@hyveon/cloud-aws` does not yet exist — the AWS S3 implementation is deferred to a separate child issue of epic #137. The `satisfies` test object in `cloud.test.ts` serves as the compile-time proof that the interface is implementable.
- `index.ts` already re-exports everything from `cloud.js` via wildcard so `RemoteFileStore` is automatically visible from `@hyveon/shared` with no index change needed.