### PR TITLE
feat(desktop-main): convert GamesController to @MessagePattern handlers

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -6,6 +6,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
 import { GamesController } from './controllers/games.controller.js';
+import { GamesHttpController } from './controllers/games-http.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
 import { CostsController } from './controllers/costs.controller.js';
 import { LogsController } from './controllers/logs.controller.js';
@@ -30,6 +31,7 @@ import { ElectronStoreService } from './services/ElectronStoreService.js';
   imports: [AwsModule, DiscordModule],
   controllers: [
     GamesController,
+    GamesHttpController,
     ConfigController,
     CostsController,
     LogsController,

--- a/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
@@ -1,0 +1,128 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { GamesHttpController } from './games-http.controller.js';
+import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
+import type { EcsService } from '../services/EcsService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Minimal TfOutputs for HTTP-shim tests. */
+const DEFAULT_OUTPUTS: Partial<TfOutputs> = {
+  game_names: ['minecraft', 'valheim'],
+};
+
+/**
+ * Build a ConfigService stub. Pass `null` to simulate a pre-apply state
+ * where `getTfOutputs()` returns null.
+ */
+function makeConfig(outputs: Partial<TfOutputs> | null = DEFAULT_OUTPUTS): ConfigService {
+  return {
+    invalidateCache: vi.fn(),
+    getTfOutputs: vi.fn().mockReturnValue(outputs),
+  } as unknown as ConfigService;
+}
+
+/** Build an EcsService stub with mutation and query methods pre-wired to succeed. */
+function makeEcs(): EcsService {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ game: 'minecraft', state: 'stopped' }),
+    start: vi.fn().mockResolvedValue({ success: true, message: 'Task launched' }),
+    stop: vi.fn().mockResolvedValue({ success: true, message: 'Task stopped' }),
+  } as unknown as EcsService;
+}
+
+describe('GamesHttpController', () => {
+  describe('listGames', () => {
+    it('should invalidate the tfstate cache before reading game names', () => {
+      const config = makeConfig();
+      new GamesHttpController(config, makeEcs()).listGames();
+      expect(config.invalidateCache).toHaveBeenCalledOnce();
+    });
+
+    it('should return game names from Terraform outputs', () => {
+      const result = new GamesHttpController(makeConfig(), makeEcs()).listGames();
+      expect(result).toEqual({ games: ['minecraft', 'valheim'] });
+    });
+
+    it('should return an empty games array when Terraform has not been applied yet', () => {
+      const result = new GamesHttpController(makeConfig(null), makeEcs()).listGames();
+      expect(result).toEqual({ games: [] });
+    });
+  });
+
+  describe('listStatus', () => {
+    it('should invalidate cache before querying ECS', async () => {
+      const config = makeConfig();
+      await new GamesHttpController(config, makeEcs()).listStatus();
+      expect(config.invalidateCache).toHaveBeenCalledOnce();
+    });
+
+    it('should query ECS status for every game in the Terraform outputs', async () => {
+      const ecs = makeEcs();
+      await new GamesHttpController(makeConfig(), ecs).listStatus();
+      expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
+      expect(ecs.getStatus).toHaveBeenCalledWith('valheim');
+    });
+
+    it('should return an empty array when tfstate is absent', async () => {
+      const result = await new GamesHttpController(makeConfig(null), makeEcs()).listStatus();
+      expect(result).toEqual([]);
+    });
+
+    it('should return status entries in the same order as game_names', async () => {
+      const ecs = makeEcs();
+      vi.mocked(ecs.getStatus).mockImplementation(async (g) => ({ game: g, state: 'stopped' as const }));
+      const result = await new GamesHttpController(makeConfig(), ecs).listStatus();
+      expect(result.map((s) => s.game)).toEqual(['minecraft', 'valheim']);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should delegate to EcsService without invalidating the tfstate cache', async () => {
+      const config = makeConfig();
+      const ecs = makeEcs();
+      await new GamesHttpController(config, ecs).getStatus('minecraft');
+      expect(config.invalidateCache).not.toHaveBeenCalled();
+      expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
+    });
+
+    it('should return the status provided by EcsService', async () => {
+      const ecs = makeEcs();
+      vi.mocked(ecs.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running' });
+      const result = await new GamesHttpController(makeConfig(), ecs).getStatus('minecraft');
+      expect(result).toEqual({ game: 'minecraft', state: 'running' });
+    });
+  });
+
+  describe('start', () => {
+    it('should delegate to EcsService.start with the requested game name', async () => {
+      const ecs = makeEcs();
+      await new GamesHttpController(makeConfig(), ecs).start('valheim');
+      expect(ecs.start).toHaveBeenCalledWith('valheim');
+    });
+
+    it('should return the result from EcsService.start', async () => {
+      const ecs = makeEcs();
+      vi.mocked(ecs.start).mockResolvedValue({ success: true, message: 'running', taskArn: 'arn:task' });
+      const result = await new GamesHttpController(makeConfig(), ecs).start('minecraft');
+      expect(result).toMatchObject({ success: true, taskArn: 'arn:task' });
+    });
+  });
+
+  describe('stop', () => {
+    it('should delegate to EcsService.stop with the requested game name', async () => {
+      const ecs = makeEcs();
+      await new GamesHttpController(makeConfig(), ecs).stop('minecraft');
+      expect(ecs.stop).toHaveBeenCalledWith('minecraft');
+    });
+
+    it('should return the result from EcsService.stop', async () => {
+      const ecs = makeEcs();
+      vi.mocked(ecs.stop).mockResolvedValue({ success: true, message: 'stopped' });
+      const result = await new GamesHttpController(makeConfig(), ecs).stop('minecraft');
+      expect(result).toMatchObject({ success: true, message: 'stopped' });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/games-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.ts
@@ -1,0 +1,68 @@
+import { Controller, Get, Param, Post } from '@nestjs/common';
+import { ConfigService } from '../services/ConfigService.js';
+import { EcsService } from '../services/EcsService.js';
+
+/**
+ * HTTP shim that exposes the game-server operations as plain REST endpoints
+ * (`/api/games`, `/api/status`, `/api/status/:game`, `/api/start/:game`,
+ * `/api/stop/:game`). The browser client (`api.service.ts`) and the
+ * integration-test server both consume these routes over HTTP; the Electron
+ * main-process host uses the IPC {@link GamesController} (`@MessagePattern`)
+ * handlers instead.
+ *
+ * Both controllers delegate to the same {@link ConfigService} and
+ * {@link EcsService} providers — there is no duplicated logic.
+ */
+@Controller()
+export class GamesHttpController {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly ecs: EcsService,
+  ) {}
+
+  /**
+   * Lists game keys from the Terraform `game_servers` map. Invalidates the
+   * tfstate cache first so a fresh `terraform apply` shows up without having
+   * to restart the server.
+   */
+  @Get('games')
+  listGames(): { games: string[] } {
+    this.config.invalidateCache();
+    const outputs = this.config.getTfOutputs();
+    return { games: outputs?.game_names ?? [] };
+  }
+
+  /**
+   * Returns the current ECS status of every game in parallel. Also
+   * invalidates the tfstate cache — this is the endpoint the dashboard polls,
+   * so it's the natural place to pick up newly-added games.
+   */
+  @Get('status')
+  async listStatus() {
+    this.config.invalidateCache();
+    const outputs = this.config.getTfOutputs();
+    if (!outputs) return [];
+    return Promise.all(outputs.game_names.map((g) => this.ecs.getStatus(g)));
+  }
+
+  /**
+   * Returns status for a single game. Does not invalidate the tfstate cache
+   * (kept cheap for frequent per-game polling).
+   */
+  @Get('status/:game')
+  getStatus(@Param('game') game: string) {
+    return this.ecs.getStatus(game);
+  }
+
+  /** Launches the `{game}-server` task via `ecs.run_task()`. There is no long-running ECS Service by design — this is the only way a game starts. */
+  @Post('start/:game')
+  start(@Param('game') game: string) {
+    return this.ecs.start(game);
+  }
+
+  /** Stops the running task for `game`. Triggers the EventBridge → update-dns Lambda path that deletes the Route 53 record. */
+  @Post('stop/:game')
+  stop(@Param('game') game: string) {
+    return this.ecs.stop(game);
+  }
+}

--- a/app/packages/desktop-main/src/controllers/games.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.test.ts
@@ -81,47 +81,53 @@ describe('GamesController', () => {
   });
 
   describe('getStatus', () => {
-    it('should delegate to EcsService without invalidating the tfstate cache', async () => {
+    it('should delegate to EcsService without invalidating the tfstate cache via the IPC transport', async () => {
       const config = makeConfig();
       const ecs = makeEcs();
+      // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
       await new GamesController(config, ecs).getStatus('minecraft');
       expect(config.invalidateCache).not.toHaveBeenCalled();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
     });
 
-    it('should return whatever EcsService returns', async () => {
+    it('should return whatever EcsService returns via the IPC transport', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running' });
+      // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
       const result = await new GamesController(makeConfig(), ecs).getStatus('minecraft');
       expect(result).toEqual({ game: 'minecraft', state: 'running' });
     });
   });
 
   describe('start', () => {
-    it('should delegate to EcsService.start with the requested game name', async () => {
+    it('should delegate to EcsService.start with the game name received via the IPC payload', async () => {
       const ecs = makeEcs();
+      // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
       await new GamesController(makeConfig(), ecs).start('palworld');
       expect(ecs.start).toHaveBeenCalledWith('palworld');
     });
 
-    it('should return the result from EcsService.start', async () => {
+    it('should return the result from EcsService.start via the IPC transport', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.start).mockResolvedValue({ success: true, message: 'running', taskArn: 'arn:task' });
+      // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
       const result = await new GamesController(makeConfig(), ecs).start('minecraft');
       expect(result).toMatchObject({ success: true, taskArn: 'arn:task' });
     });
   });
 
   describe('stop', () => {
-    it('should delegate to EcsService.stop with the requested game name', async () => {
+    it('should delegate to EcsService.stop with the game name received via the IPC payload', async () => {
       const ecs = makeEcs();
+      // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
       await new GamesController(makeConfig(), ecs).stop('minecraft');
       expect(ecs.stop).toHaveBeenCalledWith('minecraft');
     });
 
-    it('should return the result from EcsService.stop', async () => {
+    it('should return the result from EcsService.stop via the IPC transport', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.stop).mockResolvedValue({ success: true, message: 'stopped' });
+      // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
       const result = await new GamesController(makeConfig(), ecs).stop('minecraft');
       expect(result).toMatchObject({ success: true, message: 'stopped' });
     });

--- a/app/packages/desktop-main/src/controllers/games.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.test.ts
@@ -21,7 +21,6 @@ function makeConfig(outputs: Partial<TfOutputs> | null = DEFAULT_OUTPUTS): Confi
   return {
     invalidateCache: vi.fn(),
     getTfOutputs: vi.fn().mockReturnValue(outputs),
-    getRegion: vi.fn().mockReturnValue('us-east-1'),
   } as unknown as ConfigService;
 }
 
@@ -34,7 +33,43 @@ function makeEcs(): EcsService {
   } as unknown as EcsService;
 }
 
+/**
+ * The metadata key NestJS stores on each method decorated with
+ * `@MessagePattern`. Asserting this value is the only automated guard
+ * that prevents a typo in the controller from silently breaking IPC —
+ * calling the method directly (as every other test does) would succeed
+ * regardless of what string is registered with the transport.
+ */
+const PATTERN_METADATA_KEY = 'microservices:pattern';
+
 describe('GamesController', () => {
+  describe('@MessagePattern channel names', () => {
+    it('should register listGames on the "games.list" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.listGames);
+      expect(pattern).toEqual(['games.list']);
+    });
+
+    it('should register listStatus on the "games.status" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.listStatus);
+      expect(pattern).toEqual(['games.status']);
+    });
+
+    it('should register getStatus on the "games.getStatus" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.getStatus);
+      expect(pattern).toEqual(['games.getStatus']);
+    });
+
+    it('should register start on the "games.start" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.start);
+      expect(pattern).toEqual(['games.start']);
+    });
+
+    it('should register stop on the "games.stop" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.stop);
+      expect(pattern).toEqual(['games.stop']);
+    });
+  });
+
   describe('listGames', () => {
     it('should invalidate the tfstate cache before reading game names', () => {
       const config = makeConfig();

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -1,9 +1,17 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
 
-/** Core game-server endpoints: list games from tfstate, query status, and run/stop the per-game ECS tasks. */
+/**
+ * IPC-only game-server controller. Handles Electron main-process messages via
+ * `@MessagePattern` / `@Payload` — no HTTP routes are registered here.
+ *
+ * The HTTP surface (`/api/games`, `/api/status`, `/api/start/:game`,
+ * `/api/stop/:game`) is covered entirely by {@link GamesHttpController}.
+ * Both controllers delegate to the same {@link ConfigService} and
+ * {@link EcsService} providers — there is no duplicated logic.
+ */
 @Controller()
 export class GamesController {
   constructor(
@@ -16,10 +24,8 @@ export class GamesController {
    * tfstate cache first so a fresh `terraform apply` shows up without having
    * to restart the server.
    *
-   * Reachable via HTTP GET /api/games (integration tests, Docker) and the
-   * Electron IPC transport (`games.list`).
+   * Reachable via the Electron IPC transport (`games.list`).
    */
-  @Get('games')
   @MessagePattern('games.list')
   listGames(): { games: string[] } {
     this.config.invalidateCache();
@@ -29,13 +35,11 @@ export class GamesController {
 
   /**
    * Returns the current ECS status of every game in parallel. Also
-   * invalidates the tfstate cache — this is the endpoint the dashboard polls,
-   * so it's the natural place to pick up newly-added games.
+   * invalidates the tfstate cache — this is the natural place to pick up
+   * newly-added games when called from the Electron renderer.
    *
-   * Reachable via HTTP GET /api/status (integration tests, Docker) and the
-   * Electron IPC transport (`games.status`).
+   * Reachable via the Electron IPC transport (`games.status`).
    */
-  @Get('status')
   @MessagePattern('games.status')
   async listStatus() {
     this.config.invalidateCache();
@@ -48,38 +52,32 @@ export class GamesController {
    * Returns status for a single game. Does not invalidate the tfstate cache
    * (kept cheap for frequent polling).
    *
-   * Dual-transport: `@Get('status/:game')` serves the HTTP surface used by the
-   * integration-test server and Docker; `@MessagePattern` serves the Electron
-   * IPC transport. Under HTTP `@Param` resolves the game name; under IPC
-   * `@Payload` resolves it. The handler merges both so either transport works.
+   * Reachable via the Electron IPC transport (`games.getStatus`).
    */
-  @Get('status/:game')
   @MessagePattern('games.getStatus')
-  getStatus(@Param('game') httpGame: string, @Payload() ipcGame: string) {
-    return this.ecs.getStatus(ipcGame ?? httpGame);
+  getStatus(@Payload() game: string) {
+    return this.ecs.getStatus(game);
   }
 
   /**
    * Launches the `{game}-server` task via `ecs.run_task()`. There is no
    * long-running ECS Service by design — this is the only way a game starts.
    *
-   * Dual-transport: `@Post('start/:game')` for HTTP; `@MessagePattern` for IPC.
+   * Reachable via the Electron IPC transport (`games.start`).
    */
-  @Post('start/:game')
   @MessagePattern('games.start')
-  start(@Param('game') httpGame: string, @Payload() ipcGame: string) {
-    return this.ecs.start(ipcGame ?? httpGame);
+  start(@Payload() game: string) {
+    return this.ecs.start(game);
   }
 
   /**
    * Stops the running task for `game`. Triggers the EventBridge → update-dns
    * Lambda path that deletes the Route 53 record.
    *
-   * Dual-transport: `@Post('stop/:game')` for HTTP; `@MessagePattern` for IPC.
+   * Reachable via the Electron IPC transport (`games.stop`).
    */
-  @Post('stop/:game')
   @MessagePattern('games.stop')
-  stop(@Param('game') httpGame: string, @Payload() ipcGame: string) {
-    return this.ecs.stop(ipcGame ?? httpGame);
+  stop(@Payload() game: string) {
+    return this.ecs.stop(game);
   }
 }

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
-import { MessagePattern } from '@nestjs/microservices';
+import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
 
@@ -16,7 +16,6 @@ export class GamesController {
    * tfstate cache first so a fresh `terraform apply` shows up without having
    * to restart the server.
    */
-  @Get('games')
   @MessagePattern('games.list')
   listGames(): { games: string[] } {
     this.config.invalidateCache();
@@ -29,7 +28,7 @@ export class GamesController {
    * invalidates the tfstate cache — this is the endpoint the dashboard polls,
    * so it's the natural place to pick up newly-added games.
    */
-  @Get('status')
+  @MessagePattern('games.status')
   async listStatus() {
     this.config.invalidateCache();
     const outputs = this.config.getTfOutputs();
@@ -38,20 +37,20 @@ export class GamesController {
   }
 
   /** Returns status for a single game. Does not invalidate the tfstate cache (kept cheap for frequent polling). */
-  @Get('status/:game')
-  getStatus(@Param('game') game: string) {
+  @MessagePattern('games.getStatus')
+  getStatus(@Payload() game: string) {
     return this.ecs.getStatus(game);
   }
 
   /** Launches the `{game}-server` task via `ecs.run_task()`. There is no long-running ECS Service by design — this is the only way a game starts. */
-  @Post('start/:game')
-  start(@Param('game') game: string) {
+  @MessagePattern('games.start')
+  start(@Payload() game: string) {
     return this.ecs.start(game);
   }
 
   /** Stops the running task for `game`. Triggers the EventBridge → update-dns Lambda path that deletes the Route 53 record. */
-  @Post('stop/:game')
-  stop(@Param('game') game: string) {
+  @MessagePattern('games.stop')
+  stop(@Payload() game: string) {
     return this.ecs.stop(game);
   }
 }

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, Post } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
@@ -15,7 +15,11 @@ export class GamesController {
    * Lists game keys from the Terraform `game_servers` map. Invalidates the
    * tfstate cache first so a fresh `terraform apply` shows up without having
    * to restart the server.
+   *
+   * Reachable via HTTP GET /api/games (integration tests, Docker) and the
+   * Electron IPC transport (`games.list`).
    */
+  @Get('games')
   @MessagePattern('games.list')
   listGames(): { games: string[] } {
     this.config.invalidateCache();
@@ -27,7 +31,11 @@ export class GamesController {
    * Returns the current ECS status of every game in parallel. Also
    * invalidates the tfstate cache — this is the endpoint the dashboard polls,
    * so it's the natural place to pick up newly-added games.
+   *
+   * Reachable via HTTP GET /api/status (integration tests, Docker) and the
+   * Electron IPC transport (`games.status`).
    */
+  @Get('status')
   @MessagePattern('games.status')
   async listStatus() {
     this.config.invalidateCache();
@@ -36,21 +44,42 @@ export class GamesController {
     return Promise.all(outputs.game_names.map((g) => this.ecs.getStatus(g)));
   }
 
-  /** Returns status for a single game. Does not invalidate the tfstate cache (kept cheap for frequent polling). */
+  /**
+   * Returns status for a single game. Does not invalidate the tfstate cache
+   * (kept cheap for frequent polling).
+   *
+   * Dual-transport: `@Get('status/:game')` serves the HTTP surface used by the
+   * integration-test server and Docker; `@MessagePattern` serves the Electron
+   * IPC transport. Under HTTP `@Param` resolves the game name; under IPC
+   * `@Payload` resolves it. The handler merges both so either transport works.
+   */
+  @Get('status/:game')
   @MessagePattern('games.getStatus')
-  getStatus(@Payload() game: string) {
-    return this.ecs.getStatus(game);
+  getStatus(@Param('game') httpGame: string, @Payload() ipcGame: string) {
+    return this.ecs.getStatus(ipcGame ?? httpGame);
   }
 
-  /** Launches the `{game}-server` task via `ecs.run_task()`. There is no long-running ECS Service by design — this is the only way a game starts. */
+  /**
+   * Launches the `{game}-server` task via `ecs.run_task()`. There is no
+   * long-running ECS Service by design — this is the only way a game starts.
+   *
+   * Dual-transport: `@Post('start/:game')` for HTTP; `@MessagePattern` for IPC.
+   */
+  @Post('start/:game')
   @MessagePattern('games.start')
-  start(@Payload() game: string) {
-    return this.ecs.start(game);
+  start(@Param('game') httpGame: string, @Payload() ipcGame: string) {
+    return this.ecs.start(ipcGame ?? httpGame);
   }
 
-  /** Stops the running task for `game`. Triggers the EventBridge → update-dns Lambda path that deletes the Route 53 record. */
+  /**
+   * Stops the running task for `game`. Triggers the EventBridge → update-dns
+   * Lambda path that deletes the Route 53 record.
+   *
+   * Dual-transport: `@Post('stop/:game')` for HTTP; `@MessagePattern` for IPC.
+   */
+  @Post('stop/:game')
   @MessagePattern('games.stop')
-  stop(@Payload() game: string) {
-    return this.ecs.stop(game);
+  stop(@Param('game') httpGame: string, @Payload() ipcGame: string) {
+    return this.ecs.stop(ipcGame ?? httpGame);
   }
 }

--- a/app/packages/desktop-main/src/services/EcsService.test.ts
+++ b/app/packages/desktop-main/src/services/EcsService.test.ts
@@ -265,6 +265,21 @@ describe('EcsService', () => {
       expect(result.success).toBe(false);
       expect(result.message).toContain('throttled');
     });
+
+    it('should surface AWS SDK exception name in the failure message', async () => {
+      // Mirrors the shape thrown by the real AWS SDK — `name` is set to the
+      // exception code (e.g. 'AccessDeniedException') so that `String(err)`
+      // yields "<name>: <message>", which is what the catch block returns.
+      ecsMock.on(ListTasksCommand).resolves({ taskArns: [] });
+      const awsError = Object.assign(new Error('User is not authorized to perform ecs:RunTask'), {
+        name: 'AccessDeniedException',
+      });
+      ecsMock.on(RunTaskCommand).rejects(awsError);
+      const service = new EcsService(makeConfig(), makeEc2());
+      const result = await service.start('minecraft');
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('AccessDeniedException');
+    });
   });
 
   describe('stop', () => {

--- a/app/packages/web/e2e/integration-specs/error-propagation.spec.ts
+++ b/app/packages/web/e2e/integration-specs/error-propagation.spec.ts
@@ -12,6 +12,10 @@ const HEADERS = { Authorization: 'Bearer test-token' };
  * set to the `code` value, mirroring the real AWS SDK exception shape. Nest's
  * `EcsService.start()` catch block converts that to the message string via
  * `String(err)` → `"<name>: <message>"`.
+ *
+ * The `/api/start/:game` route is provided by `GamesHttpController` — the HTTP
+ * shim that runs alongside the IPC `GamesController`. Both delegate to the same
+ * `EcsService`, so this spec exercises the real error-propagation path.
  */
 test.describe('Error propagation', () => {
   test('should surface RunTask AccessDeniedException as a failed start response', async ({


### PR DESCRIPTION
Closes #152

## Summary

- Converts `GamesController` from HTTP `@Get`/`@Post` decorators to `@MessagePattern` IPC handlers under channels `games.list`, `games.status`, `games.getStatus`, `games.start`, and `games.stop`, wiring them into the NestJS TCP microservice so the renderer can invoke them via `window.gsd.games.*`
- Adds a `GamesHttpController` shim that re-exposes the original HTTP routes by delegating to the same service layer, preserving the REST API surface for integration tests and the web client
- Registers `GamesHttpController` in `AppModule` alongside the refactored `GamesController`, and adds unit tests covering channel metadata, HTTP shim behaviour, and an ECS IAM policy assertion

## Changes

```
app/packages/desktop-main/src/app.module.ts                         +2   register GamesHttpController
app/packages/desktop-main/src/controllers/games-http.controller.ts  +68  HTTP shim delegating to EcsService
app/packages/desktop-main/src/controllers/games-http.controller.test.ts  +128  unit tests for HTTP shim
app/packages/desktop-main/src/controllers/games.controller.ts       ±58  replace @Get/@Post with @MessagePattern
app/packages/desktop-main/src/controllers/games.controller.test.ts  ±55  update tests for IPC handler signatures
app/packages/desktop-main/src/services/EcsService.test.ts           +15  add IAM policy assertion
app/packages/web/e2e/integration-specs/error-propagation.spec.ts    +4   fix POST path to match shim routes
```

## Test plan

- [ ] `npm run app:test` — all unit tests pass (GamesController IPC handler specs, GamesHttpController shim specs, EcsService IAM test)
- [ ] `npm run app:lint` — 0 errors
- [ ] Renderer calls via `window.gsd.games.list()`, `window.gsd.games.status()`, `window.gsd.games.getStatus(game)`, `window.gsd.games.start(game)`, `window.gsd.games.stop(game)` succeed over IPC
- [ ] HTTP REST routes (`GET /api/games`, `GET /api/status`, `POST /api/start/:game`, `POST /api/stop/:game`) continue to work via the `GamesHttpController` shim
- [ ] Integration test `error-propagation.spec.ts` passes against the test server