### PR TITLE
feat(desktop-main): fix-path on boot to inherit login-shell PATH

### DIFF
--- a/app/packages/desktop-main/package.json
+++ b/app/packages/desktop-main/package.json
@@ -23,6 +23,7 @@
     "@nestjs/microservices": "^10.4.0",
     "@nestjs/platform-express": "^10.4.0",
     "express": "^4.19.2",
+    "fix-path": "^4.0.0",
     "nestjs-electron-ipc-transport": "^1.0.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/app/packages/desktop-main/src/fix-path-bootstrap.test.ts
+++ b/app/packages/desktop-main/src/fix-path-bootstrap.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/*
+ * Hoist the mock spy so it is available when vi.mock() factory runs (vi.mock
+ * calls are hoisted above regular declarations in compiled output).
+ */
+const { fixPathMock } = vi.hoisted(() => {
+  /** Spy standing in for fix-path's default export (the shell-spawning function). */
+  const fixPathMock = vi.fn();
+  return { fixPathMock };
+});
+
+/**
+ * Mock the fix-path ESM module so no real login shell is ever spawned during
+ * tests. Its default export is replaced with a vi.fn() we can assert on.
+ */
+vi.mock('fix-path', () => ({
+  default: fixPathMock,
+}));
+
+// Import the module under test AFTER mocks are registered.
+import { applyFixPath } from './fix-path-bootstrap.js';
+
+describe('applyFixPath', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('should call fix-path when platform is darwin', () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    applyFixPath();
+
+    expect(vi.mocked(fixPathMock)).toHaveBeenCalledOnce();
+  });
+
+  it('should call fix-path when platform is linux', () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+
+    applyFixPath();
+
+    expect(vi.mocked(fixPathMock)).toHaveBeenCalledOnce();
+  });
+
+  it('should NOT call fix-path when platform is win32', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    applyFixPath();
+
+    expect(vi.mocked(fixPathMock)).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/desktop-main/src/fix-path-bootstrap.ts
+++ b/app/packages/desktop-main/src/fix-path-bootstrap.ts
@@ -1,0 +1,22 @@
+import fixPath from 'fix-path';
+
+/**
+ * Applies the fix-path workaround for GUI applications on macOS and Linux.
+ *
+ * When an application is launched from a graphical environment (e.g. a dock,
+ * file manager, or Electron shell) rather than a terminal, the process does not
+ * inherit the user's login shell PATH. This means executables that are only
+ * available after sourcing `~/.profile`, `~/.bashrc`, `~/.zshrc`, etc. — such
+ * as `node`, `aws`, or any tool installed via nvm/homebrew — will not be found.
+ *
+ * fix-path resolves this by spawning a login shell, reading its PATH, and
+ * applying it to the current process before any child processes are started.
+ *
+ * This function is a no-op on Windows, where the problem does not apply.
+ */
+export function applyFixPath(): void {
+  if (process.platform === 'win32') {
+    return;
+  }
+  fixPath();
+}

--- a/app/packages/desktop-main/src/main.test.ts
+++ b/app/packages/desktop-main/src/main.test.ts
@@ -6,14 +6,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * vi.mock() factory functions run (vi.mock calls are hoisted to the top of the
  * compiled output, above regular const/let declarations).
  */
-const { ElectronIPCTransportMock, fakeApp, createMicroserviceMock } = vi.hoisted(() => {
+const { ElectronIPCTransportMock, fakeApp, createMicroserviceMock, applyFixPathMock } = vi.hoisted(() => {
   /** Fake NestJS microservice app returned by `NestFactory.createMicroservice`. */
   const fakeApp = { listen: vi.fn().mockResolvedValue(undefined) };
   /** Spy constructor for ElectronIPCTransport — tracks `new` invocations. */
   const ElectronIPCTransportMock = vi.fn().mockImplementation(() => ({}));
   /** Spy for `NestFactory.createMicroservice`. */
   const createMicroserviceMock = vi.fn().mockResolvedValue(fakeApp);
-  return { ElectronIPCTransportMock, fakeApp, createMicroserviceMock };
+  /** Spy for `applyFixPath` — verifies the fix-path bootstrap is called during startup. */
+  const applyFixPathMock = vi.fn();
+  return { ElectronIPCTransportMock, fakeApp, createMicroserviceMock, applyFixPathMock };
 });
 
 vi.mock('nestjs-electron-ipc-transport', () => ({
@@ -35,6 +37,10 @@ vi.mock('./app.module.js', () => ({
   AppModule: class AppModule {},
 }));
 
+vi.mock('./fix-path-bootstrap.js', () => ({
+  applyFixPath: applyFixPathMock,
+}));
+
 describe('main bootstrap', () => {
   beforeEach(() => {
     /*
@@ -45,6 +51,7 @@ describe('main bootstrap', () => {
     ElectronIPCTransportMock.mockImplementation(() => ({}));
     createMicroserviceMock.mockResolvedValue(fakeApp);
     fakeApp.listen.mockResolvedValue(undefined);
+    applyFixPathMock.mockImplementation(() => undefined);
     // Simulate an Electron main-process environment so the module-level guard passes.
     vi.stubGlobal('process', { ...process, versions: { ...process.versions, electron: '36.0.0' } });
   });
@@ -91,5 +98,16 @@ describe('main bootstrap', () => {
 
     // listen() should have been called on the fake app.
     expect(fakeApp.listen).toHaveBeenCalledOnce();
+  });
+
+  it('should call applyFixPath during bootstrap', async () => {
+    vi.resetModules();
+    await import('./main.js');
+
+    // Flush the event loop so the async bootstrap chain fully resolves.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    // applyFixPath must be invoked exactly once before NestFactory.createMicroservice.
+    expect(applyFixPathMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/packages/desktop-main/src/main.ts
+++ b/app/packages/desktop-main/src/main.ts
@@ -3,6 +3,9 @@ import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions } from '@nestjs/microservices';
 import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
 import { AppModule } from './app.module.js';
+import { applyFixPath } from './fix-path-bootstrap.js';
+
+applyFixPath();
 
 // ElectronIPCTransport requires ipcMain, which is only available inside an
 // Electron main process. Fail fast with a readable message rather than a

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@nestjs/microservices": "^10.4.0",
         "@nestjs/platform-express": "^10.4.0",
         "express": "^4.19.2",
+        "fix-path": "^4.0.0",
         "nestjs-electron-ipc-transport": "^1.0.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -6356,7 +6357,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6540,6 +6540,18 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-shell": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-2.2.0.tgz",
+      "integrity": "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -7304,6 +7316,47 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7620,6 +7673,21 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fix-path/-/fix-path-4.0.0.tgz",
+      "integrity": "sha512-g31GX207Tt+psI53ZSaB1egprYbEN0ZYl90aKcO22A2LmCNnFsSq3b5YpoKp3E/QEiWByTXGJOkFQG4S07Bc1A==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-path": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8230,6 +8298,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8757,7 +8834,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9298,6 +9374,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9334,6 +9416,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -9591,6 +9682,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "dev": true,
@@ -9736,6 +9839,21 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -9901,7 +10019,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10845,7 +10962,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10858,10 +10974,41 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-env": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-4.0.3.tgz",
+      "integrity": "sha512-Ioe5h+hCDZ7pKL5+JGzbtPvZ5ESMHePZ8nLxohlDL+twmlcmutttMhRkrQOed8DeLT8mkYBgbwZfohe8pqaA3g==",
+      "license": "MIT",
+      "dependencies": {
+        "default-shell": "^2.0.0",
+        "execa": "^5.1.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shell-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-3.1.0.tgz",
+      "integrity": "sha512-s/9q9PEtcRmDTz69+cJ3yYBAe9yGrL7e46gm2bU4pQ9N48ecPK9QrGFnLwYgb4smOHskx4PL7wCNMktW2AoD+g==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-env": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/shell-quote": {
@@ -11261,7 +11408,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -11291,13 +11437,21 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-indent": {
@@ -13093,7 +13247,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"


### PR DESCRIPTION
Closes #148

## Summary

- Adds `fix-path ^4.0.0` as a runtime dependency of `@hyveon/desktop-main`
- Creates `fix-path-bootstrap.ts` — a thin wrapper that calls `fix-path` on macOS/Linux and is a no-op on Windows; `process.platform` is read at call-time so tests can stub it cleanly
- Calls `applyFixPath()` as the very first executable statement in `main.ts`, before the Electron-version guard and `bootstrap()`, ensuring PATH is fixed before any `child_process.spawn` for terraform/aws
- Adds 3 unit tests in `fix-path-bootstrap.test.ts` (darwin calls fix-path, linux calls fix-path, win32 skips) and extends `main.test.ts` with a spy asserting `applyFixPath` is invoked during bootstrap (500 tests passing)

## Implementation notes

- `fix-path` v4 is pure ESM, compatible with `desktop-main`'s `"type": "module"` and the ESNext module target in `tsconfig.base.json`
- The indirection through `fix-path-bootstrap.ts` is required so `main.test.ts` can intercept the module boundary with `vi.mock` — a top-level ESM side-effect in `main.ts` itself would race the test setup
- The issue acceptance criterion "integration test asserts `process.env.PATH` includes `/opt/homebrew/bin` on a fixture machine" is deferred to a future issue — the Electron e2e tier (Epic F, #135) does not exist yet. The unit tests here prove the wiring is correct; a real fixture test can be added once the Playwright Electron tier lands.

## Test plan

- [ ] `npm run app:test` — 500 tests pass
- [ ] `npm run app:lint` — 0 errors
- [ ] On macOS with Homebrew: packaged app can find `terraform` on PATH (manual smoke test)