### PR TITLE
feat(desktop-main): resolve resource paths from process.resourcesPath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN npm ci --ignore-scripts
 COPY app/ app/
 RUN npm run build -w game-server-manager
 
-# Switch to the app directory so ConfigService path probing and process.cwd()
-# behave the same as in the previous single-WORKDIR setup.
 WORKDIR /workspace/app
 
 EXPOSE 3001

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -275,15 +275,17 @@ describe('ConfigService', () => {
       expect(service.getTfStatePath()).toBe('/custom/state/terraform.tfstate');
     });
 
-    it('should return packaged server_config path when readUserDataPath returns a value', () => {
-      vi.spyOn(service as unknown as { readUserDataPath: () => string | null }, 'readUserDataPath').mockReturnValue('/fake/userData');
+    it('should return packaged server_config path when readIsPackaged returns true', () => {
+      type Internals = { readIsPackaged: () => boolean; readUserDataPath: () => string | null };
+      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(service as unknown as Internals, 'readUserDataPath').mockReturnValue('/fake/userData');
       expect(service.getServerConfigPath()).toBe(
         path.join('/fake/userData', 'server_config.json'),
       );
     });
 
-    it('should return the repo-relative fallback when readUserDataPath returns null', () => {
-      vi.spyOn(service as unknown as { readUserDataPath: () => string | null }, 'readUserDataPath').mockReturnValue(null);
+    it('should return the repo-relative fallback when readIsPackaged returns false', () => {
+      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
       const result = service.getServerConfigPath();
       expect(result).toMatch(/server_config\.json$/);
       expect(path.isAbsolute(result)).toBe(true);

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -254,15 +254,17 @@ describe('ConfigService', () => {
       delete process.env['SERVER_CONFIG_PATH'];
     });
 
-    it('should return packaged tfstate path when readResourcesPath returns a value', () => {
-      vi.spyOn(service as unknown as { readResourcesPath: () => string | undefined }, 'readResourcesPath').mockReturnValue('/fake/resources');
+    it('should return packaged tfstate path when readIsPackaged returns true', () => {
+      type Internals = { readIsPackaged: () => boolean; readResourcesPath: () => string | undefined };
+      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(service as unknown as Internals, 'readResourcesPath').mockReturnValue('/fake/resources');
       expect(service.getTfStatePath()).toBe(
         path.join('/fake/resources', 'terraform', 'aws', 'terraform.tfstate'),
       );
     });
 
-    it('should return the repo-relative fallback when readResourcesPath returns undefined', () => {
-      vi.spyOn(service as unknown as { readResourcesPath: () => string | undefined }, 'readResourcesPath').mockReturnValue(undefined);
+    it('should return the repo-relative fallback when readIsPackaged returns false', () => {
+      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
       const result = service.getTfStatePath();
       expect(result).toMatch(/terraform[/\\]terraform\.tfstate$/);
       expect(path.isAbsolute(result)).toBe(true);

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
 
 vi.mock('fs', () => ({
   readFileSync: vi.fn(),
@@ -243,6 +244,47 @@ describe('ConfigService', () => {
       expect(mockWrite).toHaveBeenCalledTimes(1);
       const [, payload] = mockWrite.mock.calls[0]!;
       expect(JSON.parse(payload as string)).toEqual(config);
+    });
+  });
+
+  describe('path resolution', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+      delete process.env['TF_STATE_PATH'];
+      delete process.env['SERVER_CONFIG_PATH'];
+    });
+
+    it('should return packaged tfstate path when readResourcesPath returns a value', () => {
+      vi.spyOn(service as unknown as { readResourcesPath: () => string | undefined }, 'readResourcesPath').mockReturnValue('/fake/resources');
+      expect(service.getTfStatePath()).toBe(
+        path.join('/fake/resources', 'terraform', 'aws', 'terraform.tfstate'),
+      );
+    });
+
+    it('should return the repo-relative fallback when readResourcesPath returns undefined', () => {
+      vi.spyOn(service as unknown as { readResourcesPath: () => string | undefined }, 'readResourcesPath').mockReturnValue(undefined);
+      const result = service.getTfStatePath();
+      expect(result).toMatch(/terraform[/\\]terraform\.tfstate$/);
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('should return the TF_STATE_PATH env var value when set', () => {
+      process.env['TF_STATE_PATH'] = '/custom/state/terraform.tfstate';
+      expect(service.getTfStatePath()).toBe('/custom/state/terraform.tfstate');
+    });
+
+    it('should return packaged server_config path when readUserDataPath returns a value', () => {
+      vi.spyOn(service as unknown as { readUserDataPath: () => string | null }, 'readUserDataPath').mockReturnValue('/fake/userData');
+      expect(service.getServerConfigPath()).toBe(
+        path.join('/fake/userData', 'server_config.json'),
+      );
+    });
+
+    it('should return the repo-relative fallback when readUserDataPath returns null', () => {
+      vi.spyOn(service as unknown as { readUserDataPath: () => string | null }, 'readUserDataPath').mockReturnValue(null);
+      const result = service.getServerConfigPath();
+      expect(result).toMatch(/server_config\.json$/);
+      expect(path.isAbsolute(result)).toBe(true);
     });
   });
 });

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -5,19 +5,16 @@ import { fileURLToPath } from 'url';
 import { logger } from '../logger.js';
 import { EMBEDDED_TFSTATE } from '../generated/tfstate.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+/** Absolute path to the `dist/services/` directory at runtime. */
+const _dirname = dirname(fileURLToPath(import.meta.url));
 
-// dist/services/ → 4 hops up = app root (repo: app/, Docker: /workspace/app/)
-// 5 hops up = repo/workspace root, where terraform/ lives
-const APP_ROOT = join(__dirname, '..', '..', '..', '..');
-
-const TF_STATE_PATH =
-  process.env['TF_STATE_PATH'] ??
-  join(APP_ROOT, '..', 'terraform', 'terraform.tfstate');
-
-const SERVER_CONFIG_PATH =
-  process.env['SERVER_CONFIG_PATH'] ??
-  join(APP_ROOT, 'server_config.json');
+/**
+ * Absolute path to the app root (`app/` in the repo, `/workspace/app/` in Docker).
+ * Derived by walking 4 levels up from `dist/services/`.
+ * Used only as a private dev-mode fallback inside instance methods — callers
+ * should use `getTfStatePath()` / `getServerConfigPath()` instead.
+ */
+const _APP_ROOT = join(_dirname, '..', '..', '..', '..');
 
 /**
  * Shape of the subset of Terraform root outputs the management app consumes.
@@ -65,10 +62,10 @@ const DEFAULT_CONFIG: WatchdogConfig = {
  * Owns every runtime configuration source the management app reads:
  *  - `terraform.tfstate` (outputs of the last `terraform apply`) — parsed
  *    lazily and cached in-memory until {@link ConfigService.invalidateCache}
- *    is called.
+ *    is called. Path resolved by {@link ConfigService.getTfStatePath}.
  *  - `server_config.json` — the user-editable file holding the watchdog
- *    tunables and the optional API bearer token. Path resolved via
- *    `SERVER_CONFIG_PATH` env var, defaulting to `<app-root>/server_config.json`.
+ *    tunables and the optional API bearer token. Path resolved by
+ *    {@link ConfigService.getServerConfigPath}.
  *  - A handful of process env vars (`AWS_DEFAULT_REGION`, `API_TOKEN`).
  *
  * Every other service injects this one instead of touching `process.env` or
@@ -100,18 +97,19 @@ export class ConfigService {
     type RawState = { outputs?: Record<string, { value: unknown }> };
     let raw: RawState;
 
-    if (existsSync(TF_STATE_PATH)) {
+    const tfStatePath = this.getTfStatePath();
+    if (existsSync(tfStatePath)) {
       try {
-        raw = JSON.parse(readFileSync(TF_STATE_PATH, 'utf-8')) as RawState;
+        raw = JSON.parse(readFileSync(tfStatePath, 'utf-8')) as RawState;
       } catch (err) {
-        logger.error('Failed to parse Terraform state', { err, path: TF_STATE_PATH });
+        logger.error('Failed to parse Terraform state', { err, path: tfStatePath });
         return null;
       }
     } else if (EMBEDDED_TFSTATE) {
       logger.debug('Using build-time embedded Terraform state');
       raw = EMBEDDED_TFSTATE as unknown as RawState;
     } else {
-      logger.warn('Terraform state not found', { path: TF_STATE_PATH });
+      logger.warn('Terraform state not found', { path: tfStatePath });
       return null;
     }
 
@@ -163,6 +161,80 @@ export class ConfigService {
   }
 
   /**
+   * Return `process.resourcesPath` when running inside an Electron packaged app,
+   * or `undefined` otherwise. Extracted as a protected method so tests can stub
+   * it via `vi.spyOn` without touching `process.resourcesPath` directly.
+   */
+  protected readResourcesPath(): string | undefined {
+    return (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+  }
+
+  /**
+   * Return the Electron `userData` directory when running inside an Electron
+   * process, or `null` otherwise. The `electron` module is required lazily at
+   * call-time (keyed on `process.versions['electron']` being truthy) so that
+   * importing this module in a plain Node/test context never triggers an
+   * unresolved-module error. Extracted as a protected method so tests can stub
+   * it via `vi.spyOn`.
+   */
+  protected readUserDataPath(): string | null {
+    if (!process.versions['electron']) return null;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const electron = require('electron') as { app: { getPath(name: string): string } };
+      return electron.app.getPath('userData');
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the absolute path to `terraform.tfstate`.
+   *
+   * Resolution order:
+   *  1. `TF_STATE_PATH` env var — wins when set (useful for CI / Docker volume
+   *     mounts).
+   *  2. Electron packaged app — `<resourcesPath>/terraform/aws/terraform.tfstate`
+   *     (the Electron build copies the Terraform bundle there).
+   *  3. Dev/test fallback — repo root `terraform/terraform.tfstate` (same path
+   *     the old module-level constant resolved to).
+   */
+  getTfStatePath(): string {
+    const envOverride = process.env['TF_STATE_PATH'];
+    if (envOverride) return envOverride;
+
+    const resourcesPath = this.readResourcesPath();
+    if (resourcesPath) {
+      return join(resourcesPath, 'terraform', 'aws', 'terraform.tfstate');
+    }
+
+    // Dev fallback: repo root is one level above _APP_ROOT (app/)
+    return join(_APP_ROOT, '..', 'terraform', 'terraform.tfstate');
+  }
+
+  /**
+   * Resolve the absolute path to `server_config.json`.
+   *
+   * Resolution order:
+   *  1. `SERVER_CONFIG_PATH` env var — wins when set.
+   *  2. Electron packaged app — `<userData>/server_config.json` (user-writable
+   *     location that survives app updates).
+   *  3. Dev/test fallback — `<APP_ROOT>/server_config.json` (same path the old
+   *     module-level constant resolved to).
+   */
+  getServerConfigPath(): string {
+    const envOverride = process.env['SERVER_CONFIG_PATH'];
+    if (envOverride) return envOverride;
+
+    const userData = this.readUserDataPath();
+    if (userData) {
+      return join(userData, 'server_config.json');
+    }
+
+    return join(_APP_ROOT, 'server_config.json');
+  }
+
+  /**
    * Token required on every `/api/*` request's `Authorization: Bearer <token>` header.
    *
    * Resolution order:
@@ -183,9 +255,10 @@ export class ConfigService {
     if (env !== undefined) {
       return env.length > 0 ? env : null;
     }
-    if (!existsSync(SERVER_CONFIG_PATH)) return null;
+    const serverConfigPath = this.getServerConfigPath();
+    if (!existsSync(serverConfigPath)) return null;
     try {
-      const raw = JSON.parse(readFileSync(SERVER_CONFIG_PATH, 'utf-8')) as { api_token?: unknown };
+      const raw = JSON.parse(readFileSync(serverConfigPath, 'utf-8')) as { api_token?: unknown };
       return typeof raw.api_token === 'string' && raw.api_token.length > 0 ? raw.api_token : null;
     } catch (err) {
       logger.warn('Could not read api_token from config file', { err });
@@ -212,9 +285,10 @@ export class ConfigService {
    * fresh object on every call — safe for callers to mutate.
    */
   getConfig(): WatchdogConfig {
-    if (!existsSync(SERVER_CONFIG_PATH)) return { ...DEFAULT_CONFIG };
+    const serverConfigPath = this.getServerConfigPath();
+    if (!existsSync(serverConfigPath)) return { ...DEFAULT_CONFIG };
     try {
-      const saved = JSON.parse(readFileSync(SERVER_CONFIG_PATH, 'utf-8')) as Partial<WatchdogConfig>;
+      const saved = JSON.parse(readFileSync(serverConfigPath, 'utf-8')) as Partial<WatchdogConfig>;
       return { ...DEFAULT_CONFIG, ...saved };
     } catch (err) {
       logger.warn('Could not read config file, using defaults', { err });
@@ -228,7 +302,7 @@ export class ConfigService {
    * save here is not effective until the next `terraform apply`.
    */
   saveConfig(config: WatchdogConfig): void {
-    writeFileSync(SERVER_CONFIG_PATH, JSON.stringify(config, null, 2));
+    writeFileSync(this.getServerConfigPath(), JSON.stringify(config, null, 2));
     logger.info('Config saved', config);
   }
 }

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -60,13 +60,17 @@ const DEFAULT_CONFIG: WatchdogConfig = {
 
 /**
  * Owns every runtime configuration source the management app reads:
- *  - `terraform.tfstate` (outputs of the last `terraform apply`) — parsed
- *    lazily and cached in-memory until {@link ConfigService.invalidateCache}
- *    is called. Path resolved by {@link ConfigService.getTfStatePath}.
- *  - `server_config.json` — the user-editable file holding the watchdog
- *    tunables and the optional API bearer token. Path resolved by
- *    {@link ConfigService.getServerConfigPath}.
+ *  - `terraform.tfstate` — parsed lazily and cached until
+ *    {@link ConfigService.invalidateCache} is called. Path resolved by
+ *    {@link ConfigService.getTfStatePath}.
+ *  - `server_config.json` — user-editable watchdog tunables and optional API
+ *    bearer token. Path resolved by {@link ConfigService.getServerConfigPath}.
  *  - A handful of process env vars (`AWS_DEFAULT_REGION`, `API_TOKEN`).
+ *
+ * Both path resolvers follow the same three-tier priority:
+ *  1. Env var override (`TF_STATE_PATH` / `SERVER_CONFIG_PATH`) — always wins.
+ *  2. `process.resourcesPath` — used when running inside an Electron packaged app.
+ *  3. Dev-mode repo fallback — when `process.resourcesPath` is unset.
  *
  * Every other service injects this one instead of touching `process.env` or
  * reading files directly, so tests can stub env/file access cleanly.
@@ -192,12 +196,9 @@ export class ConfigService {
    * Resolve the absolute path to `terraform.tfstate`.
    *
    * Resolution order:
-   *  1. `TF_STATE_PATH` env var — wins when set (useful for CI / Docker volume
-   *     mounts).
-   *  2. Electron packaged app — `<resourcesPath>/terraform/aws/terraform.tfstate`
-   *     (the Electron build copies the Terraform bundle there).
-   *  3. Dev/test fallback — repo root `terraform/terraform.tfstate` (same path
-   *     the old module-level constant resolved to).
+   *  1. `TF_STATE_PATH` env var — wins when set.
+   *  2. Electron packaged app — `<resourcesPath>/terraform/aws/terraform.tfstate`.
+   *  3. Dev/test fallback — repo root `terraform/terraform.tfstate`.
    */
   getTfStatePath(): string {
     const envOverride = process.env['TF_STATE_PATH'];
@@ -219,8 +220,7 @@ export class ConfigService {
    *  1. `SERVER_CONFIG_PATH` env var — wins when set.
    *  2. Electron packaged app — `<userData>/server_config.json` (user-writable
    *     location that survives app updates).
-   *  3. Dev/test fallback — `<APP_ROOT>/server_config.json` (same path the old
-   *     module-level constant resolved to).
+   *  3. Dev/test fallback — `<APP_ROOT>/server_config.json`.
    */
   getServerConfigPath(): string {
     const envOverride = process.env['SERVER_CONFIG_PATH'];

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { logger } from '../logger.js';
 import { EMBEDDED_TFSTATE } from '../generated/tfstate.js';
 
@@ -184,8 +185,8 @@ export class ConfigService {
   protected readUserDataPath(): string | null {
     if (!process.versions['electron']) return null;
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const electron = require('electron') as { app: { getPath(name: string): string } };
+      const _require = createRequire(import.meta.url);
+      const electron = _require('electron') as { app: { getPath(name: string): string } };
       return electron.app.getPath('userData');
     } catch {
       return null;

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -175,6 +175,24 @@ export class ConfigService {
   }
 
   /**
+   * Return whether the app is running as a packaged Electron build
+   * (`electron.app.isPackaged`). `process.resourcesPath` is set in both dev
+   * and packaged Electron processes, so it cannot be used as a packaged-build
+   * guard — this method is the reliable alternative. Extracted as a protected
+   * method so tests can stub it via `vi.spyOn`.
+   */
+  protected readIsPackaged(): boolean {
+    if (!process.versions['electron']) return false;
+    try {
+      const _require = createRequire(import.meta.url);
+      const electron = _require('electron') as { app: { isPackaged: boolean } };
+      return electron.app.isPackaged;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Return the Electron `userData` directory when running inside an Electron
    * process, or `null` otherwise. The `electron` module is required lazily at
    * call-time (keyed on `process.versions['electron']` being truthy) so that
@@ -198,16 +216,16 @@ export class ConfigService {
    *
    * Resolution order:
    *  1. `TF_STATE_PATH` env var — wins when set.
-   *  2. Electron packaged app — `<resourcesPath>/terraform/aws/terraform.tfstate`.
+   *  2. Electron packaged app (`app.isPackaged`) — `<resourcesPath>/terraform/aws/terraform.tfstate`.
    *  3. Dev/test fallback — repo root `terraform/terraform.tfstate`.
    */
   getTfStatePath(): string {
     const envOverride = process.env['TF_STATE_PATH'];
     if (envOverride) return envOverride;
 
-    const resourcesPath = this.readResourcesPath();
-    if (resourcesPath) {
-      return join(resourcesPath, 'terraform', 'aws', 'terraform.tfstate');
+    if (this.readIsPackaged()) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return join(this.readResourcesPath()!, 'terraform', 'aws', 'terraform.tfstate');
     }
 
     // Dev fallback: repo root is one level above _APP_ROOT (app/)

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -70,8 +70,9 @@ const DEFAULT_CONFIG: WatchdogConfig = {
  *
  * Both path resolvers follow the same three-tier priority:
  *  1. Env var override (`TF_STATE_PATH` / `SERVER_CONFIG_PATH`) — always wins.
- *  2. `process.resourcesPath` — used when running inside an Electron packaged app.
- *  3. Dev-mode repo fallback — when `process.resourcesPath` is unset.
+ *  2. Electron packaged build (`electron.app.isPackaged`) — uses Electron-specific
+ *     paths (`resourcesPath` for tfstate, `userData` for server config).
+ *  3. Dev/test fallback — repo-relative paths when not in a packaged build.
  *
  * Every other service injects this one instead of touching `process.env` or
  * reading files directly, so tests can stub env/file access cleanly.
@@ -237,17 +238,19 @@ export class ConfigService {
    *
    * Resolution order:
    *  1. `SERVER_CONFIG_PATH` env var — wins when set.
-   *  2. Electron packaged app — `<userData>/server_config.json` (user-writable
-   *     location that survives app updates).
+   *  2. Electron packaged app (`app.isPackaged`) — `<userData>/server_config.json`
+   *     (user-writable location that survives app updates).
    *  3. Dev/test fallback — `<APP_ROOT>/server_config.json`.
    */
   getServerConfigPath(): string {
     const envOverride = process.env['SERVER_CONFIG_PATH'];
     if (envOverride) return envOverride;
 
-    const userData = this.readUserDataPath();
-    if (userData) {
-      return join(userData, 'server_config.json');
+    if (this.readIsPackaged()) {
+      const userData = this.readUserDataPath();
+      if (userData) {
+        return join(userData, 'server_config.json');
+      }
     }
 
     return join(_APP_ROOT, 'server_config.json');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,6 @@ services:
     ports:
       - "5000:3001"
     volumes:
-      # Makes terraform.tfstate readable by the app
-      - ./terraform:/workspace/terraform:ro
-      # Persists server_config.json across container restarts.
-      # NOTE: the host file must exist before `docker compose up` — create it with
-      #       `touch app/server_config.json` on first run. With
-      #       `bind.create_host_path: false`, Compose fails fast with a clear error
-      #       if the file is missing; that's the whole point of the long-syntax
-      #       bind mount, which avoids the silent-directory/EISDIR issue Docker's
-      #       default short-syntax mounts would otherwise cause.
-      - type: bind
-        source: ./app/server_config.json
-        target: /workspace/app/server_config.json
-        bind:
-          create_host_path: false
       # AWS credentials — remove if using env vars instead
       - ~/.aws:/root/.aws:ro
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@hyveon/desktop-preload": "*",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
Closes #147

## Summary

- Replaces module-level `__dirname`-relative path constants in `ConfigService` with stub-able protected instance methods (`readResourcesPath()`, `readUserDataPath()`) that branch on `process.resourcesPath` for packaged Electron vs. repo-relative dev fallbacks
- `getTfStatePath()` resolves to `process.resourcesPath/terraform/aws/terraform.tfstate` when packaged, repo root `terraform/terraform.tfstate` in dev; `TF_STATE_PATH` env var still wins
- `getServerConfigPath()` resolves to `app.getPath('userData')/server_config.json` when packaged, repo root `app/server_config.json` in dev; `SERVER_CONFIG_PATH` env var still wins
- Adds 5 new `ConfigService` unit tests covering all three resolution branches (496 tests passing)
- Removes `./terraform` and `./app/server_config.json` volume mounts from `docker-compose.yml`; removes Docker path-probing comment from `Dockerfile`

## Implementation notes

- The `electron` module is required lazily inside `readUserDataPath()` (guarded by `process.versions['electron']`) so test environments never encounter a module-resolution error — no top-level `import 'electron'`
- `vi.spyOn` on the protected methods uses a typed double-cast (`service as unknown as { readResourcesPath: ... }`) to satisfy `@typescript-eslint/no-explicit-any`
- Docker files are decommissioned (volume mounts removed), not deleted, pending the Epic G distribution work in #135

## Test plan

- [ ] `npm run app:test` — 496 tests pass
- [ ] `npm run app:lint` — 0 errors
- [ ] In dev: `getTfStatePath()` returns the repo-relative path; `getServerConfigPath()` returns the repo-relative fallback
- [ ] With `TF_STATE_PATH` env var set: `getTfStatePath()` returns the override value