### PR TITLE
feat(desktop-main): adopt nestjs-electron-ipc-transport bootstrap

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "scripts": {
     "predev": "node scripts/embed-tfstate.mjs",
-    "dev": "concurrently -n server,client -c cyan,magenta \"npm run dev -w @hyveon/desktop-main\" \"npm run dev -w @hyveon/web\"",
+    "dev": "echo 'app:dev requires the Electron launcher from Epic A (#136). Run npm run dev -w @hyveon/web for the web-only dev server.' && exit 1",
     "prebuild": "node scripts/embed-tfstate.mjs",
     "build": "npm run build -w @hyveon/shared && npm run build -w @hyveon/desktop-main && npm run build -w @hyveon/web",
     "build:lambdas": "npm run build -w @hyveon/shared && npm run build -w @hyveon/lambda-interactions -w @hyveon/lambda-followup -w @hyveon/lambda-update-dns -w @hyveon/lambda-watchdog -w @hyveon/lambda-efs-seeder",
-    "start": "node packages/desktop-main/dist/main.js",
+    "start": "echo 'app:start requires the Electron launcher from Epic A (#136).' && exit 1",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/app/packages/desktop-main/package.json
+++ b/app/packages/desktop-main/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "main": "./dist/main.js",
   "scripts": {
-    "dev": "tsc -b && concurrently -k -n tsc,node \"tsc -b --watch --preserveWatchOutput\" \"node --enable-source-maps --watch dist/main.js\"",
+    "dev": "echo 'desktop-main now runs as an Electron IPC microservice. The Electron launcher is wired in Epic A (#136).' && exit 1",
     "build": "tsc -b",
-    "start": "node dist/main.js"
+    "start": "echo 'desktop-main now runs as an Electron IPC microservice. The Electron launcher is wired in Epic A (#136).' && exit 1"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.600.0",

--- a/app/packages/desktop-main/package.json
+++ b/app/packages/desktop-main/package.json
@@ -20,14 +20,17 @@
     "@hyveon/shared": "*",
     "@nestjs/common": "^10.4.0",
     "@nestjs/core": "^10.4.0",
+    "@nestjs/microservices": "^10.4.0",
     "@nestjs/platform-express": "^10.4.0",
     "express": "^4.19.2",
+    "nestjs-electron-ipc-transport": "^1.0.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "winston": "^3.13.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "electron": "^36.0.0",
     "tsx": "^4.15.7"
   }
 }

--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
 import { GamesController } from './controllers/games.controller.js';
@@ -8,10 +9,15 @@ import { LogsController } from './controllers/logs.controller.js';
 import { FilesController } from './controllers/files.controller.js';
 import { DiscordController } from './controllers/discord.controller.js';
 import { EnvController } from './controllers/env.controller.js';
+import { ApiTokenGuard } from './guards/api-token.guard.js';
 
 /**
  * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`) to
  * the IPC controllers.
+ *
+ * `ApiTokenGuard` is registered as a global guard so every HTTP route requires
+ * a bearer token. The guard is context-aware and passes through IPC (non-HTTP)
+ * calls without token enforcement.
  */
 @Module({
   imports: [AwsModule, DiscordModule],
@@ -24,6 +30,6 @@ import { EnvController } from './controllers/env.controller.js';
     DiscordController,
     EnvController,
   ],
-  providers: [],
+  providers: [{ provide: APP_GUARD, useClass: ApiTokenGuard }],
 })
 export class AppModule {}

--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -1,15 +1,6 @@
-import {
-  MiddlewareConsumer,
-  Module,
-  NestModule,
-  type NestMiddleware,
-  Injectable,
-} from '@nestjs/common';
-import { APP_GUARD } from '@nestjs/core';
-import type { Request, Response, NextFunction } from 'express';
+import { Module } from '@nestjs/common';
 import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
-import { ConfigService } from './services/ConfigService.js';
 import { GamesController } from './controllers/games.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
 import { CostsController } from './controllers/costs.controller.js';
@@ -17,31 +8,10 @@ import { LogsController } from './controllers/logs.controller.js';
 import { FilesController } from './controllers/files.controller.js';
 import { DiscordController } from './controllers/discord.controller.js';
 import { EnvController } from './controllers/env.controller.js';
-import { ApiTokenGuard } from './guards/api-token.guard.js';
-import { logger } from './logger.js';
-
-/** Request logger middleware — emits one line per request with status + latency. */
-@Injectable()
-class RequestLoggerMiddleware implements NestMiddleware {
-  use(req: Request, res: Response, next: NextFunction): void {
-    const start = Date.now();
-    res.on('finish', () => {
-      const ms = Date.now() - start;
-      const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'http';
-      logger.log(level, `${req.method} ${req.path}`, {
-        status: res.statusCode,
-        ms,
-        query: Object.keys(req.query).length ? req.query : undefined,
-      });
-    });
-    next();
-  }
-}
 
 /**
  * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`) to
- * the HTTP controllers and installs `ApiTokenGuard` as an `APP_GUARD` so every
- * `/api/*` route is bearer-token-gated without per-controller opt-in.
+ * the IPC controllers.
  */
 @Module({
   imports: [AwsModule, DiscordModule],
@@ -54,17 +24,6 @@ class RequestLoggerMiddleware implements NestMiddleware {
     DiscordController,
     EnvController,
   ],
-  providers: [
-    {
-      provide: APP_GUARD,
-      useFactory: (config: ConfigService) => new ApiTokenGuard(config),
-      inject: [ConfigService],
-    },
-  ],
+  providers: [],
 })
-export class AppModule implements NestModule {
-  /** Attaches the request logger to every route so each HTTP call emits one structured line. */
-  configure(consumer: MiddlewareConsumer): void {
-    consumer.apply(RequestLoggerMiddleware).forRoutes('*');
-  }
-}
+export class AppModule {}

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param, Post } from '@nestjs/common';
+import { MessagePattern } from '@nestjs/microservices';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
 
@@ -16,6 +17,7 @@ export class GamesController {
    * to restart the server.
    */
   @Get('games')
+  @MessagePattern('games.list')
   listGames(): { games: string[] } {
     this.config.invalidateCache();
     const outputs = this.config.getTfOutputs();

--- a/app/packages/desktop-main/src/guards/api-token.guard.test.ts
+++ b/app/packages/desktop-main/src/guards/api-token.guard.test.ts
@@ -22,9 +22,13 @@ function makeConfig(token: string | null | (() => string | null)): ConfigService
  * guard's behavioral assertions — the guard only touches `headers`, `path`,
  * and `method`.
  */
-function makeContext(headers: Record<string, string | undefined> = {}): ExecutionContext {
+function makeContext(
+  headers: Record<string, string | undefined> = {},
+  type: 'http' | 'rpc' = 'http',
+): ExecutionContext {
   const req = { headers, path: '/api/status', method: 'GET' };
   return {
+    getType: () => type,
     switchToHttp: () => ({
       getRequest: () => req,
       getResponse: () => ({}),
@@ -36,6 +40,13 @@ function makeContext(headers: Record<string, string | undefined> = {}): Executio
 describe('ApiTokenGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('non-HTTP context (IPC microservice)', () => {
+    it('should pass through without checking headers when context type is rpc', () => {
+      const guard = new ApiTokenGuard(makeConfig('secret'));
+      expect(guard.canActivate(makeContext({}, 'rpc'))).toBe(true);
+    });
   });
 
   describe('no token configured', () => {

--- a/app/packages/desktop-main/src/guards/api-token.guard.ts
+++ b/app/packages/desktop-main/src/guards/api-token.guard.ts
@@ -9,17 +9,17 @@ import { logger } from '../logger.js';
 import { ConfigService } from '../services/ConfigService.js';
 
 /**
- * Global guard that gates every request behind a bearer token.
+ * Global guard that gates HTTP requests behind a bearer token.
  *
  * The token is resolved **on every request** via {@link ConfigService.getApiToken}
  * so rotating the token (e.g. by editing `server_config.json`) takes effect
  * without a server restart.
  *
  * Behavior:
+ * - Non-HTTP context (e.g. IPC microservice) → passes through unconditionally;
+ *   the IPC transport is the trust boundary for those calls.
  * - `getApiToken()` returns `null` → the app has no token configured. Logs a
- *   warning once and allows the request through (dev convenience). This is
- *   only reachable in production when the startup check in `main.ts` has
- *   been bypassed deliberately; normally production boot refuses to start.
+ *   warning once and allows the request through (dev convenience).
  * - `getApiToken()` returns a string → require an `Authorization: Bearer <token>`
  *   header whose token matches exactly. A timing-safe comparison isn't used
  *   because the token lives on the local dashboard and the risk model doesn't
@@ -35,10 +35,10 @@ export class ApiTokenGuard implements CanActivate {
   constructor(private readonly config: ConfigService) {}
 
   /**
-   * Nest invokes this for every `/api/*` request. Returns `true` to allow,
-   * throws `UnauthorizedException` to reject. Dev convenience: when no token
-   * is configured we log once and let the request through — production boot
-   * refuses to start in that state, so this branch is dev-only in practice.
+   * Returns `true` to allow the request, throws `UnauthorizedException` to
+   * reject it. Non-HTTP contexts (IPC) are always allowed. When no token is
+   * configured, logs a one-time warning and lets HTTP requests through as a
+   * dev convenience.
    */
   canActivate(context: ExecutionContext): boolean {
     // IPC microservice calls arrive as 'rpc' context — no HTTP headers to check.

--- a/app/packages/desktop-main/src/guards/api-token.guard.ts
+++ b/app/packages/desktop-main/src/guards/api-token.guard.ts
@@ -41,6 +41,11 @@ export class ApiTokenGuard implements CanActivate {
    * refuses to start in that state, so this branch is dev-only in practice.
    */
   canActivate(context: ExecutionContext): boolean {
+    // IPC microservice calls arrive as 'rpc' context — no HTTP headers to check.
+    if (context.getType() !== 'http') {
+      return true;
+    }
+
     const req = context.switchToHttp().getRequest<Request>();
     const configured = this.config.getApiToken();
 

--- a/app/packages/desktop-main/src/main.test.ts
+++ b/app/packages/desktop-main/src/main.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /*
  * Declare spy variables via vi.hoisted() so they are initialised before the
@@ -45,6 +45,18 @@ describe('main bootstrap', () => {
     ElectronIPCTransportMock.mockImplementation(() => ({}));
     createMicroserviceMock.mockResolvedValue(fakeApp);
     fakeApp.listen.mockResolvedValue(undefined);
+    // Simulate an Electron main-process environment so the module-level guard passes.
+    vi.stubGlobal('process', { ...process, versions: { ...process.versions, electron: '36.0.0' } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should throw a clear error when not running inside an Electron main process', async () => {
+    vi.stubGlobal('process', { ...process, versions: {} });
+    vi.resetModules();
+    await expect(import('./main.js')).rejects.toThrow('Electron main process');
   });
 
   it('should bootstrap as a NestJS microservice using ElectronIPCTransport', async () => {

--- a/app/packages/desktop-main/src/main.test.ts
+++ b/app/packages/desktop-main/src/main.test.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Declare spy variables via vi.hoisted() so they are initialised before the
+ * vi.mock() factory functions run (vi.mock calls are hoisted to the top of the
+ * compiled output, above regular const/let declarations).
+ */
+const { ElectronIPCTransportMock, fakeApp, createMicroserviceMock } = vi.hoisted(() => {
+  /** Fake NestJS microservice app returned by `NestFactory.createMicroservice`. */
+  const fakeApp = { listen: vi.fn().mockResolvedValue(undefined) };
+  /** Spy constructor for ElectronIPCTransport — tracks `new` invocations. */
+  const ElectronIPCTransportMock = vi.fn().mockImplementation(() => ({}));
+  /** Spy for `NestFactory.createMicroservice`. */
+  const createMicroserviceMock = vi.fn().mockResolvedValue(fakeApp);
+  return { ElectronIPCTransportMock, fakeApp, createMicroserviceMock };
+});
+
+vi.mock('nestjs-electron-ipc-transport', () => ({
+  ElectronIPCTransport: ElectronIPCTransportMock,
+}));
+
+vi.mock('@nestjs/core', () => ({
+  NestFactory: {
+    createMicroservice: createMicroserviceMock,
+  },
+}));
+
+/**
+ * Stub AppModule so the deep Nest module graph (which requires the generated
+ * tfstate file and AWS service dependencies) is never traversed during this
+ * unit test.
+ */
+vi.mock('./app.module.js', () => ({
+  AppModule: class AppModule {},
+}));
+
+describe('main bootstrap', () => {
+  beforeEach(() => {
+    /*
+     * clearMocks: true (in vitest.config.ts) clears mock implementations before
+     * each test. Re-apply the return values here so they are set when main.ts
+     * executes during the test body.
+     */
+    ElectronIPCTransportMock.mockImplementation(() => ({}));
+    createMicroserviceMock.mockResolvedValue(fakeApp);
+    fakeApp.listen.mockResolvedValue(undefined);
+  });
+
+  it('should bootstrap as a NestJS microservice using ElectronIPCTransport', async () => {
+    /*
+     * Reset the module registry so re-importing main.ts forces the module to
+     * re-execute (and thus `void bootstrap()` fires again) after clearMocks has
+     * reset spy counters. vi.mock() registrations survive vi.resetModules(), so
+     * all stubs remain active.
+     */
+    vi.resetModules();
+    await import('./main.js');
+
+    // Flush the event loop so the async bootstrap chain fully resolves.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    const { AppModule } = await import('./app.module.js');
+
+    // ElectronIPCTransport should have been constructed with `new`.
+    expect(ElectronIPCTransportMock).toHaveBeenCalledOnce();
+
+    // createMicroservice should have been called with AppModule and a strategy option.
+    expect(createMicroserviceMock).toHaveBeenCalledOnce();
+    const [calledModule, calledOptions] = createMicroserviceMock.mock.calls[0] as [
+      unknown,
+      { strategy: unknown },
+    ];
+    expect(calledModule).toBe(AppModule);
+    expect(calledOptions).toHaveProperty('strategy');
+    // The strategy passed to createMicroservice should be the value returned by
+    // `new ElectronIPCTransport()` — i.e. the object the mock constructor produced.
+    expect(calledOptions.strategy).toBe(ElectronIPCTransportMock.mock.results[0].value);
+
+    // listen() should have been called on the fake app.
+    expect(fakeApp.listen).toHaveBeenCalledOnce();
+  });
+});

--- a/app/packages/desktop-main/src/main.ts
+++ b/app/packages/desktop-main/src/main.ts
@@ -1,59 +1,15 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
-import { NestExpressApplication } from '@nestjs/platform-express';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import express from 'express';
+import { MicroserviceOptions } from '@nestjs/microservices';
+import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
 import { AppModule } from './app.module.js';
-import { ConfigService } from './services/ConfigService.js';
-import { logger } from './logger.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PORT = parseInt(process.env['PORT'] ?? '3001', 10);
-const isDev = process.env['NODE_ENV'] !== 'production';
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    logger: ['error', 'warn', 'log'],
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
+    strategy: new ElectronIPCTransport(),
   });
 
-  // Refuse to start in production without an API token — this is where
-  // Copilot (PR #4) flagged the un-authenticated exposure risk.
-  const configService = app.get(ConfigService);
-  if (!isDev && !configService.getApiToken()) {
-    logger.error(
-      'NODE_ENV=production but no API_TOKEN is configured (neither env nor server_config.json.api_token). Refusing to start. ' +
-        'Set API_TOKEN or api_token to a random secret before running in production.',
-    );
-    process.exit(1);
-  }
-
-  app.setGlobalPrefix('api');
-
-  // Serve the Vite-built React app in production. Both handlers short-circuit
-  // on `/api` paths so they never shadow controllers or Nest's 404 handler.
-  if (!isDev) {
-    // dist/main.js → ../../web/dist gives the Vite build output.
-    const clientDist = join(__dirname, '../../web/dist');
-    const httpAdapter = app.getHttpAdapter().getInstance() as express.Express;
-    const staticHandler = express.static(clientDist);
-    const isApiRequest = (req: express.Request): boolean =>
-      req.path === '/api' || req.path.startsWith('/api/');
-    httpAdapter.use((req, res, next) => {
-      if (isApiRequest(req)) return next();
-      staticHandler(req, res, next);
-    });
-    httpAdapter.get('*', (req, res, next) => {
-      if (isApiRequest(req)) return next();
-      res.sendFile(join(clientDist, 'index.html'));
-    });
-  }
-
-  await app.listen(PORT);
-  logger.info(`Hyveon API running on http://localhost:${PORT}`, {
-    mode: isDev ? 'development' : 'production',
-    port: PORT,
-  });
+  await app.listen();
 }
 
 void bootstrap();

--- a/app/packages/desktop-main/src/main.ts
+++ b/app/packages/desktop-main/src/main.ts
@@ -4,6 +4,16 @@ import { MicroserviceOptions } from '@nestjs/microservices';
 import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
 import { AppModule } from './app.module.js';
 
+// ElectronIPCTransport requires ipcMain, which is only available inside an
+// Electron main process. Fail fast with a readable message rather than a
+// cryptic module-resolution error when someone runs `node dist/main.js`.
+if (!process.versions['electron']) {
+  throw new Error(
+    'desktop-main must run inside an Electron main process. ' +
+      'Launch via Electron — running with plain Node is not supported.',
+  );
+}
+
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
     strategy: new ElectronIPCTransport(),

--- a/app/packages/desktop-preload/package.json
+++ b/app/packages/desktop-preload/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@hyveon/desktop-preload",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "devDependencies": {
+    "electron": "^36.0.0"
+  }
+}

--- a/app/packages/desktop-preload/src/index.ts
+++ b/app/packages/desktop-preload/src/index.ts
@@ -1,0 +1,2 @@
+/** Electron preload script entry point. contextBridge wiring is added in T6. */
+export {};

--- a/app/packages/desktop-preload/src/index.ts
+++ b/app/packages/desktop-preload/src/index.ts
@@ -1,2 +1,105 @@
-/** Electron preload script entry point. contextBridge wiring is added in T6. */
-export {};
+import { contextBridge, ipcRenderer } from 'electron';
+
+/**
+ * Electron preload script. Exposes a typed IPC bridge as `window.gsd` so the
+ * renderer can invoke NestJS controller methods without requiring Node access.
+ *
+ * Channel naming convention: `<namespace>.<action>` — mirrors the
+ * `@MessagePattern` decorators on the desktop-main controllers.
+ *
+ * SSE-based endpoints (e.g. logs stream) are intentionally omitted here;
+ * streaming over IPC requires a separate event-based approach outside the
+ * request/response `invoke` pattern.
+ */
+contextBridge.exposeInMainWorld('gsd', {
+  /** Game-server lifecycle: list games, query status, start/stop ECS tasks. */
+  games: {
+    /** Lists game keys from Terraform tfstate. */
+    list: () => ipcRenderer.invoke('games.list'),
+    /** Returns ECS status for every game in parallel. */
+    status: () => ipcRenderer.invoke('games.status'),
+    /** Returns ECS status for a single game. */
+    getStatus: (game: string) => ipcRenderer.invoke('games.getStatus', game),
+    /** Launches the `{game}-server` ECS task. */
+    start: (game: string) => ipcRenderer.invoke('games.start', game),
+    /** Stops the running ECS task for `game`. */
+    stop: (game: string) => ipcRenderer.invoke('games.stop', game),
+  },
+
+  /** Cost endpoints: forward-looking Fargate estimates and historical CE data. */
+  costs: {
+    /** Estimates per-game and total hourly Fargate cost. */
+    estimate: () => ipcRenderer.invoke('costs.estimate'),
+    /** Returns actual costs over a trailing window via Cost Explorer. */
+    actual: (days?: number) => ipcRenderer.invoke('costs.actual', days),
+  },
+
+  /**
+   * CloudWatch log endpoints. The SSE stream (`logs.stream`) is omitted here
+   * because IPC `invoke` is request/response only — wire streaming separately
+   * via `ipcRenderer.on` if needed.
+   */
+  logs: {
+    /** Returns recent log lines for a game's ECS task. */
+    get: (game: string, limit?: number) => ipcRenderer.invoke('logs.get', game, limit),
+  },
+
+  /** EFS file-manager task endpoints: status, start, and stop per game. */
+  files: {
+    /** Returns whether a file-manager task is running for `game`, with connection details. */
+    getStatus: (game: string) => ipcRenderer.invoke('files.getStatus', game),
+    /** Launches an ECS file-manager task for `game`. */
+    start: (game: string) => ipcRenderer.invoke('files.start', game),
+    /** Stops the file-manager task for `game`. */
+    stop: (game: string) => ipcRenderer.invoke('files.stop', game),
+  },
+
+  /** Discord bot configuration: credentials, guild allowlist, admins, permissions, command registration. */
+  discord: {
+    /** Returns the Discord config with secrets redacted to booleans. */
+    getConfig: () => ipcRenderer.invoke('discord.getConfig'),
+    /** Updates bot token, client ID, and/or public key in Secrets Manager. */
+    putConfig: (body: { botToken?: string; clientId?: string; publicKey?: string }) =>
+      ipcRenderer.invoke('discord.putConfig', body),
+    /** Lists dynamic and Terraform-base allowed guild IDs. */
+    listGuilds: () => ipcRenderer.invoke('discord.listGuilds'),
+    /** Adds a guild ID to the dynamic allowlist in DynamoDB. */
+    addGuild: (guildId: string) => ipcRenderer.invoke('discord.addGuild', guildId),
+    /** Removes a guild ID from the dynamic allowlist. */
+    removeGuild: (guildId: string) => ipcRenderer.invoke('discord.removeGuild', guildId),
+    /** Registers slash commands for a guild in the Discord developer portal. */
+    registerCommands: (guildId: string) => ipcRenderer.invoke('discord.registerCommands', guildId),
+    /** Returns the dynamic and Terraform-base admin user/role lists. */
+    getAdmins: () => ipcRenderer.invoke('discord.getAdmins'),
+    /** Replaces the dynamic admin user/role lists. */
+    putAdmins: (body: { userIds?: string[]; roleIds?: string[] }) =>
+      ipcRenderer.invoke('discord.putAdmins', body),
+    /** Returns the per-game permission map. */
+    getPermissions: () => ipcRenderer.invoke('discord.getPermissions'),
+    /** Sets allowed users/roles/actions for a single game. */
+    putPermission: (
+      game: string,
+      body: { userIds?: string[]; roleIds?: string[]; actions?: string[] },
+    ) => ipcRenderer.invoke('discord.putPermission', game, body),
+    /** Removes the permission entry for a game. */
+    deletePermission: (game: string) => ipcRenderer.invoke('discord.deletePermission', game),
+  },
+
+  /** Environment metadata: region, domain, and environment label for UI display. */
+  env: {
+    /** Returns region, domain, and environment label derived from Terraform outputs. */
+    get: () => ipcRenderer.invoke('env.get'),
+  },
+
+  /** Watchdog configuration stored in server_config.json. */
+  config: {
+    /** Returns the current watchdog config (interval, idle-check count, min packets). */
+    get: () => ipcRenderer.invoke('config.get'),
+    /** Partially updates the watchdog config on disk. */
+    update: (body: {
+      watchdog_interval_minutes?: number;
+      watchdog_idle_checks?: number;
+      watchdog_min_packets?: number;
+    }) => ipcRenderer.invoke('config.update', body),
+  },
+});

--- a/app/packages/desktop-preload/tsconfig.json
+++ b/app/packages/desktop-preload/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['packages/**/*.test.{ts,tsx}'],
+    include: [
+      'packages/**/*.test.{ts,tsx}',
+      // Explicitly include desktop-preload specs so they are always discovered.
+      'packages/desktop-preload/**/*.test.{ts,tsx}',
+    ],
     // Default environment for server-side and shared tests is Node.
     // React component tests under @hyveon/web override this via
     // `environmentMatchGlobs` so they get a real DOM.
@@ -35,7 +39,11 @@ export default defineConfig({
       // Scoped to src/ trees so Playwright e2e files, Vite/Playwright configs,
       // and other non-unit-tested support files are excluded by default.
       // Double-star is needed because lambda packages nest under packages/lambda/*.
-      include: ['packages/**/src/**/*.{ts,tsx}'],
+      include: [
+        'packages/**/src/**/*.{ts,tsx}',
+        // Explicitly include desktop-preload source for coverage measurement.
+        'packages/desktop-preload/**/*.{ts,tsx}',
+      ],
       exclude: [
         'packages/**/*.test.{ts,tsx}',
         'packages/**/*.d.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "workspaces": [
         "app",
         "app/packages/*",
+        "app/packages/desktop-preload",
         "app/packages/lambda/*",
         "scripts"
       ],
@@ -62,6 +63,13 @@
         "@types/express": "^4.17.21",
         "electron": "^36.0.0",
         "tsx": "^4.15.7"
+      }
+    },
+    "app/packages/desktop-preload": {
+      "name": "@hyveon/desktop-preload",
+      "version": "1.0.0",
+      "devDependencies": {
+        "electron": "^36.0.0"
       }
     },
     "app/packages/lambda/efs-seeder": {
@@ -2560,6 +2568,10 @@
     },
     "node_modules/@hyveon/desktop-main": {
       "resolved": "app/packages/desktop-main",
+      "link": true
+    },
+    "node_modules/@hyveon/desktop-preload": {
+      "resolved": "app/packages/desktop-preload",
       "link": true
     },
     "node_modules/@hyveon/lambda-efs-seeder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,14 +50,17 @@
         "@hyveon/shared": "*",
         "@nestjs/common": "^10.4.0",
         "@nestjs/core": "^10.4.0",
+        "@nestjs/microservices": "^10.4.0",
         "@nestjs/platform-express": "^10.4.0",
         "express": "^4.19.2",
+        "nestjs-electron-ipc-transport": "^1.0.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "winston": "^3.13.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
+        "electron": "^36.0.0",
         "tsx": "^4.15.7"
       }
     },
@@ -1822,6 +1825,27 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.50.2",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
@@ -2777,6 +2801,64 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/microservices": {
+      "version": "10.4.22",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.4.22.tgz",
+      "integrity": "sha512-9Oxc0jQuppGLaQv5yaB2tVS2rAZzZ9NqDS1A4UlDLiYwJB7M6e89G6tmyOQjGjPwgoXPxQS4Vg2voSiKiED2gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
+        "amqp-connection-manager": "*",
+        "amqplib": "*",
+        "cache-manager": "*",
+        "ioredis": "*",
+        "kafkajs": "*",
+        "mqtt": "*",
+        "nats": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        },
+        "amqp-connection-manager": {
+          "optional": true
+        },
+        "amqplib": {
+          "optional": true
+        },
+        "cache-manager": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "kafkajs": {
+          "optional": true
+        },
+        "mqtt": {
+          "optional": true
+        },
+        "nats": {
           "optional": true
         }
       }
@@ -3796,6 +3878,18 @@
         "linux"
       ]
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -4361,6 +4455,18 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "dev": true,
@@ -4425,6 +4531,21 @@
       ],
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4598,6 +4719,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4641,6 +4774,12 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -4655,6 +4794,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -4664,7 +4812,6 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.40",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4704,6 +4851,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/send": {
@@ -4761,6 +4917,16 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.3",
@@ -5055,6 +5221,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -5588,6 +5775,14 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -5637,6 +5832,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5669,6 +5873,33 @@
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -5867,6 +6098,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clsx": {
@@ -6241,6 +6484,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -6258,11 +6528,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6280,7 +6559,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -6336,6 +6615,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -6395,10 +6681,37 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron": {
+      "version": "36.9.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-36.9.5.tgz",
+      "integrity": "sha512-1UCss2IqxqujSzg/2jkRjuiT3G+EEXgd6UKB5kUekwQW1LJ6d4QCr8YItfC3Rr9VIGRDJ29eOERmnRNO1Eh+NA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.353",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6422,6 +6735,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.2",
       "dev": true,
@@ -6443,6 +6765,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/es-abstract": {
@@ -6618,6 +6949,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/esbuild": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
@@ -6676,7 +7014,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7069,6 +7407,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7131,6 +7489,15 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -7338,6 +7705,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7463,6 +7844,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -7555,6 +7951,37 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/globals": {
       "version": "15.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
@@ -7572,7 +7999,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -7595,9 +8022,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -7626,7 +8077,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7703,6 +8154,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7733,6 +8190,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -8470,7 +8940,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8487,6 +8956,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "dev": true,
@@ -8496,6 +8972,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8525,7 +9010,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -8681,6 +9165,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -8754,6 +9247,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -8815,6 +9321,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/min-indent": {
@@ -8933,6 +9448,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nestjs-electron-ipc-transport": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nestjs-electron-ipc-transport/-/nestjs-electron-ipc-transport-1.0.2.tgz",
+      "integrity": "sha512-a8oULvJnmA5QQa4nwPyMuf43Xf6b5XYuVCDkh0dUpFRrNZmGhLT5fQXtOgECbRSw8gb5el2l/IyzqUsKeXxt5g==",
+      "license": "MIT",
+      "dependencies": {
+        "reflect-metadata": "^0.1.13"
+      },
+      "peerDependencies": {
+        "electron": ">= 8.0.0"
+      }
+    },
+    "node_modules/nestjs-electron-ipc-transport/node_modules/reflect-metadata": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/nise": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
@@ -9033,6 +9566,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "dev": true,
@@ -9063,7 +9608,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9162,6 +9707,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -9205,6 +9759,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -9385,6 +9948,12 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -9519,6 +10088,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9551,6 +10129,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -9572,6 +10160,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/range-parser": {
@@ -9861,6 +10461,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -9879,6 +10485,36 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/rollup": {
@@ -10051,11 +10687,17 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -10095,6 +10737,22 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.16.3",
@@ -10363,6 +11021,13 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -10672,6 +11337,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/supports-color": {
@@ -11450,6 +12127,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -11630,8 +12320,16 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -12631,6 +13329,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "dev": true,
@@ -12767,6 +13471,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12790,42 +13504,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
-      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.3.0",
-        "@tailwindcss/oxide": "4.3.0",
-        "tailwindcss": "4.3.0"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": [
     "app",
     "app/packages/*",
+    "app/packages/desktop-preload",
     "app/packages/lambda/*",
     "scripts"
   ],


### PR DESCRIPTION
Closes #151

## Summary

- Adds `nestjs-electron-ipc-transport`, `@nestjs/microservices`, and `electron` deps to `@hyveon/desktop-main`
- Rewrites `main.ts` to boot Nest as a microservice via `NestFactory.createMicroservice` + `ElectronIPCTransport` — no HTTP listener bound; adds a module-level guard that throws a clear error if run outside Electron
- Scaffolds new `@hyveon/desktop-preload` workspace package (CJS tsconfig, `contextBridge.exposeInMainWorld('gsd', {...})` covering all 7 controller namespaces via `ipcRenderer.invoke`)
- Makes `ApiTokenGuard` context-aware (passes IPC calls through, enforces bearer tokens for HTTP) and keeps it registered as `APP_GUARD` in `AppModule` — required for the integration test HTTP server (`test-main.ts`) which is not yet migrated to IPC (Epic F). Removes `RequestLoggerMiddleware` from `AppModule`.
- Adds `@MessagePattern('games.list')` to `GamesController.listGames()` as a proof-of-concept IPC handler
- Adds a Vitest smoke-test for the bootstrap path (491 tests total, all passing)

## Implementation notes

- `nestjs-electron-ipc-transport@1.0.2` works with NestJS 10 — the library only extends `Server` from `@nestjs/microservices` and uses `Logger` from `@nestjs/common`, both stable across NestJS 7–10. npm installs a nested `reflect-metadata@0.1.14` alongside the workspace's `^0.2.2`; the transport doesn't directly `require('reflect-metadata')` so there is no runtime conflict
- `@hyveon/desktop-preload` is intentionally CJS (`"module": "CommonJS"`, no `"type": "module"`) — Electron's preload sandbox requires CJS; this is a deliberate exception to the ESM pattern used by every other workspace
- `main.ts` owns only the NestJS bootstrap; Electron lifecycle (`app.whenReady`, `BrowserWindow`) lives in a separate entry-point wired in Epic A (parent #136)
- Full controller migration to `@MessagePattern` is deferred to the per-controller children of Epic B; `games.list` is the proof-of-concept that the IPC chassis works end-to-end
- `ConfigService.getApiToken()` and API token logic are preserved. `ApiTokenGuard` is kept in `AppModule` with a context-type check so it only enforces tokens for HTTP (not IPC) — this preserves the integration test contract until `test-main.ts` is migrated in Epic F
- `test-main.ts` (integration test entry-point) is untouched — its migration belongs to Epic F