### PR TITLE
test(e2e): migrate dashboard spec to Playwright Electron

### DIFF
--- a/app/packages/web/e2e/fixtures/electron-launch.ts
+++ b/app/packages/web/e2e/fixtures/electron-launch.ts
@@ -1,0 +1,178 @@
+/**
+ * Reusable helpers for the Playwright `electron` project.
+ *
+ * Provides two exports:
+ *
+ * - `launchElectron()` — launches the packaged Electron app via
+ *   `_electron.launch()` using the `electronMain` / `electronEnv` values
+ *   from the playwright config, and returns `{ app, win }` where `win` is the
+ *   first-opened `Page`.
+ *
+ * - `applyGsdMocks(win, opts)` — seeds `window.gsd.__test.mock()` for every
+ *   IPC channel the dashboard and its shared provider stack consume, using the
+ *   same `StubOptions` shape and `game-data` fixture constants that the
+ *   Chromium tier uses for `page.route()` stubs. Designed to be called inside
+ *   a `beforeEach` or at the top of a test body, before navigating to a page.
+ */
+
+import type { Page } from '@playwright/test';
+import { _electron } from '@playwright/test';
+import { electronMain, electronEnv } from '../../playwright.config.js';
+import type { StubOptions } from './index.js';
+import {
+  ENV_DATA,
+  STOPPED_GAME,
+  COST_DATA,
+  WATCHDOG_CONFIG,
+  CONFIGURED_DISCORD_CONFIG,
+  makeActualCosts,
+} from './game-data.js';
+import type {
+  GameStatus,
+  ActionResult,
+  CostEstimates,
+  ActualCosts,
+  EnvInfo,
+  WatchdogConfig,
+  DiscordConfigRedacted,
+} from './index.js';
+import type { ElectronApplication } from 'playwright-core';
+
+// ---------------------------------------------------------------------------
+// launchElectron
+// ---------------------------------------------------------------------------
+
+/** Return value of {@link launchElectron}. */
+export interface ElectronHandle {
+  /** The `ElectronApplication` instance — close it in the test's `finally` block. */
+  app: ElectronApplication;
+  /** The first opened `Page` (the renderer window). */
+  win: Page;
+}
+
+/**
+ * Launches the packaged Electron app and waits for the first `BrowserWindow`.
+ *
+ * Uses the `electronMain` entry-point and `electronEnv` (which includes
+ * `HYVEON_TEST_MODE=1`) exported from the playwright config, so all Electron
+ * e2e specs go through the same launch configuration without duplicating it.
+ *
+ * @example
+ * ```ts
+ * test('should show the dashboard', async () => {
+ *   const { app, win } = await launchElectron();
+ *   try {
+ *     await applyGsdMocks(win, { statuses: [RUNNING_GAME] });
+ *     await win.goto('/');
+ *     // ...assertions...
+ *   } finally {
+ *     await app.close();
+ *   }
+ * });
+ * ```
+ */
+export async function launchElectron(): Promise<ElectronHandle> {
+  const app = await _electron.launch({ args: [electronMain], env: electronEnv });
+  const win = await app.firstWindow();
+  return { app, win };
+}
+
+// ---------------------------------------------------------------------------
+// applyGsdMocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Seeds `window.gsd.__test.mock()` for every IPC channel the dashboard and
+ * its shared provider stack call at startup.
+ *
+ * Mirrors the defaults and per-spec overrides of `stubApis` so the same
+ * `StubOptions` vocabulary works for both the Chromium and Electron tiers.
+ * Must be called **before** the renderer navigates to the page under test
+ * (i.e. before `win.goto()`), because the preload consults the mock registry
+ * on each `invoke()` call.
+ *
+ * The following channels are mocked:
+ * - `env.get`         → `EnvInfo`
+ * - `games.status`    → `GameStatus[]`
+ * - `games.list`      → `{ games: string[] }`
+ * - `costs.estimate`  → `CostEstimates`
+ * - `costs.actual`    → `ActualCosts` (receives the `days` argument)
+ * - `games.start`     → `ActionResult`
+ * - `games.stop`      → `ActionResult`
+ * - `discord.getConfig` → `DiscordConfigRedacted`
+ * - `config.get`      → `WatchdogConfig`
+ *
+ * @param win  - The Playwright `Page` for the Electron renderer window.
+ * @param opts - Per-spec overrides; uses the same defaults as `stubApis`.
+ */
+export async function applyGsdMocks(win: Page, opts: StubOptions = {}): Promise<void> {
+  const statuses: GameStatus[] = opts.statuses ?? [STOPPED_GAME];
+  const costs: CostEstimates = opts.costs ?? COST_DATA;
+  const env: EnvInfo = opts.env ?? ENV_DATA;
+  const config: WatchdogConfig = opts.config ?? WATCHDOG_CONFIG;
+  const startResult: ActionResult = opts.startResult ?? { success: true, message: 'Started' };
+  const discord: DiscordConfigRedacted = opts.discord ?? CONFIGURED_DISCORD_CONFIG;
+  const games: string[] = opts.games ?? statuses.map((s) => s.game);
+  const actualCostsFn: (days: number) => ActualCosts =
+    typeof opts.actualCosts === 'function'
+      ? opts.actualCosts
+      : opts.actualCosts !== undefined
+        ? () => opts.actualCosts as ActualCosts
+        : (days) => makeActualCosts(days);
+
+  // Playwright serialises the `evaluate` callback to source and re-evaluates
+  // it in the browser context, so we snapshot all values into plain objects
+  // and pass them as a single serialisable argument.
+  await win.evaluate(
+    ({
+      envData,
+      statusList,
+      gameList,
+      costEstimates,
+      startRes,
+      discordConfig,
+      watchdogConfig,
+      actualCostsMap,
+    }: {
+      envData: EnvInfo;
+      statusList: GameStatus[];
+      gameList: string[];
+      costEstimates: CostEstimates;
+      startRes: ActionResult;
+      discordConfig: DiscordConfigRedacted;
+      watchdogConfig: WatchdogConfig;
+      actualCostsMap: Record<string, ActualCosts>;
+    }) => {
+      const gsd = (window as Record<string, unknown>)['gsd'] as {
+        __test: { mock: (channel: string, handler: unknown) => void };
+      };
+
+      gsd.__test.mock('env.get', () => Promise.resolve(envData));
+      gsd.__test.mock('games.status', () => Promise.resolve(statusList));
+      gsd.__test.mock('games.list', () => Promise.resolve({ games: gameList }));
+      gsd.__test.mock('costs.estimate', () => Promise.resolve(costEstimates));
+      gsd.__test.mock('costs.actual', (days: unknown) => {
+        const d = typeof days === 'number' ? days : 7;
+        const key = String(d);
+        return Promise.resolve(actualCostsMap[key] ?? actualCostsMap['7']);
+      });
+      gsd.__test.mock('games.start', () => Promise.resolve(startRes));
+      gsd.__test.mock('games.stop', () => Promise.resolve({ success: true, message: 'Stopped' }));
+      gsd.__test.mock('discord.getConfig', () => Promise.resolve(discordConfig));
+      gsd.__test.mock('config.get', () => Promise.resolve(watchdogConfig));
+    },
+    {
+      envData: env,
+      statusList: statuses,
+      gameList: games,
+      costEstimates: costs,
+      startRes: startResult,
+      discordConfig: discord,
+      watchdogConfig: config,
+      // Pre-compute the costs.actual responses for the query windows the Costs
+      // page uses (7 and 14 days) so the callback in the browser can do a
+      // synchronous map lookup without calling back into Node.
+      actualCostsMap: { '7': actualCostsFn(7), '14': actualCostsFn(14) },
+    },
+  );
+}

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -266,6 +266,8 @@ export const test = base.extend<E2EFixtures>({
 // fixtures, but those are lazy — an Electron spec that drives its own
 // `_electron.launch()` and requests no page fixtures never instantiates them.
 export { expect, _electron } from '@playwright/test';
+export type { Page } from '@playwright/test';
+export type { ElectronApplication } from 'playwright-core';
 
 export { launchElectron, applyGsdMocks } from './electron-launch.js';
 export type { ElectronHandle } from './electron-launch.js';

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -266,3 +266,6 @@ export const test = base.extend<E2EFixtures>({
 // fixtures, but those are lazy — an Electron spec that drives its own
 // `_electron.launch()` and requests no page fixtures never instantiates them.
 export { expect, _electron } from '@playwright/test';
+
+export { launchElectron, applyGsdMocks } from './electron-launch.js';
+export type { ElectronHandle } from './electron-launch.js';

--- a/app/packages/web/e2e/pages/AppLayout.ts
+++ b/app/packages/web/e2e/pages/AppLayout.ts
@@ -24,6 +24,11 @@ export class AppLayout {
     await this.page.waitForURL(expectedPath);
   }
 
+  /** Main heading rendered by the Logs page (`/logs`). */
+  logsPageHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Server Logs' });
+  }
+
   /** A visible Sonner toast matched by its message text. */
   toastMessage(text: string | RegExp): import('@playwright/test').Locator {
     return this.page.locator('[data-sonner-toast]').filter({ hasText: text });

--- a/app/packages/web/e2e/pages/AppLayout.ts
+++ b/app/packages/web/e2e/pages/AppLayout.ts
@@ -18,10 +18,18 @@ export class AppLayout {
     return this.page.getByRole('link', { name: label });
   }
 
-  /** Click a sidebar nav link and wait for the URL to change to `expectedPath`. */
+  /**
+   * Click a sidebar nav link and wait for the route to change to `expectedPath`.
+   *
+   * Matches on `url.pathname` rather than passing `expectedPath` as a glob:
+   * under chromium a bare path is resolved against `baseURL`, but the Electron
+   * shell has no `baseURL` and serves from a `file://` origin, so a bare-path
+   * glob would never match `file:///logs`. Comparing pathnames works for both
+   * (`http://localhost:4173/logs` and `file:///logs` both resolve to `/logs`).
+   */
   async navigateTo(label: string, expectedPath: string): Promise<void> {
     await this.sidebarLink(label).click();
-    await this.page.waitForURL(expectedPath);
+    await this.page.waitForURL((url) => url.pathname === expectedPath);
   }
 
   /** Main heading rendered by the Logs page (`/logs`). */

--- a/app/packages/web/e2e/pages/DashboardPage.ts
+++ b/app/packages/web/e2e/pages/DashboardPage.ts
@@ -21,6 +21,39 @@ export class DashboardPage {
     await this.page.goto('/');
   }
 
+  /**
+   * Show the dashboard inside the Electron shell, where `page.goto('/')` is an
+   * invalid URL — the packaged app loads from a `file://` origin with no
+   * dev-server base. Instead of navigating by URL this:
+   *
+   *  1. Returns to the `/` route via in-app history navigation (a full reload
+   *     would re-run the preload and wipe the `window.gsd.__test` mock registry
+   *     that the test just seeded), so it works even after a sidebar-nav test
+   *     left the app on another route.
+   *  2. Clicks the top-bar "Refresh all" button. The app-level status poller
+   *     fires once at launch — before the test registers its IPC mocks — so the
+   *     grid must be re-fetched for the seeded `games.status` mock to take
+   *     effect.
+   *
+   * Call after `applyGsdMocks()` so the mocks are in place before the refresh.
+   */
+  async gotoElectron(): Promise<void> {
+    await this.page.evaluate(() => {
+      window.history.pushState({}, '', '/');
+      window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+    });
+    // Wait for the launch-time status poll to settle before refreshing. While
+    // a poll is in flight the registry's `inFlight` guard would silently drop
+    // a `refreshAll()`, so the seeded mock would never be re-fetched. The
+    // top-bar button mirrors that state via `aria-busy`, so it's a reliable
+    // "the poller is idle" signal to gate the click on.
+    await this.page.waitForFunction(() => {
+      const btn = document.querySelector('button[aria-label="Refresh all"]');
+      return btn !== null && !btn.hasAttribute('disabled') && btn.getAttribute('aria-busy') === 'false';
+    });
+    await this.page.getByRole('button', { name: 'Refresh all' }).click();
+  }
+
   // ── GameCard grid ────────────────────────────────────────────────────
 
   /** `<h3>` element inside a card whose game name matches `name`. */

--- a/app/packages/web/e2e/pages/DashboardPage.ts
+++ b/app/packages/web/e2e/pages/DashboardPage.ts
@@ -45,12 +45,22 @@ export class DashboardPage {
     return this.page.getByRole('link', { name: /open setup guide/i });
   }
 
+  /** "Edit terraform.tfvars" CTA link inside the no-games card. */
+  tfvarsLink(): Locator {
+    return this.page.getByRole('link', { name: /terraform\.tfvars/i });
+  }
+
   /** Empty-state when the search input filters out every card. */
   emptySearchMessage(): Locator {
     return this.page.getByText(/no games match/i);
   }
 
   // ── Card action buttons ──────────────────────────────────────────────
+
+  /** IP address / hostname text rendered on a running game card. */
+  gameIpAddress(hostname: string): Locator {
+    return this.page.getByText(hostname);
+  }
 
   /** Primary CTA shown on a stopped/not-deployed/error card. */
   startButton(): Locator {
@@ -60,6 +70,11 @@ export class DashboardPage {
   /** Primary CTA shown on a running/starting card. */
   stopButton(): Locator {
     return this.page.getByRole('button', { name: 'Stop' });
+  }
+
+  /** Confirmation button inside the stop-confirmation dialog. */
+  confirmStopButton(): Locator {
+    return this.page.getByRole('button', { name: /stop server/i });
   }
 
   // ── Search filter ────────────────────────────────────────────────────

--- a/app/packages/web/e2e/specs/dashboard.spec.ts
+++ b/app/packages/web/e2e/specs/dashboard.spec.ts
@@ -1,74 +1,125 @@
+import type { Page } from '@playwright/test';
+import type { ElectronApplication } from 'playwright-core';
 import {
   test,
   expect,
-  stubApis,
+  launchElectron,
+  applyGsdMocks,
   STOPPED_GAME,
   RUNNING_GAME,
   MULTI_GAME_STATUSES,
 } from '../fixtures/index.js';
+import { DashboardPage, AppLayout } from '../pages/index.js';
 
-
+/**
+ * Dashboard spec — driven via `_electron.launch()` and the
+ * `window.gsd.__test.mock()` IPC seam instead of `vite preview` + `page.route()`.
+ *
+ * A single `ElectronApplication` is shared across all tests in the describe
+ * block (launched in `beforeAll`, closed in `afterAll`). Each test calls
+ * `applyGsdMocks()` to seed its own IPC responses, then resets the mock
+ * registry in `afterEach` via `window.gsd.__test.clearMocks()` so stale
+ * handlers do not bleed into later tests.
+ */
 test.describe('dashboard', () => {
-  test('should render a game card for a stopped game', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: [STOPPED_GAME] });
+  let app: ElectronApplication;
+  let win: Page;
+  let dashboard: DashboardPage;
+  let layout: AppLayout;
+
+  test.beforeAll(async () => {
+    ({ app, win } = await launchElectron());
+    dashboard = new DashboardPage(win);
+    layout = new AppLayout(win);
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+  });
+
+  test.afterEach(async () => {
+    await win.evaluate(() => {
+      const gsd = (window as Record<string, unknown>)['gsd'] as {
+        __test: { clearMocks: () => void };
+      };
+      gsd.__test.clearMocks();
+    });
+  });
+
+  test('should render a game card for a stopped game', async () => {
+    await applyGsdMocks(win, { statuses: [STOPPED_GAME] });
     await dashboard.goto();
 
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
     await expect(dashboard.statusBadge('STOPPED')).toBeVisible();
   });
 
-  test('should render a game card for a running game with IP', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: [RUNNING_GAME] });
+  test('should render a game card for a running game with IP', async () => {
+    await applyGsdMocks(win, { statuses: [RUNNING_GAME] });
     await dashboard.goto();
 
     await expect(dashboard.statusBadge('RUNNING')).toBeVisible();
-    await expect(dashboard.page.getByText('minecraft.example.com')).toBeVisible();
+    await expect(win.getByText('minecraft.example.com')).toBeVisible();
   });
 
-  test('should render multiple game cards', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: MULTI_GAME_STATUSES });
+  test('should render multiple game cards', async () => {
+    await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
     await dashboard.goto();
 
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
     await expect(dashboard.gameCardHeading('valheim')).toBeVisible();
   });
 
-  test('should show empty-state message when no games are configured', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: [] });
+  test('should show empty-state message when no games are configured', async () => {
+    await applyGsdMocks(win, { statuses: [] });
     await dashboard.goto();
 
     await expect(dashboard.emptyConfiguredMessage()).toBeVisible();
   });
 
-  test('should show setup guide and terraform.tfvars CTAs in the no-games card', async ({
-    dashboard,
-  }) => {
-    await stubApis(dashboard.page, { statuses: [] });
+  test('should show setup guide and terraform.tfvars CTAs in the no-games card', async () => {
+    await applyGsdMocks(win, { statuses: [] });
     await dashboard.goto();
 
     await expect(dashboard.setupGuideLink()).toBeVisible();
-    await expect(
-      dashboard.page.getByRole('link', { name: /terraform\.tfvars/i }),
-    ).toBeVisible();
+    await expect(win.getByRole('link', { name: /terraform\.tfvars/i })).toBeVisible();
   });
 
-  test('should fire POST /api/start/:game when Start is clicked', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: [STOPPED_GAME] });
+  test('should fire games.start IPC channel when Start is clicked', async () => {
+    await applyGsdMocks(win, { statuses: [STOPPED_GAME] });
 
-    let startCalled = false;
-    await dashboard.page.route('**/api/start/minecraft', (route) => {
-      startCalled = true;
-      return route.fulfill({ json: { success: true, message: 'Started' } });
+    // Override the games.start mock with one that records the call before
+    // resolving, using window.__calledChannels as the in-browser flag store.
+    await win.evaluate(() => {
+      (window as Record<string, unknown>)['__calledChannels'] = {} as Record<string, boolean>;
+      const gsd = (window as Record<string, unknown>)['gsd'] as {
+        __test: { mock: (channel: string, handler: unknown) => void };
+      };
+      gsd.__test.mock('games.start', () => {
+        ((window as Record<string, unknown>)['__calledChannels'] as Record<string, boolean>)[
+          'games.start'
+        ] = true;
+        return Promise.resolve({ success: true, message: 'Started' });
+      });
     });
 
     await dashboard.goto();
     await dashboard.startButton().click();
 
-    await expect.poll(() => startCalled).toBe(true);
+    await expect
+      .poll(() =>
+        win.evaluate(
+          () =>
+            (
+              (window as Record<string, unknown>)['__calledChannels'] as Record<string, boolean>
+            )['games.start'] === true,
+        ),
+      )
+      .toBe(true);
   });
 
-  test('should show only Stop as the primary action for a running game', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: [RUNNING_GAME] });
+  test('should show only Stop as the primary action for a running game', async () => {
+    await applyGsdMocks(win, { statuses: [RUNNING_GAME] });
     await dashboard.goto();
 
     // The redesigned card swaps the primary CTA based on state instead of
@@ -77,8 +128,8 @@ test.describe('dashboard', () => {
     await expect(dashboard.startButton()).toHaveCount(0);
   });
 
-  test('should filter game cards by name in real time', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: MULTI_GAME_STATUSES });
+  test('should filter game cards by name in real time', async () => {
+    await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
     await dashboard.goto();
 
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
@@ -90,16 +141,16 @@ test.describe('dashboard', () => {
     await expect(dashboard.gameCardHeading('valheim')).toBeVisible();
   });
 
-  test('should show empty-state message when search has no matches', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: MULTI_GAME_STATUSES });
+  test('should show empty-state message when search has no matches', async () => {
+    await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
     await dashboard.goto();
 
     await dashboard.filter('nonexistent');
     await expect(dashboard.emptySearchMessage()).toBeVisible();
   });
 
-  test('should render the KPI strip with the four ops tiles', async ({ dashboard }) => {
-    await stubApis(dashboard.page, { statuses: MULTI_GAME_STATUSES });
+  test('should render the KPI strip with the four ops tiles', async () => {
+    await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
     await dashboard.goto();
 
     await expect(dashboard.kpiTileLabel('Servers running')).toBeVisible();
@@ -110,32 +161,32 @@ test.describe('dashboard', () => {
     await expect(dashboard.serversRunningValue('1/2')).toBeVisible();
   });
 
-  test('should navigate to the Logs page via sidebar', async ({ dashboard, layout }) => {
-    await stubApis(dashboard.page, { statuses: [] });
+  test('should navigate to the Logs page via sidebar', async () => {
+    await applyGsdMocks(win, { statuses: [] });
     await dashboard.goto();
 
     await layout.navigateTo('Logs', '/logs');
     // The /logs route is no longer a placeholder — verify the redesigned
     // page actually renders so a regression to the placeholder breaks here.
-    await expect(dashboard.page.getByRole('heading', { name: 'Server Logs' })).toBeVisible();
+    await expect(win.getByRole('heading', { name: 'Server Logs' })).toBeVisible();
   });
 
-  test('should navigate to the Discord page via sidebar', async ({ dashboard, layout }) => {
-    await stubApis(dashboard.page, { statuses: [] });
+  test('should navigate to the Discord page via sidebar', async () => {
+    await applyGsdMocks(win, { statuses: [] });
     await dashboard.goto();
 
     await layout.navigateTo('Discord', '/discord');
   });
 
-  test('should navigate to the Settings page via sidebar', async ({ dashboard, layout }) => {
-    await stubApis(dashboard.page, { statuses: [] });
+  test('should navigate to the Settings page via sidebar', async () => {
+    await applyGsdMocks(win, { statuses: [] });
     await dashboard.goto();
 
     await layout.navigateTo('Settings', '/settings');
   });
 
-  test('should show a success toast after starting a game', async ({ dashboard, layout }) => {
-    await stubApis(dashboard.page, { statuses: [STOPPED_GAME] });
+  test('should show a success toast after starting a game', async () => {
+    await applyGsdMocks(win, { statuses: [STOPPED_GAME] });
     await dashboard.goto();
 
     await dashboard.startButton().click();
@@ -143,16 +194,42 @@ test.describe('dashboard', () => {
     await expect(layout.toastMessage('minecraft is starting')).toBeVisible();
   });
 
-  test('should show a stop toast with an Undo button after stopping a game', async ({ dashboard, layout }) => {
-    await stubApis(dashboard.page, { statuses: [RUNNING_GAME] });
-    await dashboard.goto();
+  test('should show a stop toast with an Undo button after stopping a game', async () => {
+    await applyGsdMocks(win, { statuses: [RUNNING_GAME] });
 
+    // Override the games.stop mock with one that records the call before
+    // resolving, using window.__calledChannels as the in-browser flag store.
+    await win.evaluate(() => {
+      (window as Record<string, unknown>)['__calledChannels'] = {} as Record<string, boolean>;
+      const gsd = (window as Record<string, unknown>)['gsd'] as {
+        __test: { mock: (channel: string, handler: unknown) => void };
+      };
+      gsd.__test.mock('games.stop', () => {
+        ((window as Record<string, unknown>)['__calledChannels'] as Record<string, boolean>)[
+          'games.stop'
+        ] = true;
+        return Promise.resolve({ success: true, message: 'Stopped' });
+      });
+    });
+
+    await dashboard.goto();
     await dashboard.stopButton().click();
 
     // ConfirmDialog appears — confirm the stop.
-    await dashboard.page.getByRole('button', { name: /stop server/i }).click();
+    await win.getByRole('button', { name: /stop server/i }).click();
 
     await expect(layout.toastMessage('minecraft stopped')).toBeVisible();
     await expect(layout.toastUndoButton()).toBeVisible();
+
+    await expect
+      .poll(() =>
+        win.evaluate(
+          () =>
+            (
+              (window as Record<string, unknown>)['__calledChannels'] as Record<string, boolean>
+            )['games.stop'] === true,
+        ),
+      )
+      .toBe(true);
   });
 });

--- a/app/packages/web/e2e/specs/dashboard.spec.ts
+++ b/app/packages/web/e2e/specs/dashboard.spec.ts
@@ -1,4 +1,4 @@
-import type { Page, ElectronApplication } from 'playwright-core';
+import type { Page, ElectronApplication } from '../fixtures/index.js';
 import {
   test,
   expect,
@@ -37,6 +37,7 @@ test.describe('dashboard', () => {
   });
 
   test.afterEach(async () => {
+    if (!win) return;
     await win.evaluate(() => {
       const gsd = (window as Record<string, unknown>)['gsd'] as {
         __test: { clearMocks: () => void };

--- a/app/packages/web/e2e/specs/dashboard.spec.ts
+++ b/app/packages/web/e2e/specs/dashboard.spec.ts
@@ -48,7 +48,7 @@ test.describe('dashboard', () => {
 
   test('should render a game card for a stopped game', async () => {
     await applyGsdMocks(win, { statuses: [STOPPED_GAME] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
     await expect(dashboard.statusBadge('STOPPED')).toBeVisible();
@@ -56,7 +56,7 @@ test.describe('dashboard', () => {
 
   test('should render a game card for a running game with IP', async () => {
     await applyGsdMocks(win, { statuses: [RUNNING_GAME] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.statusBadge('RUNNING')).toBeVisible();
     await expect(dashboard.gameIpAddress('minecraft.example.com')).toBeVisible();
@@ -64,7 +64,7 @@ test.describe('dashboard', () => {
 
   test('should render multiple game cards', async () => {
     await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
     await expect(dashboard.gameCardHeading('valheim')).toBeVisible();
@@ -72,14 +72,14 @@ test.describe('dashboard', () => {
 
   test('should show empty-state message when no games are configured', async () => {
     await applyGsdMocks(win, { statuses: [] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.emptyConfiguredMessage()).toBeVisible();
   });
 
   test('should show setup guide and terraform.tfvars CTAs in the no-games card', async () => {
     await applyGsdMocks(win, { statuses: [] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.setupGuideLink()).toBeVisible();
     await expect(dashboard.tfvarsLink()).toBeVisible();
@@ -103,7 +103,7 @@ test.describe('dashboard', () => {
       });
     });
 
-    await dashboard.goto();
+    await dashboard.gotoElectron();
     await dashboard.startButton().click();
 
     await expect
@@ -120,7 +120,7 @@ test.describe('dashboard', () => {
 
   test('should show only Stop as the primary action for a running game', async () => {
     await applyGsdMocks(win, { statuses: [RUNNING_GAME] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     // The redesigned card swaps the primary CTA based on state instead of
     // disabling the inactive button — Start should not exist while running.
@@ -130,7 +130,7 @@ test.describe('dashboard', () => {
 
   test('should filter game cards by name in real time', async () => {
     await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.gameCardHeading('minecraft')).toBeVisible();
     await expect(dashboard.gameCardHeading('valheim')).toBeVisible();
@@ -143,7 +143,7 @@ test.describe('dashboard', () => {
 
   test('should show empty-state message when search has no matches', async () => {
     await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await dashboard.filter('nonexistent');
     await expect(dashboard.emptySearchMessage()).toBeVisible();
@@ -151,7 +151,7 @@ test.describe('dashboard', () => {
 
   test('should render the KPI strip with the four ops tiles', async () => {
     await applyGsdMocks(win, { statuses: MULTI_GAME_STATUSES });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await expect(dashboard.kpiTileLabel('Servers running')).toBeVisible();
     await expect(dashboard.kpiTileLabel('Spend today')).toBeVisible();
@@ -163,7 +163,7 @@ test.describe('dashboard', () => {
 
   test('should navigate to the Logs page via sidebar', async () => {
     await applyGsdMocks(win, { statuses: [] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await layout.navigateTo('Logs', '/logs');
     // The /logs route is no longer a placeholder — verify the redesigned
@@ -173,21 +173,21 @@ test.describe('dashboard', () => {
 
   test('should navigate to the Discord page via sidebar', async () => {
     await applyGsdMocks(win, { statuses: [] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await layout.navigateTo('Discord', '/discord');
   });
 
   test('should navigate to the Settings page via sidebar', async () => {
     await applyGsdMocks(win, { statuses: [] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await layout.navigateTo('Settings', '/settings');
   });
 
   test('should show a success toast after starting a game', async () => {
     await applyGsdMocks(win, { statuses: [STOPPED_GAME] });
-    await dashboard.goto();
+    await dashboard.gotoElectron();
 
     await dashboard.startButton().click();
 
@@ -212,7 +212,7 @@ test.describe('dashboard', () => {
       });
     });
 
-    await dashboard.goto();
+    await dashboard.gotoElectron();
     await dashboard.stopButton().click();
 
     // ConfirmDialog appears — confirm the stop.

--- a/app/packages/web/e2e/specs/dashboard.spec.ts
+++ b/app/packages/web/e2e/specs/dashboard.spec.ts
@@ -1,5 +1,4 @@
-import type { Page } from '@playwright/test';
-import type { ElectronApplication } from 'playwright-core';
+import type { Page, ElectronApplication } from 'playwright-core';
 import {
   test,
   expect,
@@ -22,7 +21,7 @@ import { DashboardPage, AppLayout } from '../pages/index.js';
  * handlers do not bleed into later tests.
  */
 test.describe('dashboard', () => {
-  let app: ElectronApplication;
+  let app: ElectronApplication | undefined;
   let win: Page;
   let dashboard: DashboardPage;
   let layout: AppLayout;
@@ -34,7 +33,7 @@ test.describe('dashboard', () => {
   });
 
   test.afterAll(async () => {
-    await app.close();
+    if (app) await app.close();
   });
 
   test.afterEach(async () => {
@@ -59,7 +58,7 @@ test.describe('dashboard', () => {
     await dashboard.goto();
 
     await expect(dashboard.statusBadge('RUNNING')).toBeVisible();
-    await expect(win.getByText('minecraft.example.com')).toBeVisible();
+    await expect(dashboard.gameIpAddress('minecraft.example.com')).toBeVisible();
   });
 
   test('should render multiple game cards', async () => {
@@ -82,7 +81,7 @@ test.describe('dashboard', () => {
     await dashboard.goto();
 
     await expect(dashboard.setupGuideLink()).toBeVisible();
-    await expect(win.getByRole('link', { name: /terraform\.tfvars/i })).toBeVisible();
+    await expect(dashboard.tfvarsLink()).toBeVisible();
   });
 
   test('should fire games.start IPC channel when Start is clicked', async () => {
@@ -168,7 +167,7 @@ test.describe('dashboard', () => {
     await layout.navigateTo('Logs', '/logs');
     // The /logs route is no longer a placeholder — verify the redesigned
     // page actually renders so a regression to the placeholder breaks here.
-    await expect(win.getByRole('heading', { name: 'Server Logs' })).toBeVisible();
+    await expect(layout.logsPageHeading()).toBeVisible();
   });
 
   test('should navigate to the Discord page via sidebar', async () => {
@@ -216,7 +215,7 @@ test.describe('dashboard', () => {
     await dashboard.stopButton().click();
 
     // ConfirmDialog appears — confirm the stop.
-    await win.getByRole('button', { name: /stop server/i }).click();
+    await dashboard.confirmStopButton().click();
 
     await expect(layout.toastMessage('minecraft stopped')).toBeVisible();
     await expect(layout.toastUndoButton()).toBeVisible();

--- a/app/packages/web/playwright.config.ts
+++ b/app/packages/web/playwright.config.ts
@@ -41,10 +41,15 @@ export const electronEnv: Record<string, string> = {
  *    seam spec against the packaged main bundle. Each spec manages its own
  *    ElectronApplication.
  *
- * `electron-smoke.spec.ts` and `ipc-mock.spec.ts` are matched only by the
- * `electron` project and ignored by `chromium`; every other spec is the reverse.
+ * `electron-smoke.spec.ts`, `ipc-mock.spec.ts`, and `dashboard.spec.ts` are
+ * matched only by the `electron` project and ignored by `chromium`; every other
+ * spec is the reverse.
  */
-const ELECTRON_SPECS = ['**/electron-smoke.spec.ts', '**/ipc-mock.spec.ts'];
+const ELECTRON_SPECS = [
+  '**/electron-smoke.spec.ts',
+  '**/ipc-mock.spec.ts',
+  '**/dashboard.spec.ts',
+];
 
 export default defineConfig({
   testDir: './e2e/specs',


### PR DESCRIPTION
Closes #190

## Summary

- Adds reusable Electron-launch and GSD stub helpers (`electron-launch.ts`) providing `launchElectron()`, `stubGsdGames()`, and related utilities for Playwright Electron specs.
- Rewrites `dashboard.spec.ts` to drive the real Electron app via `_electron.launch()` and the `window.gsd.__test.mock()` IPC seam (from #245), removing all `page.route()` HTTP stubs.
- Moves `dashboard.spec.ts` from the `chromium` project to the `electron` project in `playwright.config.ts`.

## Changes

```
 app/packages/web/e2e/fixtures/electron-launch.ts | 178 +++++++++++++++++++++++
 app/packages/web/e2e/fixtures/index.ts           |   3 +
 app/packages/web/e2e/specs/dashboard.spec.ts     | 171 ++++++++++++++++------
 app/packages/web/playwright.config.ts            |  11 +-
 4 files changed, 313 insertions(+), 50 deletions(-)
```

## Test plan

- [ ] `npm run app:test` — all unit tests pass
- [ ] `npm run app:lint` — 0 errors
- [ ] `desktop:build` then `PLAYWRIGHT_PROJECT=electron npm run app:test:e2e` — all dashboard assertions pass
- [ ] No `page.route()` calls remain in `dashboard.spec.ts`
- [ ] `PLAYWRIGHT_PROJECT=chromium npm run app:test:e2e` — existing Chromium specs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)