### PR TITLE
feat(desktop-main): convert LogsController to IPC streaming channel

### DIFF
--- a/app/packages/desktop-main/src/controllers/logs.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.test.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi } from 'vitest';
-import { Observable } from 'rxjs';
 import { LogsController } from './logs.controller.js';
 import type { LogsService } from '../services/LogsService.js';
 
@@ -16,33 +15,64 @@ function makeLogs(): LogsService {
   } as unknown as LogsService;
 }
 
+/**
+ * Build a minimal execution-context stub that carries an AbortSignal,
+ * matching what StreamingElectronIPCTransport wires into `ctx.signal`.
+ */
+function makeCtx(signal?: AbortSignal): { signal: AbortSignal } {
+  return { signal: signal ?? new AbortController().signal };
+}
+
+/** Collect all values from an AsyncGenerator into an array. */
+async function collectGenerator<T>(gen: AsyncGenerator<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const item of gen) {
+    results.push(item);
+  }
+  return results;
+}
+
+/**
+ * The metadata key NestJS stores on each method decorated with
+ * `@MessagePattern`. Asserting this value guards against typos in the
+ * channel name that would silently break IPC routing.
+ */
+const PATTERN_METADATA_KEY = 'microservices:pattern';
+
 describe('LogsController', () => {
-  describe('getLogs', () => {
+  describe('@MessagePattern channel names', () => {
+    it('should register getRecentLogs on the "logs.get" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, LogsController.prototype.getRecentLogs);
+      expect(pattern).toEqual(['logs.get']);
+    });
+
+    it('should register streamLogs on the "logs.stream" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, LogsController.prototype.streamLogs);
+      expect(pattern).toEqual(['logs.stream']);
+    });
+  });
+
+  describe('getRecentLogs', () => {
     it('should return the game name and log lines from LogsService', async () => {
-      const result = await new LogsController(makeLogs()).getLogs('minecraft');
+      const result = await new LogsController(makeLogs()).getRecentLogs({ game: 'minecraft' });
       expect(result).toEqual({ game: 'minecraft', lines: ['line1', 'line2'] });
     });
 
-    it('should default to 50 log lines when no limit query param is provided', async () => {
+    it('should default to 50 log lines when no limit is provided in the payload', async () => {
       const logs = makeLogs();
-      await new LogsController(logs).getLogs('palworld', undefined);
+      await new LogsController(logs).getRecentLogs({ game: 'palworld' });
       expect(logs.getRecentLogs).toHaveBeenCalledWith('palworld', 50);
     });
 
-    it('should parse the limit query param and forward the integer to LogsService', async () => {
+    it('should forward the explicit limit from the payload to LogsService', async () => {
       const logs = makeLogs();
-      await new LogsController(logs).getLogs('minecraft', '100');
+      await new LogsController(logs).getRecentLogs({ game: 'minecraft', limit: 100 });
       expect(logs.getRecentLogs).toHaveBeenCalledWith('minecraft', 100);
     });
   });
 
   describe('streamLogs', () => {
-    it('should return an Observable', () => {
-      const result = new LogsController(makeLogs()).streamLogs('minecraft');
-      expect(result).toBeInstanceOf(Observable);
-    });
-
-    it('should emit MessageEvent objects for each line yielded by LogsService.streamLogs', async () => {
+    it('should yield each string line from LogsService.streamLogs', async () => {
       async function* fakeStream() {
         yield 'hello';
         yield 'world';
@@ -50,76 +80,32 @@ describe('LogsController', () => {
       const logs = makeLogs();
       vi.mocked(logs.streamLogs).mockImplementation(fakeStream);
 
-      const ctrl = new LogsController(logs);
-      const obs = ctrl.streamLogs('minecraft');
+      const gen = new LogsController(logs).streamLogs('minecraft', makeCtx());
+      const received = await collectGenerator(gen);
 
-      const received: unknown[] = [];
-      await new Promise<void>((resolve, reject) => {
-        obs.subscribe({
-          next: (event) => received.push(event),
-          error: reject,
-          complete: resolve,
-        });
-      });
-
-      expect(received).toEqual([
-        { data: { line: 'hello' } },
-        { data: { line: 'world' } },
-      ]);
+      expect(received).toEqual(['hello', 'world']);
     });
 
-    it('should complete the stream without error when the generator is exhausted', async () => {
+    it('should stop cleanly when the generator is exhausted', async () => {
       async function* empty() { /* no lines */ }
       const logs = makeLogs();
       vi.mocked(logs.streamLogs).mockImplementation(empty);
 
-      let completed = false;
-      await new Promise<void>((resolve, reject) => {
-        new LogsController(logs).streamLogs('minecraft').subscribe({
-          complete: () => { completed = true; resolve(); },
-          error: reject,
-        });
-      });
+      const gen = new LogsController(logs).streamLogs('minecraft', makeCtx());
+      const received = await collectGenerator(gen);
 
-      expect(completed).toBe(true);
+      expect(received).toEqual([]);
     });
 
-    it('should complete instead of erroring when LogsService throws an AbortError', async () => {
-      async function* abortStream() {
-        const err = new Error('aborted');
-        err.name = 'AbortError';
-        throw err;
-        yield 'unreachable';
-      }
+    it('should propagate the AbortSignal from ctx.signal to LogsService.streamLogs', async () => {
       const logs = makeLogs();
-      vi.mocked(logs.streamLogs).mockImplementation(abortStream);
+      const abortController = new AbortController();
+      const ctx = makeCtx(abortController.signal);
 
-      let completed = false;
-      await new Promise<void>((resolve, reject) => {
-        new LogsController(logs).streamLogs('minecraft').subscribe({
-          complete: () => { completed = true; resolve(); },
-          error: reject,
-        });
-      });
+      const gen = new LogsController(logs).streamLogs('minecraft', ctx);
+      await collectGenerator(gen);
 
-      expect(completed).toBe(true);
-    });
-
-    it('should forward non-AbortError exceptions to the subscriber as errors', async () => {
-      async function* badStream() {
-        throw new Error('CloudWatch throttled');
-        yield 'unreachable';
-      }
-      const logs = makeLogs();
-      vi.mocked(logs.streamLogs).mockImplementation(badStream);
-
-      const err = await new Promise<Error>((resolve) => {
-        new LogsController(logs).streamLogs('minecraft').subscribe({
-          error: (e: Error) => resolve(e),
-        });
-      });
-
-      expect(err.message).toBe('CloudWatch throttled');
+      expect(logs.streamLogs).toHaveBeenCalledWith('minecraft', abortController.signal);
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/logs.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.test.ts
@@ -16,11 +16,17 @@ import type { LogsService } from '../services/LogsService.js';
  * made by `onModuleInit()`. Without it, calling `onModuleInit` in a test
  * environment (where the real Electron `ipcMain` is absent) would throw.
  */
-const { mockIpcMainHandle, mockIpcMainOnce, mockIpcMainRemoveAllListeners } = vi.hoisted(() => {
+const {
+  mockIpcMainHandle,
+  mockIpcMainOnce,
+  mockIpcMainRemoveAllListeners,
+  mockIpcMainRemoveHandler,
+} = vi.hoisted(() => {
   const mockIpcMainHandle = vi.fn();
   const mockIpcMainOnce = vi.fn();
   const mockIpcMainRemoveAllListeners = vi.fn();
-  return { mockIpcMainHandle, mockIpcMainOnce, mockIpcMainRemoveAllListeners };
+  const mockIpcMainRemoveHandler = vi.fn();
+  return { mockIpcMainHandle, mockIpcMainOnce, mockIpcMainRemoveAllListeners, mockIpcMainRemoveHandler };
 });
 
 vi.mock('electron', () => ({
@@ -28,6 +34,7 @@ vi.mock('electron', () => ({
     handle: mockIpcMainHandle,
     once: mockIpcMainOnce,
     removeAllListeners: mockIpcMainRemoveAllListeners,
+    removeHandler: mockIpcMainRemoveHandler,
   },
 }));
 
@@ -112,6 +119,17 @@ describe('LogsController', () => {
       // destructured in the preload.
       await new LogsController(makeLogs()).onModuleInit();
       expect(mockIpcMainHandle).toHaveBeenCalledWith('logs.stream', expect.any(Function));
+    });
+
+    it('should remove any existing "logs.stream" handler before registering so hot-reload re-bootstrap does not throw', async () => {
+      // A second bootstrap (hot-reload / dev restart) would otherwise hit
+      // "Attempted to register a second handler for 'logs.stream'". Clearing the
+      // handler first keeps re-registration idempotent.
+      await new LogsController(makeLogs()).onModuleInit();
+      expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith('logs.stream');
+      expect(mockIpcMainRemoveHandler.mock.invocationCallOrder[0]).toBeLessThan(
+        mockIpcMainHandle.mock.invocationCallOrder[0],
+      );
     });
   });
 

--- a/app/packages/desktop-main/src/controllers/logs.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.test.ts
@@ -1,13 +1,45 @@
 import 'reflect-metadata';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LogsController } from './logs.controller.js';
 import type { LogsService } from '../services/LogsService.js';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state — must be declared before any vi.mock() factory runs.
+// ---------------------------------------------------------------------------
+
+/**
+ * Captures every listener registered via `ipcMain.handle` or `ipcMain.once`
+ * so tests can assert on routing registration and fire cancel callbacks
+ * synchronously.
+ *
+ * `mockIpcMainHandle` captures the `ipcMain.handle('logs.stream', ...)` call
+ * made by `onModuleInit()`. Without it, calling `onModuleInit` in a test
+ * environment (where the real Electron `ipcMain` is absent) would throw.
+ */
+const { mockIpcMainHandle, mockIpcMainOnce, mockIpcMainRemoveAllListeners } = vi.hoisted(() => {
+  const mockIpcMainHandle = vi.fn();
+  const mockIpcMainOnce = vi.fn();
+  const mockIpcMainRemoveAllListeners = vi.fn();
+  return { mockIpcMainHandle, mockIpcMainOnce, mockIpcMainRemoveAllListeners };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mockIpcMainHandle,
+    once: mockIpcMainOnce,
+    removeAllListeners: mockIpcMainRemoveAllListeners,
+  },
+}));
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-/** Build a LogsService stub. */
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a LogsService stub with default no-op implementations. */
 function makeLogs(): LogsService {
   return {
     getRecentLogs: vi.fn().mockResolvedValue(['line1', 'line2']),
@@ -16,20 +48,24 @@ function makeLogs(): LogsService {
 }
 
 /**
- * Build a minimal execution-context stub that carries an AbortSignal,
- * matching what StreamingElectronIPCTransport wires into `ctx.signal`.
+ * Build a minimal `IpcMainInvokeEvent` stub with a controlled `sender`
+ * (WebContents). Tests can inspect calls on `sender.send` and control the
+ * return value of `sender.isDestroyed()`.
  */
-function makeCtx(signal?: AbortSignal): { signal: AbortSignal } {
-  return { signal: signal ?? new AbortController().signal };
+function makeCtx(isDestroyed = false) {
+  const sender = {
+    send: vi.fn(),
+    isDestroyed: vi.fn().mockReturnValue(isDestroyed),
+  };
+  return {
+    ctx: { evt: { sender } } as unknown as { evt: { sender: typeof sender } },
+    sender,
+  };
 }
 
-/** Collect all values from an AsyncGenerator into an array. */
-async function collectGenerator<T>(gen: AsyncGenerator<T>): Promise<T[]> {
-  const results: T[] = [];
-  for await (const item of gen) {
-    results.push(item);
-  }
-  return results;
+/** Flush the microtask queue so async fire-and-forget loops fully settle. */
+function flushPromises(): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 /**
@@ -39,7 +75,19 @@ async function collectGenerator<T>(gen: AsyncGenerator<T>): Promise<T[]> {
  */
 const PATTERN_METADATA_KEY = 'microservices:pattern';
 
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
 describe('LogsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // @MessagePattern channel name registration
+  // -------------------------------------------------------------------------
+
   describe('@MessagePattern channel names', () => {
     it('should register getRecentLogs on the "logs.get" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, LogsController.prototype.getRecentLogs);
@@ -51,6 +99,25 @@ describe('LogsController', () => {
       expect(pattern).toEqual(['logs.stream']);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // onModuleInit — ipcMain.handle bridge for logs.stream
+  // -------------------------------------------------------------------------
+
+  describe('onModuleInit', () => {
+    it('should register ipcMain.handle for "logs.stream" so ipcRenderer.invoke can resolve', async () => {
+      // onModuleInit bridges the gap between @MessagePattern (transport-internal
+      // dispatch only) and ipcMain.handle (required by ipcRenderer.invoke). Without
+      // this registration, invoke hangs indefinitely and { streamId } is never
+      // destructured in the preload.
+      await new LogsController(makeLogs()).onModuleInit();
+      expect(mockIpcMainHandle).toHaveBeenCalledWith('logs.stream', expect.any(Function));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getRecentLogs
+  // -------------------------------------------------------------------------
 
   describe('getRecentLogs', () => {
     it('should return the game name and log lines from LogsService', async () => {
@@ -71,41 +138,160 @@ describe('LogsController', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // streamLogs
+  // -------------------------------------------------------------------------
+
   describe('streamLogs', () => {
-    it('should yield each string line from LogsService.streamLogs', async () => {
-      async function* fakeStream() {
+    it('should return a non-empty streamId string immediately', async () => {
+      const logs = makeLogs();
+      const { ctx } = makeCtx();
+
+      const result = await new LogsController(logs).streamLogs('minecraft', ctx);
+
+      expect(result).toHaveProperty('streamId');
+      expect(typeof result.streamId).toBe('string');
+      expect(result.streamId.length).toBeGreaterThan(0);
+    });
+
+    it('should register a cancel listener on the per-stream cancel channel', async () => {
+      const logs = makeLogs();
+      const { ctx } = makeCtx();
+
+      const { streamId } = await new LogsController(logs).streamLogs('minecraft', ctx);
+
+      expect(mockIpcMainOnce).toHaveBeenCalledWith(
+        `logs.stream.${streamId}.cancel`,
+        expect.any(Function),
+      );
+    });
+
+    it('should send each log line as a chunk to the renderer via sender.send', async () => {
+      async function* twoLines() {
         yield 'hello';
         yield 'world';
       }
       const logs = makeLogs();
-      vi.mocked(logs.streamLogs).mockImplementation(fakeStream);
+      vi.mocked(logs.streamLogs).mockImplementation(twoLines);
+      const { ctx, sender } = makeCtx();
 
-      const gen = new LogsController(logs).streamLogs('minecraft', makeCtx());
-      const received = await collectGenerator(gen);
+      const { streamId } = await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
 
-      expect(received).toEqual(['hello', 'world']);
+      expect(sender.send).toHaveBeenCalledWith(`logs.stream.${streamId}.chunk`, 'hello');
+      expect(sender.send).toHaveBeenCalledWith(`logs.stream.${streamId}.chunk`, 'world');
     });
 
-    it('should stop cleanly when the generator is exhausted', async () => {
+    it('should send an end message with no error when the generator is exhausted', async () => {
       async function* empty() { /* no lines */ }
       const logs = makeLogs();
       vi.mocked(logs.streamLogs).mockImplementation(empty);
+      const { ctx, sender } = makeCtx();
 
-      const gen = new LogsController(logs).streamLogs('minecraft', makeCtx());
-      const received = await collectGenerator(gen);
+      const { streamId } = await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
 
-      expect(received).toEqual([]);
+      expect(sender.send).toHaveBeenCalledWith(`logs.stream.${streamId}.end`, {});
     });
 
-    it('should propagate the AbortSignal from ctx.signal to LogsService.streamLogs', async () => {
+    it('should send an end message with no error when the stream is cancelled (AbortError)', async () => {
+      async function* throwsAbort(): AsyncGenerator<string> {
+        yield 'partial';
+        throw new DOMException('Aborted', 'AbortError');
+      }
       const logs = makeLogs();
-      const abortController = new AbortController();
-      const ctx = makeCtx(abortController.signal);
+      vi.mocked(logs.streamLogs).mockImplementation(throwsAbort);
+      const { ctx, sender } = makeCtx();
 
-      const gen = new LogsController(logs).streamLogs('minecraft', ctx);
-      await collectGenerator(gen);
+      const { streamId } = await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
 
-      expect(logs.streamLogs).toHaveBeenCalledWith('minecraft', abortController.signal);
+      expect(sender.send).toHaveBeenCalledWith(`logs.stream.${streamId}.end`, {});
+      // The error field must NOT be present on an AbortError end message.
+      const endCall = sender.send.mock.calls.find(([ch]) => ch === `logs.stream.${streamId}.end`);
+      expect(endCall?.[1]).not.toHaveProperty('error');
+    });
+
+    it('should send an end message with an error string when the generator throws a non-abort error', async () => {
+      async function* throwsNonAbort(): AsyncGenerator<string> {
+        yield 'partial';
+        throw new Error('CloudWatch throttled');
+      }
+      const logs = makeLogs();
+      vi.mocked(logs.streamLogs).mockImplementation(throwsNonAbort);
+      const { ctx, sender } = makeCtx();
+
+      const { streamId } = await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
+
+      const endCall = sender.send.mock.calls.find(([ch]) => ch === `logs.stream.${streamId}.end`);
+      expect(endCall?.[1]).toHaveProperty('error');
+      expect(String(endCall?.[1]?.error)).toContain('CloudWatch throttled');
+    });
+
+    it('should create its own AbortController and pass the signal to LogsService.streamLogs', async () => {
+      const logs = makeLogs();
+      const { ctx } = makeCtx();
+
+      await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
+
+      // The signal passed to streamLogs must be an AbortSignal created by the controller.
+      expect(logs.streamLogs).toHaveBeenCalledWith('minecraft', expect.any(AbortSignal));
+    });
+
+    it('should abort the stream when the cancel IPC listener is invoked', async () => {
+      // Make streamLogs block until signalled so we can inspect the abort state.
+      let capturedSignal: AbortSignal | null = null;
+      async function* waitForAbort(
+        _game: string,
+        signal: AbortSignal,
+      ): AsyncGenerator<string> {
+        capturedSignal = signal;
+        // Yield one line then wait indefinitely so the cancel path is exercised.
+        yield 'first';
+        await new Promise<void>((_, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        });
+      }
+      const logs = makeLogs();
+      vi.mocked(logs.streamLogs).mockImplementation(waitForAbort);
+      const { ctx } = makeCtx();
+
+      await new LogsController(logs).streamLogs('minecraft', ctx);
+
+      // Retrieve the cancel handler registered via ipcMain.once and invoke it.
+      const [, cancelHandler] = mockIpcMainOnce.mock.calls[0] as [string, () => void];
+      cancelHandler();
+
+      await flushPromises();
+
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it('should remove the cancel listener after the stream ends naturally', async () => {
+      async function* empty() { /* terminates immediately */ }
+      const logs = makeLogs();
+      vi.mocked(logs.streamLogs).mockImplementation(empty);
+      const { ctx } = makeCtx();
+
+      const { streamId } = await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
+
+      expect(mockIpcMainRemoveAllListeners).toHaveBeenCalledWith(`logs.stream.${streamId}.cancel`);
+    });
+
+    it('should not send to a destroyed WebContents', async () => {
+      async function* oneLine() { yield 'line'; }
+      const logs = makeLogs();
+      vi.mocked(logs.streamLogs).mockImplementation(oneLine);
+      // Simulate WebContents already destroyed before the loop runs.
+      const { ctx, sender } = makeCtx(true);
+
+      await new LogsController(logs).streamLogs('minecraft', ctx);
+      await flushPromises();
+
+      expect(sender.send).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/logs.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LogsController } from './logs.controller.js';
 import type { LogsService } from '../services/LogsService.js';
 
@@ -112,6 +112,31 @@ describe('LogsController', () => {
   // -------------------------------------------------------------------------
 
   describe('onModuleInit', () => {
+    // onModuleInit only wires the bridge when running inside a real Electron
+    // main process, detected via `process.versions.electron`. Vitest runs under
+    // plain Node where it's undefined, so fake it for the "is Electron" cases
+    // and restore afterwards.
+    const realElectronVersion = process.versions.electron;
+    const setElectron = (value: string | undefined): void => {
+      if (value === undefined) {
+        delete (process.versions as { electron?: string }).electron;
+      } else {
+        Object.defineProperty(process.versions, 'electron', { value, configurable: true });
+      }
+    };
+    beforeEach(() => setElectron('30.0.0'));
+    afterEach(() => setElectron(realElectronVersion));
+
+    it('should skip the ipcMain bridge when not running inside an Electron main process', async () => {
+      // Plain-Node runtimes (integration test server, Docker, CI) have no
+      // `process.versions.electron`; importing electron there would throw, so
+      // the bridge must be skipped without touching ipcMain at all.
+      setElectron(undefined);
+      await new LogsController(makeLogs()).onModuleInit();
+      expect(mockIpcMainHandle).not.toHaveBeenCalled();
+      expect(mockIpcMainRemoveHandler).not.toHaveBeenCalled();
+    });
+
     it('should register ipcMain.handle for "logs.stream" so ipcRenderer.invoke can resolve', async () => {
       // onModuleInit bridges the gap between @MessagePattern (transport-internal
       // dispatch only) and ipcMain.handle (required by ipcRenderer.invoke). Without

--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -30,11 +30,24 @@ export class LogsController implements OnModuleInit {
   async onModuleInit(): Promise<void> {
     try {
       const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
+      // Remove any existing handler first so hot-reload re-registration does
+      // not throw "IPC channel already registered".
+      ipcMain.removeHandler('logs.stream');
       ipcMain.handle('logs.stream', (evt, game: string) =>
         this.streamLogs(game, { evt: evt as IpcMainInvokeEvent }),
       );
-    } catch {
-      // Not running inside the Electron main process — ipcMain bridge skipped.
+    } catch (err) {
+      // Only swallow errors that indicate Electron is absent from this runtime
+      // (plain-Node integration server, Docker, CI).  Any other error — e.g. a
+      // coding mistake inside the handle callback — must propagate so startup
+      // fails visibly rather than leaving the IPC bridge silently broken.
+      const code = (err as NodeJS.ErrnoException).code;
+      const msg = (err as Error).message ?? '';
+      if (code === 'MODULE_NOT_FOUND' || msg.includes('Cannot find module')) {
+        // Not running inside the Electron main process — ipcMain bridge skipped.
+        return;
+      }
+      throw err;
     }
   }
 

--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -23,32 +23,27 @@ export class LogsController implements OnModuleInit {
    * dispatcher — it does **not** call `ipcMain.handle`, so `ipcRenderer.invoke`
    * would otherwise hang. This hook bridges the gap.
    *
-   * The Electron import is wrapped in try/catch so the module boots cleanly
-   * in plain-Node environments (integration test server, Docker) where the
-   * Electron binary is absent.
+   * Only runs inside a real Electron main process. In plain-Node runtimes
+   * (integration test server, Docker, CI) `process.versions.electron` is
+   * undefined and importing `electron` would throw — either MODULE_NOT_FOUND
+   * or "Electron failed to install correctly" when the package is present but
+   * its binary isn't — so we skip the bridge entirely rather than guessing
+   * which error means "no Electron" from the message. When we *are* in
+   * Electron, the import succeeds and any `ipcMain.handle` failure propagates
+   * so a broken bridge fails startup loudly instead of hanging invoke.
    */
   async onModuleInit(): Promise<void> {
-    try {
-      const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
-      // Remove any existing handler first so hot-reload re-registration does
-      // not throw "IPC channel already registered".
-      ipcMain.removeHandler('logs.stream');
-      ipcMain.handle('logs.stream', (evt, game: string) =>
-        this.streamLogs(game, { evt: evt as IpcMainInvokeEvent }),
-      );
-    } catch (err) {
-      // Only swallow errors that indicate Electron is absent from this runtime
-      // (plain-Node integration server, Docker, CI).  Any other error — e.g. a
-      // coding mistake inside the handle callback — must propagate so startup
-      // fails visibly rather than leaving the IPC bridge silently broken.
-      const code = (err as NodeJS.ErrnoException).code;
-      const msg = (err as Error).message ?? '';
-      if (code === 'MODULE_NOT_FOUND' || msg.includes('Cannot find module')) {
-        // Not running inside the Electron main process — ipcMain bridge skipped.
-        return;
-      }
-      throw err;
+    if (!process.versions.electron) {
+      // Not running inside the Electron main process — ipcMain bridge skipped.
+      return;
     }
+    const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
+    // Remove any existing handler first so hot-reload re-registration does
+    // not throw "IPC channel already registered".
+    ipcMain.removeHandler('logs.stream');
+    ipcMain.handle('logs.stream', (evt, game: string) =>
+      this.streamLogs(game, { evt: evt as IpcMainInvokeEvent }),
+    );
   }
 
   /**

--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -1,6 +1,9 @@
-import { Controller } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { Controller, OnModuleInit } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
+import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
 import { LogsService } from '../services/LogsService.js';
+import { logger } from '../logger.js';
 
 /** IPC-only logs controller. Handles Electron main-process messages via
  * `@MessagePattern` — no HTTP routes are registered here.
@@ -8,8 +11,30 @@ import { LogsService } from '../services/LogsService.js';
  * Tails CloudWatch logs from the `/ecs/{game}-server` log group.
  */
 @Controller()
-export class LogsController {
+export class LogsController implements OnModuleInit {
   constructor(private readonly logs: LogsService) {}
+
+  /**
+   * Registers `ipcMain.handle('logs.stream', ...)` after the Nest module is
+   * initialised so that `ipcRenderer.invoke('logs.stream', game)` in the
+   * preload resolves with `{ streamId }`.
+   *
+   * `@MessagePattern('logs.stream')` only registers a handler in the
+   * transport's internal `ipcMessageDispatcher` — it does **not** call
+   * `ipcMain.handle`, so `ipcRenderer.invoke` would otherwise hang. This
+   * lifecycle hook bridges the gap by wiring an explicit `ipcMain.handle`
+   * that forwards the call into `streamLogs` through the same context shape
+   * (`{ evt }`) that `ElectronIPCTransport.onMessage` produces.
+   *
+   * The electron import is deferred so the module remains loadable in
+   * plain-Node test environments where the Electron runtime is absent.
+   */
+  async onModuleInit(): Promise<void> {
+    const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
+    ipcMain.handle('logs.stream', (evt, game: string) =>
+      this.streamLogs(game, { evt: evt as IpcMainInvokeEvent }),
+    );
+  }
 
   /**
    * Returns the most recent `limit` (default 50) log lines for a game's ECS task.
@@ -26,19 +51,70 @@ export class LogsController {
   }
 
   /**
-   * Async-generator stream of new log lines for a game, delivered as they
-   * arrive from `FilterLogEvents`. The `AbortSignal` is sourced from the
-   * Nest execution context (`ctx.signal`) as wired by
-   * `StreamingElectronIPCTransport` — the renderer cancels the stream by
-   * sending the matching `.cancel` IPC message.
+   * Opens a live log stream for `game` and returns an opaque `streamId`
+   * immediately. Chunks are pushed back to the renderer via
+   * `evt.sender.send(`logs.stream.${streamId}.chunk`, line)` as they arrive
+   * from `FilterLogEvents`. The stream ends with a
+   * `logs.stream.${streamId}.end` message carrying `{ error?: string }`.
+   *
+   * The renderer cancels the stream by sending
+   * `logs.stream.${streamId}.cancel` via `ipcRenderer.send`.
+   *
+   * The controller creates its own `AbortController` per invocation because
+   * `ElectronIPCTransport` passes `{ evt }` as the execution context — there
+   * is no `signal` property injected by the transport.
    *
    * Reachable via the Electron IPC transport (`logs.stream`).
    */
   @MessagePattern('logs.stream')
-  async *streamLogs(
+  async streamLogs(
     @Payload() game: string,
-    ctx: { signal: AbortSignal },
-  ): AsyncGenerator<string> {
-    yield* this.logs.streamLogs(game, ctx.signal);
+    ctx: { evt: IpcMainInvokeEvent },
+  ): Promise<{ streamId: string }> {
+    const streamId = randomUUID();
+    const ac = new AbortController();
+    const sender: WebContents = ctx.evt.sender;
+    const chunkChannel = `logs.stream.${streamId}.chunk`;
+    const endChannel = `logs.stream.${streamId}.end`;
+    const cancelChannel = `logs.stream.${streamId}.cancel`;
+
+    // Lazily import ipcMain so the module stays importable in plain-Node test
+    // environments where the Electron runtime is absent.
+    const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
+
+    // Register a one-shot cancel listener so the renderer can abort the stream.
+    ipcMain.once(cancelChannel, () => {
+      ac.abort();
+    });
+
+    // Fire-and-forget the streaming loop. Chunks are pushed back to the
+    // renderer directly via WebContents.send rather than through the normal
+    // invoke reply mechanism, which only supports a single return value.
+    void (async () => {
+      try {
+        for await (const line of this.logs.streamLogs(game, ac.signal)) {
+          if (sender.isDestroyed()) break;
+          sender.send(chunkChannel, line);
+        }
+        if (!sender.isDestroyed()) {
+          sender.send(endChannel, {});
+        }
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') {
+          if (!sender.isDestroyed()) sender.send(endChannel, {});
+        } else {
+          logger.error('Log stream error', { err, game, streamId });
+          if (!sender.isDestroyed()) {
+            sender.send(endChannel, { error: String(err) });
+          }
+        }
+      } finally {
+        // Ensure the cancel listener is removed if the stream ended on its own
+        // so it doesn't linger until the next cancel message arrives.
+        ipcMain.removeAllListeners(cancelChannel);
+      }
+    })();
+
+    return { streamId };
   }
 }

--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -1,48 +1,44 @@
-import { Controller, Get, MessageEvent, Param, Query, Sse } from '@nestjs/common';
-import { Observable } from 'rxjs';
+import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
 import { LogsService } from '../services/LogsService.js';
 
-/** Tails CloudWatch logs from the `/ecs/{game}-server` log group. */
-@Controller('logs')
+/** IPC-only logs controller. Handles Electron main-process messages via
+ * `@MessagePattern` — no HTTP routes are registered here.
+ *
+ * Tails CloudWatch logs from the `/ecs/{game}-server` log group.
+ */
+@Controller()
 export class LogsController {
   constructor(private readonly logs: LogsService) {}
 
-  /** Returns the most recent `limit` (default 50) log lines for a game's ECS task. */
-  @Get(':game')
-  async getLogs(@Param('game') game: string, @Query('limit') limitRaw?: string) {
-    const limit = parseInt(String(limitRaw ?? '50'), 10);
+  /**
+   * Returns the most recent `limit` (default 50) log lines for a game's ECS task.
+   *
+   * Reachable via the Electron IPC transport (`logs.get`).
+   */
+  @MessagePattern('logs.get')
+  async getRecentLogs(
+    @Payload() payload: { game: string; limit?: number },
+  ): Promise<{ game: string; lines: string[] }> {
+    const { game, limit = 50 } = payload;
     const lines = await this.logs.getRecentLogs(game, limit);
     return { game, lines };
   }
 
   /**
-   * SSE stream of new log lines for a game, delivered as they arrive from
-   * `FilterLogEvents`. The client receives `{ data: { line: "..." } }` events.
-   * Auth: `Authorization: Bearer` header OR `?token=` query param (the latter
-   * is required because the browser's native `EventSource` cannot set headers).
+   * Async-generator stream of new log lines for a game, delivered as they
+   * arrive from `FilterLogEvents`. The `AbortSignal` is sourced from the
+   * Nest execution context (`ctx.signal`) as wired by
+   * `StreamingElectronIPCTransport` — the renderer cancels the stream by
+   * sending the matching `.cancel` IPC message.
+   *
+   * Reachable via the Electron IPC transport (`logs.stream`).
    */
-  @Sse(':game/stream')
-  streamLogs(@Param('game') game: string): Observable<MessageEvent> {
-    const ac = new AbortController();
-
-    return new Observable<MessageEvent>((subscriber) => {
-      const run = async () => {
-        try {
-          for await (const line of this.logs.streamLogs(game, ac.signal)) {
-            subscriber.next({ data: { line } } as MessageEvent);
-          }
-          subscriber.complete();
-        } catch (err) {
-          if ((err as Error).name === 'AbortError') {
-            subscriber.complete();
-          } else {
-            subscriber.error(err);
-          }
-        }
-      };
-      void run();
-
-      return () => ac.abort();
-    });
+  @MessagePattern('logs.stream')
+  async *streamLogs(
+    @Payload() game: string,
+    ctx: { signal: AbortSignal },
+  ): AsyncGenerator<string> {
+    yield* this.logs.streamLogs(game, ctx.signal);
   }
 }

--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -95,7 +95,7 @@ export class LogsController implements OnModuleInit {
     void (async () => {
       try {
         for await (const line of this.logs.streamLogs(game, ac.signal)) {
-          if (sender.isDestroyed()) break;
+          if (sender.isDestroyed()) { ac.abort(); break; }
           sender.send(chunkChannel, line);
         }
         if (!sender.isDestroyed()) {

--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -15,25 +15,27 @@ export class LogsController implements OnModuleInit {
   constructor(private readonly logs: LogsService) {}
 
   /**
-   * Registers `ipcMain.handle('logs.stream', ...)` after the Nest module is
-   * initialised so that `ipcRenderer.invoke('logs.stream', game)` in the
-   * preload resolves with `{ streamId }`.
+   * Registers an `ipcMain.handle` bridge for the `logs.stream` channel after
+   * the Nest module initialises, so that `ipcRenderer.invoke('logs.stream')`
+   * in the preload resolves with `{ streamId }`.
    *
-   * `@MessagePattern('logs.stream')` only registers a handler in the
-   * transport's internal `ipcMessageDispatcher` — it does **not** call
-   * `ipcMain.handle`, so `ipcRenderer.invoke` would otherwise hang. This
-   * lifecycle hook bridges the gap by wiring an explicit `ipcMain.handle`
-   * that forwards the call into `streamLogs` through the same context shape
-   * (`{ evt }`) that `ElectronIPCTransport.onMessage` produces.
+   * `@MessagePattern('logs.stream')` only wires the transport's internal
+   * dispatcher — it does **not** call `ipcMain.handle`, so `ipcRenderer.invoke`
+   * would otherwise hang. This hook bridges the gap.
    *
-   * The electron import is deferred so the module remains loadable in
-   * plain-Node test environments where the Electron runtime is absent.
+   * The Electron import is wrapped in try/catch so the module boots cleanly
+   * in plain-Node environments (integration test server, Docker) where the
+   * Electron binary is absent.
    */
   async onModuleInit(): Promise<void> {
-    const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
-    ipcMain.handle('logs.stream', (evt, game: string) =>
-      this.streamLogs(game, { evt: evt as IpcMainInvokeEvent }),
-    );
+    try {
+      const { ipcMain } = await import('electron') as unknown as { ipcMain: IpcMain };
+      ipcMain.handle('logs.stream', (evt, game: string) =>
+        this.streamLogs(game, { evt: evt as IpcMainInvokeEvent }),
+      );
+    } catch {
+      // Not running inside the Electron main process — ipcMain bridge skipped.
+    }
   }
 
   /**
@@ -52,10 +54,10 @@ export class LogsController implements OnModuleInit {
 
   /**
    * Opens a live log stream for `game` and returns an opaque `streamId`
-   * immediately. Chunks are pushed back to the renderer via
-   * `evt.sender.send(`logs.stream.${streamId}.chunk`, line)` as they arrive
-   * from `FilterLogEvents`. The stream ends with a
-   * `logs.stream.${streamId}.end` message carrying `{ error?: string }`.
+   * immediately. Chunks are pushed to the renderer via `sender.send` on the
+   * `logs.stream.<streamId>.chunk` channel as they arrive from FilterLogEvents.
+   * The stream terminates with a `logs.stream.<streamId>.end` message
+   * carrying `{ error?: string }`.
    *
    * The renderer cancels the stream by sending
    * `logs.stream.${streamId}.cancel` via `ipcRenderer.send`.

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -66,6 +66,9 @@ export interface GameLogs {
   lines: string[];
 }
 
+/** A single chunk of streamed log text delivered over IPC. */
+export type LogChunk = string;
+
 /** State of the EFS FileBrowser helper task for a game. */
 export interface FileMgrStatus {
   game: string;
@@ -191,16 +194,27 @@ export interface GsdCostsApi {
   actual: (days?: number) => Promise<ActualCosts>;
 }
 
-/**
- * CloudWatch log endpoints.
- *
- * Note: the SSE log stream (`logs.stream`) is intentionally absent — IPC
- * `invoke` is request/response only. Wire streaming separately via
- * `ipcRenderer.on` if needed.
- */
+/** CloudWatch log endpoints: poll recent lines or open a live IPC stream. */
 export interface GsdLogsApi {
   /** Returns recent log lines for a game's ECS task. */
   get: (game: string, limit?: number) => Promise<GameLogs>;
+  /**
+   * Opens a live log stream for `game` via IPC and returns the opaque
+   * `streamId` used to subscribe to chunk/end events and to cancel the stream.
+   */
+  stream: (game: string) => Promise<{ streamId: string }>;
+  /**
+   * Subscribe to incoming log chunks for a stream. Returns a cleanup function
+   * that removes the listener when called.
+   */
+  onChunk: (streamId: string, cb: (chunk: string) => void) => () => void;
+  /**
+   * Subscribe to the end-of-stream notification. Returns a cleanup function.
+   * `err` is set when the stream terminated due to an error.
+   */
+  onEnd: (streamId: string, cb: (err?: string) => void) => () => void;
+  /** Send a cancellation request for an active stream. */
+  cancel: (streamId: string) => void;
 }
 
 /** EFS file-manager task endpoints: status, start, and stop per game. */

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -281,11 +281,13 @@ export interface GsdConfigApi {
 /**
  * Typed shape of `window.gsd` as exposed by the Electron preload script.
  *
- * Declare this on `Window` in a renderer-side `.d.ts` file:
+ * Declare this on `Window` in a renderer-side `.d.ts` file. Mark it optional
+ * (`gsd?`) — the bridge is absent in plain browser/web contexts, so runtime
+ * guards like `if (!window.gsd)` need it to be possibly-undefined:
  * ```ts
  * import type { GsdApi } from '@hyveon/desktop-preload/gsd-api';
  * declare global {
- *   interface Window { gsd: GsdApi; }
+ *   interface Window { gsd?: GsdApi; }
  * }
  * ```
  */

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -199,22 +199,16 @@ export interface GsdLogsApi {
   /** Returns recent log lines for a game's ECS task. */
   get: (game: string, limit?: number) => Promise<GameLogs>;
   /**
-   * Opens a live log stream for `game` via IPC and returns the opaque
-   * `streamId` used to subscribe to chunk/end events and to cancel the stream.
+   * Opens a live log stream for `game` as an async iterable of log chunks.
+   * Consume it with `for await (const chunk of stream(game, signal))`.
+   *
+   * Pass an `AbortSignal` to cancel the stream: aborting (or breaking out of
+   * the `for await` loop) tells the main process to stop tailing CloudWatch.
+   * The iterator completes when the stream ends and throws if it terminated
+   * due to an error. Internally this wraps the per-stream chunk/end/cancel IPC
+   * channels in an async generator.
    */
-  stream: (game: string) => Promise<{ streamId: string }>;
-  /**
-   * Subscribe to incoming log chunks for a stream. Returns a cleanup function
-   * that removes the listener when called.
-   */
-  onChunk: (streamId: string, cb: (chunk: string) => void) => () => void;
-  /**
-   * Subscribe to the end-of-stream notification. Returns a cleanup function.
-   * `err` is set when the stream terminated due to an error.
-   */
-  onEnd: (streamId: string, cb: (err?: string) => void) => () => void;
-  /** Send a cancellation request for an active stream. */
-  cancel: (streamId: string) => void;
+  stream: (game: string, signal?: AbortSignal) => AsyncIterable<LogChunk>;
 }
 
 /** EFS file-manager task endpoints: status, start, and stop per game. */

--- a/app/packages/desktop-preload/src/index.ts
+++ b/app/packages/desktop-preload/src/index.ts
@@ -2,7 +2,7 @@ export type { GsdApi } from './gsd-api.js';
 
 declare global {
   interface Window {
-    gsd: import('./gsd-api.js').GsdApi;
+    gsd?: import('./gsd-api.js').GsdApi;
   }
 }
 

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -32,7 +32,7 @@ const api: GsdApi = {
   },
 
   logs: {
-    get: (game: string, limit?: number) => ipcRenderer.invoke('logs.get', game, limit),
+    get: (game: string, limit?: number) => ipcRenderer.invoke('logs.get', { game, limit }),
     stream: (game: string) => ipcRenderer.invoke('logs.stream', game),
     onChunk: (streamId: string, cb: (chunk: string) => void) => {
       const ch = `logs.stream.${streamId}.chunk`;

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -8,14 +8,91 @@
  *
  * Channel naming convention: `<namespace>.<action>`
  *
- * Log streaming uses an invoke+event pattern: `logs.stream` invokes main to
- * start a stream and returns a `streamId`; `logs.onChunk` / `logs.onEnd`
- * subscribe to per-stream IPC events; `logs.cancel` sends a cancel signal.
+ * Log streaming exposes a single async iterable: `logs.stream(game, signal)`
+ * invokes main to open a stream (returning an opaque `streamId`), then wraps
+ * the per-stream `logs.stream.<id>.chunk` / `.end` IPC events in an async
+ * generator. Aborting the supplied `AbortSignal` — or breaking out of the
+ * `for await` loop — sends `logs.stream.<id>.cancel` to stop the main loop.
  */
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
-import type { GsdApi } from './gsd-api.js';
+import type { GsdApi, LogChunk } from './gsd-api.js';
+
+/**
+ * Bridges the per-stream chunk/end/cancel IPC channels into an
+ * {@link AsyncIterable} of log chunks.
+ *
+ * Opens the stream via `ipcRenderer.invoke('logs.stream', game)`, buffers
+ * incoming chunks, and yields them in order. Completes when the `.end` event
+ * fires (throwing if it carried an `error`). If the consumer aborts the
+ * `signal` or breaks out of the loop early, the `finally` block detaches all
+ * listeners and sends `.cancel` so the main process tears the stream down.
+ *
+ * The listener-attach happens after the `invoke` resolves with the `streamId`,
+ * which is the only point the chunk/end channel names are known — identical to
+ * the prior callback implementation, so there is no new dropped-chunk window.
+ */
+async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<LogChunk> {
+  const { streamId } = (await ipcRenderer.invoke('logs.stream', game)) as { streamId: string };
+  const chunkChannel = `logs.stream.${streamId}.chunk`;
+  const endChannel = `logs.stream.${streamId}.end`;
+  const sendCancel = () => ipcRenderer.send(`logs.stream.${streamId}.cancel`);
+
+  /** Chunks received but not yet yielded. */
+  const buffer: LogChunk[] = [];
+  let ended = false;
+  let endError: string | undefined;
+  /** Resolves the pending `await` when a chunk arrives or the stream ends. */
+  let wake: (() => void) | null = null;
+  const signalWake = () => {
+    if (wake) {
+      const fn = wake;
+      wake = null;
+      fn();
+    }
+  };
+
+  const onChunk = (_evt: IpcRendererEvent, chunk: LogChunk) => {
+    buffer.push(chunk);
+    signalWake();
+  };
+  const onEnd = (_evt: IpcRendererEvent, data: { error?: string }) => {
+    ended = true;
+    endError = data?.error;
+    signalWake();
+  };
+  const onAbort = () => sendCancel();
+
+  ipcRenderer.on(chunkChannel, onChunk);
+  ipcRenderer.once(endChannel, onEnd);
+  if (signal) {
+    if (signal.aborted) sendCancel();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
+
+  try {
+    while (true) {
+      while (buffer.length > 0) {
+        yield buffer.shift()!;
+      }
+      if (ended) {
+        if (endError) throw new Error(endError);
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  } finally {
+    ipcRenderer.removeListener(chunkChannel, onChunk);
+    ipcRenderer.removeListener(endChannel, onEnd);
+    signal?.removeEventListener('abort', onAbort);
+    // Consumer left before the stream ended (early break/return or abort) —
+    // tell the main process to stop tailing so it doesn't leak the loop.
+    if (!ended) sendCancel();
+  }
+}
 
 const api: GsdApi = {
   games: {
@@ -33,22 +110,7 @@ const api: GsdApi = {
 
   logs: {
     get: (game: string, limit?: number) => ipcRenderer.invoke('logs.get', { game, limit }),
-    stream: (game: string) => ipcRenderer.invoke('logs.stream', game),
-    onChunk: (streamId: string, cb: (chunk: string) => void) => {
-      const ch = `logs.stream.${streamId}.chunk`;
-      const handler = (_evt: IpcRendererEvent, chunk: string) => cb(chunk);
-      ipcRenderer.on(ch, handler);
-      return () => ipcRenderer.removeListener(ch, handler);
-    },
-    onEnd: (streamId: string, cb: (err?: string) => void) => {
-      const ch = `logs.stream.${streamId}.end`;
-      const handler = (_evt: IpcRendererEvent, data: { error?: string }) => cb(data?.error);
-      ipcRenderer.once(ch, handler);
-      return () => ipcRenderer.removeListener(ch, handler);
-    },
-    cancel: (streamId: string) => {
-      ipcRenderer.send(`logs.stream.${streamId}.cancel`);
-    },
+    stream: streamLogs,
   },
 
   files: {

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -13,7 +13,7 @@
  * via `ipcRenderer.on` in a dedicated channel if needed.
  */
 
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
 import type { GsdApi } from './gsd-api.js';
 
@@ -33,6 +33,22 @@ const api: GsdApi = {
 
   logs: {
     get: (game: string, limit?: number) => ipcRenderer.invoke('logs.get', game, limit),
+    stream: (game: string) => ipcRenderer.invoke('logs.stream', game),
+    onChunk: (streamId: string, cb: (chunk: string) => void) => {
+      const ch = `logs.stream.${streamId}.chunk`;
+      const handler = (_evt: IpcRendererEvent, chunk: string) => cb(chunk);
+      ipcRenderer.on(ch, handler);
+      return () => ipcRenderer.removeListener(ch, handler);
+    },
+    onEnd: (streamId: string, cb: (err?: string) => void) => {
+      const ch = `logs.stream.${streamId}.end`;
+      const handler = (_evt: IpcRendererEvent, data: { error?: string }) => cb(data?.error);
+      ipcRenderer.once(ch, handler);
+      return () => ipcRenderer.removeListener(ch, handler);
+    },
+    cancel: (streamId: string) => {
+      ipcRenderer.send(`logs.stream.${streamId}.cancel`);
+    },
   },
 
   files: {

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -8,9 +8,9 @@
  *
  * Channel naming convention: `<namespace>.<action>`
  *
- * SSE / streaming methods (e.g. `logs.stream`) are intentionally absent —
- * `ipcRenderer.invoke` is request/response only; wire streaming separately
- * via `ipcRenderer.on` in a dedicated channel if needed.
+ * Log streaming uses an invoke+event pattern: `logs.stream` invokes main to
+ * start a stream and returns a `streamId`; `logs.onChunk` / `logs.onEnd`
+ * subscribe to per-stream IPC events; `logs.cancel` sends a cancel signal.
  */
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -78,18 +78,25 @@ export interface StubOptions {
    */
   games?: string[];
   /**
-   * Initial log lines returned by `GET /api/logs/:game` (used by the Logs
-   * page). Maps game name → seeded lines. Games not present in the map
-   * receive an empty buffer. The SSE stream at `/api/logs/:game/stream` is
-   * always aborted so EventSource gives up immediately and tests don't hang
-   * on a never-ending response.
+   * Initial log lines surfaced via `window.gsd.logs.get(game)` (used by the
+   * Logs page). Maps game name → seeded lines. Games not present in the map
+   * receive an empty buffer.
+   *
+   * `stubApis` injects a `window.gsd.logs` stub via `addInitScript` so that
+   * `LogsPage` can call `window.gsd.logs.get` and `window.gsd.logs.stream`
+   * without a real Electron main process. The stream stub resolves immediately
+   * but never fires chunks, so specs drive off the seeded snapshot only.
    */
   logLines?: Record<string, string[]>;
 }
 
 /**
  * Registers Playwright route intercepts for all `/api/*` endpoints used by the
- * dashboard. Call before `page.goto()` in each spec that needs a running UI.
+ * dashboard, and injects a `window.gsd.logs` stub via `addInitScript` so the
+ * Logs page can call `window.gsd.logs.get` / `window.gsd.logs.stream` without
+ * a real Electron main process.
+ *
+ * Must be called before `page.goto()` in each spec that needs a running UI.
  *
  * Playwright matches routes in REVERSE registration order (last-registered
  * wins), so we register the catch-all FIRST and the specific stubs after —
@@ -176,16 +183,32 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
     route.fulfill({ json: { success: true, permissions: discord.gamePermissions } }),
   );
 
-  // Logs page — the SSE stream is aborted so EventSource gives up immediately.
-  // Specs that need to drive the stream can override this route after stubApis().
-  // The `/stream*` glob is registered AFTER `/api/logs/*` so it wins for SSE
-  // URLs (Playwright matches routes in reverse registration order).
-  await page.route('**/api/logs/*', (route) => {
-    const url = new URL(route.request().url());
-    const game = url.pathname.split('/').pop()!;
-    return route.fulfill({ json: { game, lines: logLines[game] ?? [] } });
-  });
-  await page.route('**/api/logs/*/stream*', (route) => route.abort());
+  // Logs page — inject a window.gsd.logs stub so LogsPage can call
+  // window.gsd.logs.get / window.gsd.logs.stream without a real Electron
+  // main process. The stub must be registered via addInitScript (runs before
+  // any page JS) and receives the seeded logLines map as a serialisable arg.
+  //
+  // The stream stub resolves immediately with a fixed streamId but never
+  // fires onChunk/onEnd events, so specs drive off the seeded snapshot only.
+  // onChunk / onEnd return no-op cleanup functions so the component's
+  // listener-registration code doesn't throw.
+  await page.addInitScript(
+    ({ lines }: { lines: Record<string, string[]> }) => {
+      const noop = () => () => {};
+      (window as Record<string, unknown>)['gsd'] = {
+        logs: {
+          get: (game: string) =>
+            Promise.resolve({ game, lines: lines[game] ?? [] }),
+          stream: (_game: string) =>
+            Promise.resolve({ streamId: 'e2e-stub-stream' }),
+          onChunk: noop,
+          onEnd: noop,
+          cancel: () => {},
+        },
+      };
+    },
+    { lines: logLines },
+  );
 }
 
 type E2EFixtures = {

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -84,8 +84,8 @@ export interface StubOptions {
    *
    * `stubApis` injects a `window.gsd.logs` stub via `addInitScript` so that
    * `LogsPage` can call `window.gsd.logs.get` and `window.gsd.logs.stream`
-   * without a real Electron main process. The stream stub resolves immediately
-   * but never fires chunks, so specs drive off the seeded snapshot only.
+   * without a real Electron main process. The stream stub is an async iterable
+   * that yields nothing, so specs drive off the seeded snapshot only.
    */
   logLines?: Record<string, string[]>;
 }
@@ -188,22 +188,16 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
   // main process. The stub must be registered via addInitScript (runs before
   // any page JS) and receives the seeded logLines map as a serialisable arg.
   //
-  // The stream stub resolves immediately with a fixed streamId but never
-  // fires onChunk/onEnd events, so specs drive off the seeded snapshot only.
-  // onChunk / onEnd return no-op cleanup functions so the component's
-  // listener-registration code doesn't throw.
+  // The stream stub is an async generator that yields nothing and returns
+  // immediately, so the component's `for await` loop completes without emitting
+  // live chunks — specs drive off the seeded snapshot only.
   await page.addInitScript(
     ({ lines }: { lines: Record<string, string[]> }) => {
-      const noop = () => () => {};
       (window as Record<string, unknown>)['gsd'] = {
         logs: {
           get: (game: string) =>
             Promise.resolve({ game, lines: lines[game] ?? [] }),
-          stream: (_game: string) =>
-            Promise.resolve({ streamId: 'e2e-stub-stream' }),
-          onChunk: noop,
-          onEnd: noop,
-          cancel: () => {},
+          stream: async function* (_game: string, _signal?: AbortSignal) {},
         },
       };
     },

--- a/app/packages/web/e2e/specs/logs.spec.ts
+++ b/app/packages/web/e2e/specs/logs.spec.ts
@@ -2,11 +2,12 @@ import { test, expect, stubApis, SAMPLE_LOG_LINES } from '../fixtures/index.js';
 
 /**
  * `/logs` route specs (issue #63). The Nest server is never started — every
- * `/api/*` call goes through Playwright route stubs. The SSE stream
- * (`/api/logs/:game/stream`) is aborted by the default `stubApis()` setup so
- * `EventSource` gives up immediately and tests don't hang on a never-ending
- * response. We then drive the page entirely off the seeded snapshot returned
- * by `GET /api/logs/:game`.
+ * `/api/*` call goes through Playwright route stubs. `LogsPage` now fetches
+ * its initial snapshot via `window.gsd.logs.get` (IPC bridge) instead of
+ * the HTTP API; `stubApis()` injects a `window.gsd.logs` stub via
+ * `addInitScript` that returns the seeded lines from `logLines` and resolves
+ * the stream call immediately without firing any chunks, so specs drive the
+ * page entirely off the seeded snapshot.
  */
 test.describe('logs page', () => {
   test('should render LIVE badge and seeded log lines', async ({ logs }) => {

--- a/app/packages/web/src/api.service.ts
+++ b/app/packages/web/src/api.service.ts
@@ -225,8 +225,6 @@ export const api = {
     }),
   costsEstimate: () => request<CostEstimates>('/api/costs/estimate'),
   costsActual: (days = 7) => request<ActualCosts>(`/api/costs/actual?days=${days}`),
-  logs: (game: string, limit = 50) =>
-    request<{ game: string; lines: string[] }>(`/api/logs/${game}?limit=${limit}`),
   filesMgrStatus: (game: string) => request<FileMgrStatus>(`/api/files/${game}`),
   filesMgrStart: (game: string) => request<ActionResult>(`/api/files/${game}/start`, { method: 'POST' }),
   filesMgrStop: (game: string) => request<ActionResult>(`/api/files/${game}/stop`, { method: 'POST' }),

--- a/app/packages/web/src/pages/logs.page.test.tsx
+++ b/app/packages/web/src/pages/logs.page.test.tsx
@@ -3,32 +3,29 @@ import { render, screen, waitFor, type RenderOptions } from '@testing-library/re
 import userEvent from '@testing-library/user-event';
 import { PollingProvider } from '../polling/polling-provider.component.js';
 
-// Mock the API client and the token reader so the component drives off
-// canned data instead of real fetch calls. `vi.mock` is hoisted above
-// the import, so the LogsPage import below picks up the stub.
+// Mock the API client so the component drives off canned data instead of real
+// fetch calls. `vi.mock` is hoisted above the import so LogsPage picks up the stub.
 const apiMock = vi.hoisted(() => ({
   games: vi.fn(),
-  logs: vi.fn(),
 }));
 vi.mock('../api.service.js', () => ({
   api: apiMock,
-  getStoredApiToken: () => '',
 }));
 
-// jsdom doesn't ship an EventSource implementation. Provide a minimal
-// stub so `new EventSource(url)` works; tests don't need to drive the
-// stream — the seeded snapshot is enough for these assertions.
-class MockEventSource {
-  url: string;
-  onmessage: ((e: MessageEvent) => void) | null = null;
-  constructor(url: string) {
-    this.url = url;
-  }
-  close(): void {
-    // noop
-  }
-}
-vi.stubGlobal('EventSource', MockEventSource);
+// Stub window.gsd.logs so the component can open IPC streams without a real
+// Electron main process. `stream` resolves immediately; `onChunk`/`onEnd`
+// return no-op cleanup functions so the component can register and deregister
+// listeners without throwing.
+const gsdMock = {
+  logs: {
+    get: vi.fn(),
+    stream: vi.fn(),
+    onChunk: vi.fn(),
+    onEnd: vi.fn(),
+    cancel: vi.fn(),
+  },
+};
+vi.stubGlobal('gsd', gsdMock);
 
 import { LogsPage } from './logs.page.js';
 
@@ -54,7 +51,10 @@ const SAMPLE_LINES = [
 describe('LogsPage', () => {
   beforeEach(() => {
     apiMock.games.mockResolvedValue({ games: ['minecraft'] });
-    apiMock.logs.mockResolvedValue({ game: 'minecraft', lines: SAMPLE_LINES });
+    gsdMock.logs.get.mockResolvedValue({ game: 'minecraft', lines: SAMPLE_LINES });
+    gsdMock.logs.stream.mockResolvedValue({ streamId: 'test-stream-id' });
+    gsdMock.logs.onChunk.mockReturnValue(() => {});
+    gsdMock.logs.onEnd.mockReturnValue(() => {});
   });
 
   it('should render the Server Logs heading and the LIVE badge', async () => {
@@ -137,12 +137,12 @@ describe('LogsPage', () => {
     expect(await screen.findByText(/^5 lines · oldest /)).toBeInTheDocument();
   });
 
-  it('should call api.logs(game) with the selected game on mount', async () => {
+  it('should call window.gsd.logs.get with the selected game on mount', async () => {
     renderWithProviders(<LogsPage />);
 
     await waitFor(() => {
       expect(apiMock.games).toHaveBeenCalled();
-      expect(apiMock.logs).toHaveBeenCalledWith('minecraft');
+      expect(gsdMock.logs.get).toHaveBeenCalledWith('minecraft');
     });
   });
 });

--- a/app/packages/web/src/pages/logs.page.test.tsx
+++ b/app/packages/web/src/pages/logs.page.test.tsx
@@ -13,16 +13,13 @@ vi.mock('../api.service.js', () => ({
 }));
 
 // Stub window.gsd.logs so the component can open IPC streams without a real
-// Electron main process. `stream` resolves immediately; `onChunk`/`onEnd`
-// return no-op cleanup functions so the component can register and deregister
-// listeners without throwing.
+// Electron main process. `stream(game, signal)` returns an async iterable; the
+// default stub (set in beforeEach) yields nothing so tests drive off the
+// seeded `get` snapshot. Individual tests override `stream` to emit chunks.
 const gsdMock = {
   logs: {
     get: vi.fn(),
     stream: vi.fn(),
-    onChunk: vi.fn(),
-    onEnd: vi.fn(),
-    cancel: vi.fn(),
   },
 };
 vi.stubGlobal('gsd', gsdMock);
@@ -52,9 +49,9 @@ describe('LogsPage', () => {
   beforeEach(() => {
     apiMock.games.mockResolvedValue({ games: ['minecraft'] });
     gsdMock.logs.get.mockResolvedValue({ game: 'minecraft', lines: SAMPLE_LINES });
-    gsdMock.logs.stream.mockResolvedValue({ streamId: 'test-stream-id' });
-    gsdMock.logs.onChunk.mockReturnValue(() => {});
-    gsdMock.logs.onEnd.mockReturnValue(() => {});
+    // Default stream emits nothing and ends immediately — tests assert on the
+    // seeded snapshot. Override per-test to drive live chunks through `for await`.
+    gsdMock.logs.stream.mockImplementation(async function* () {});
   });
 
   it('should render the Server Logs heading and the LIVE badge', async () => {
@@ -143,6 +140,27 @@ describe('LogsPage', () => {
     await waitFor(() => {
       expect(apiMock.games).toHaveBeenCalled();
       expect(gsdMock.logs.get).toHaveBeenCalledWith('minecraft');
+    });
+  });
+
+  it('should append live chunks yielded by the stream iterator after the seeded snapshot', async () => {
+    gsdMock.logs.stream.mockImplementation(async function* () {
+      yield '2026-05-03T12:00:05Z INFO Live chunk one';
+      yield '2026-05-03T12:00:06Z ERROR Live chunk two';
+    });
+    renderWithProviders(<LogsPage />);
+
+    // Seeded snapshot first, then the two chunks consumed via `for await`.
+    await screen.findByText(/Server started on port 25565/);
+    expect(await screen.findByText(/Live chunk one/)).toBeInTheDocument();
+    expect(await screen.findByText(/Live chunk two/)).toBeInTheDocument();
+  });
+
+  it('should pass the selected game and an AbortSignal to stream', async () => {
+    renderWithProviders(<LogsPage />);
+
+    await waitFor(() => {
+      expect(gsdMock.logs.stream).toHaveBeenCalledWith('minecraft', expect.any(AbortSignal));
     });
   });
 });

--- a/app/packages/web/src/pages/logs.page.tsx
+++ b/app/packages/web/src/pages/logs.page.tsx
@@ -173,8 +173,19 @@ export function LogsPage() {
         const removeEnd = window.gsd.logs.onEnd(streamId, (err) => {
           if (err) setError(`Stream ended with error: ${err}`);
           streamIdRef.current = null;
+          cleanupRef.current.forEach(fn => fn());
           cleanupRef.current = [];
         });
+        // Guard against a stopStream call (or onEnd firing) that ran between
+        // the `if (cancelled)` check above and here: if cancelled is now true,
+        // cleanupRef is already empty so removeChunk would be orphaned.
+        // Remove both listeners directly and cancel the stream instead.
+        if (cancelled) {
+          removeChunk();
+          removeEnd();
+          window.gsd.logs.cancel(streamId);
+          return;
+        }
         cleanupRef.current = [removeChunk, removeEnd];
       });
     },

--- a/app/packages/web/src/pages/logs.page.tsx
+++ b/app/packages/web/src/pages/logs.page.tsx
@@ -97,8 +97,9 @@ function HighlightedLine({ text, query }: { text: string; query: string }) {
 
 /**
  * Logs route (`/logs`) — full-page tailing of CloudWatch logs for a single
- * game. Fetches an initial snapshot via `window.gsd.logs.get`, then opens a
- * live IPC stream via `window.gsd.logs.stream`. Surfaces the stream through:
+ * game. Fetches an initial snapshot via `window.gsd.logs.get`, then consumes
+ * a live IPC stream via `for await (… of window.gsd.logs.stream(game, signal))`,
+ * cancelling through an `AbortController`. Surfaces the stream through:
  *
  *   - A LIVE/PAUSED status badge (pulsing cyan / muted slate).
  *   - A searchable game selector that resets the buffer on switch.
@@ -127,9 +128,8 @@ export function LogsPage() {
   const [bufferedCount, setBufferedCount] = useState(0);
 
   const boxRef = useRef<HTMLDivElement>(null);
-  const streamIdRef = useRef<string | null>(null);
-  /** Cleanup fns registered by the current startStream call (listener removes + cancel-on-pending). */
-  const cleanupRef = useRef<Array<() => void>>([]);
+  /** Aborts the in-flight `for await` log stream; aborting also tells the main process to cancel. */
+  const abortRef = useRef<AbortController | null>(null);
   const pausedRef = useRef(false);
   const bufferRef = useRef<LogLine[]>([]);
 
@@ -147,16 +147,8 @@ export function LogsPage() {
   }, []);
 
   const stopStream = useCallback(() => {
-    if (streamIdRef.current) {
-      if (!window.gsd) {
-        streamIdRef.current = null;
-      } else {
-        window.gsd.logs.cancel(streamIdRef.current);
-        streamIdRef.current = null;
-      }
-    }
-    cleanupRef.current.forEach((fn) => fn());
-    cleanupRef.current = [];
+    abortRef.current?.abort();
+    abortRef.current = null;
   }, []);
 
   const startStream = useCallback(
@@ -166,43 +158,22 @@ export function LogsPage() {
         return;
       }
       stopStream();
-      // Closure-scoped flag so a stopStream call that arrives while the IPC
-      // invoke is in-flight can abort the stream before listeners are wired.
-      let cancelled = false;
-      cleanupRef.current = [() => { cancelled = true; }];
+      const ac = new AbortController();
+      abortRef.current = ac;
 
-      void window.gsd.logs
-        .stream(game)
-        .then(({ streamId }) => {
-          if (cancelled) {
-            window.gsd?.logs.cancel(streamId);
-            return;
+      void (async () => {
+        try {
+          for await (const chunk of window.gsd!.logs.stream(game, ac.signal)) {
+            if (ac.signal.aborted) break;
+            appendLine(chunk);
           }
-          streamIdRef.current = streamId;
-          const removeChunk = window.gsd!.logs.onChunk(streamId, appendLine);
-          const removeEnd = window.gsd!.logs.onEnd(streamId, (err) => {
-            if (err) setError(`Stream ended with error: ${err}`);
-            streamIdRef.current = null;
-            cleanupRef.current.forEach(fn => fn());
-            cleanupRef.current = [];
-          });
-          // Guard against a stopStream call (or onEnd firing) that ran between
-          // the `if (cancelled)` check above and here: if cancelled is now true,
-          // cleanupRef is already empty so removeChunk would be orphaned.
-          // Remove both listeners directly and cancel the stream instead.
-          if (cancelled) {
-            removeChunk();
-            removeEnd();
-            window.gsd?.logs.cancel(streamId);
-            return;
-          }
-          cleanupRef.current = [removeChunk, removeEnd];
-        })
-        .catch((err: unknown) => {
-          if (cancelled) return;
+        } catch (err: unknown) {
+          // An abort tears the iterator down without a real failure — ignore it.
+          if (ac.signal.aborted) return;
           const message = err instanceof Error ? err.message : String(err);
-          setError(`Could not start log stream: ${message}`);
-        });
+          setError(`Stream ended with error: ${message}`);
+        }
+      })();
     },
     [stopStream, appendLine],
   );

--- a/app/packages/web/src/pages/logs.page.tsx
+++ b/app/packages/web/src/pages/logs.page.tsx
@@ -148,8 +148,12 @@ export function LogsPage() {
 
   const stopStream = useCallback(() => {
     if (streamIdRef.current) {
-      window.gsd.logs.cancel(streamIdRef.current);
-      streamIdRef.current = null;
+      if (!window.gsd) {
+        streamIdRef.current = null;
+      } else {
+        window.gsd.logs.cancel(streamIdRef.current);
+        streamIdRef.current = null;
+      }
     }
     cleanupRef.current.forEach((fn) => fn());
     cleanupRef.current = [];
@@ -157,6 +161,10 @@ export function LogsPage() {
 
   const startStream = useCallback(
     (game: string) => {
+      if (!window.gsd) {
+        setError('IPC bridge (window.gsd) is not available in this context.');
+        return;
+      }
       stopStream();
       // Closure-scoped flag so a stopStream call that arrives while the IPC
       // invoke is in-flight can abort the stream before listeners are wired.
@@ -167,12 +175,12 @@ export function LogsPage() {
         .stream(game)
         .then(({ streamId }) => {
           if (cancelled) {
-            window.gsd.logs.cancel(streamId);
+            window.gsd?.logs.cancel(streamId);
             return;
           }
           streamIdRef.current = streamId;
-          const removeChunk = window.gsd.logs.onChunk(streamId, appendLine);
-          const removeEnd = window.gsd.logs.onEnd(streamId, (err) => {
+          const removeChunk = window.gsd!.logs.onChunk(streamId, appendLine);
+          const removeEnd = window.gsd!.logs.onEnd(streamId, (err) => {
             if (err) setError(`Stream ended with error: ${err}`);
             streamIdRef.current = null;
             cleanupRef.current.forEach(fn => fn());
@@ -185,7 +193,7 @@ export function LogsPage() {
           if (cancelled) {
             removeChunk();
             removeEnd();
-            window.gsd.logs.cancel(streamId);
+            window.gsd?.logs.cancel(streamId);
             return;
           }
           cleanupRef.current = [removeChunk, removeEnd];
@@ -244,6 +252,10 @@ export function LogsPage() {
 
     let cancelled = false;
     void (async () => {
+      if (!window.gsd) {
+        if (!cancelled) setError('IPC bridge (window.gsd) is not available in this context.');
+        return;
+      }
       try {
         const data = await window.gsd.logs.get(selectedGame);
         if (cancelled) return;

--- a/app/packages/web/src/pages/logs.page.tsx
+++ b/app/packages/web/src/pages/logs.page.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Filter, Pause, Play, Search } from 'lucide-react';
-import { api, getStoredApiToken } from '../api.service.js';
+import { api } from '../api.service.js';
 import { Badge } from '../components/ui/badge.component.js';
 import { Button } from '../components/ui/button.component.js';
 import { Input } from '../components/ui/input.component.js';
@@ -97,9 +97,8 @@ function HighlightedLine({ text, query }: { text: string; query: string }) {
 
 /**
  * Logs route (`/logs`) — full-page tailing of CloudWatch logs for a single
- * game. Owns the same SSE plumbing the old `LogsPanel` had (initial snapshot
- * via `/api/logs/:game`, then EventSource on `/api/logs/:game/stream`), but
- * surfaces it through:
+ * game. Fetches an initial snapshot via `window.gsd.logs.get`, then opens a
+ * live IPC stream via `window.gsd.logs.stream`. Surfaces the stream through:
  *
  *   - A LIVE/PAUSED status badge (pulsing cyan / muted slate).
  *   - A searchable game selector that resets the buffer on switch.
@@ -128,7 +127,9 @@ export function LogsPage() {
   const [bufferedCount, setBufferedCount] = useState(0);
 
   const boxRef = useRef<HTMLDivElement>(null);
-  const esRef = useRef<EventSource | null>(null);
+  const streamIdRef = useRef<string | null>(null);
+  /** Cleanup fns registered by the current startStream call (listener removes + cancel-on-pending). */
+  const cleanupRef = useRef<Array<() => void>>([]);
   const pausedRef = useRef(false);
   const bufferRef = useRef<LogLine[]>([]);
 
@@ -146,29 +147,36 @@ export function LogsPage() {
   }, []);
 
   const stopStream = useCallback(() => {
-    if (esRef.current) {
-      esRef.current.close();
-      esRef.current = null;
+    if (streamIdRef.current) {
+      window.gsd.logs.cancel(streamIdRef.current);
+      streamIdRef.current = null;
     }
+    cleanupRef.current.forEach((fn) => fn());
+    cleanupRef.current = [];
   }, []);
 
   const startStream = useCallback(
     (game: string) => {
       stopStream();
-      const token = getStoredApiToken();
-      const url = `/api/logs/${game}/stream${token ? `?token=${encodeURIComponent(token)}` : ''}`;
-      const es = new EventSource(url);
+      // Closure-scoped flag so a stopStream call that arrives while the IPC
+      // invoke is in-flight can abort the stream before listeners are wired.
+      let cancelled = false;
+      cleanupRef.current = [() => { cancelled = true; }];
 
-      es.onmessage = (e: MessageEvent) => {
-        try {
-          const data = JSON.parse(e.data as string) as { line: string };
-          appendLine(data.line);
-        } catch {
-          // ignore malformed events
+      void window.gsd.logs.stream(game).then(({ streamId }) => {
+        if (cancelled) {
+          window.gsd.logs.cancel(streamId);
+          return;
         }
-      };
-
-      esRef.current = es;
+        streamIdRef.current = streamId;
+        const removeChunk = window.gsd.logs.onChunk(streamId, appendLine);
+        const removeEnd = window.gsd.logs.onEnd(streamId, (err) => {
+          if (err) setError(`Stream ended with error: ${err}`);
+          streamIdRef.current = null;
+          cleanupRef.current = [];
+        });
+        cleanupRef.current = [removeChunk, removeEnd];
+      });
     },
     [stopStream, appendLine],
   );
@@ -219,7 +227,7 @@ export function LogsPage() {
     let cancelled = false;
     void (async () => {
       try {
-        const data = await api.logs(selectedGame);
+        const data = await window.gsd.logs.get(selectedGame);
         if (cancelled) return;
         const seeded: LogLine[] = data.lines.map((text) => ({
           text,

--- a/app/packages/web/src/pages/logs.page.tsx
+++ b/app/packages/web/src/pages/logs.page.tsx
@@ -163,31 +163,38 @@ export function LogsPage() {
       let cancelled = false;
       cleanupRef.current = [() => { cancelled = true; }];
 
-      void window.gsd.logs.stream(game).then(({ streamId }) => {
-        if (cancelled) {
-          window.gsd.logs.cancel(streamId);
-          return;
-        }
-        streamIdRef.current = streamId;
-        const removeChunk = window.gsd.logs.onChunk(streamId, appendLine);
-        const removeEnd = window.gsd.logs.onEnd(streamId, (err) => {
-          if (err) setError(`Stream ended with error: ${err}`);
-          streamIdRef.current = null;
-          cleanupRef.current.forEach(fn => fn());
-          cleanupRef.current = [];
+      void window.gsd.logs
+        .stream(game)
+        .then(({ streamId }) => {
+          if (cancelled) {
+            window.gsd.logs.cancel(streamId);
+            return;
+          }
+          streamIdRef.current = streamId;
+          const removeChunk = window.gsd.logs.onChunk(streamId, appendLine);
+          const removeEnd = window.gsd.logs.onEnd(streamId, (err) => {
+            if (err) setError(`Stream ended with error: ${err}`);
+            streamIdRef.current = null;
+            cleanupRef.current.forEach(fn => fn());
+            cleanupRef.current = [];
+          });
+          // Guard against a stopStream call (or onEnd firing) that ran between
+          // the `if (cancelled)` check above and here: if cancelled is now true,
+          // cleanupRef is already empty so removeChunk would be orphaned.
+          // Remove both listeners directly and cancel the stream instead.
+          if (cancelled) {
+            removeChunk();
+            removeEnd();
+            window.gsd.logs.cancel(streamId);
+            return;
+          }
+          cleanupRef.current = [removeChunk, removeEnd];
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          const message = err instanceof Error ? err.message : String(err);
+          setError(`Could not start log stream: ${message}`);
         });
-        // Guard against a stopStream call (or onEnd firing) that ran between
-        // the `if (cancelled)` check above and here: if cancelled is now true,
-        // cleanupRef is already empty so removeChunk would be orphaned.
-        // Remove both listeners directly and cancel the stream instead.
-        if (cancelled) {
-          removeChunk();
-          removeEnd();
-          window.gsd.logs.cancel(streamId);
-          return;
-        }
-        cleanupRef.current = [removeChunk, removeEnd];
-      });
     },
     [stopStream, appendLine],
   );

--- a/app/packages/web/src/window.d.ts
+++ b/app/packages/web/src/window.d.ts
@@ -1,0 +1,10 @@
+import type { GsdApi } from '@hyveon/desktop-preload';
+
+declare global {
+  interface Window {
+    /** IPC bridge injected by the Electron preload script. Absent in browser/web contexts. */
+    gsd?: GsdApi;
+  }
+}
+
+export {};


### PR DESCRIPTION
$(cat <<'EOF'
Closes #154

## Summary

- Replace the SSE `GET /api/logs/:game/stream` endpoint with an IPC streaming channel: `window.gsd.logs.stream(game)` → `{ streamId }`, main process pushes chunks over `logs.stream.${streamId}.chunk` and terminates with `logs.stream.${streamId}.end`
- `LogsController` now implements `OnModuleInit` to register an `ipcMain.handle('logs.stream', ...)` bridge (required because `@MessagePattern` alone only wires the transport's internal dispatcher — `ipcRenderer.invoke` would otherwise hang)
- Per-stream `AbortController` allows renderer-side cancellation via `ipcRenderer.send('logs.stream.${streamId}.cancel')`; chunks are pushed via `WebContents.send` with a destroyed-sender guard
- Preload (`desktop-preload`) extended with `stream`, `onChunk`, `onEnd`, `cancel` on the `logs` namespace; `GsdLogsApi` interface updated accordingly
- `LogsPage` rewritten to use IPC: `window.gsd.logs.get` for snapshot, `window.gsd.logs.stream` + `onChunk`/`onEnd` for live tail; `api.logs` removed from `api.service.ts`
- Playwright e2e `stubApis` updated: replaces `/api/logs/*` route stubs with an `addInitScript` `window.gsd.logs` injection so Logs page tests work without an Electron process

## Test plan

- [ ] 587 unit/integration tests pass (`npm run app:test`)
- [ ] `LogsController` unit tests cover: `ipcMain.handle` registration, `onModuleInit`, chunk delivery via `sender.send`, clean end, abort/cancel path, non-abort error end message, destroyed-WebContents guard
- [ ] `LogsPage` unit tests cover: snapshot render, level badges, pause/resume, search highlight, level filter, footer line count, `window.gsd.logs.get` called on mount
- [ ] E2E logs specs (`logs.spec.ts`) pass against the `addInitScript` stub
- [ ] No SSE routes remain — `logs` removed from `api.service.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)