### PR TITLE
test(e2e): delete auth-gate specs (no auth in desktop)

### DIFF
--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -217,42 +217,32 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
 }
 
 type E2EFixtures = {
-  /**
-   * Raw page handle for specs that need direct page access (e.g. to call
-   * `stubApis` or `addInitScript`); prefer `dashboard` / `costs` / `layout`
-   * for higher-level interactions. Retained as a named alias now that the API
-   * no longer requires a pre-seeded token.
-   */
-  authedPage: Page;
-  /** Page object for the dashboard route — use in any authed-dashboard spec. */
+  /** Page object for the dashboard route. */
   dashboard: DashboardPage;
-  /** Page object for the `/costs` route — use in any authed-costs spec. */
+  /** Page object for the `/costs` route. */
   costs: CostsPage;
-  /** Page object for the `/logs` route — use in any authed-logs spec. */
+  /** Page object for the `/logs` route. */
   logs: LogsPage;
-  /** Page object for the `/settings` route — use in any authed-settings spec. */
+  /** Page object for the `/settings` route. */
   settings: SettingsPage;
   /** Page object for the persistent nav shell (sidebar + top bar). */
   layout: AppLayout;
 };
 
 export const test = base.extend<E2EFixtures>({
-  authedPage: async ({ page }, use) => {
-    await use(page);
+  // Every page object wraps the raw `page` fixture directly — there's no
+  // token seeding or auth gate to resolve through.
+  dashboard: async ({ page }, use) => {
+    await use(new DashboardPage(page));
   },
-  // `dashboard` and `costs` resolve through `authedPage`; `layout` uses the raw
-  // `page`. Both are plain page handles now that no token seeding is required.
-  dashboard: async ({ authedPage }, use) => {
-    await use(new DashboardPage(authedPage));
+  costs: async ({ page }, use) => {
+    await use(new CostsPage(page));
   },
-  costs: async ({ authedPage }, use) => {
-    await use(new CostsPage(authedPage));
+  logs: async ({ page }, use) => {
+    await use(new LogsPage(page));
   },
-  logs: async ({ authedPage }, use) => {
-    await use(new LogsPage(authedPage));
-  },
-  settings: async ({ authedPage }, use) => {
-    await use(new SettingsPage(authedPage));
+  settings: async ({ page }, use) => {
+    await use(new SettingsPage(page));
   },
   layout: async ({ page }, use) => {
     await use(new AppLayout(page));
@@ -260,11 +250,10 @@ export const test = base.extend<E2EFixtures>({
 });
 
 // `_electron` is re-exported so Electron specs import their whole Playwright
-// surface (`test`, `expect`, `_electron`) from this single shared entrypoint,
-// matching the convention that non-auth-gate specs never reach into
-// `@playwright/test` directly. The extended `test` carries browser-page
-// fixtures, but those are lazy — an Electron spec that drives its own
-// `_electron.launch()` and requests no page fixtures never instantiates them.
+// surface (`test`, `expect`, `_electron`) from this single shared entrypoint.
+// The extended `test` carries browser-page fixtures, but those are lazy — an
+// Electron spec that drives its own `_electron.launch()` and requests no page
+// fixtures never instantiates them.
 export { expect, _electron } from '@playwright/test';
 export type { Page } from '@playwright/test';
 export type { ElectronApplication } from 'playwright-core';

--- a/app/packages/web/e2e/fixtures/server-mocks.ts
+++ b/app/packages/web/e2e/fixtures/server-mocks.ts
@@ -1,5 +1,5 @@
 import { test as base } from '@playwright/test';
-import type { APIRequestContext, Page } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
 import { DashboardPage } from '../pages/DashboardPage.js';
 import { installGsdHttpBridge } from './gsd-http-bridge.js';
 
@@ -51,12 +51,7 @@ type IntegrationFixtures = {
    * test so no queued responses leak between specs.
    */
   serverMocks: ServerMocks;
-  /**
-   * Page with the `window.gsd` HTTP bridge installed so every navigation to the
-   * Vite preview can reach the real Nest server on :3002.
-   */
-  authedPage: Page;
-  /** Dashboard page object backed by `authedPage`. */
+  /** Dashboard page object backed by `page`. */
   dashboard: DashboardPage;
 };
 
@@ -68,7 +63,7 @@ export const test = base.extend<IntegrationFixtures>({
     await mocks.reset();
   },
 
-  authedPage: async ({ page }, use) => {
+  page: async ({ page }, use) => {
     // The web client talks to `window.gsd.*`; install a browser-side bridge
     // that forwards each IPC call to the matching `/api/*` route, which the
     // integration preview proxies to the real Nest server on :3002.
@@ -76,7 +71,7 @@ export const test = base.extend<IntegrationFixtures>({
     await use(page);
   },
 
-  dashboard: async ({ authedPage }, use) => {
-    await use(new DashboardPage(authedPage));
+  dashboard: async ({ page }, use) => {
+    await use(new DashboardPage(page));
   },
 });

--- a/app/packages/web/e2e/integration-specs/index.ts
+++ b/app/packages/web/e2e/integration-specs/index.ts
@@ -1,8 +1,7 @@
 /**
  * Re-exports for integration specs. Import `test` and `expect` from here
  * rather than from `@playwright/test` directly — `test` includes the
- * `serverMocks`, `authedPage`, and `dashboard` fixtures that every integration
- * spec needs.
+ * `serverMocks` and `dashboard` fixtures that every integration spec needs.
  */
 export { test, type MockResponse, ServerMocks } from '../fixtures/server-mocks.js';
 export { expect } from '@playwright/test';

--- a/app/packages/web/e2e/pages/AppLayout.ts
+++ b/app/packages/web/e2e/pages/AppLayout.ts
@@ -3,7 +3,7 @@ import type { Page, Locator } from '@playwright/test';
 /**
  * Page object for the persistent navigation shell rendered by `AppLayout.tsx`
  * (sidebar + top bar). Encapsulates locators that are shared across every
- * authenticated route so individual specs don't reach into the layout chrome.
+ * route so individual specs don't reach into the layout chrome.
  */
 export class AppLayout {
   constructor(public readonly page: Page) {}


### PR DESCRIPTION
Closes #196

## Summary

- Removes the `authedPage` fixture from both the Chromium e2e (`e2e/fixtures/index.ts`) and integration (`e2e/integration-specs/index.ts`, `e2e/fixtures/server-mocks.ts`) fixture sets, since the desktop app has no API token and page objects now wrap the raw `page` fixture directly.
- Cleans up stale "authenticated route" / auth-gate doc comments left in `AppLayout.ts` and the fixtures barrel so comments match the no-auth reality of the desktop shell.
- Completes the auth-gate cleanup started for #140 (Electron desktop pivot): `auth-gate.spec.ts` and the `ApiTokenModal` fixtures were already deleted; this PR removes the last fixture-level auth vestiges.

## Changes

```
 app/packages/web/e2e/fixtures/index.ts          | 47 ++++++++++---------------
 app/packages/web/e2e/fixtures/server-mocks.ts   | 15 +++-----
 app/packages/web/e2e/integration-specs/index.ts |  3 +-
 app/packages/web/e2e/pages/AppLayout.ts         |  2 +-
 4 files changed, 25 insertions(+), 42 deletions(-)
```

## Test plan

- [x] `auth-gate.spec.ts` and `ApiTokenModal` fixtures deleted (confirmed no remaining references)
- [ ] `npm run app:test` — all unit tests pass
- [ ] `npm run app:lint` — 0 errors
- [ ] `npm run app:test:e2e` — Chromium e2e specs pass without the `authedPage` fixture
- [ ] `npm run app:test:integration` — integration specs pass without the `authedPage` fixture
- [ ] CI green without auth-gate specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
