### PR TITLE
test: cap Vitest fork pool to prevent OOM on high-core hosts

### DIFF
--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -19,6 +19,22 @@ export default defineConfig({
     },
   },
   test: {
+    // Cap the worker pool so the suite can't fan out to one process per core.
+    // On high-core dev boxes (e.g. 32 cores) the default span one worker per
+    // core, each ballooning to ~1 GB under jsdom + large module graphs, which
+    // exhausts RAM/swap and OOMs the machine. The `forks` pool also reclaims
+    // memory better between files than the default `threads` pool. Four forks
+    // (~4 GB) keeps the suite fast without starving the host; CI boxes with
+    // fewer cores are unaffected since the cap is only an upper bound.
+    pool: 'forks',
+    maxWorkers: 4,
+    minWorkers: 1,
+    poolOptions: {
+      forks: {
+        maxForks: 4,
+        minForks: 1,
+      },
+    },
     include: [
       'packages/**/*.test.{ts,tsx}',
       // Explicitly include desktop-preload specs so they are always discovered.

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   },
   test: {
     // Cap the worker pool so the suite can't fan out to one process per core.
-    // On high-core dev boxes (e.g. 32 cores) the default span one worker per
+    // On high-core dev boxes (e.g. 32 cores) the default spawns one worker per
     // core, each ballooning to ~1 GB under jsdom + large module graphs, which
     // exhausts RAM/swap and OOMs the machine. The `forks` pool also reclaims
     // memory better between files than the default `threads` pool. Four forks


### PR DESCRIPTION
## Summary

Vitest defaulted to one worker process per CPU core. On a 32-core dev box that spawned ~31 `node (vitest N)` workers, each ballooning to ~1 GB under jsdom plus large module graphs — roughly **31 GB demand against a 24 GB cap**, exhausting swap (16/16 GB) and OOM-killing the host (load average ~39 on 32 cores).

This pins the test pool so it can no longer fan out to one process per core:

```ts
pool: 'forks',
maxWorkers: 4,
minWorkers: 1,
poolOptions: { forks: { maxForks: 4, minForks: 1 } },
```

- **4 forks (~4 GB)** instead of ~31 GB — the cap is an upper bound, so lower-core CI runners are unaffected.
- **`forks` pool** reclaims memory better between files than the default `threads` pool, which matters for the jsdom-heavy `@hyveon/web` specs.

## Why

This is the failure mode that froze the machine during `npm run app:test`. Capping parallelism in committed config means it can't recur for anyone running the suite locally.

## Test plan

- [x] `npx vitest run` — **560 tests / 56 files passing** in ~8s with the capped pool
- [x] Confirmed worker count no longer scales to core count

🤖 Generated with [Claude Code](https://claude.com/claude-code)