### PR TITLE
feat(shared): define DiscordEventReceiver interface

### DIFF
--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -41,6 +41,7 @@ export interface TfOutputs {
   discord_bot_token_secret_arn: string;
   discord_public_key_secret_arn: string;
   interactions_invoke_url: string | null;
+  discord_interactions_url: string | null;
 }
 
 /**
@@ -136,6 +137,7 @@ export class ConfigService {
         discord_bot_token_secret_arn: get('discord_bot_token_secret_arn', ''),
         discord_public_key_secret_arn: get('discord_public_key_secret_arn', ''),
         interactions_invoke_url: get('interactions_invoke_url', null),
+        discord_interactions_url: get('discord_interactions_url', null),
       };
 
       logger.debug('Loaded Terraform outputs', { games: this.tfCache.game_names });

--- a/app/packages/shared/src/cloud.test.ts
+++ b/app/packages/shared/src/cloud.test.ts
@@ -6,6 +6,7 @@ import type {
   CloudProvider,
   CostBreakdown,
   DateRange,
+  DiscordEventReceiver,
   LogChunk,
   RemoteFileStore,
   SecretsStore,
@@ -95,5 +96,21 @@ describe('RemoteFileStore', () => {
     } satisfies RemoteFileStore;
 
     expect(store).toBeDefined();
+  });
+});
+
+describe('DiscordEventReceiver', () => {
+  it('should be implementable with a plain object satisfying getInteractionEndpointUrl', () => {
+    /**
+     * Compile-time check: this object must satisfy DiscordEventReceiver or tsc/vitest
+     * will fail. The runtime assertion just confirms the object is truthy.
+     */
+    const receiver = {
+      async getInteractionEndpointUrl(): Promise<string | null> {
+        return 'https://example.execute-api.us-east-1.amazonaws.com/interactions';
+      },
+    } satisfies DiscordEventReceiver;
+
+    expect(receiver).toBeDefined();
   });
 });

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -131,3 +131,20 @@ export interface RemoteFileStore {
    */
   listVersions(path: string): Promise<Array<{ versionId: string; lastModified: Date }>>;
 }
+
+/**
+ * Cloud-agnostic interface for resolving the Discord interactions endpoint URL
+ * from provider-managed configuration (e.g. an API Gateway invoke URL stored in
+ * infrastructure state or a secrets store). Callers depend only on this contract;
+ * no `@aws-sdk/*` shapes appear in this interface or its parameter/return types.
+ */
+export interface DiscordEventReceiver {
+  /**
+   * Resolves the public HTTPS URL that Discord will POST interaction events to.
+   *
+   * @returns The fully-qualified interactions endpoint URL (e.g. the API Gateway
+   *   invoke URL for the interactions Lambda), or `null` if no endpoint has been
+   *   configured or provisioned yet.
+   */
+  getInteractionEndpointUrl(): Promise<string | null>;
+}

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -142,9 +142,9 @@ export interface DiscordEventReceiver {
   /**
    * Resolves the public HTTPS URL that Discord will POST interaction events to.
    *
-   * @returns The fully-qualified interactions endpoint URL (e.g. the API Gateway
-   *   invoke URL for the interactions Lambda), or `null` if no endpoint has been
-   *   configured or provisioned yet.
+   * @returns The fully-qualified interactions endpoint URL registered with Discord
+   *   (e.g. a custom domain or provider-managed public URL), or `null` if no
+   *   endpoint has been configured or provisioned yet.
    */
   getInteractionEndpointUrl(): Promise<string | null>;
 }

--- a/app/packages/shared/src/discord/awsLambdaDiscordReceiver.test.ts
+++ b/app/packages/shared/src/discord/awsLambdaDiscordReceiver.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { AwsLambdaDiscordReceiver } from './awsLambdaDiscordReceiver.js';
+
+describe('AwsLambdaDiscordReceiver', () => {
+  it('should return the url when discord_interactions_url is set', async () => {
+    const url = 'https://abc123.execute-api.us-east-1.amazonaws.com/interactions';
+    const receiver = new AwsLambdaDiscordReceiver({ discord_interactions_url: url });
+    expect(await receiver.getInteractionEndpointUrl()).toBe(url);
+  });
+
+  it('should return null when discord_interactions_url is null', async () => {
+    const receiver = new AwsLambdaDiscordReceiver({ discord_interactions_url: null });
+    expect(await receiver.getInteractionEndpointUrl()).toBeNull();
+  });
+
+  it('should return null when discord_interactions_url is not provided', async () => {
+    const receiver = new AwsLambdaDiscordReceiver({ discord_interactions_url: undefined });
+    expect(await receiver.getInteractionEndpointUrl()).toBeNull();
+  });
+});

--- a/app/packages/shared/src/discord/awsLambdaDiscordReceiver.ts
+++ b/app/packages/shared/src/discord/awsLambdaDiscordReceiver.ts
@@ -6,8 +6,9 @@ import type { DiscordEventReceiver } from '../cloud.js';
  * package — `@hyveon/shared` must not depend on application packages.
  */
 export interface DiscordReceiverConfig {
-  /** The API Gateway invoke URL provisioned for the interactions Lambda, or
-   *  `null` / `undefined` when no endpoint has been deployed yet. */
+  /** The public custom-domain URL for the Discord interactions endpoint
+   *  (terraform output `discord_interactions_url`), or `null` / `undefined`
+   *  when no endpoint has been deployed yet. */
   discord_interactions_url: string | null | undefined;
 }
 
@@ -21,7 +22,7 @@ export interface DiscordReceiverConfig {
  * @example
  * ```ts
  * const receiver = new AwsLambdaDiscordReceiver({
- *   discord_interactions_url: tfOutputs.interactions_invoke_url,
+ *   discord_interactions_url: tfOutputs.discord_interactions_url,
  * });
  * const url = await receiver.getInteractionEndpointUrl();
  * ```

--- a/app/packages/shared/src/discord/awsLambdaDiscordReceiver.ts
+++ b/app/packages/shared/src/discord/awsLambdaDiscordReceiver.ts
@@ -1,0 +1,51 @@
+import type { DiscordEventReceiver } from '../cloud.js';
+
+/**
+ * Minimal subset of a TfOutputs-shaped object that this receiver needs.
+ * Keeping this narrow avoids importing ConfigService or any desktop-main
+ * package — `@hyveon/shared` must not depend on application packages.
+ */
+export interface DiscordReceiverConfig {
+  /** The API Gateway invoke URL provisioned for the interactions Lambda, or
+   *  `null` / `undefined` when no endpoint has been deployed yet. */
+  discord_interactions_url: string | null | undefined;
+}
+
+/**
+ * AWS Lambda-backed implementation of {@link DiscordEventReceiver}.
+ *
+ * Resolves the Discord interactions endpoint URL from a pre-resolved
+ * Terraform-outputs-shaped configuration object. No `@aws-sdk/*` imports
+ * are needed — the URL is a plain string read directly from the config.
+ *
+ * @example
+ * ```ts
+ * const receiver = new AwsLambdaDiscordReceiver({
+ *   discord_interactions_url: tfOutputs.interactions_invoke_url,
+ * });
+ * const url = await receiver.getInteractionEndpointUrl();
+ * ```
+ */
+export class AwsLambdaDiscordReceiver implements DiscordEventReceiver {
+  private readonly url: string | null;
+
+  /**
+   * @param config - An object containing the `discord_interactions_url` field.
+   *   Typically the parsed Terraform outputs for the current deployment.
+   */
+  constructor(config: DiscordReceiverConfig) {
+    this.url = config.discord_interactions_url ?? null;
+  }
+
+  /**
+   * Returns the fully-qualified HTTPS URL that Discord POSTs interaction
+   * events to, or `null` if no endpoint has been provisioned yet.
+   *
+   * @returns A promise that resolves to the interactions endpoint URL string,
+   *   or `null` when {@link DiscordReceiverConfig.discord_interactions_url}
+   *   was absent or `null` at construction time.
+   */
+  async getInteractionEndpointUrl(): Promise<string | null> {
+    return this.url;
+  }
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -8,3 +8,5 @@ export * from './ddb/client.js';
 export * from './ddb/configStore.js';
 export * from './ddb/pendingStore.js';
 export * from './secrets/secretsStore.js';
+export type { DiscordEventReceiver } from './cloud.js';
+export * from './discord/awsLambdaDiscordReceiver.js';


### PR DESCRIPTION
Closes #167

## Summary

- Adds `DiscordEventReceiver` interface to `@hyveon/shared/src/cloud.ts` with one method: `getInteractionEndpointUrl(): Promise<string | null>`
- Adds compile-time `satisfies` test for `DiscordEventReceiver` in `cloud.test.ts`, matching the pattern established for `CloudProvider`, `SecretsStore`, and `RemoteFileStore`
- Wires `discord_interactions_url: string | null` into `TfOutputs` in `ConfigService.ts` so the CloudFront/custom-domain URL is available from terraform state
- Adds `AwsLambdaDiscordReceiver` class (in `@hyveon/shared/src/discord/`) that implements `DiscordEventReceiver` by reading `discord_interactions_url` from a TfOutputs-shaped config object — no `@aws-sdk/*` imports required
- Re-exports both `DiscordEventReceiver` and `AwsLambdaDiscordReceiver` from the `@hyveon/shared` barrel

## Implementation notes

- `getInteractionEndpointUrl()` returns the CloudFront custom-domain URL (`discord_interactions_url`) rather than the raw Lambda Function URL (`interactions_invoke_url`) — this is the URL operators paste into Discord's developer portal
- `AwsLambdaDiscordReceiver` accepts a minimal `DiscordReceiverConfig` shape (not a full `ConfigService` dependency) so `@hyveon/shared` remains free of any `@hyveon/desktop-main` coupling
- `discord_interactions_url` is typed `string | null` in `TfOutputs`; the implementation propagates `null` faithfully when the terraform output is absent
- `cloud.ts` still contains zero import statements of any kind — the file-level test in `cloud.test.ts` enforces this