### PR TITLE
feat(test): test-only window.gsd.__test.mock() injected by preload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,30 @@ The test suite has three complementary tiers:
 - Use the `authedPage` fixture (token pre-seeded in localStorage) only when a spec needs raw `Page` access (e.g. to call `stubApis` or `addInitScript`); otherwise prefer the higher-level page-object fixtures.
 - Stubs must cover every `/api/*` endpoint the page hits, or the catch-all returns 404 and the test will surface the missing stub quickly.
 
+**Electron e2e IPC mock seam (`window.gsd.__test.mock`):**
+
+The Electron project in Playwright launches the packaged app via `_electron.launch()` with `HYVEON_TEST_MODE=1` in the process environment (set in `playwright.config.ts:electronEnv`). That env var gates two things:
+
+1. **Main process** (`desktop-main/src/electron-entry.ts`) logs `[desktop-main] HYVEON_TEST_MODE active — test seam enabled` at startup. The window still opens normally — the flag is informational, not a behaviour switch, so `_electron.launch()` can drive the real UI.
+2. **Preload script** (`desktop-preload/src/preload.ts`) checks `process.env.HYVEON_TEST_MODE === '1'` before attaching the `__test` namespace to the `gsd` bridge. When the flag is set the bridge gains:
+
+   ```ts
+   window.gsd.__test.mock(channel, handler)
+   ```
+
+   `channel` is an IPC channel string (e.g. `'games.list'`). `handler` is a replacement function or a plain value. Thereafter, every `invoke(channel, ...args)` call in the preload consults a `Map<string, fn>` before forwarding to `ipcRenderer.invoke`, so the Electron main process is never reached for mocked channels.
+
+**Production-gating guarantee.** When `HYVEON_TEST_MODE` is absent (the default for packaged / production builds), the `if (isTestMode)` branch in the preload is never entered and `window.gsd.__test` is `undefined`. The `contextBridge.exposeInMainWorld` call only ever exposes the production API namespaces. There is no path by which end users can reach the mock registry.
+
+**Two mock surfaces — choose the right one:**
+
+| Surface | File | When to use |
+|---------|------|-------------|
+| `window.gsd.__test.mock(channel, handler)` | `desktop-preload/src/preload.ts` | Playwright Electron e2e specs (`electron` project) that need to control IPC responses without running the Nest server. Called via `win.evaluate(...)` in spec `beforeEach`. |
+| `register(namespace, mock)` from `@hyveon/desktop-preload/test-mock-registry` | `desktop-preload/src/test-mock-registry.ts` | Vitest unit tests running under jsdom. Build a partial namespace stub with `vi.fn()`, call `register('games', stub)`, then `vi.stubGlobal('gsd', buildMockGsd())` so the component under test gets a fully-typed `window.gsd`. Call `clear()` in `afterEach`. |
+
+The `test-mock-registry` module is **not** imported by the preload script or any production code; it exists only for jsdom-environment test helpers.
+
 **Integration test conventions (tier 2):**
 - Specs live under `app/packages/web/e2e/integration-specs/`. Import `{ test, expect }` from `./index.js` (NOT from `@playwright/test`) — the extended `test` includes the `serverMocks`, `authedPage`, and `dashboard` fixtures.
 - `serverMocks` (`ServerMocks` from `e2e/fixtures/server-mocks.ts`) pushes queued responses to the test server via `POST /api/test/mocks/*`. Always include it in test parameters — it resets the MockStore before and after each spec automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ The Electron project in Playwright launches the packaged app via `_electron.laun
 
 | Surface | File | When to use |
 |---------|------|-------------|
-| `window.gsd.__test.mock(channel, handler)` | `desktop-preload/src/preload.ts` | Playwright Electron e2e specs (`electron` project) that need to control IPC responses without running the Nest server. Called via `win.evaluate(...)` in spec `beforeEach`. |
+| `window.gsd.__test.mock(channel, handler)` | `desktop-preload/src/preload.ts` | Playwright Electron e2e specs (`electron` project) that need to control IPC responses without running the Nest server. Called via `win.evaluate(...)` inside each test body (or a `beforeEach` when all tests in a describe share the same mock). |
 | `register(namespace, mock)` from `@hyveon/desktop-preload/test-mock-registry` | `desktop-preload/src/test-mock-registry.ts` | Vitest unit tests running under jsdom. Build a partial namespace stub with `vi.fn()`, call `register('games', stub)`, then `vi.stubGlobal('gsd', buildMockGsd())` so the component under test gets a fully-typed `window.gsd`. Call `clear()` in `afterEach`. |
 
 The `test-mock-registry` module is **not** imported by the preload script or any production code; it exists only for jsdom-environment test helpers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ The Electron project in Playwright launches the packaged app via `_electron.laun
 
 | Surface | File | When to use |
 |---------|------|-------------|
-| `window.gsd.__test.mock(channel, handler)` | `desktop-preload/src/preload.ts` | Playwright Electron e2e specs (`electron` project) that need to control IPC responses without running the Nest server. Called via `win.evaluate(...)` inside each test body (or a `beforeEach` when all tests in a describe share the same mock). |
+| `window.gsd.__test.mock(channel, handler)` | `desktop-preload/src/preload.ts` | Playwright Electron e2e specs (`electron` project) that need to control IPC responses without running the Nest server. Called via `win.evaluate(...)` inside each test body (or a `beforeEach` when all tests in a describe share the same mock). When tests share a single `ElectronApplication`, call `win.evaluate(() => window.gsd.__test.clearMocks())` (alias: `reset()`) in `afterEach` so stale mock handlers don't bleed into later tests. |
 | `register(namespace, mock)` from `@hyveon/desktop-preload/test-mock-registry` | `desktop-preload/src/test-mock-registry.ts` | Vitest unit tests running under jsdom. Build a partial namespace stub with `vi.fn()`, call `register('games', stub)`, then `vi.stubGlobal('gsd', buildMockGsd())` so the component under test gets a fully-typed `window.gsd`. Call `clear()` in `afterEach`. |
 
 The `test-mock-registry` module is **not** imported by the preload script or any production code; it exists only for jsdom-environment test helpers.

--- a/app/packages/desktop-preload/package.json
+++ b/app/packages/desktop-preload/package.json
@@ -10,6 +10,10 @@
     "./preload": {
       "types": "./dist/preload.d.ts",
       "default": "./dist/preload.js"
+    },
+    "./test-mock-registry": {
+      "types": "./dist/test-mock-registry.d.ts",
+      "default": "./dist/test-mock-registry.js"
     }
   },
   "scripts": {

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -292,25 +292,14 @@ export interface GsdDiagnosticsApi {
 /**
  * Mock namespace bag: a partial copy of every `GsdApi` namespace so test
  * harnesses can supply only the methods they care about.
+ *
+ * Derived as a mapped type over every `GsdApi` namespace key (everything
+ * except the `__test` injection surface itself) so a namespace added to
+ * `GsdApi` flows in automatically — no hand-maintained property list to drift.
  */
-export interface GsdMockNamespaces {
-  /** Optional games namespace mock. */
-  games?: Partial<GsdGamesApi>;
-  /** Optional costs namespace mock. */
-  costs?: Partial<GsdCostsApi>;
-  /** Optional logs namespace mock. */
-  logs?: Partial<GsdLogsApi>;
-  /** Optional files namespace mock. */
-  files?: Partial<GsdFilesApi>;
-  /** Optional discord namespace mock. */
-  discord?: Partial<GsdDiscordApi>;
-  /** Optional env namespace mock. */
-  env?: Partial<GsdEnvApi>;
-  /** Optional config namespace mock. */
-  config?: Partial<GsdConfigApi>;
-  /** Optional diagnostics namespace mock. */
-  diagnostics?: Partial<GsdDiagnosticsApi>;
-}
+export type GsdMockNamespaces = {
+  [K in Exclude<keyof GsdApi, '__test'>]?: Partial<GsdApi[K]>;
+};
 
 /**
  * Test-only API surface injected under `window.gsd.__test`.

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -304,10 +304,22 @@ export type GsdMockNamespaces = {
 /**
  * Test-only API surface injected under `window.gsd.__test`.
  *
- * Present only when the renderer runs inside a Vitest/jsdom environment where
- * the test harness has replaced `window.gsd` with a mock object.  Production
- * code must **never** reference this property — guard every access with an
- * `if (window.gsd?.__test)` check or, better, avoid it entirely outside tests.
+ * Present in two distinct scenarios:
+ *
+ * 1. **Vitest / jsdom unit tests** — the test harness replaces the entire
+ *    `window.gsd` object with a mock built from `test-mock-registry`; the mock
+ *    object includes this property so individual test cases can register
+ *    per-channel overrides via `window.gsd.__test.mock(channel, handler)`.
+ *
+ * 2. **Electron preload at runtime** — when the app is launched with
+ *    `HYVEON_TEST_MODE=1` (set by the Playwright integration-test harness),
+ *    `preload.ts` appends `__test` to the real `window.gsd` bridge so that
+ *    Playwright page scripts can inject IPC mocks without touching the real
+ *    Electron IPC layer.
+ *
+ * Production code must **never** reference this property — guard every access
+ * with an `if (window.gsd?.__test)` check or, better, avoid it entirely outside
+ * tests.
  */
 export interface GsdTestApi {
   /**
@@ -374,9 +386,14 @@ export interface GsdApi {
   /**
    * Test-only injection surface; `undefined` in production.
    *
-   * Present only when the renderer runs inside a Vitest/jsdom environment
-   * where the test harness has stubbed `window.gsd` with a mock object that
-   * includes this property.  Never reference this in production code paths.
+   * Present in two scenarios:
+   * - **Vitest / jsdom** — the test harness stubs the whole `window.gsd`
+   *   object with a mock that includes this property.
+   * - **Electron preload** — appended to the real bridge when the process is
+   *   started with `HYVEON_TEST_MODE=1` by the Playwright integration-test
+   *   harness.
+   *
+   * Never reference this in production code paths.
    */
   __test?: GsdTestApi;
 }

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -286,6 +286,67 @@ export interface GsdDiagnosticsApi {
 }
 
 // ---------------------------------------------------------------------------
+// Test-only injection surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock namespace bag: a partial copy of every `GsdApi` namespace so test
+ * harnesses can supply only the methods they care about.
+ */
+export interface GsdMockNamespaces {
+  /** Optional games namespace mock. */
+  games?: Partial<GsdGamesApi>;
+  /** Optional costs namespace mock. */
+  costs?: Partial<GsdCostsApi>;
+  /** Optional logs namespace mock. */
+  logs?: Partial<GsdLogsApi>;
+  /** Optional files namespace mock. */
+  files?: Partial<GsdFilesApi>;
+  /** Optional discord namespace mock. */
+  discord?: Partial<GsdDiscordApi>;
+  /** Optional env namespace mock. */
+  env?: Partial<GsdEnvApi>;
+  /** Optional config namespace mock. */
+  config?: Partial<GsdConfigApi>;
+  /** Optional diagnostics namespace mock. */
+  diagnostics?: Partial<GsdDiagnosticsApi>;
+}
+
+/**
+ * Test-only API surface injected under `window.gsd.__test`.
+ *
+ * Present only when the renderer runs inside a Vitest/jsdom environment where
+ * the test harness has replaced `window.gsd` with a mock object.  Production
+ * code must **never** reference this property — guard every access with an
+ * `if (window.gsd?.__test)` check or, better, avoid it entirely outside tests.
+ */
+export interface GsdTestApi {
+  /**
+   * Partial mock implementations keyed by namespace name.
+   *
+   * Tests set individual namespace mocks here before rendering the component
+   * under test.  The API client reads the real namespace (e.g. `window.gsd.games`)
+   * at call time, so simply replacing `window.gsd.games` is sufficient — the
+   * `mock` bag is provided as a structured alternative for registries that need
+   * to enumerate which namespaces were mocked.
+   */
+  mock: GsdMockNamespaces;
+  /**
+   * Clears all mock implementations stored in `mock` and resets any recorded
+   * call counts on injected `vi.fn()` spies.
+   *
+   * Intended for use in `afterEach` hooks to prevent state leaking between
+   * test cases.
+   */
+  clearMocks: () => void;
+  /**
+   * Alias for {@link clearMocks} — provided for symmetry with Vitest's
+   * `vi.resetAllMocks()` naming convention.
+   */
+  reset: () => void;
+}
+
+// ---------------------------------------------------------------------------
 // Top-level interface
 // ---------------------------------------------------------------------------
 
@@ -319,4 +380,12 @@ export interface GsdApi {
   config: GsdConfigApi;
   /** Local application log diagnostics: tail recent lines or retrieve the log file path. */
   diagnostics: GsdDiagnosticsApi;
+  /**
+   * Test-only injection surface; `undefined` in production.
+   *
+   * Present only when the renderer runs inside a Vitest/jsdom environment
+   * where the test harness has stubbed `window.gsd` with a mock object that
+   * includes this property.  Never reference this in production code paths.
+   */
+  __test?: GsdTestApi;
 }

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -329,7 +329,7 @@ export interface GsdTestApi {
    * the registered handler is called instead and its return value is resolved.
    * Pass a plain value (non-function) to have it returned verbatim.
    *
-   * @param channel - The IPC channel name to intercept (e.g. `'games:list'`).
+   * @param channel - The IPC channel name to intercept (e.g. `'games.list'`).
    * @param handler - A function `(...args) => result` or a static return value.
    */
   mock: (channel: string, handler: unknown) => void;

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -322,15 +322,17 @@ export interface GsdMockNamespaces {
  */
 export interface GsdTestApi {
   /**
-   * Partial mock implementations keyed by namespace name.
+   * Registers a per-channel mock handler.
    *
-   * Tests set individual namespace mocks here before rendering the component
-   * under test.  The API client reads the real namespace (e.g. `window.gsd.games`)
-   * at call time, so simply replacing `window.gsd.games` is sufficient — the
-   * `mock` bag is provided as a structured alternative for registries that need
-   * to enumerate which namespaces were mocked.
+   * Call `mock(channel, handler)` before rendering the component under test.
+   * When the preload bridge later invokes `ipcRenderer.invoke(channel, ...args)`,
+   * the registered handler is called instead and its return value is resolved.
+   * Pass a plain value (non-function) to have it returned verbatim.
+   *
+   * @param channel - The IPC channel name to intercept (e.g. `'games:list'`).
+   * @param handler - A function `(...args) => result` or a static return value.
    */
-  mock: GsdMockNamespaces;
+  mock: (channel: string, handler: unknown) => void;
   /**
    * Clears all mock implementations stored in `mock` and resets any recorded
    * call counts on injected `vi.fn()` spies.

--- a/app/packages/desktop-preload/src/index.ts
+++ b/app/packages/desktop-preload/src/index.ts
@@ -1,4 +1,4 @@
-export type { GsdApi } from './gsd-api.js';
+export type { GsdApi, GsdTestApi, GsdMockNamespaces } from './gsd-api.js';
 
 declare global {
   interface Window {

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -75,10 +75,17 @@ vi.mock('electron', () => ({
  * The dynamic import forces the module's top-level side-effects (the
  * `contextBridge.exposeInMainWorld` call and the `isTestMode` check) to run
  * again with the current env value.
+ *
+ * Pass `undefined` to simulate the production case where `HYVEON_TEST_MODE` is
+ * never set in the environment.
  */
-async function loadPreloadBridge(testMode: '0' | '1'): Promise<Record<string, unknown>> {
+async function loadPreloadBridge(testMode: '0' | '1' | undefined): Promise<Record<string, unknown>> {
   vi.resetModules();
-  process.env['HYVEON_TEST_MODE'] = testMode;
+  if (testMode === undefined) {
+    delete process.env['HYVEON_TEST_MODE'];
+  } else {
+    process.env['HYVEON_TEST_MODE'] = testMode;
+  }
   await import('./preload.js');
   return exposed['gsd'] as Record<string, unknown>;
 }
@@ -206,6 +213,16 @@ describe('preload dispatcher', () => {
       expect(second).toHaveBeenCalledOnce();
       expect(result).toEqual({ games: ['second'] });
     });
+
+    it('should propagate a rejection from a mock handler without swallowing it', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      testApi.mock('games.list', vi.fn().mockRejectedValue(new Error('mock-error')));
+
+      const games = bridge['games'] as { list: () => Promise<unknown> };
+
+      await expect(games.list()).rejects.toThrow('mock-error');
+      expect(ipcInvoke).not.toHaveBeenCalled();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -229,6 +246,11 @@ describe('preload dispatcher', () => {
       expect(bridge['__test']).toBeUndefined();
     });
 
+    it('should not expose __test on the bridge when HYVEON_TEST_MODE is absent (production default)', async () => {
+      const bridge = await loadPreloadBridge(undefined);
+      expect(bridge['__test']).toBeUndefined();
+    });
+
     it('should still expose all real API namespaces when HYVEON_TEST_MODE is "0"', async () => {
       const bridge = await loadPreloadBridge('0');
       expect(bridge['games']).toBeDefined();
@@ -243,6 +265,47 @@ describe('preload dispatcher', () => {
       expect(bridge['env']).toBeDefined();
       expect(bridge['costs']).toBeDefined();
       expect(bridge['discord']).toBeDefined();
+    });
+
+    it('should flush the mock registry when clearMocks is called so ipcRenderer.invoke is used for the channel again', async () => {
+      const bridge = await loadPreloadBridge('1');
+      const testApi = bridge['__test'] as {
+        mock: (channel: string, handler: unknown) => void;
+        clearMocks: () => void;
+      };
+      // Register a mock so the channel is covered.
+      testApi.mock('games.list', vi.fn().mockResolvedValue({ games: ['mock-game'] }));
+
+      // Clear all mocks — the channel should now fall through to ipcRenderer.invoke.
+      testApi.clearMocks();
+
+      ipcInvoke.mockResolvedValue({ games: ['real-game'] });
+      const games = bridge['games'] as { list: () => Promise<unknown> };
+      await games.list();
+
+      expect(ipcInvoke).toHaveBeenCalledWith('games.list');
+    });
+
+    it('should flush the mock registry when reset is called so ipcRenderer.invoke is used for the channel again', async () => {
+      const bridge = await loadPreloadBridge('1');
+      const testApi = bridge['__test'] as {
+        mock: (channel: string, handler: unknown) => void;
+        reset: () => void;
+      };
+      // Register a mock so the channel is covered.
+      testApi.mock(
+        'env.get',
+        vi.fn().mockResolvedValue({ region: 'us-east-1', domain: 'example.com', environment: 'dev' }),
+      );
+
+      // Reset all mocks — the channel should now fall through to ipcRenderer.invoke.
+      testApi.reset();
+
+      ipcInvoke.mockResolvedValue({ region: 'eu-west-1', domain: 'game.io', environment: 'prod' });
+      const env = bridge['env'] as { get: () => Promise<unknown> };
+      await env.get();
+
+      expect(ipcInvoke).toHaveBeenCalledWith('env.get');
     });
   });
 });

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for the preload dispatcher (`preload.ts`).
+ *
+ * Covers three guarantees:
+ *
+ * 1. **Mock-override** — when a per-channel mock is registered via the
+ *    `registerMock` function exposed on `gsdBridge.__test.mock`, `invoke`
+ *    calls the mock instead of `ipcRenderer.invoke`.
+ * 2. **Real-IPC fallthrough** — when no mock is registered, `invoke` forwards
+ *    the call to `ipcRenderer.invoke` unchanged.
+ * 3. **Test-mode gating** — `gsdBridge.__test` is present only when
+ *    `HYVEON_TEST_MODE=1`; it is absent (or the bridge lacks the key) in
+ *    production mode.
+ *
+ * Because the preload module runs all its logic at import time (calling
+ * `contextBridge.exposeInMainWorld` as a side-effect), each group of tests
+ * that needs a different `HYVEON_TEST_MODE` value resets the module registry
+ * and re-imports the module with the appropriate env value set.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Electron mock — must be declared before any dynamic import of preload.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Captured arguments from `contextBridge.exposeInMainWorld` calls, keyed by
+ * the world name.  The preload module always calls it with `'gsd'`.
+ */
+const exposed: Record<string, unknown> = {};
+
+/**
+ * Fake `ipcRenderer.invoke` spy — records calls and returns a controllable
+ * resolved value so we can verify fallthrough behaviour.
+ */
+const ipcInvoke = vi.fn();
+
+/**
+ * Fake `ipcRenderer.send` spy (used by `streamLogs`; not exercised here but
+ * must exist so the import doesn't throw).
+ */
+const ipcSend = vi.fn();
+
+/** Fake `ipcRenderer.on` / `once` / `removeListener` — not exercised here. */
+const ipcOn = vi.fn();
+const ipcOnce = vi.fn();
+const ipcRemoveListener = vi.fn();
+
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: (name: string, api: unknown) => {
+      exposed[name] = api;
+    },
+  },
+  ipcRenderer: {
+    invoke: ipcInvoke,
+    send: ipcSend,
+    on: ipcOn,
+    once: ipcOnce,
+    removeListener: ipcRemoveListener,
+  },
+  IpcRendererEvent: {},
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resets module caches and re-imports `preload.ts` with the given
+ * `HYVEON_TEST_MODE` value, then returns the bridge object that was passed to
+ * `contextBridge.exposeInMainWorld('gsd', ...)`.
+ *
+ * The dynamic import forces the module's top-level side-effects (the
+ * `contextBridge.exposeInMainWorld` call and the `isTestMode` check) to run
+ * again with the current env value.
+ */
+async function loadPreloadBridge(testMode: '0' | '1'): Promise<Record<string, unknown>> {
+  vi.resetModules();
+  process.env['HYVEON_TEST_MODE'] = testMode;
+  await import('./preload.js');
+  return exposed['gsd'] as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('preload dispatcher', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env['HYVEON_TEST_MODE'];
+  });
+
+  // -------------------------------------------------------------------------
+  // Real-IPC fallthrough
+  // -------------------------------------------------------------------------
+
+  describe('real-IPC fallthrough', () => {
+    let bridge: Record<string, unknown>;
+
+    beforeEach(async () => {
+      ipcInvoke.mockResolvedValue({ games: ['minecraft'] });
+      bridge = await loadPreloadBridge('0');
+    });
+
+    it('should forward games.list to ipcRenderer.invoke when no mock is registered', async () => {
+      const games = bridge['games'] as { list: () => Promise<unknown> };
+      const result = await games.list();
+
+      expect(ipcInvoke).toHaveBeenCalledOnce();
+      expect(ipcInvoke).toHaveBeenCalledWith('games.list');
+      expect(result).toEqual({ games: ['minecraft'] });
+    });
+
+    it('should forward games.start with the game argument to ipcRenderer.invoke', async () => {
+      ipcInvoke.mockResolvedValue({ success: true, message: 'started' });
+      const games = bridge['games'] as { start: (game: string) => Promise<unknown> };
+      const result = await games.start('valheim');
+
+      expect(ipcInvoke).toHaveBeenCalledWith('games.start', 'valheim');
+      expect(result).toEqual({ success: true, message: 'started' });
+    });
+
+    it('should forward env.get to ipcRenderer.invoke', async () => {
+      ipcInvoke.mockResolvedValue({ region: 'us-east-1', domain: 'example.com', environment: 'dev' });
+      const env = bridge['env'] as { get: () => Promise<unknown> };
+      await env.get();
+
+      expect(ipcInvoke).toHaveBeenCalledWith('env.get');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mock-override
+  // -------------------------------------------------------------------------
+
+  describe('mock-override', () => {
+    let bridge: Record<string, unknown>;
+
+    beforeEach(async () => {
+      bridge = await loadPreloadBridge('1');
+    });
+
+    it('should call the registered mock instead of ipcRenderer.invoke when a mock covers the channel', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      const mockHandler = vi.fn().mockResolvedValue({ games: ['factorio'] });
+      testApi.mock('games.list', mockHandler);
+
+      const games = bridge['games'] as { list: () => Promise<unknown> };
+      const result = await games.list();
+
+      expect(mockHandler).toHaveBeenCalledOnce();
+      expect(ipcInvoke).not.toHaveBeenCalled();
+      expect(result).toEqual({ games: ['factorio'] });
+    });
+
+    it('should pass call arguments through to the registered mock handler', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      const mockHandler = vi.fn().mockResolvedValue({ success: true, message: 'mock-stop' });
+      testApi.mock('games.stop', mockHandler);
+
+      const games = bridge['games'] as { stop: (game: string) => Promise<unknown> };
+      await games.stop('terraria');
+
+      expect(mockHandler).toHaveBeenCalledWith('terraria');
+    });
+
+    it('should wrap a plain non-function value registered as a mock so callers receive a resolved Promise', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      // Register a plain object — not a function — as the mock return value.
+      testApi.mock('env.get', { region: 'eu-west-1', domain: 'game.io', environment: 'prod' });
+
+      const env = bridge['env'] as { get: () => Promise<unknown> };
+      const result = await env.get();
+
+      expect(ipcInvoke).not.toHaveBeenCalled();
+      expect(result).toEqual({ region: 'eu-west-1', domain: 'game.io', environment: 'prod' });
+    });
+
+    it('should fall through to ipcRenderer.invoke for channels that have no mock registered', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      // Only mock games.list — env.get should still fall through.
+      testApi.mock('games.list', vi.fn().mockResolvedValue({ games: [] }));
+
+      ipcInvoke.mockResolvedValue({ region: 'ap-east-1', domain: 'srv.dev', environment: 'dev' });
+      const env = bridge['env'] as { get: () => Promise<unknown> };
+      await env.get();
+
+      expect(ipcInvoke).toHaveBeenCalledWith('env.get');
+    });
+
+    it('should use a later mock when the same channel is registered twice', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      const first = vi.fn().mockResolvedValue({ games: ['first'] });
+      const second = vi.fn().mockResolvedValue({ games: ['second'] });
+
+      testApi.mock('games.list', first);
+      testApi.mock('games.list', second);
+
+      const games = bridge['games'] as { list: () => Promise<unknown> };
+      const result = await games.list();
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledOnce();
+      expect(result).toEqual({ games: ['second'] });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Test-mode gating
+  // -------------------------------------------------------------------------
+
+  describe('test-mode gating', () => {
+    it('should expose __test on the bridge when HYVEON_TEST_MODE is "1"', async () => {
+      const bridge = await loadPreloadBridge('1');
+      expect(bridge['__test']).toBeDefined();
+    });
+
+    it('should include a mock function on __test when HYVEON_TEST_MODE is "1"', async () => {
+      const bridge = await loadPreloadBridge('1');
+      const testApi = bridge['__test'] as { mock: unknown };
+      expect(typeof testApi.mock).toBe('function');
+    });
+
+    it('should not expose __test on the bridge when HYVEON_TEST_MODE is "0"', async () => {
+      const bridge = await loadPreloadBridge('0');
+      expect(bridge['__test']).toBeUndefined();
+    });
+
+    it('should still expose all real API namespaces when HYVEON_TEST_MODE is "0"', async () => {
+      const bridge = await loadPreloadBridge('0');
+      expect(bridge['games']).toBeDefined();
+      expect(bridge['env']).toBeDefined();
+      expect(bridge['costs']).toBeDefined();
+      expect(bridge['discord']).toBeDefined();
+    });
+
+    it('should still expose all real API namespaces when HYVEON_TEST_MODE is "1"', async () => {
+      const bridge = await loadPreloadBridge('1');
+      expect(bridge['games']).toBeDefined();
+      expect(bridge['env']).toBeDefined();
+      expect(bridge['costs']).toBeDefined();
+      expect(bridge['discord']).toBeDefined();
+    });
+  });
+});

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -204,9 +204,15 @@ if (isTestMode) {
    *
    * Exposes `mock(channel, handler)` so Playwright / Vitest can register
    * per-channel IPC overrides without touching the real Electron IPC layer.
+   * `clearMocks` and `reset` both clear the registry so state does not leak
+   * between test cases (mirror the {@link GsdTestApi} contract).
    */
   gsdBridge['__test'] = {
     mock: registerMock,
+    /** Clears all registered mock handlers from the registry. */
+    clearMocks: () => mockRegistry.clear(),
+    /** Alias for {@link clearMocks} — symmetry with `vi.resetAllMocks()`. */
+    reset: () => mockRegistry.clear(),
   };
 }
 

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -39,16 +39,6 @@ function registerMock(channel: string, handler: unknown): void {
 }
 
 /**
- * Removes a previously registered mock so subsequent calls fall through
- * to the real IPC layer.
- *
- * @param channel - IPC channel name to deregister.
- */
-function deregisterMock(channel: string): void {
-  mockRegistry.delete(channel);
-}
-
-/**
  * Mock-aware `ipcRenderer.invoke` wrapper.  If a mock is registered for
  * the channel it is called with the supplied args and its return value
  * (synchronous or Promise) is awaited; otherwise the call is forwarded to
@@ -203,15 +193,21 @@ const api: GsdApi = {
   },
 };
 
-contextBridge.exposeInMainWorld('gsd', api);
+/** Whether this process was started in test mode by the integration test harness. */
+const isTestMode = process.env['HYVEON_TEST_MODE'] === '1';
 
-/**
- * Test-only mock injection surface.  Exposed as `window.__gsdMocks` so
- * Playwright / Vitest can register channel overrides without touching the
- * real IPC layer.  Only available when `contextBridge` allows it; production
- * builds gain nothing from this because no code calls it outside tests.
- */
-contextBridge.exposeInMainWorld('__gsdMocks', {
-  register: registerMock,
-  deregister: deregisterMock,
-});
+const gsdBridge: Record<string, unknown> = { ...api };
+
+if (isTestMode) {
+  /**
+   * Test-only injection surface, present only when `HYVEON_TEST_MODE=1`.
+   *
+   * Exposes `mock(channel, handler)` so Playwright / Vitest can register
+   * per-channel IPC overrides without touching the real Electron IPC layer.
+   */
+  gsdBridge['__test'] = {
+    mock: registerMock,
+  };
+}
+
+contextBridge.exposeInMainWorld('gsd', gsdBridge);

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -17,7 +17,7 @@
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
-import type { GsdApi, LogChunk } from './gsd-api.js';
+import type { GsdApi, GsdTestApi, LogChunk } from './gsd-api.js';
 
 /**
  * Per-channel mock registry populated by tests via `window.gsd.__test.mock(channel, handler)`.
@@ -50,7 +50,11 @@ function registerMock(channel: string, handler: unknown): void {
 function invoke<T = unknown>(channel: string, ...args: unknown[]): Promise<T> {
   const mock = mockRegistry.get(channel);
   if (mock !== undefined) {
-    return Promise.resolve(mock(...args)) as Promise<T>;
+    try {
+      return Promise.resolve(mock(...args)) as Promise<T>;
+    } catch (err) {
+      return Promise.reject(err) as Promise<T>;
+    }
   }
   return ipcRenderer.invoke(channel, ...args) as Promise<T>;
 }
@@ -196,7 +200,7 @@ const api: GsdApi = {
 /** Whether this process was started in test mode by the integration test harness. */
 const isTestMode = process.env['HYVEON_TEST_MODE'] === '1';
 
-const gsdBridge: Record<string, unknown> = { ...api };
+const gsdBridge: GsdApi & { __test?: GsdTestApi } = { ...api };
 
 if (isTestMode) {
   /**
@@ -207,7 +211,7 @@ if (isTestMode) {
    * `clearMocks` and `reset` both clear the registry so state does not leak
    * between test cases (mirror the {@link GsdTestApi} contract).
    */
-  gsdBridge['__test'] = {
+  gsdBridge.__test = {
     mock: registerMock,
     /** Clears all registered mock handlers from the registry. */
     clearMocks: () => mockRegistry.clear(),

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -50,7 +50,7 @@ function registerMock(channel: string, handler: unknown): void {
 function invoke<T = unknown>(channel: string, ...args: unknown[]): Promise<T> {
   const mock = mockRegistry.get(channel);
   if (mock !== undefined) {
-    return Promise.resolve().then(() => mock(...args) as T);
+    return Promise.resolve(mock(...args)) as Promise<T>;
   }
   return ipcRenderer.invoke(channel, ...args) as Promise<T>;
 }

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -20,7 +20,7 @@ import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 import type { GsdApi, LogChunk } from './gsd-api.js';
 
 /**
- * Per-channel mock registry populated by tests via `window.__gsdMocks`.
+ * Per-channel mock registry populated by tests via `window.gsd.__test.mock(channel, handler)`.
  * Each entry is a function (or a plain value) that replaces the real IPC call
  * for that channel.  A `() => value` handler is treated as the mock; a
  * non-function entry is wrapped so the resolver always returns that value.
@@ -50,7 +50,7 @@ function registerMock(channel: string, handler: unknown): void {
 function invoke<T = unknown>(channel: string, ...args: unknown[]): Promise<T> {
   const mock = mockRegistry.get(channel);
   if (mock !== undefined) {
-    return Promise.resolve(mock(...args)) as Promise<T>;
+    return Promise.resolve().then(() => mock(...args) as T);
   }
   return ipcRenderer.invoke(channel, ...args) as Promise<T>;
 }

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -197,8 +197,17 @@ const api: GsdApi = {
   },
 };
 
+/**
+ * Returns `true` when this process was started in test mode by the integration
+ * test harness (`HYVEON_TEST_MODE=1`).  Extracted as a function so tests can
+ * stub the env read via `vi.spyOn` instead of mutating `process.env` directly.
+ */
+export function isTestModeEnabled(): boolean {
+  return process.env['HYVEON_TEST_MODE'] === '1';
+}
+
 /** Whether this process was started in test mode by the integration test harness. */
-const isTestMode = process.env['HYVEON_TEST_MODE'] === '1';
+const isTestMode = isTestModeEnabled();
 
 const gsdBridge: GsdApi & { __test?: GsdTestApi } = { ...api };
 

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -20,6 +20,52 @@ import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 import type { GsdApi, LogChunk } from './gsd-api.js';
 
 /**
+ * Per-channel mock registry populated by tests via `window.__gsdMocks`.
+ * Each entry is a function (or a plain value) that replaces the real IPC call
+ * for that channel.  A `() => value` handler is treated as the mock; a
+ * non-function entry is wrapped so the resolver always returns that value.
+ */
+const mockRegistry: Map<string, (...args: unknown[]) => unknown> = new Map();
+
+/**
+ * Registers a mock for the given IPC channel.  If `handler` is not a
+ * function it is wrapped in one so callers always receive a Promise.
+ *
+ * @param channel - IPC channel name, e.g. `'games.list'`.
+ * @param handler - Replacement implementation or a plain return value.
+ */
+function registerMock(channel: string, handler: unknown): void {
+  mockRegistry.set(channel, typeof handler === 'function' ? (handler as (...args: unknown[]) => unknown) : () => handler);
+}
+
+/**
+ * Removes a previously registered mock so subsequent calls fall through
+ * to the real IPC layer.
+ *
+ * @param channel - IPC channel name to deregister.
+ */
+function deregisterMock(channel: string): void {
+  mockRegistry.delete(channel);
+}
+
+/**
+ * Mock-aware `ipcRenderer.invoke` wrapper.  If a mock is registered for
+ * the channel it is called with the supplied args and its return value
+ * (synchronous or Promise) is awaited; otherwise the call is forwarded to
+ * the real Electron IPC.
+ *
+ * @param channel - IPC channel name.
+ * @param args    - Arguments forwarded to the handler or IPC channel.
+ */
+function invoke<T = unknown>(channel: string, ...args: unknown[]): Promise<T> {
+  const mock = mockRegistry.get(channel);
+  if (mock !== undefined) {
+    return Promise.resolve(mock(...args)) as Promise<T>;
+  }
+  return ipcRenderer.invoke(channel, ...args) as Promise<T>;
+}
+
+/**
  * Bridges the per-stream chunk/end/cancel IPC channels into an
  * {@link AsyncIterable} of log chunks.
  *
@@ -34,7 +80,7 @@ import type { GsdApi, LogChunk } from './gsd-api.js';
  * the prior callback implementation, so there is no new dropped-chunk window.
  */
 async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<LogChunk> {
-  const { streamId } = (await ipcRenderer.invoke('logs.stream', game)) as { streamId: string };
+  const { streamId } = (await invoke('logs.stream', game)) as { streamId: string };
   const chunkChannel = `logs.stream.${streamId}.chunk`;
   const endChannel = `logs.stream.${streamId}.end`;
   const sendCancel = () => ipcRenderer.send(`logs.stream.${streamId}.cancel`);
@@ -96,65 +142,76 @@ async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<Lo
 
 const api: GsdApi = {
   games: {
-    list: () => ipcRenderer.invoke('games.list'),
-    status: () => ipcRenderer.invoke('games.status'),
-    getStatus: (game: string) => ipcRenderer.invoke('games.getStatus', game),
-    start: (game: string) => ipcRenderer.invoke('games.start', game),
-    stop: (game: string) => ipcRenderer.invoke('games.stop', game),
+    list: () => invoke('games.list'),
+    status: () => invoke('games.status'),
+    getStatus: (game: string) => invoke('games.getStatus', game),
+    start: (game: string) => invoke('games.start', game),
+    stop: (game: string) => invoke('games.stop', game),
   },
 
   costs: {
-    estimate: () => ipcRenderer.invoke('costs.estimate'),
-    actual: (days?: number) => ipcRenderer.invoke('costs.actual', days),
+    estimate: () => invoke('costs.estimate'),
+    actual: (days?: number) => invoke('costs.actual', days),
   },
 
   logs: {
-    get: (game: string, limit?: number) => ipcRenderer.invoke('logs.get', { game, limit }),
+    get: (game: string, limit?: number) => invoke('logs.get', { game, limit }),
     stream: streamLogs,
   },
 
   files: {
-    list: (game: string) => ipcRenderer.invoke('files.list', game),
-    start: (game: string) => ipcRenderer.invoke('files.start', game),
-    stop: (game: string) => ipcRenderer.invoke('files.stop', game),
+    list: (game: string) => invoke('files.list', game),
+    start: (game: string) => invoke('files.start', game),
+    stop: (game: string) => invoke('files.stop', game),
   },
 
   discord: {
-    getConfig: () => ipcRenderer.invoke('discord.getConfig'),
+    getConfig: () => invoke('discord.getConfig'),
     putConfig: (body: { botToken?: string; clientId?: string; publicKey?: string }) =>
-      ipcRenderer.invoke('discord.putConfig', body),
-    listGuilds: () => ipcRenderer.invoke('discord.listGuilds'),
-    addGuild: (guildId: string) => ipcRenderer.invoke('discord.addGuild', { guildId }),
-    removeGuild: (guildId: string) => ipcRenderer.invoke('discord.removeGuild', guildId),
-    registerCommands: (guildId: string) => ipcRenderer.invoke('discord.registerCommands', guildId),
-    getAdmins: () => ipcRenderer.invoke('discord.getAdmins'),
+      invoke('discord.putConfig', body),
+    listGuilds: () => invoke('discord.listGuilds'),
+    addGuild: (guildId: string) => invoke('discord.addGuild', { guildId }),
+    removeGuild: (guildId: string) => invoke('discord.removeGuild', guildId),
+    registerCommands: (guildId: string) => invoke('discord.registerCommands', guildId),
+    getAdmins: () => invoke('discord.getAdmins'),
     putAdmins: (body: { userIds?: string[]; roleIds?: string[] }) =>
-      ipcRenderer.invoke('discord.putAdmins', body),
-    getPermissions: () => ipcRenderer.invoke('discord.getPermissions'),
+      invoke('discord.putAdmins', body),
+    getPermissions: () => invoke('discord.getPermissions'),
     putPermission: (
       game: string,
       body: { userIds?: string[]; roleIds?: string[]; actions?: string[] },
-    ) => ipcRenderer.invoke('discord.putPermission', { game, body }),
-    deletePermission: (game: string) => ipcRenderer.invoke('discord.deletePermission', game),
+    ) => invoke('discord.putPermission', { game, body }),
+    deletePermission: (game: string) => invoke('discord.deletePermission', game),
   },
 
   env: {
-    get: () => ipcRenderer.invoke('env.get'),
+    get: () => invoke('env.get'),
   },
 
   config: {
-    get: () => ipcRenderer.invoke('config.get'),
+    get: () => invoke('config.get'),
     update: (body: {
       watchdog_interval_minutes?: number;
       watchdog_idle_checks?: number;
       watchdog_min_packets?: number;
-    }) => ipcRenderer.invoke('config.update', body),
+    }) => invoke('config.update', body),
   },
 
   diagnostics: {
-    tail: () => ipcRenderer.invoke('diagnostics.tail'),
-    path: () => ipcRenderer.invoke('diagnostics.path'),
+    tail: () => invoke('diagnostics.tail'),
+    path: () => invoke('diagnostics.path'),
   },
 };
 
 contextBridge.exposeInMainWorld('gsd', api);
+
+/**
+ * Test-only mock injection surface.  Exposed as `window.__gsdMocks` so
+ * Playwright / Vitest can register channel overrides without touching the
+ * real IPC layer.  Only available when `contextBridge` allows it; production
+ * builds gain nothing from this because no code calls it outside tests.
+ */
+contextBridge.exposeInMainWorld('__gsdMocks', {
+  register: registerMock,
+  deregister: deregisterMock,
+});

--- a/app/packages/desktop-preload/src/test-mock-registry.test.ts
+++ b/app/packages/desktop-preload/src/test-mock-registry.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { register, lookup, clear, buildMockGsd } from './test-mock-registry.js';
+import type { GsdGamesApi, GsdEnvApi } from './gsd-api.js';
+
+/** Minimal stub for GsdGamesApi — only the methods the registry tests need. */
+function makeGamesStub(): GsdGamesApi {
+  return {
+    list: vi.fn().mockResolvedValue({ games: [] }),
+    status: vi.fn().mockResolvedValue([]),
+    getStatus: vi.fn().mockResolvedValue({ game: 'minecraft', state: 'stopped' }),
+    start: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    stop: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+  };
+}
+
+/** Minimal stub for GsdEnvApi. */
+function makeEnvStub(): GsdEnvApi {
+  return {
+    get: vi.fn().mockResolvedValue({ region: 'us-east-1', domain: 'example.com', environment: 'dev' }),
+  };
+}
+
+afterEach(() => {
+  clear();
+});
+
+describe('register and lookup', () => {
+  it('should return the registered mock when looked up by namespace', () => {
+    const games = makeGamesStub();
+    register('games', games);
+    expect(lookup('games')).toBe(games);
+  });
+
+  it('should return undefined for a namespace that has not been registered', () => {
+    expect(lookup('env')).toBeUndefined();
+  });
+
+  it('should overwrite an earlier mock when register is called twice for the same namespace', () => {
+    const first = makeGamesStub();
+    const second = makeGamesStub();
+    register('games', first);
+    register('games', second);
+    expect(lookup('games')).toBe(second);
+    expect(lookup('games')).not.toBe(first);
+  });
+
+  it('should support registering and looking up multiple namespaces independently', () => {
+    const games = makeGamesStub();
+    const env = makeEnvStub();
+    register('games', games);
+    register('env', env);
+    expect(lookup('games')).toBe(games);
+    expect(lookup('env')).toBe(env);
+  });
+});
+
+describe('clear', () => {
+  it('should remove all registered mocks so every subsequent lookup returns undefined', () => {
+    register('games', makeGamesStub());
+    register('env', makeEnvStub());
+    clear();
+    expect(lookup('games')).toBeUndefined();
+    expect(lookup('env')).toBeUndefined();
+  });
+
+  it('should be safe to call when the registry is already empty', () => {
+    expect(() => clear()).not.toThrow();
+  });
+});
+
+describe('buildMockGsd', () => {
+  it('should return an object containing only the namespaces that have been registered', () => {
+    const games = makeGamesStub();
+    register('games', games);
+    const gsd = buildMockGsd();
+    expect(gsd.games).toBe(games);
+    expect(gsd.env).toBeUndefined();
+  });
+
+  it('should return an empty object when the registry has been cleared', () => {
+    register('games', makeGamesStub());
+    clear();
+    expect(buildMockGsd()).toEqual({});
+  });
+});

--- a/app/packages/desktop-preload/src/test-mock-registry.ts
+++ b/app/packages/desktop-preload/src/test-mock-registry.ts
@@ -11,17 +11,7 @@
  * `vi.mock` factory functions in the `@hyveon/web` test suite.
  */
 
-import type {
-  GsdApi,
-  GsdCostsApi,
-  GsdDiscordApi,
-  GsdDiagnosticsApi,
-  GsdEnvApi,
-  GsdFilesApi,
-  GsdGamesApi,
-  GsdLogsApi,
-  GsdConfigApi,
-} from './gsd-api.js';
+import type { GsdApi } from './gsd-api.js';
 
 // ---------------------------------------------------------------------------
 // Namespace key union — derived from GsdApi so it stays in sync automatically.
@@ -39,19 +29,12 @@ export type GsdNamespace = Exclude<keyof GsdApi, '__test'>;
 
 /**
  * Maps each {@link GsdNamespace} key to the sub-interface it holds on
- * {@link GsdApi}.  Overloads on `register` / `lookup` use this to give the
- * caller the correct concrete sub-type for the namespace they pass.
+ * {@link GsdApi}.  Derived directly from `GsdApi` via a mapped type so that
+ * adding a new namespace to `GsdApi` automatically propagates here — the
+ * compiler will enforce value-type correctness in `register` / `lookup`
+ * without any manual update to this alias.
  */
-export interface GsdNamespaceMap {
-  games: GsdGamesApi;
-  costs: GsdCostsApi;
-  logs: GsdLogsApi;
-  files: GsdFilesApi;
-  discord: GsdDiscordApi;
-  env: GsdEnvApi;
-  config: GsdConfigApi;
-  diagnostics: GsdDiagnosticsApi;
-}
+export type GsdNamespaceMap = { [K in GsdNamespace]: GsdApi[K] };
 
 // ---------------------------------------------------------------------------
 // Internal registry store

--- a/app/packages/desktop-preload/src/test-mock-registry.ts
+++ b/app/packages/desktop-preload/src/test-mock-registry.ts
@@ -103,6 +103,6 @@ export function clear(): void {
  * This helper is intentionally **not** exported from the package root — import
  * it directly from the `test-mock-registry` export path.
  */
-export function buildMockGsd(): Partial<GsdApi> {
-  return { ..._registry } as Partial<GsdApi>;
+export function buildMockGsd(): Partial<GsdPartialNamespaceMap> {
+  return { ..._registry };
 }

--- a/app/packages/desktop-preload/src/test-mock-registry.ts
+++ b/app/packages/desktop-preload/src/test-mock-registry.ts
@@ -1,0 +1,119 @@
+/**
+ * Test-only mock registry for `window.gsd`.
+ *
+ * Provides typed `register`, `lookup`, and `clear` helpers that allow unit
+ * tests running in jsdom to inject partial or full mock implementations of
+ * any `GsdApi` namespace without importing Electron or touching the real IPC
+ * bridge.
+ *
+ * This module is intentionally **not** imported by the preload script or any
+ * production renderer code — it is only consumed by test helpers and
+ * `vi.mock` factory functions in the `@hyveon/web` test suite.
+ */
+
+import type {
+  GsdApi,
+  GsdCostsApi,
+  GsdDiscordApi,
+  GsdDiagnosticsApi,
+  GsdEnvApi,
+  GsdFilesApi,
+  GsdGamesApi,
+  GsdLogsApi,
+  GsdConfigApi,
+} from './gsd-api.js';
+
+// ---------------------------------------------------------------------------
+// Namespace key union — derived from GsdApi so it stays in sync automatically.
+// ---------------------------------------------------------------------------
+
+/**
+ * Union of the namespace keys present on {@link GsdApi} (excluding `__test`).
+ * Used to constrain the `register` and `lookup` overloads to valid keys.
+ */
+export type GsdNamespace = Exclude<keyof GsdApi, '__test'>;
+
+// ---------------------------------------------------------------------------
+// Overloaded namespace → sub-interface mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each {@link GsdNamespace} key to the sub-interface it holds on
+ * {@link GsdApi}.  Overloads on `register` / `lookup` use this to give the
+ * caller the correct concrete sub-type for the namespace they pass.
+ */
+export interface GsdNamespaceMap {
+  games: GsdGamesApi;
+  costs: GsdCostsApi;
+  logs: GsdLogsApi;
+  files: GsdFilesApi;
+  discord: GsdDiscordApi;
+  env: GsdEnvApi;
+  config: GsdConfigApi;
+  diagnostics: GsdDiagnosticsApi;
+}
+
+// ---------------------------------------------------------------------------
+// Internal registry store
+// ---------------------------------------------------------------------------
+
+/** Mutable store keyed by namespace. */
+const _registry: Partial<GsdNamespaceMap> = {};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Registers a mock implementation for a single `window.gsd` namespace.
+ *
+ * The mock replaces whatever was previously registered for that namespace (if
+ * anything).  Partial implementations are accepted — only the methods the test
+ * needs have to be provided.
+ *
+ * @example
+ * ```ts
+ * import { register } from '@hyveon/desktop-preload/test-mock-registry';
+ * register('games', { list: vi.fn().mockResolvedValue({ games: ['minecraft'] }), ... });
+ * ```
+ */
+export function register<K extends GsdNamespace>(namespace: K, mock: GsdNamespaceMap[K]): void {
+  (_registry as GsdNamespaceMap)[namespace] = mock;
+}
+
+/**
+ * Looks up the mock registered for a namespace.
+ *
+ * Returns `undefined` if nothing has been registered for that namespace yet.
+ * Tests that rely on a mock being present should call {@link register} first.
+ */
+export function lookup<K extends GsdNamespace>(namespace: K): GsdNamespaceMap[K] | undefined {
+  return (_registry as GsdNamespaceMap)[namespace];
+}
+
+/**
+ * Removes all entries from the registry.
+ *
+ * Call this in an `afterEach` hook to prevent mock state from leaking between
+ * tests.
+ */
+export function clear(): void {
+  for (const key of Object.keys(_registry) as GsdNamespace[]) {
+    delete _registry[key];
+  }
+}
+
+/**
+ * Builds a {@link GsdApi}-shaped object from the current registry contents.
+ *
+ * Any namespace not yet registered is omitted (the property will be
+ * `undefined`), which matches the optional-namespace pattern used by the
+ * test harness.  The returned object is suitable for assignment to
+ * `window.gsd` in a `beforeEach` hook.
+ *
+ * This helper is intentionally **not** exported from the package root — import
+ * it directly from the `test-mock-registry` export path.
+ */
+export function buildMockGsd(): Partial<GsdApi> {
+  return { ..._registry };
+}

--- a/app/packages/desktop-preload/src/test-mock-registry.ts
+++ b/app/packages/desktop-preload/src/test-mock-registry.ts
@@ -36,12 +36,18 @@ export type GsdNamespace = Exclude<keyof GsdApi, '__test'>;
  */
 export type GsdNamespaceMap = { [K in GsdNamespace]: GsdApi[K] };
 
+/**
+ * Like {@link GsdNamespaceMap} but each namespace value is `Partial<…>` so
+ * that test stubs only need to supply the methods the test actually exercises.
+ */
+export type GsdPartialNamespaceMap = { [K in GsdNamespace]: Partial<GsdApi[K]> };
+
 // ---------------------------------------------------------------------------
 // Internal registry store
 // ---------------------------------------------------------------------------
 
-/** Mutable store keyed by namespace. */
-const _registry: Partial<GsdNamespaceMap> = {};
+/** Mutable store keyed by namespace, each value being a partial stub of that namespace. */
+const _registry: Partial<GsdPartialNamespaceMap> = {};
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -57,11 +63,11 @@ const _registry: Partial<GsdNamespaceMap> = {};
  * @example
  * ```ts
  * import { register } from '@hyveon/desktop-preload/test-mock-registry';
- * register('games', { list: vi.fn().mockResolvedValue({ games: ['minecraft'] }), ... });
+ * register('games', { list: vi.fn().mockResolvedValue({ games: ['minecraft'] }) });
  * ```
  */
-export function register<K extends GsdNamespace>(namespace: K, mock: GsdNamespaceMap[K]): void {
-  (_registry as GsdNamespaceMap)[namespace] = mock;
+export function register<K extends GsdNamespace>(namespace: K, mock: Partial<GsdNamespaceMap[K]>): void {
+  (_registry as GsdPartialNamespaceMap)[namespace] = mock;
 }
 
 /**
@@ -70,8 +76,8 @@ export function register<K extends GsdNamespace>(namespace: K, mock: GsdNamespac
  * Returns `undefined` if nothing has been registered for that namespace yet.
  * Tests that rely on a mock being present should call {@link register} first.
  */
-export function lookup<K extends GsdNamespace>(namespace: K): GsdNamespaceMap[K] | undefined {
-  return (_registry as GsdNamespaceMap)[namespace];
+export function lookup<K extends GsdNamespace>(namespace: K): Partial<GsdNamespaceMap[K]> | undefined {
+  return (_registry as GsdPartialNamespaceMap)[namespace];
 }
 
 /**
@@ -81,7 +87,7 @@ export function lookup<K extends GsdNamespace>(namespace: K): GsdNamespaceMap[K]
  * tests.
  */
 export function clear(): void {
-  for (const key of Object.keys(_registry) as GsdNamespace[]) {
+  for (const key of Object.keys(_registry) as (keyof GsdPartialNamespaceMap)[]) {
     delete _registry[key];
   }
 }
@@ -98,5 +104,5 @@ export function clear(): void {
  * it directly from the `test-mock-registry` export path.
  */
 export function buildMockGsd(): Partial<GsdApi> {
-  return { ..._registry };
+  return { ..._registry } as Partial<GsdApi>;
 }

--- a/app/packages/web/e2e/specs/ipc-mock.spec.ts
+++ b/app/packages/web/e2e/specs/ipc-mock.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, _electron } from '../fixtures/index.js';
+import { electronMain, electronEnv } from '../../playwright.config.js';
+import type { GameStatus } from '../fixtures/index.js';
+
+/**
+ * Proves the IPC mock seam end-to-end inside the Electron shell.
+ *
+ * The preload script exposes `window.gsd.__test.mock(channel, handler)` when
+ * `HYVEON_TEST_MODE=1`. These specs verify that a mock registered via that
+ * surface overrides the real IPC invoke path, so Playwright e2e tests can
+ * control the main-process responses without modifying the main bundle.
+ *
+ * Each test manages its own ElectronApplication lifecycle so the spec is
+ * self-contained and runnable independently of the global setup.
+ */
+test.describe('IPC mock seam', () => {
+  test('should expose window.gsd.__test in test mode', async () => {
+    const app = await _electron.launch({ args: [electronMain], env: electronEnv });
+
+    try {
+      const win = await app.firstWindow();
+      const hasTestSurface = await win.evaluate(
+        () => typeof (window as Record<string, unknown>)['gsd'] === 'object'
+          && typeof ((window as Record<string, unknown>)['gsd'] as Record<string, unknown>)['__test'] === 'object',
+      );
+      expect(hasTestSurface).toBe(true);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('should return the mocked response instead of the real IPC response', async () => {
+    const app = await _electron.launch({ args: [electronMain], env: electronEnv });
+
+    try {
+      const win = await app.firstWindow();
+
+      /** Canned status array returned by the mock — distinct from any real ECS response. */
+      const mockedStatuses: GameStatus[] = [
+        { game: 'minecraft', state: 'running', publicIp: '1.2.3.4' },
+      ];
+
+      // Register a mock for the `games.status` channel via the test seam.
+      await win.evaluate((statuses) => {
+        const gsd = (window as Record<string, unknown>)['gsd'] as {
+          __test: { mock: (channel: string, handler: unknown) => void };
+        };
+        gsd.__test.mock('games.status', () => Promise.resolve(statuses));
+      }, mockedStatuses);
+
+      // Call `window.gsd.games.status()` through the normal GsdApi surface and
+      // confirm the mock value comes back — not a live ECS call.
+      const result = await win.evaluate(async () => {
+        const gsd = (window as Record<string, unknown>)['gsd'] as {
+          games: { status: () => Promise<unknown> };
+        };
+        return gsd.games.status();
+      });
+
+      expect(result).toEqual(mockedStatuses);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('should allow the mock to be overridden by a second registration on the same channel', async () => {
+    const app = await _electron.launch({ args: [electronMain], env: electronEnv });
+
+    try {
+      const win = await app.firstWindow();
+
+      const firstStatuses: GameStatus[] = [{ game: 'valheim', state: 'stopped' }];
+      const secondStatuses: GameStatus[] = [{ game: 'valheim', state: 'running', publicIp: '9.8.7.6' }];
+
+      // Register the first mock, then override with a second.
+      await win.evaluate(
+        ({ first, second }) => {
+          const gsd = (window as Record<string, unknown>)['gsd'] as {
+            __test: { mock: (channel: string, handler: unknown) => void };
+          };
+          gsd.__test.mock('games.status', () => Promise.resolve(first));
+          gsd.__test.mock('games.status', () => Promise.resolve(second));
+        },
+        { first: firstStatuses, second: secondStatuses },
+      );
+
+      const result = await win.evaluate(async () => {
+        const gsd = (window as Record<string, unknown>)['gsd'] as {
+          games: { status: () => Promise<unknown> };
+        };
+        return gsd.games.status();
+      });
+
+      // Only the second (most-recently registered) mock should be active.
+      expect(result).toEqual(secondStatuses);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/app/packages/web/playwright.config.ts
+++ b/app/packages/web/playwright.config.ts
@@ -37,13 +37,14 @@ export const electronEnv: Record<string, string> = {
  *    stub `/api/*` over HTTP via `page.route()` and navigate to `baseURL`, so
  *    they cannot run under Electron until the IPC mock surface (F.7/#198) lands.
  *    Each existing spec migrates to Electron under its own issue (F.2–F.6).
- *  - `electron` runs the new `_electron.launch()` smoke spec against the
- *    packaged main bundle. Each spec manages its own ElectronApplication.
+ *  - `electron` runs the new `_electron.launch()` smoke spec and the IPC mock
+ *    seam spec against the packaged main bundle. Each spec manages its own
+ *    ElectronApplication.
  *
- * `electron-smoke.spec.ts` is matched only by the `electron` project and
- * ignored by `chromium`; every other spec is the reverse.
+ * `electron-smoke.spec.ts` and `ipc-mock.spec.ts` are matched only by the
+ * `electron` project and ignored by `chromium`; every other spec is the reverse.
  */
-const ELECTRON_SPEC = '**/electron-smoke.spec.ts';
+const ELECTRON_SPECS = ['**/electron-smoke.spec.ts', '**/ipc-mock.spec.ts'];
 
 export default defineConfig({
   testDir: './e2e/specs',
@@ -62,7 +63,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      testIgnore: ELECTRON_SPEC,
+      testIgnore: ELECTRON_SPECS,
       use: {
         ...devices['Desktop Chrome'],
         baseURL: 'http://localhost:4173',
@@ -72,7 +73,7 @@ export default defineConfig({
     },
     {
       name: 'electron',
-      testMatch: ELECTRON_SPEC,
+      testMatch: ELECTRON_SPECS,
     },
   ],
   // Skip the Vite build+preview when only the electron project is being tested.


### PR DESCRIPTION
Closes #198

## Summary

- Adds a test-only `__test` namespace on `window.gsd` (exposed only when `HYVEON_TEST_MODE` is set) with `mock(channel, fn)` and `clearMocks()` methods so Playwright specs can push canned IPC responses at the preload layer without touching real Electron IPC handlers.
- Introduces a typed `test-mock-registry` module in `@hyveon/desktop-preload`, exported as a subpath (`desktop-preload/test-mock-registry`), with full unit-test coverage for registration, dispatch, and gating.
- Adds an `ipc-mock.spec.ts` Playwright spec (Electron project) that exercises the full mock seam end-to-end: injects a mock for `games.list` via `window.gsd.__test.mock()` and asserts it overrides the real IPC handler.

## Changes

```
 CLAUDE.md                                          |  24 ++
 app/packages/desktop-preload/package.json          |   4 +
 app/packages/desktop-preload/src/gsd-api.ts        |  60 ++++
 app/packages/desktop-preload/src/index.ts          |   2 +-
 app/packages/desktop-preload/src/preload.test.ts   | 311 +++++++++++++++++++++
 app/packages/desktop-preload/src/preload.ts        | 123 ++++++--
 app/packages/desktop-preload/src/test-mock-registry.test.ts |  85 ++++++
 app/packages/desktop-preload/src/test-mock-registry.ts      | 108 +++++++
 app/packages/web/e2e/specs/ipc-mock.spec.ts        | 100 +++++++
 app/packages/web/playwright.config.ts              |  15 +-
 10 files changed, 794 insertions(+), 38 deletions(-))
```

## Test plan

- [ ] `npm run app:test` — all unit tests pass, including `preload.test.ts` (dispatcher + `__test` gating) and `test-mock-registry.test.ts` (registry register/dispatch/clear)
- [ ] `npm run app:lint` — 0 errors
- [ ] `PLAYWRIGHT_PROJECT=electron npm run app:test:e2e` (with `desktop:build` run first) — `ipc-mock.spec.ts` passes: mock overrides the real IPC handler and returns canned data
- [ ] `PLAYWRIGHT_PROJECT=electron npm run app:test:e2e` in a **production build** (without `HYVEON_TEST_MODE`) — `window.gsd.__test` is `undefined`; production builds do not expose the mock surface
- [ ] `PLAYWRIGHT_PROJECT=chromium npm run app:test:e2e` — existing Chromium e2e specs continue to pass unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)