### PR TITLE
feat(cloud-aws): AwsCloudProvider.streamWorkloadLogs from CloudWatch

### DIFF
--- a/app/packages/cloud-aws/src/AwsCloudProvider.test.ts
+++ b/app/packages/cloud-aws/src/AwsCloudProvider.test.ts
@@ -8,12 +8,20 @@ import {
   StopTaskCommand,
 } from '@aws-sdk/client-ecs';
 import { EC2Client, DescribeNetworkInterfacesCommand } from '@aws-sdk/client-ec2';
-import { AwsCloudProvider, WorkloadLaunchError, type AwsCloudProviderConfig } from './AwsCloudProvider.js';
+import { CloudWatchLogsClient, FilterLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs';
+import {
+  AwsCloudProvider,
+  WorkloadGuardError,
+  WorkloadLaunchError,
+  type AwsCloudProviderConfig,
+} from './AwsCloudProvider.js';
 
 /** Typed stand-in for the AWS ECS SDK client. */
 const ecsMock = mockClient(ECSClient);
 /** Typed stand-in for the AWS EC2 SDK client. */
 const ec2Mock = mockClient(EC2Client);
+/** Typed stand-in for the AWS CloudWatch Logs SDK client. */
+const logsMock = mockClient(CloudWatchLogsClient);
 
 /**
  * A canonical set of provider configuration used by most tests. Individual
@@ -40,6 +48,7 @@ describe('AwsCloudProvider', () => {
   beforeEach(() => {
     ecsMock.reset();
     ec2Mock.reset();
+    logsMock.reset();
   });
 
   describe('startWorkload', () => {
@@ -288,6 +297,189 @@ describe('AwsCloudProvider', () => {
       const status = await provider.getWorkloadStatus('minecraft');
 
       expect(status).toEqual({ state: 'error', message: 'Error: unexpected failure' });
+    });
+  });
+
+  describe('streamWorkloadLogs', () => {
+    it('should throw a WorkloadGuardError when no config is available', async () => {
+      const provider = makeProvider(null);
+      const ac = new AbortController();
+      await expect(
+        (async () => {
+          for await (const _chunk of provider.streamWorkloadLogs('minecraft', ac.signal, 0)) {
+            // no config means the generator should throw before yielding anything
+          }
+        })(),
+      ).rejects.toThrow(WorkloadGuardError);
+    });
+
+    it('should terminate immediately when signal is already aborted before the first poll', async () => {
+      const ac = new AbortController();
+      ac.abort();
+
+      const provider = makeProvider();
+      const chunks: unknown[] = [];
+      for await (const chunk of provider.streamWorkloadLogs('minecraft', ac.signal, 0)) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([]);
+      expect(logsMock.commandCalls(FilterLogEventsCommand)).toHaveLength(0);
+    });
+
+    it('should yield log chunks from the first poll and terminate on abort', async () => {
+      logsMock.on(FilterLogEventsCommand).resolves({
+        events: [
+          { eventId: 'e1', timestamp: 1000, message: 'line1' },
+          { eventId: 'e2', timestamp: 2000, message: 'line2' },
+        ],
+      });
+
+      const provider = makeProvider();
+      const ac = new AbortController();
+      const gen = provider.streamWorkloadLogs('minecraft', ac.signal, 0);
+
+      const { value: c1 } = await gen.next();
+      const { value: c2 } = await gen.next();
+      ac.abort();
+      const { done } = await gen.next();
+
+      expect(c1).toEqual({ message: 'line1', timestamp: new Date(1000) });
+      expect(c2).toEqual({ message: 'line2', timestamp: new Date(2000) });
+      expect(done).toBe(true);
+    });
+
+    it('should yield new events from successive polls', async () => {
+      logsMock
+        .on(FilterLogEventsCommand)
+        .resolvesOnce({ events: [{ eventId: 'e1', timestamp: 1000, message: 'first' }] })
+        .resolves({ events: [{ eventId: 'e2', timestamp: 2000, message: 'second' }] });
+
+      const provider = makeProvider();
+      const ac = new AbortController();
+      const gen = provider.streamWorkloadLogs('minecraft', ac.signal, 0);
+
+      const { value: c1 } = await gen.next();
+      const { value: c2 } = await gen.next();
+      ac.abort();
+      await gen.return(undefined);
+
+      expect(c1).toEqual({ message: 'first', timestamp: new Date(1000) });
+      expect(c2).toEqual({ message: 'second', timestamp: new Date(2000) });
+    });
+
+    it('should de-duplicate events with the same eventId across polls', async () => {
+      logsMock
+        .on(FilterLogEventsCommand)
+        .resolvesOnce({ events: [{ eventId: 'e1', timestamp: 1000, message: 'line1' }] })
+        .resolvesOnce({
+          events: [
+            { eventId: 'e1', timestamp: 1000, message: 'line1' }, // already seen
+            { eventId: 'e2', timestamp: 2000, message: 'line2' }, // new
+          ],
+        });
+
+      const provider = makeProvider();
+      const ac = new AbortController();
+      const gen = provider.streamWorkloadLogs('minecraft', ac.signal, 0);
+
+      const { value: c1 } = await gen.next(); // first poll yields 'line1'
+      const { value: c2 } = await gen.next(); // second poll skips duplicate, yields 'line2'
+      ac.abort();
+      await gen.return(undefined);
+
+      expect(c1).toEqual({ message: 'line1', timestamp: new Date(1000) });
+      expect(c2).toEqual({ message: 'line2', timestamp: new Date(2000) });
+    });
+
+    it('should query the /ecs/{game}-server log group', async () => {
+      logsMock.on(FilterLogEventsCommand).resolves({
+        events: [{ eventId: 'e1', timestamp: 1000, message: 'hello' }],
+      });
+
+      const provider = makeProvider();
+      const ac = new AbortController();
+      const gen = provider.streamWorkloadLogs('valheim', ac.signal, 0);
+
+      await gen.next(); // first poll runs and yields 'hello'
+      ac.abort();
+      await gen.return(undefined);
+
+      const calls = logsMock.commandCalls(FilterLogEventsCommand);
+      expect(calls[0]!.args[0].input.logGroupName).toBe('/ecs/valheim-server');
+    });
+
+    it('should yield a stream-error sentinel and continue when a poll throws', async () => {
+      logsMock
+        .on(FilterLogEventsCommand)
+        .rejectsOnce(new Error('throttled'))
+        .resolves({ events: [{ eventId: 'e1', timestamp: 1000, message: 'recovered' }] });
+
+      const provider = makeProvider();
+      const ac = new AbortController();
+      const gen = provider.streamWorkloadLogs('minecraft', ac.signal, 0);
+
+      const { value: errChunk } = (await gen.next()) as { value: { message: string } };
+      const { value: okChunk } = await gen.next();
+      ac.abort();
+      await gen.return(undefined);
+
+      expect(errChunk.message).toMatch(/\[stream error\].*throttled/);
+      expect(okChunk).toEqual({ message: 'recovered', timestamp: new Date(1000) });
+    });
+
+    it('should map a missing event.message to an empty string', async () => {
+      logsMock.on(FilterLogEventsCommand).resolves({
+        events: [{ eventId: 'e1', timestamp: 1000 }], // no message field
+      });
+
+      const provider = makeProvider();
+      const ac = new AbortController();
+      const gen = provider.streamWorkloadLogs('minecraft', ac.signal, 0);
+
+      const { value: chunk } = await gen.next();
+      ac.abort();
+      await gen.return(undefined);
+
+      expect(chunk).toEqual({ message: '', timestamp: new Date(1000) });
+    });
+
+    it('should default the poll cadence to 2000ms when pollInterval is not specified', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        // Second poll must return a *new* eventId — a duplicate would be
+        // deduped without yielding, so the generator would keep polling
+        // (and sleeping) indefinitely instead of settling `nextPromise`
+        // right after the second poll's sleep completes.
+        logsMock
+          .on(FilterLogEventsCommand)
+          .resolvesOnce({ events: [{ eventId: 'e1', timestamp: 1000, message: 'line1' }] })
+          .resolves({ events: [{ eventId: 'e2', timestamp: 2000, message: 'line2' }] });
+
+        const provider = makeProvider();
+        const ac = new AbortController();
+        const gen = provider.streamWorkloadLogs('minecraft', ac.signal); // default pollInterval
+
+        await gen.next(); // consumes the first poll's single yielded chunk
+
+        let secondPollSettled = false;
+        const nextPromise = gen.next().then((result) => {
+          secondPollSettled = true;
+          return result;
+        });
+
+        await vi.advanceTimersByTimeAsync(1999);
+        expect(secondPollSettled).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1);
+        await nextPromise;
+        expect(secondPollSettled).toBe(true);
+
+        ac.abort();
+        await gen.return(undefined);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/app/packages/cloud-aws/src/AwsCloudProvider.ts
+++ b/app/packages/cloud-aws/src/AwsCloudProvider.ts
@@ -458,7 +458,7 @@ export class AwsCloudProvider implements CloudProvider {
         }
       } catch (err) {
         if ((err as Error).name === 'AbortError') break;
-        this.logger?.error('Log stream poll error', err);
+        this.logger?.error(`Log stream poll error for game=${game} logGroup=${logGroup}`, err);
         yield { message: `[stream error] ${String(err)}`, timestamp: new Date() };
       }
 

--- a/app/packages/cloud-aws/src/AwsCloudProvider.ts
+++ b/app/packages/cloud-aws/src/AwsCloudProvider.ts
@@ -7,6 +7,7 @@ import {
   type Task,
 } from '@aws-sdk/client-ecs';
 import { EC2Client, DescribeNetworkInterfacesCommand } from '@aws-sdk/client-ec2';
+import { CloudWatchLogsClient, FilterLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs';
 import type {
   CloudProvider,
   CostBreakdown,
@@ -16,6 +17,31 @@ import type {
   WorkloadHandle,
   WorkloadStatus,
 } from '@hyveon/shared';
+
+/**
+ * Sleep for `ms` milliseconds, but reject immediately if `signal` is aborted.
+ * Mirrors `LogsService`'s `sleepInterruptible` helper so `streamWorkloadLogs`'s
+ * poll loop exits promptly when the caller aborts, rather than waiting out a
+ * full cadence after the last poll.
+ */
+function sleepInterruptible(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort);
+  });
+}
 
 /**
  * Thrown by {@link AwsCloudProvider.startWorkload} / {@link
@@ -108,14 +134,18 @@ export interface AwsCloudProviderLogger {
  * `@hyveon/desktop-main` — configuration is supplied via the constructor's
  * `getConfig` callback instead of `ConfigService`.
  *
- * `streamWorkloadLogs`, `getCostEstimate` and `getActualCosts` remain stubs
- * until their own follow-up tasks (#172, #174, #176) land.
+ * `streamWorkloadLogs` reproduces `LogsService.streamLogs`'s CloudWatch Logs
+ * polling behaviour (see the method for details). `getCostEstimate` and
+ * `getActualCosts` remain stubs until their own follow-up tasks (#174, #176)
+ * land.
  */
 export class AwsCloudProvider implements CloudProvider {
   private ecsClient: ECSClient | null = null;
   private ecsClientRegion: string | null = null;
   private ec2Client: EC2Client | null = null;
   private ec2ClientRegion: string | null = null;
+  private logsClient: CloudWatchLogsClient | null = null;
+  private logsClientRegion: string | null = null;
 
   /**
    * Per-game tail of the in-flight critical-section chain, used by {@link
@@ -167,6 +197,19 @@ export class AwsCloudProvider implements CloudProvider {
       this.ec2ClientRegion = region;
     }
     return this.ec2Client;
+  }
+
+  /**
+   * Lazily constructs the CloudWatch Logs client, recreating it whenever
+   * `region` differs from the region the cached client was built with — see
+   * {@link getEcsClient} for why this matters.
+   */
+  private getLogsClient(region: string): CloudWatchLogsClient {
+    if (!this.logsClient || this.logsClientRegion !== region) {
+      this.logsClient = new CloudWatchLogsClient({ region });
+      this.logsClientRegion = region;
+    }
+    return this.logsClient;
   }
 
   /**
@@ -369,12 +412,62 @@ export class AwsCloudProvider implements CloudProvider {
   /**
    * Streams log chunks for a running game workload on AWS.
    *
-   * @param _game - The game identifier to stream logs for.
-   * @param _signal - Aborts the stream when triggered.
-   * @returns Never yields — stub throws until implemented.
+   * Reproduces `LogsService.streamLogs`'s polling behaviour: polls
+   * `FilterLogEvents` against the Terraform-provisioned `/ecs/{game}-server`
+   * log group every `pollInterval` ms (default 2000, matching the SSE
+   * client's expected cadence), de-duplicates by `eventId` (falling back to
+   * `{timestamp}-{message}` when a CloudWatch event has no `eventId`) so
+   * overlapping `startTime` windows never yield the same line twice, and
+   * exits cleanly once `signal` is aborted. A poll failure yields a single
+   * `[stream error] ...` sentinel chunk instead of terminating the generator,
+   * so a transient CloudWatch/SDK hiccup doesn't kill the whole stream —
+   * matching `LogsService.streamLogs`'s resiliency.
+   *
+   * @param game - The game identifier to stream logs for.
+   * @param signal - Aborts the stream when triggered.
+   * @param pollInterval - Milliseconds between polls. Defaults to 2000.
    */
-  streamWorkloadLogs(_game: string, _signal: AbortSignal): AsyncIterable<LogChunk> {
-    throw new Error('Not implemented: streamWorkloadLogs — see Epic #137');
+  async *streamWorkloadLogs(
+    game: string,
+    signal: AbortSignal,
+    pollInterval = 2000,
+  ): AsyncGenerator<LogChunk> {
+    const config = this.getConfig?.() ?? null;
+    if (!config) throw new WorkloadGuardError("Terraform not applied. Run 'terraform apply' first.");
+
+    const { region } = config;
+    const logGroup = `/ecs/${game}-server`;
+    let startTime = Date.now();
+    const seen = new Set<string>();
+
+    while (!signal.aborted) {
+      try {
+        const resp = await this.getLogsClient(region).send(
+          new FilterLogEventsCommand({ logGroupName: logGroup, startTime, limit: 100 }),
+          { abortSignal: signal },
+        );
+        for (const e of resp.events ?? []) {
+          const id = e.eventId ?? `${e.timestamp}-${e.message}`;
+          if (!seen.has(id)) {
+            seen.add(id);
+            yield { message: e.message ?? '', timestamp: new Date(e.timestamp ?? Date.now()) };
+          }
+          if ((e.timestamp ?? 0) >= startTime) {
+            startTime = (e.timestamp ?? startTime) + 1;
+          }
+        }
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') break;
+        this.logger?.error('Log stream poll error', err);
+        yield { message: `[stream error] ${String(err)}`, timestamp: new Date() };
+      }
+
+      try {
+        await sleepInterruptible(pollInterval, signal);
+      } catch {
+        break;
+      }
+    }
   }
 
   /**

--- a/app/packages/cloud-aws/src/index.test.ts
+++ b/app/packages/cloud-aws/src/index.test.ts
@@ -16,9 +16,9 @@ import {
  * return types, but throw synchronously (they aren't `async` functions), so
  * those assertions use `expect(() => ...).toThrow(...)` rather than
  * `.rejects.toThrow(...)`. `AwsCloudProvider`'s workload methods
- * (`startWorkload`/`stopWorkload`/`getWorkloadStatus`) are real `async`
- * implementations, so their "no config supplied" branch is asserted via
- * `.rejects`/`.resolves` instead.
+ * (`startWorkload`/`stopWorkload`/`getWorkloadStatus`/`streamWorkloadLogs`)
+ * are real `async`/async-generator implementations, so their "no config
+ * supplied" branch is asserted via `.rejects`/`.resolves` instead.
  */
 describe('cloud-aws barrel export', () => {
   it('should export AwsCloudProvider as a constructible class', () => {
@@ -42,11 +42,15 @@ describe('cloud-aws barrel export', () => {
     });
   });
 
-  it('should throw a Not implemented error when streamWorkloadLogs is called', () => {
+  it('should reject with a "Terraform not applied" error when streamWorkloadLogs is iterated without config', async () => {
     const controller = new AbortController();
-    expect(() => new AwsCloudProvider().streamWorkloadLogs('x', controller.signal)).toThrow(
-      'Not implemented',
-    );
+    await expect(
+      (async () => {
+        for await (const _chunk of new AwsCloudProvider().streamWorkloadLogs('x', controller.signal)) {
+          // draining the generator triggers the guard check on first iteration
+        }
+      })(),
+    ).rejects.toThrow("Terraform not applied. Run 'terraform apply' first.");
   });
 
   it('should throw a Not implemented error when getCostEstimate is called', () => {

--- a/app/packages/desktop-main/src/services/LogsService.test.ts
+++ b/app/packages/desktop-main/src/services/LogsService.test.ts
@@ -37,6 +37,11 @@ const TF_OUTPUTS: TfOutputs = {
   game_names: ['minecraft'],
   alb_dns_name: null,
   acm_certificate_arn: null,
+  discord_table_name: 'discord-table',
+  discord_bot_token_secret_arn: 'arn:aws:secretsmanager:us-east-1:123:secret:bot-token',
+  discord_public_key_secret_arn: 'arn:aws:secretsmanager:us-east-1:123:secret:public-key',
+  interactions_invoke_url: null,
+  discord_interactions_url: null,
 };
 
 /**

--- a/app/packages/desktop-main/src/services/LogsService.test.ts
+++ b/app/packages/desktop-main/src/services/LogsService.test.ts
@@ -13,17 +13,42 @@ vi.mock('../logger.js', () => ({
 }));
 
 import { LogsService } from './LogsService.js';
-import type { ConfigService } from './ConfigService.js';
+import type { ConfigService, TfOutputs } from './ConfigService.js';
 
 /** Typed stand-in for the AWS CloudWatch Logs SDK client. */
 const cwMock = mockClient(CloudWatchLogsClient);
 
 /**
+ * A minimal set of Terraform outputs satisfying `AwsCloudProvider`'s
+ * `getConfig` callback. `streamLogs` only reads `region` off the resolved
+ * config, but `buildProviderConfig` (shared with `EcsService`) always maps
+ * the full `TfOutputs` shape, so every field needs a value here.
+ */
+const TF_OUTPUTS: TfOutputs = {
+  aws_region: 'us-east-1',
+  ecs_cluster_name: 'game-cluster',
+  ecs_cluster_arn: 'arn:aws:ecs:us-east-1:123:cluster/game-cluster',
+  subnet_ids: 'subnet-a',
+  security_group_id: 'sg-game',
+  file_manager_security_group_id: 'sg-files',
+  efs_file_system_id: 'fs-1',
+  efs_access_points: {},
+  domain_name: 'example.com',
+  game_names: ['minecraft'],
+  alb_dns_name: null,
+  acm_certificate_arn: null,
+};
+
+/**
  * Build a minimal ConfigService stub exposing only the members LogsService
- * actually reads at runtime.
+ * (and, transitively, the default `AwsCloudProvider` it delegates
+ * `streamLogs` to) actually read at runtime.
  */
 function makeConfig(): ConfigService {
-  const stub: Partial<ConfigService> = { getRegion: () => 'us-east-1' };
+  const stub: Partial<ConfigService> = {
+    getRegion: () => 'us-east-1',
+    getTfOutputs: () => TF_OUTPUTS,
+  };
   return stub as ConfigService;
 }
 

--- a/app/packages/desktop-main/src/services/LogsService.ts
+++ b/app/packages/desktop-main/src/services/LogsService.ts
@@ -2,34 +2,12 @@ import { Injectable } from '@nestjs/common';
 import {
   CloudWatchLogsClient,
   DescribeLogStreamsCommand,
-  FilterLogEventsCommand,
   GetLogEventsCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
+import { AwsCloudProvider } from '@hyveon/cloud-aws';
 import { logger } from '../logger.js';
 import { ConfigService } from './ConfigService.js';
-
-/**
- * Sleep for `ms` milliseconds, but reject immediately if `signal` is aborted.
- * Used by `streamLogs` so the poll loop exits promptly when the SSE client disconnects.
- */
-function sleepInterruptible(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal.aborted) {
-      reject(new DOMException('Aborted', 'AbortError'));
-      return;
-    }
-    const onAbort = () => {
-      clearTimeout(timer);
-      signal.removeEventListener('abort', onAbort);
-      reject(new DOMException('Aborted', 'AbortError'));
-    };
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    signal.addEventListener('abort', onAbort);
-  });
-}
+import { createAwsCloudProvider } from './EcsService.js';
 
 /**
  * Fetches recent CloudWatch Logs lines for a game's ECS task so the UI can
@@ -40,7 +18,15 @@ function sleepInterruptible(ms: number, signal: AbortSignal): Promise<void> {
 export class LogsService {
   private client: CloudWatchLogsClient | null = null;
 
-  constructor(private readonly config: ConfigService) {}
+  constructor(
+    private readonly config: ConfigService,
+    // Shares the same `AwsCloudProvider` instance `EcsService` uses (wired via
+    // `AwsModule`'s `useFactory` provider) so `streamLogs` delegates to
+    // `AwsCloudProvider.streamWorkloadLogs` instead of duplicating its
+    // CloudWatch Logs polling logic. Defaults to a freshly constructed
+    // provider for call sites (and tests) that don't go through Nest DI.
+    private readonly provider: AwsCloudProvider = createAwsCloudProvider(config),
+  ) {}
 
   private getClient(): CloudWatchLogsClient {
     if (!this.client) {
@@ -50,51 +36,21 @@ export class LogsService {
   }
 
   /**
-   * Async generator that polls `FilterLogEvents` every `pollInterval` ms and
-   * yields new log lines as they arrive. De-duplicates by `eventId` so lines
-   * are never emitted twice even when `startTime` windows overlap at the
-   * boundary. The generator exits cleanly when `signal` is aborted (i.e.
-   * when the SSE client disconnects).
-   *
-   * Queries the whole log group so that a stop+start of the ECS task
-   * (which creates a new stream) is handled automatically without reconnecting.
+   * Async generator that yields new log lines as they arrive for `game`.
+   * Delegates to {@link AwsCloudProvider.streamWorkloadLogs}, which polls
+   * `FilterLogEvents` every `pollInterval` ms (de-duplicated by `eventId`,
+   * exiting cleanly when `signal` is aborted) — see that method's TSDoc for
+   * the full behaviour this preserves. Only the `message` of each yielded
+   * `LogChunk` is surfaced here, matching this method's pre-existing
+   * `AsyncGenerator<string>` contract.
    */
   async *streamLogs(
     game: string,
     signal: AbortSignal,
     pollInterval = 2000,
   ): AsyncGenerator<string> {
-    const logGroup = `/ecs/${game}-server`;
-    let startTime = Date.now();
-    const seen = new Set<string>();
-
-    while (!signal.aborted) {
-      try {
-        const resp = await this.getClient().send(
-          new FilterLogEventsCommand({ logGroupName: logGroup, startTime, limit: 100 }),
-          { abortSignal: signal },
-        );
-        for (const e of resp.events ?? []) {
-          const id = e.eventId ?? `${e.timestamp}-${e.message}`;
-          if (!seen.has(id)) {
-            seen.add(id);
-            yield e.message ?? '';
-          }
-          if ((e.timestamp ?? 0) >= startTime) {
-            startTime = (e.timestamp ?? startTime) + 1;
-          }
-        }
-      } catch (err) {
-        if ((err as Error).name === 'AbortError') break;
-        logger.error('Log stream poll error', { err, game, logGroup });
-        yield `[stream error] ${String(err)}`;
-      }
-
-      try {
-        await sleepInterruptible(pollInterval, signal);
-      } catch {
-        break;
-      }
+    for await (const chunk of this.provider.streamWorkloadLogs(game, signal, pollInterval)) {
+      yield chunk.message;
     }
   }
 


### PR DESCRIPTION
Closes #172

## Summary

- Implements `streamWorkloadLogs(game, signal)` in `AwsCloudProvider` as an `AsyncIterable<LogChunk>`, moving the CloudWatch Logs polling loop out of the server's `LogsService` and into the cloud-provider abstraction.
- Preserves the existing 2-second polling cadence and `AbortSignal`-driven backpressure/cancellation behavior during the move.
- Refactors `LogsService` to delegate to `AwsCloudProvider.streamWorkloadLogs`, and updates/adds unit test coverage in both `AwsCloudProvider.test.ts` and `LogsService.test.ts` to reflect the new delegation pattern, including restoring game/log-group context in poll-failure logging.

## Changes

```
 .../cloud-aws/src/AwsCloudProvider.test.ts         | 194 ++++++++++++++++++++-
 app/packages/cloud-aws/src/AwsCloudProvider.ts     | 107 +++++++++++-
 app/packages/cloud-aws/src/index.test.ts           |  18 +-
 .../desktop-main/src/services/LogsService.test.ts  |  31 +++-
 .../desktop-main/src/services/LogsService.ts       |  84 +++------
 5 files changed, 352 insertions(+), 82 deletions(-)
```

## Test plan

- [x] `streamWorkloadLogs` implemented in `AwsCloudProvider` as an `AsyncIterable<LogChunk>`, preserving the 2-second polling cadence
- [x] `AbortSignal`-driven cancellation/backpressure behavior preserved
- [x] `LogsService` delegates to `AwsCloudProvider.streamWorkloadLogs`; existing log-streaming tests pass after the class move
- [x] New/updated unit tests in `AwsCloudProvider.test.ts` and `LogsService.test.ts` cover the streaming behavior
- [ ] `npm run app:test` — all unit tests pass
- [ ] `npm run app:lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)