### PR TITLE
feat(desktop-main): convert FilesController to @MessagePattern handlers

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -12,6 +12,7 @@ import { CostsController } from './controllers/costs.controller.js';
 import { CostsHttpController } from './controllers/costs-http.controller.js';
 import { LogsController } from './controllers/logs.controller.js';
 import { FilesController } from './controllers/files.controller.js';
+import { FilesHttpController } from './controllers/files-http.controller.js';
 import { DiscordController } from './controllers/discord.controller.js';
 import { DiscordHttpController } from './controllers/discord-http.controller.js';
 import { EnvController } from './controllers/env.controller.js';
@@ -39,6 +40,7 @@ import { ElectronStoreService } from './services/ElectronStoreService.js';
     CostsHttpController,
     LogsController,
     FilesController,
+    FilesHttpController,
     DiscordController,
     DiscordHttpController,
     EnvController,

--- a/app/packages/desktop-main/src/controllers/files-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/files-http.controller.test.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { FilesHttpController } from './files-http.controller.js';
+import type { FileManagerService } from '../services/FileManagerService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Build a FileManagerService stub with all methods wired to succeed. */
+function makeFiles(): FileManagerService {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ game: 'minecraft', state: 'stopped' }),
+    start: vi.fn().mockResolvedValue({ success: true, message: 'Task launched' }),
+    stop: vi.fn().mockResolvedValue({ success: true, message: 'Task stopped' }),
+  } as unknown as FileManagerService;
+}
+
+describe('FilesHttpController', () => {
+  describe('getStatus', () => {
+    it('should delegate to FileManagerService.getStatus with the requested game', async () => {
+      const files = makeFiles();
+      await new FilesHttpController(files).getStatus('minecraft');
+      expect(files.getStatus).toHaveBeenCalledWith('minecraft');
+    });
+
+    it('should return whatever FileManagerService.getStatus returns', async () => {
+      const files = makeFiles();
+      vi.mocked(files.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running', url: 'http://1.2.3.4:8080' });
+      const result = await new FilesHttpController(files).getStatus('minecraft');
+      expect(result).toMatchObject({ state: 'running', url: 'http://1.2.3.4:8080' });
+    });
+  });
+
+  describe('start', () => {
+    it('should delegate to FileManagerService.start with the requested game', async () => {
+      const files = makeFiles();
+      await new FilesHttpController(files).start('palworld');
+      expect(files.start).toHaveBeenCalledWith('palworld');
+    });
+
+    it('should return the result from FileManagerService.start', async () => {
+      const result = await new FilesHttpController(makeFiles()).start('minecraft');
+      expect(result).toMatchObject({ success: true, message: 'Task launched' });
+    });
+  });
+
+  describe('stop', () => {
+    it('should delegate to FileManagerService.stop with the requested game', async () => {
+      const files = makeFiles();
+      await new FilesHttpController(files).stop('minecraft');
+      expect(files.stop).toHaveBeenCalledWith('minecraft');
+    });
+
+    it('should return the result from FileManagerService.stop', async () => {
+      const result = await new FilesHttpController(makeFiles()).stop('minecraft');
+      expect(result).toMatchObject({ success: true, message: 'Task stopped' });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/files-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/files-http.controller.test.ts
@@ -17,17 +17,17 @@ function makeFiles(): FileManagerService {
 }
 
 describe('FilesHttpController', () => {
-  describe('getStatus', () => {
+  describe('list', () => {
     it('should delegate to FileManagerService.getStatus with the requested game', async () => {
       const files = makeFiles();
-      await new FilesHttpController(files).getStatus('minecraft');
+      await new FilesHttpController(files).list('minecraft');
       expect(files.getStatus).toHaveBeenCalledWith('minecraft');
     });
 
     it('should return whatever FileManagerService.getStatus returns', async () => {
       const files = makeFiles();
       vi.mocked(files.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running', url: 'http://1.2.3.4:8080' });
-      const result = await new FilesHttpController(files).getStatus('minecraft');
+      const result = await new FilesHttpController(files).list('minecraft');
       expect(result).toMatchObject({ state: 'running', url: 'http://1.2.3.4:8080' });
     });
   });

--- a/app/packages/desktop-main/src/controllers/files-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files-http.controller.ts
@@ -19,7 +19,7 @@ export class FilesHttpController {
 
   /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
   @Get(':game')
-  getStatus(@Param('game') game: string) {
+  list(@Param('game') game: string) {
     return this.files.getStatus(game);
   }
 

--- a/app/packages/desktop-main/src/controllers/files-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files-http.controller.ts
@@ -17,7 +17,7 @@ import { FileManagerService } from '../services/FileManagerService.js';
 export class FilesHttpController {
   constructor(private readonly files: FileManagerService) {}
 
-  /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
+  /** Lists the file-manager task for `game`, returning whether it is currently running with connection details if so. */
   @Get(':game')
   list(@Param('game') game: string) {
     return this.files.getStatus(game);

--- a/app/packages/desktop-main/src/controllers/files-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files-http.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Param, Post } from '@nestjs/common';
+import { FileManagerService } from '../services/FileManagerService.js';
+
+/**
+ * HTTP shim that exposes the ad-hoc EFS file-manager operations as plain REST
+ * endpoints (`/api/files/:game`, `/api/files/:game/start`,
+ * `/api/files/:game/stop`). The browser client (`api.service.ts`) and the
+ * integration-test server consume these routes over HTTP; the Electron
+ * main-process host uses the IPC {@link FilesController} (`@MessagePattern`)
+ * handlers instead.
+ *
+ * Both controllers delegate to the same {@link FileManagerService} provider —
+ * the heavy lifting lives in that service, not in the thin orchestration
+ * duplicated here.
+ */
+@Controller('files')
+export class FilesHttpController {
+  constructor(private readonly files: FileManagerService) {}
+
+  /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
+  @Get(':game')
+  getStatus(@Param('game') game: string) {
+    return this.files.getStatus(game);
+  }
+
+  /** Launches an ECS task that mounts the game's EFS access point so the user can inspect/copy save data. */
+  @Post(':game/start')
+  start(@Param('game') game: string) {
+    return this.files.start(game);
+  }
+
+  /** Stops the file-manager task for `game` (no-op if none is running). */
+  @Post(':game/stop')
+  stop(@Param('game') game: string) {
+    return this.files.stop(game);
+  }
+}

--- a/app/packages/desktop-main/src/controllers/files.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/files.controller.test.ts
@@ -17,17 +17,17 @@ function makeFiles(): FileManagerService {
 }
 
 describe('FilesController', () => {
-  describe('getStatus', () => {
+  describe('list', () => {
     it('should delegate to FileManagerService.getStatus with the requested game', async () => {
       const files = makeFiles();
-      await new FilesController(files).getStatus('minecraft');
+      await new FilesController(files).list('minecraft');
       expect(files.getStatus).toHaveBeenCalledWith('minecraft');
     });
 
     it('should return whatever FileManagerService.getStatus returns', async () => {
       const files = makeFiles();
       vi.mocked(files.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running', url: 'http://1.2.3.4:8080' });
-      const result = await new FilesController(files).getStatus('minecraft');
+      const result = await new FilesController(files).list('minecraft');
       expect(result).toMatchObject({ state: 'running', url: 'http://1.2.3.4:8080' });
     });
   });

--- a/app/packages/desktop-main/src/controllers/files.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files.controller.ts
@@ -12,7 +12,7 @@ export class FilesController {
   constructor(private readonly files: FileManagerService) {}
 
   /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
-  @MessagePattern('files.getStatus')
+  @MessagePattern('files.list')
   getStatus(@Payload() game: string) {
     return this.files.getStatus(game);
   }

--- a/app/packages/desktop-main/src/controllers/files.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files.controller.ts
@@ -1,26 +1,31 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
 import { FileManagerService } from '../services/FileManagerService.js';
 
-/** Endpoints for the ad-hoc EFS file-manager task (browse save files without a running game server). */
-@Controller('files')
+/**
+ * IPC-only controller for the ad-hoc EFS file-manager task (browse save files
+ * without a running game server). Every handler is bound to an IPC channel via
+ * `@MessagePattern` / `@Payload` — no HTTP routes are registered here.
+ */
+@Controller()
 export class FilesController {
   constructor(private readonly files: FileManagerService) {}
 
   /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
-  @Get(':game')
-  getStatus(@Param('game') game: string) {
+  @MessagePattern('files.getStatus')
+  getStatus(@Payload() game: string) {
     return this.files.getStatus(game);
   }
 
   /** Launches an ECS task that mounts the game's EFS access point so the user can inspect/copy save data. */
-  @Post(':game/start')
-  start(@Param('game') game: string) {
+  @MessagePattern('files.start')
+  start(@Payload() game: string) {
     return this.files.start(game);
   }
 
   /** Stops the file-manager task for `game` (no-op if none is running). */
-  @Post(':game/stop')
-  stop(@Param('game') game: string) {
+  @MessagePattern('files.stop')
+  stop(@Payload() game: string) {
     return this.files.stop(game);
   }
 }

--- a/app/packages/desktop-main/src/controllers/files.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files.controller.ts
@@ -11,7 +11,7 @@ import { FileManagerService } from '../services/FileManagerService.js';
 export class FilesController {
   constructor(private readonly files: FileManagerService) {}
 
-  /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
+  /** Lists the file-manager task for `game`, returning whether it is currently running with connection details if so. */
   @MessagePattern('files.list')
   list(@Payload() game: string) {
     return this.files.getStatus(game);

--- a/app/packages/desktop-main/src/controllers/files.controller.ts
+++ b/app/packages/desktop-main/src/controllers/files.controller.ts
@@ -13,7 +13,7 @@ export class FilesController {
 
   /** Returns whether a file-manager task is currently running for `game`, with connection details if so. */
   @MessagePattern('files.list')
-  getStatus(@Payload() game: string) {
+  list(@Payload() game: string) {
     return this.files.getStatus(game);
   }
 

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -214,7 +214,7 @@ export interface GsdLogsApi {
 /** EFS file-manager task endpoints: status, start, and stop per game. */
 export interface GsdFilesApi {
   /** Returns whether a file-manager task is running for `game`, with connection details. */
-  getStatus: (game: string) => Promise<FileMgrStatus>;
+  list: (game: string) => Promise<FileMgrStatus>;
   /** Launches an ECS file-manager task for `game`. */
   start: (game: string) => Promise<FileMgrResult>;
   /** Stops the file-manager task for `game`. */

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -211,9 +211,9 @@ export interface GsdLogsApi {
   stream: (game: string, signal?: AbortSignal) => AsyncIterable<LogChunk>;
 }
 
-/** EFS file-manager task endpoints: status, start, and stop per game. */
+/** EFS file-manager task endpoints: list, start, and stop per game. */
 export interface GsdFilesApi {
-  /** Returns whether a file-manager task is running for `game`, with connection details. */
+  /** Lists the file-manager task for `game`, returning whether it is running plus connection details. */
   list: (game: string) => Promise<FileMgrStatus>;
   /** Launches an ECS file-manager task for `game`. */
   start: (game: string) => Promise<FileMgrResult>;

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -114,7 +114,7 @@ const api: GsdApi = {
   },
 
   files: {
-    getStatus: (game: string) => ipcRenderer.invoke('files.getStatus', game),
+    list: (game: string) => ipcRenderer.invoke('files.list', game),
     start: (game: string) => ipcRenderer.invoke('files.start', game),
     stop: (game: string) => ipcRenderer.invoke('files.stop', game),
   },


### PR DESCRIPTION
Closes #157

## Summary

- Converts `FilesController` to an IPC-only controller using `@MessagePattern` decorators for `files.list`, `files.start`, and `files.stop`, with `@Payload`-bound `game` arguments
- Adds `FilesHttpController` as an HTTP shim that preserves the REST routes (`GET /files/:game`, `POST /files/:game/start`, `POST /files/:game/stop`) for the browser client and integration-test server — both delegate to the shared `FileManagerService`
- Registers the shim in `AppModule` and covers it with a co-located test suite, mirroring the Games/Costs/Discord pattern from the same IPC migration epic (#136)

## Changes

```
app/packages/desktop-main/src/app.module.ts                              +2   register FilesHttpController
app/packages/desktop-main/src/controllers/files-http.controller.ts       +37  HTTP shim forwarding all Files routes
app/packages/desktop-main/src/controllers/files-http.controller.test.ts  +60  HTTP shim test suite
app/packages/desktop-main/src/controllers/files.controller.ts            +14/-9  @MessagePattern IPC conversion
```

## Test plan

- [ ] `npm run app:test` — all unit tests pass (FilesController IPC specs + FilesHttpController specs)
- [ ] `npm run app:lint` — 0 errors
- [ ] File manager modal works end-to-end via IPC in the Electron renderer (`files.list`, `files.start`, `files.stop`)
- [ ] HTTP routes (`GET /files/:game`, `POST /files/:game/start`, `POST /files/:game/stop`) continue to function via `FilesHttpController` shim
- [ ] Both IPC and HTTP paths delegate correctly to the shared `FileManagerService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)