### PR TITLE
test(e2e): migrate logs spec to Playwright Electron

### DIFF
--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -308,4 +308,220 @@ describe('preload dispatcher', () => {
       expect(ipcInvoke).toHaveBeenCalledWith('env.get');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // streamLogs
+  // -------------------------------------------------------------------------
+
+  describe('streamLogs', () => {
+    /**
+     * Helper to collect all chunks from the `logs.stream` async iterable into
+     * an array.  Drives the generator to completion without a `for await` loop
+     * so we can also exercise early-break behaviour in a separate test.
+     */
+    async function collectChunks(iterable: AsyncIterable<string>): Promise<string[]> {
+      const chunks: string[] = [];
+      for await (const chunk of iterable) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mocked-delegation branch
+    // -----------------------------------------------------------------------
+
+    describe('mocked-delegation branch', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should delegate to the registered mock iterable instead of ipcRenderer when logs.stream is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* fakeStream() {
+          yield 'chunk-a';
+          yield 'chunk-b';
+        }
+
+        const mockHandler = vi.fn().mockReturnValue(fakeStream());
+        testApi.mock('logs.stream', mockHandler);
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        const chunks = await collectChunks(logs.stream('valheim'));
+
+        expect(mockHandler).toHaveBeenCalledOnce();
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(ipcSend).not.toHaveBeenCalled();
+        expect(chunks).toEqual(['chunk-a', 'chunk-b']);
+      });
+
+      it('should forward the game argument to the mock handler', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* emptyStream() {}
+        const mockHandler = vi.fn().mockReturnValue(emptyStream());
+        testApi.mock('logs.stream', mockHandler);
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        await collectChunks(logs.stream('minecraft'));
+
+        expect(mockHandler).toHaveBeenCalledWith('minecraft', undefined);
+      });
+
+      it('should forward the AbortSignal to the mock handler when one is provided', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* emptyStream() {}
+        const mockHandler = vi.fn().mockReturnValue(emptyStream());
+        testApi.mock('logs.stream', mockHandler);
+
+        const controller = new AbortController();
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        await collectChunks(logs.stream('terraria', controller.signal));
+
+        expect(mockHandler).toHaveBeenCalledWith('terraria', controller.signal);
+      });
+
+      it('should not attach any ipcRenderer listeners when the mock handles the stream', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* singleChunk() {
+          yield 'only-chunk';
+        }
+        testApi.mock('logs.stream', vi.fn().mockReturnValue(singleChunk()));
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        await collectChunks(logs.stream('factorio'));
+
+        expect(ipcOn).not.toHaveBeenCalled();
+        expect(ipcOnce).not.toHaveBeenCalled();
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Unmocked passthrough branch
+    // -----------------------------------------------------------------------
+
+    describe('unmocked passthrough branch', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        // Load with test-mode OFF so no mock registry is active — the real IPC
+        // path is always exercised.
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should invoke logs.stream on ipcRenderer to obtain a streamId when no mock is registered', async () => {
+        const streamId = 'sid-001';
+        ipcInvoke.mockResolvedValue({ streamId });
+
+        // Simulate the main process sending an end event synchronously after the
+        // invoke so the generator completes without hanging.
+        ipcOnce.mockImplementation((_channel: string, listener: (...args: unknown[]) => void) => {
+          // Fire the end event on the next microtask so the generator has
+          // already attached the listener before it resolves.
+          Promise.resolve().then(() => listener({} as unknown, {}));
+        });
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        const chunks = await collectChunks(logs.stream('minecraft'));
+
+        expect(ipcInvoke).toHaveBeenCalledWith('logs.stream', 'minecraft');
+        expect(chunks).toEqual([]);
+      });
+
+      it('should yield chunks received over the chunk IPC channel', async () => {
+        const streamId = 'sid-002';
+        ipcInvoke.mockResolvedValue({ streamId });
+
+        const chunkChannel = `logs.stream.${streamId}.chunk`;
+        const endChannel = `logs.stream.${streamId}.end`;
+
+        // Capture the chunk listener so we can fire chunks after setup.
+        let capturedChunkListener: ((_evt: unknown, chunk: string) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (_evt: unknown, chunk: string) => void) => {
+          if (channel === chunkChannel) {
+            capturedChunkListener = listener;
+          }
+        });
+
+        // Fire two chunks then end the stream.
+        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { error?: string }) => void) => {
+          if (channel === endChannel) {
+            Promise.resolve()
+              .then(() => {
+                capturedChunkListener?.({}, 'line-1');
+                capturedChunkListener?.({}, 'line-2');
+              })
+              .then(() => listener({} as unknown, {}));
+          }
+        });
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        const chunks = await collectChunks(logs.stream('factorio'));
+
+        expect(chunks).toEqual(['line-1', 'line-2']);
+      });
+
+      it('should throw when the end event carries an error field', async () => {
+        const streamId = 'sid-003';
+        ipcInvoke.mockResolvedValue({ streamId });
+
+        const endChannel = `logs.stream.${streamId}.end`;
+
+        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { error?: string }) => void) => {
+          if (channel === endChannel) {
+            Promise.resolve().then(() => listener({} as unknown, { error: 'stream-failed' }));
+          }
+        });
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+
+        await expect(collectChunks(logs.stream('valheim'))).rejects.toThrow('stream-failed');
+      });
+
+      it('should send cancel and remove listeners when the consumer breaks early', async () => {
+        const streamId = 'sid-004';
+        ipcInvoke.mockResolvedValue({ streamId });
+
+        const chunkChannel = `logs.stream.${streamId}.chunk`;
+        const cancelChannel = `logs.stream.${streamId}.cancel`;
+
+        // Keep the stream alive — never fire the end event — so the consumer
+        // must break out of the loop manually.
+        let capturedChunkListener: ((_evt: unknown, chunk: string) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (_evt: unknown, chunk: string) => void) => {
+          if (channel === chunkChannel) capturedChunkListener = listener;
+        });
+        ipcOnce.mockImplementation(
+          (_channel: string, _listener: (_evt: unknown, data: { error?: string }) => void) => {
+            // Never fires — stream stays open until consumer breaks.
+          },
+        );
+
+        const logs = bridge['logs'] as { stream: (game: string, signal?: AbortSignal) => AsyncIterable<string> };
+        const gen = logs.stream('terraria')[Symbol.asyncIterator]();
+
+        // Call next() to start the generator — it will suspend at the inner
+        // `await new Promise` because no chunk has arrived yet and the buffer
+        // is empty.  Deliver a chunk to wake it, then immediately return.
+        const nextPromise = gen.next();
+        // Flush the ipcInvoke promise so the generator reaches its first await.
+        await Promise.resolve();
+        // Now fire a chunk to wake the suspended generator.
+        capturedChunkListener?.({}, 'first-chunk');
+        // Let the generator resume and yield the chunk.
+        await nextPromise;
+        // The generator is now at its next inner await (waiting for more chunks).
+        // Calling return() interrupts it and triggers the finally block.
+        await gen.return!(undefined);
+
+        expect(ipcSend).toHaveBeenCalledWith(cancelChannel);
+        expect(ipcRemoveListener).toHaveBeenCalledWith(chunkChannel, expect.any(Function));
+      }, 10_000);
+    });
+  });
 });

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -63,17 +63,31 @@ function invoke<T = unknown>(channel: string, ...args: unknown[]): Promise<T> {
  * Bridges the per-stream chunk/end/cancel IPC channels into an
  * {@link AsyncIterable} of log chunks.
  *
- * Opens the stream via `ipcRenderer.invoke('logs.stream', game)`, buffers
- * incoming chunks, and yields them in order. Completes when the `.end` event
- * fires (throwing if it carried an `error`). If the consumer aborts the
- * `signal` or breaks out of the loop early, the `finally` block detaches all
- * listeners and sends `.cancel` so the main process tears the stream down.
+ * When a mock is registered for the `'logs.stream'` channel (test mode only),
+ * the mock handler is called with `(game, signal)` and its return value is
+ * treated as an `AsyncIterable<LogChunk>` — the real IPC listener path is
+ * never touched. The `signal` is forwarded to the mock so test code can honour
+ * cancellation if needed.
+ *
+ * In production (no mock registered), opens the stream via
+ * `ipcRenderer.invoke('logs.stream', game)`, buffers incoming chunks, and
+ * yields them in order. Completes when the `.end` event fires (throwing if it
+ * carried an `error`). If the consumer aborts the `signal` or breaks out of
+ * the `for await` loop early, the `finally` block detaches all listeners and
+ * sends `.cancel` so the main process tears the stream down.
  *
  * The listener-attach happens after the `invoke` resolves with the `streamId`,
  * which is the only point the chunk/end channel names are known — identical to
  * the prior callback implementation, so there is no new dropped-chunk window.
  */
 async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<LogChunk> {
+  const streamMock = mockRegistry.get('logs.stream');
+  if (streamMock !== undefined) {
+    const mockIterable = streamMock(game, signal) as AsyncIterable<LogChunk>;
+    yield* mockIterable;
+    return;
+  }
+
   const { streamId } = (await invoke('logs.stream', game)) as { streamId: string };
   const chunkChannel = `logs.stream.${streamId}.chunk`;
   const endChannel = `logs.stream.${streamId}.end`;

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -266,3 +266,4 @@ export const test = base.extend<E2EFixtures>({
 // fixtures, but those are lazy — an Electron spec that drives its own
 // `_electron.launch()` and requests no page fixtures never instantiates them.
 export { expect, _electron } from '@playwright/test';
+export type { ElectronApplication, Page } from '@playwright/test';

--- a/app/packages/web/e2e/pages/LogsPage.ts
+++ b/app/packages/web/e2e/pages/LogsPage.ts
@@ -13,9 +13,20 @@ export type LogLevelLabel = 'INFO' | 'WARN' | 'ERROR' | 'DEBUG';
 export class LogsPage {
   constructor(public readonly page: Page) {}
 
-  /** Navigate to `/logs` directly. */
+  /** Navigate to `/logs` directly via URL. */
   async goto(): Promise<void> {
     await this.page.goto('/logs');
+  }
+
+  /**
+   * Navigate to `/logs` by clicking the "Logs" sidebar link and waiting for
+   * the URL to settle. Use this in Electron e2e specs where the renderer is
+   * already at a route and navigation must go through the rendered sidebar
+   * rather than a raw `page.goto()` call.
+   */
+  async gotoViaSidebar(): Promise<void> {
+    await this.page.getByRole('link', { name: 'Logs' }).click();
+    await this.page.waitForURL('**/logs');
   }
 
   // ── Header ───────────────────────────────────────────────────────────

--- a/app/packages/web/e2e/specs/logs.spec.ts
+++ b/app/packages/web/e2e/specs/logs.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, _electron, SAMPLE_LOG_LINES } from '../fixtures/index.js';
+import type { ElectronApplication, Page } from '../fixtures/index.js';
 import { electronMain, electronEnv } from '../../playwright.config.js';
 import { LogsPage } from '../pages/index.js';
-import type { ElectronApplication, Page } from '@playwright/test';
 
 /**
  * `/logs` route specs migrated to the Electron project (issue #191).

--- a/app/packages/web/e2e/specs/logs.spec.ts
+++ b/app/packages/web/e2e/specs/logs.spec.ts
@@ -1,33 +1,97 @@
-import { test, expect, stubApis, SAMPLE_LOG_LINES } from '../fixtures/index.js';
+import { test, expect, _electron, SAMPLE_LOG_LINES } from '../fixtures/index.js';
+import { electronMain, electronEnv } from '../../playwright.config.js';
+import { LogsPage } from '../pages/index.js';
+import type { ElectronApplication, Page } from '@playwright/test';
 
 /**
- * `/logs` route specs (issue #63). The Nest server is never started — every
- * `/api/*` call goes through Playwright route stubs. `LogsPage` now fetches
- * its initial snapshot via `window.gsd.logs.get` (IPC bridge) instead of
- * the HTTP API; `stubApis()` injects a `window.gsd.logs` stub via
- * `addInitScript` that returns the seeded lines from `logLines` and resolves
- * the stream call immediately without firing any chunks, so specs drive the
- * page entirely off the seeded snapshot.
+ * `/logs` route specs migrated to the Electron project (issue #191).
+ *
+ * Each test manages its own `ElectronApplication` lifecycle and seeds IPC
+ * responses exclusively via `window.gsd.__test.mock(channel, handler)` — the
+ * mock seam provided by the preload script when `HYVEON_TEST_MODE=1`.
+ *
+ * The `logs.get` mock seeds the initial snapshot displayed by `LogsPage`.
+ * The `logs.stream` mock is an async generator that yields nothing and returns
+ * immediately, so specs drive the UI off the seeded snapshot only.
+ * `games.list` supplies the game selector, and `games.status` silences the
+ * `GameStatusProvider` poller that runs in the background.
  */
+
+/** IPC channel mocked for every test — silences the background status poller. */
+const STOPPED_STATUSES = [{ game: 'minecraft', state: 'stopped' }];
+
+/**
+ * Seed IPC mocks via the `__test` surface and navigate to the Logs page via
+ * the sidebar.
+ *
+ * @param win       - The Electron renderer window handle.
+ * @param games     - Game names returned by `games.list`.
+ * @param logLines  - Map of game name → initial log lines returned by `logs.get`.
+ */
+async function setupLogsPage(
+  win: Page,
+  games: string[],
+  logLines: Record<string, string[]>,
+): Promise<void> {
+  await win.evaluate(
+    ({ games: g, logLines: ll, statuses }) => {
+      const gsd = (window as Record<string, unknown>)['gsd'] as {
+        __test: { mock: (channel: string, handler: unknown) => void };
+      };
+
+      // Silence the background GameStatusProvider poller.
+      gsd.__test.mock('games.status', () => Promise.resolve(statuses));
+
+      // Seed the game list for the combobox selector.
+      gsd.__test.mock('games.list', () => Promise.resolve({ games: g }));
+
+      // Seed the initial log snapshot for each game.
+      gsd.__test.mock('logs.get', ({ game }: { game: string }) =>
+        Promise.resolve({ game, lines: ll[game] ?? [] }),
+      );
+
+      // Stream mock: async generator that yields nothing so specs drive off the
+      // seeded snapshot and never wait for live chunks.
+      gsd.__test.mock('logs.stream', async function* () {});
+    },
+    { games, logLines, statuses: STOPPED_STATUSES },
+  );
+}
+
 test.describe('logs page', () => {
-  test('should render LIVE badge and seeded log lines', async ({ logs }) => {
-    await stubApis(logs.page, {
-      statuses: [{ game: 'minecraft', state: 'stopped' }],
-      logLines: { minecraft: SAMPLE_LOG_LINES },
+  let app: ElectronApplication;
+  let win: Page;
+  let logs: LogsPage;
+
+  test.beforeEach(async () => {
+    app = await _electron.launch({ args: [electronMain], env: electronEnv });
+    win = await app.firstWindow();
+    logs = new LogsPage(win);
+  });
+
+  test.afterEach(async () => {
+    // Clear mocks so stale handlers do not bleed into later tests.
+    await win.evaluate(() => {
+      const gsd = (window as Record<string, unknown>)['gsd'] as {
+        __test: { clearMocks: () => void };
+      };
+      gsd.__test.clearMocks();
     });
-    await logs.goto();
+    await app.close();
+  });
+
+  test('should render LIVE badge and seeded log lines', async () => {
+    await setupLogsPage(win, ['minecraft'], { minecraft: SAMPLE_LOG_LINES });
+    await logs.gotoViaSidebar();
 
     await expect(logs.heading()).toBeVisible();
     await expect(logs.liveBadge()).toBeVisible();
-    await expect(logs.page.getByText('Server started on port 25565')).toBeVisible();
+    await expect(win.getByText('Server started on port 25565')).toBeVisible();
   });
 
-  test('should toggle to Paused badge and back via the Pause/Resume button', async ({ logs }) => {
-    await stubApis(logs.page, {
-      statuses: [{ game: 'minecraft', state: 'stopped' }],
-      logLines: { minecraft: SAMPLE_LOG_LINES },
-    });
-    await logs.goto();
+  test('should toggle to Paused badge and back via the Pause/Resume button', async () => {
+    await setupLogsPage(win, ['minecraft'], { minecraft: SAMPLE_LOG_LINES });
+    await logs.gotoViaSidebar();
 
     await logs.pauseButton().click();
     await expect(logs.pausedBadge()).toBeVisible();
@@ -37,12 +101,9 @@ test.describe('logs page', () => {
     await expect(logs.liveBadge()).toBeVisible();
   });
 
-  test('should color-code lines containing INFO/WARN/ERROR/DEBUG with badges', async ({ logs }) => {
-    await stubApis(logs.page, {
-      statuses: [{ game: 'minecraft', state: 'stopped' }],
-      logLines: { minecraft: SAMPLE_LOG_LINES },
-    });
-    await logs.goto();
+  test('should color-code lines containing INFO/WARN/ERROR/DEBUG with badges', async () => {
+    await setupLogsPage(win, ['minecraft'], { minecraft: SAMPLE_LOG_LINES });
+    await logs.gotoViaSidebar();
 
     // Each level token should appear at least once as a small badge alongside
     // the matching line.
@@ -51,70 +112,55 @@ test.describe('logs page', () => {
     }
   });
 
-  test('should highlight matches via <mark> when typing into the search box without filtering lines out', async ({
-    logs,
-  }) => {
-    await stubApis(logs.page, {
-      statuses: [{ game: 'minecraft', state: 'stopped' }],
-      logLines: { minecraft: SAMPLE_LOG_LINES },
-    });
-    await logs.goto();
+  test('should highlight matches via <mark> when typing into the search box without filtering lines out', async () => {
+    await setupLogsPage(win, ['minecraft'], { minecraft: SAMPLE_LOG_LINES });
+    await logs.gotoViaSidebar();
 
     await expect(logs.highlightMarks()).toHaveCount(0);
 
     await logs.search('Connection');
     await expect(logs.highlightMark('Connection').first()).toBeVisible();
     // The matched line must remain in the buffer — search highlights, never filters.
-    await expect(logs.page.getByText('refused from 10.0.0.5')).toBeVisible();
+    await expect(win.getByText('refused from 10.0.0.5')).toBeVisible();
   });
 
-  test('should hide ERROR-level lines when ERROR is unchecked in the Levels filter', async ({
-    logs,
-  }) => {
-    await stubApis(logs.page, {
-      statuses: [{ game: 'minecraft', state: 'stopped' }],
-      logLines: { minecraft: SAMPLE_LOG_LINES },
-    });
-    await logs.goto();
+  test('should hide ERROR-level lines when ERROR is unchecked in the Levels filter', async () => {
+    await setupLogsPage(win, ['minecraft'], { minecraft: SAMPLE_LOG_LINES });
+    await logs.gotoViaSidebar();
 
-    await expect(logs.page.getByText('Connection refused from 10.0.0.5')).toBeVisible();
+    await expect(win.getByText('Connection refused from 10.0.0.5')).toBeVisible();
     await expect(logs.levelsTriggerWithCount(4)).toBeVisible();
 
     await logs.toggleLevel('ERROR');
 
-    await expect(logs.page.getByText('Connection refused from 10.0.0.5')).not.toBeVisible();
+    await expect(win.getByText('Connection refused from 10.0.0.5')).not.toBeVisible();
     await expect(logs.levelsTriggerWithCount(3)).toBeVisible();
   });
 
-  test('should switch streams via the searchable game combobox', async ({ logs }) => {
-    await stubApis(logs.page, {
-      statuses: [
-        { game: 'minecraft', state: 'stopped' },
-        { game: 'valheim', state: 'stopped' },
-      ],
-      logLines: {
+  test('should switch streams via the searchable game combobox', async () => {
+    await setupLogsPage(
+      win,
+      ['minecraft', 'valheim'],
+      {
         minecraft: ['minecraft seeded line'],
         valheim: ['valheim seeded line'],
       },
-    });
-    await logs.goto();
+    );
+    await logs.gotoViaSidebar();
 
-    await expect(logs.page.getByText('minecraft seeded line')).toBeVisible();
+    await expect(win.getByText('minecraft seeded line')).toBeVisible();
 
     await logs.selectGame('valheim');
 
-    await expect(logs.page.getByText('valheim seeded line')).toBeVisible();
+    await expect(win.getByText('valheim seeded line')).toBeVisible();
     // Switching games resets the buffer — the previous game's seeded line
     // must be gone, not just hidden.
-    await expect(logs.page.getByText('minecraft seeded line')).not.toBeVisible();
+    await expect(win.getByText('minecraft seeded line')).not.toBeVisible();
   });
 
-  test('should display line count and oldest-line age in the footer', async ({ logs }) => {
-    await stubApis(logs.page, {
-      statuses: [{ game: 'minecraft', state: 'stopped' }],
-      logLines: { minecraft: SAMPLE_LOG_LINES },
-    });
-    await logs.goto();
+  test('should display line count and oldest-line age in the footer', async () => {
+    await setupLogsPage(win, ['minecraft'], { minecraft: SAMPLE_LOG_LINES });
+    await logs.gotoViaSidebar();
 
     // SAMPLE_LOG_LINES has 5 entries; "oldest" follows the count.
     await expect(logs.footerLineCount(5)).toBeVisible();

--- a/app/packages/web/playwright.config.ts
+++ b/app/packages/web/playwright.config.ts
@@ -41,10 +41,11 @@ export const electronEnv: Record<string, string> = {
  *    seam spec against the packaged main bundle. Each spec manages its own
  *    ElectronApplication.
  *
- * `electron-smoke.spec.ts` and `ipc-mock.spec.ts` are matched only by the
- * `electron` project and ignored by `chromium`; every other spec is the reverse.
+ * `electron-smoke.spec.ts`, `ipc-mock.spec.ts`, and `logs.spec.ts` are matched
+ * only by the `electron` project and ignored by `chromium`; every other spec is
+ * the reverse.
  */
-const ELECTRON_SPECS = ['**/electron-smoke.spec.ts', '**/ipc-mock.spec.ts'];
+const ELECTRON_SPECS = ['**/electron-smoke.spec.ts', '**/ipc-mock.spec.ts', '**/logs.spec.ts'];
 
 export default defineConfig({
   testDir: './e2e/specs',


### PR DESCRIPTION
Closes #191

## Summary

- Migrates `logs.spec.ts` to the Playwright `electron` project, replacing SSE/page.route stubs with `window.gsd.__test.mock()` IPC mock seam so assertions run against the real Electron shell
- Extends the preload `streamLogs` handler to be mock-aware (delegates to the `__test` mock registry when `HYVEON_TEST_MODE=1` is set)
- Updates `LogsPage` page object with Electron-aware sidebar navigation and adds Vitest unit tests covering the new `streamLogs` mock delegation path

## Changes

```
 app/packages/desktop-preload/src/preload.test.ts | 216 +++++++++++++++++++++++
 app/packages/desktop-preload/src/preload.ts      |  24 ++-
 app/packages/web/e2e/pages/LogsPage.ts           |  13 +-
 app/packages/web/e2e/specs/logs.spec.ts          | 172 +++++++++++-------
 app/packages/web/playwright.config.ts            |   7 +-
 5 files changed, 360 insertions(+), 72 deletions(-)
```

## Test plan

- [ ] `npm run app:test` — all unit tests pass, including the new `preload.test.ts` cases covering `streamLogs` mock delegation
- [ ] `npm run app:lint` — 0 errors
- [ ] `npm run desktop:build` — Electron app builds successfully
- [ ] `PLAYWRIGHT_PROJECT=electron npm run app:test:e2e` — `logs.spec.ts` passes: pause/resume, search, and autoscroll assertions all pass against the real Electron shell
- [ ] `PLAYWRIGHT_PROJECT=chromium npm run app:test:e2e` — existing Chromium e2e specs continue to pass unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)