### PR TITLE
chore: enable pr-agent push trigger

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,4 +1,5 @@
 [github_app]
+handle_push_trigger = true
 pr_commands = [
     "/agentic_describe",
     "/agentic_review"


### PR DESCRIPTION
Adds `handle_push_trigger = true` to the existing `[github_app]` table in `.pr_agent.toml` so the PR agent (qodo) re-runs its review on pushes, not only when a PR is opened.

Merged into the existing table rather than adding a second `[github_app]` header (duplicate TOML table headers are invalid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)