### PR TITLE
feat(cloud-aws): AwsS3Store implementation

### DIFF
--- a/app/packages/cloud-aws/src/AwsRemoteFileStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRemoteFileStore.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  ListObjectVersionsCommand,
+  NoSuchKey,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { RemoteFileConflictError } from '@hyveon/shared';
+import { AwsRemoteFileStore } from './AwsRemoteFileStore.js';
+
+/** Typed stand-in for the AWS S3 SDK client. */
+const s3Mock = mockClient(S3Client);
+
+/**
+ * Build an {@link AwsRemoteFileStore} whose `getConfig` callback resolves to
+ * the given bucket/region. Pass `undefined` to simulate a store constructed
+ * with no `getConfig` callback at all (the zero-arg-constructible case).
+ */
+function makeStore(config: { bucket: string; region?: string } | undefined = { bucket: 'my-bucket' }) {
+  return new AwsRemoteFileStore(config === undefined ? undefined : () => config);
+}
+
+/** Builds a fake S3 `Body` stream whose `transformToByteArray()` resolves to the given bytes. */
+function fakeBody(bytes: Uint8Array): { transformToByteArray: () => Promise<Uint8Array> } {
+  return { transformToByteArray: async () => bytes };
+}
+
+describe('AwsRemoteFileStore', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  afterEach(() => {
+    delete process.env['AWS_REGION_'];
+    delete process.env['AWS_REGION'];
+    delete process.env['AWS_DEFAULT_REGION'];
+  });
+
+  describe('get', () => {
+    it('should return the body and unquoted etag on a successful lookup', async () => {
+      const bytes = new Uint8Array([1, 2, 3]);
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: fakeBody(bytes) as never,
+        ETag: '"abc123"',
+      });
+
+      const store = makeStore();
+      await expect(store.get('foo/bar.txt')).resolves.toEqual({ body: bytes, etag: 'abc123' });
+
+      const input = s3Mock.commandCalls(GetObjectCommand)[0]!.args[0].input;
+      expect(input.Bucket).toBe('my-bucket');
+      expect(input.Key).toBe('foo/bar.txt');
+    });
+
+    it('should return undefined when the object does not exist (NoSuchKey)', async () => {
+      s3Mock.on(GetObjectCommand).rejects(new NoSuchKey({ message: 'not found', $metadata: {} }));
+
+      const store = makeStore();
+      await expect(store.get('missing.txt')).resolves.toBeUndefined();
+    });
+
+    it('should return undefined when S3ServiceException carries a 404 status code', async () => {
+      s3Mock.on(GetObjectCommand).rejects(
+        new S3ServiceException({
+          name: 'NotFound',
+          $fault: 'client',
+          message: 'not found',
+          $metadata: { httpStatusCode: 404 },
+        }),
+      );
+
+      const store = makeStore();
+      await expect(store.get('missing.txt')).resolves.toBeUndefined();
+    });
+
+    it('should rethrow a non-404 S3ServiceException', async () => {
+      s3Mock.on(GetObjectCommand).rejects(
+        new S3ServiceException({
+          name: 'InternalError',
+          $fault: 'server',
+          message: 'internal failure',
+          $metadata: { httpStatusCode: 500 },
+        }),
+      );
+
+      const store = makeStore();
+      await expect(store.get('foo.txt')).rejects.toThrow('internal failure');
+    });
+
+    it('should rethrow errors that are not NoSuchKey or S3ServiceException', async () => {
+      s3Mock.on(GetObjectCommand).rejects(new Error('network down'));
+
+      const store = makeStore();
+      await expect(store.get('foo.txt')).rejects.toThrow('network down');
+    });
+
+    it('should return undefined when the response has no Body', async () => {
+      s3Mock.on(GetObjectCommand).resolves({ ETag: '"abc123"' });
+
+      const store = makeStore();
+      await expect(store.get('foo.txt')).resolves.toBeUndefined();
+    });
+
+    it('should return undefined when the response has no ETag', async () => {
+      s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(new Uint8Array([9])) as never });
+
+      const store = makeStore();
+      await expect(store.get('foo.txt')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('put', () => {
+    it('should write the body and return the unquoted etag when no ifMatch is given', async () => {
+      s3Mock.on(PutObjectCommand).resolves({ ETag: '"etag-1"' });
+
+      const store = makeStore();
+      const body = new Uint8Array([1, 2, 3]);
+      await expect(store.put('foo.txt', body)).resolves.toEqual({ etag: 'etag-1' });
+
+      const input = s3Mock.commandCalls(PutObjectCommand)[0]!.args[0].input;
+      expect(input.Bucket).toBe('my-bucket');
+      expect(input.Key).toBe('foo.txt');
+      expect(input.Body).toBe(body);
+      expect(input.IfMatch).toBeUndefined();
+    });
+
+    it('should send IfMatch when opts.ifMatch is provided', async () => {
+      s3Mock.on(PutObjectCommand).resolves({ ETag: '"etag-2"' });
+
+      const store = makeStore();
+      await store.put('foo.txt', new Uint8Array([1]), { ifMatch: 'stale-etag' });
+
+      const input = s3Mock.commandCalls(PutObjectCommand)[0]!.args[0].input;
+      expect(input.IfMatch).toBe('stale-etag');
+    });
+
+    it('should throw a clear error when the PutObject response has no ETag', async () => {
+      s3Mock.on(PutObjectCommand).resolves({});
+
+      const store = makeStore();
+      await expect(store.put('foo.txt', new Uint8Array([1]))).rejects.toThrow(
+        'S3 PutObject for path "foo.txt" did not return an ETag.',
+      );
+    });
+
+    it('should throw RemoteFileConflictError when S3 returns 412 Precondition Failed', async () => {
+      s3Mock.on(PutObjectCommand).rejects(
+        new S3ServiceException({
+          name: 'PreconditionFailed',
+          $fault: 'client',
+          message: 'precondition failed',
+          $metadata: { httpStatusCode: 412 },
+        }),
+      );
+
+      const store = makeStore();
+      const err: unknown = await store
+        .put('foo.txt', new Uint8Array([1]), { ifMatch: 'stale-etag' })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(RemoteFileConflictError);
+      expect((err as RemoteFileConflictError).path).toBe('foo.txt');
+      expect((err as RemoteFileConflictError).ifMatch).toBe('stale-etag');
+    });
+
+    it('should throw RemoteFileConflictError when S3 returns 409 ConditionalRequestConflict', async () => {
+      s3Mock.on(PutObjectCommand).rejects(
+        new S3ServiceException({
+          name: 'ConditionalRequestConflict',
+          $fault: 'client',
+          message: 'conflicting write',
+          $metadata: { httpStatusCode: 409 },
+        }),
+      );
+
+      const store = makeStore();
+      await expect(
+        store.put('foo.txt', new Uint8Array([1]), { ifMatch: 'stale-etag' }),
+      ).rejects.toBeInstanceOf(RemoteFileConflictError);
+    });
+
+    it('should rethrow an S3ServiceException whose status code is not a conflict code', async () => {
+      s3Mock.on(PutObjectCommand).rejects(
+        new S3ServiceException({
+          name: 'InternalError',
+          $fault: 'server',
+          message: 'internal failure',
+          $metadata: { httpStatusCode: 500 },
+        }),
+      );
+
+      const store = makeStore();
+      await expect(store.put('foo.txt', new Uint8Array([1]))).rejects.toThrow('internal failure');
+    });
+
+    it('should rethrow errors that are not S3ServiceException', async () => {
+      s3Mock.on(PutObjectCommand).rejects(new Error('network down'));
+
+      const store = makeStore();
+      await expect(store.put('foo.txt', new Uint8Array([1]))).rejects.toThrow('network down');
+    });
+  });
+
+  describe('listVersions', () => {
+    it('should return matching versions sorted newest-first', async () => {
+      s3Mock.on(ListObjectVersionsCommand).resolves({
+        Versions: [
+          { Key: 'foo.txt', VersionId: 'v1', LastModified: new Date('2024-01-01T00:00:00Z') },
+          { Key: 'foo.txt', VersionId: 'v2', LastModified: new Date('2024-06-01T00:00:00Z') },
+          { Key: 'other.txt', VersionId: 'v3', LastModified: new Date('2024-12-01T00:00:00Z') },
+        ],
+      });
+
+      const store = makeStore();
+      await expect(store.listVersions('foo.txt')).resolves.toEqual([
+        { versionId: 'v2', lastModified: new Date('2024-06-01T00:00:00Z') },
+        { versionId: 'v1', lastModified: new Date('2024-01-01T00:00:00Z') },
+      ]);
+
+      const input = s3Mock.commandCalls(ListObjectVersionsCommand)[0]!.args[0].input;
+      expect(input.Bucket).toBe('my-bucket');
+      expect(input.Prefix).toBe('foo.txt');
+    });
+
+    it('should filter out entries missing a VersionId or LastModified', async () => {
+      s3Mock.on(ListObjectVersionsCommand).resolves({
+        Versions: [
+          { Key: 'foo.txt', VersionId: undefined, LastModified: new Date() },
+          { Key: 'foo.txt', VersionId: 'v1', LastModified: undefined },
+        ],
+      });
+
+      const store = makeStore();
+      await expect(store.listVersions('foo.txt')).resolves.toEqual([]);
+    });
+
+    it('should return an empty array when the response has no Versions', async () => {
+      s3Mock.on(ListObjectVersionsCommand).resolves({});
+
+      const store = makeStore();
+      await expect(store.listVersions('foo.txt')).resolves.toEqual([]);
+    });
+  });
+
+  describe('bucket configuration', () => {
+    it('should throw a clear error when constructed without a getConfig callback', async () => {
+      const store = new AwsRemoteFileStore();
+      await expect(store.get('foo.txt')).rejects.toThrow(
+        'AwsRemoteFileStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
+      );
+    });
+
+    it('should throw a clear error when getConfig resolves an empty bucket', async () => {
+      const store = new AwsRemoteFileStore(() => ({ bucket: '' }));
+      await expect(store.put('foo.txt', new Uint8Array([1]))).rejects.toThrow('bucket not configured');
+    });
+
+    it('should throw a clear error from listVersions when no bucket is configured', async () => {
+      const store = new AwsRemoteFileStore();
+      await expect(store.listVersions('foo.txt')).rejects.toThrow('bucket not configured');
+    });
+  });
+
+  describe('region resolution', () => {
+    it('should build the S3 client with the region returned by getConfig', async () => {
+      let observedRegion: string | undefined;
+      s3Mock.on(GetObjectCommand).callsFake(async (_input, getClient) => {
+        observedRegion = await getClient().config.region();
+        return { Body: fakeBody(new Uint8Array([1])) as never, ETag: '"e"' };
+      });
+
+      const store = makeStore({ bucket: 'my-bucket', region: 'eu-west-1' });
+      await store.get('foo.txt');
+
+      expect(observedRegion).toBe('eu-west-1');
+    });
+
+    it('should rebuild the client when the configured region changes between calls', async () => {
+      const observedRegions: string[] = [];
+      s3Mock.on(GetObjectCommand).callsFake(async (_input, getClient) => {
+        observedRegions.push(await getClient().config.region());
+        return { Body: fakeBody(new Uint8Array([1])) as never, ETag: '"e"' };
+      });
+
+      // A mutable config object, rather than a call-count-based index: getConfig
+      // is invoked multiple times per store call (once for the client's region,
+      // once for the bucket name), so a naive incrementing counter would drift.
+      const config = { bucket: 'my-bucket', region: 'us-east-1' };
+      const store = new AwsRemoteFileStore(() => config);
+      await store.get('foo-a.txt');
+
+      config.region = 'eu-west-1';
+      await store.get('foo-b.txt');
+
+      expect(observedRegions).toEqual(['us-east-1', 'eu-west-1']);
+    });
+
+    it('should fall back through AWS_REGION_, AWS_REGION, AWS_DEFAULT_REGION, then us-east-1', async () => {
+      let observedRegion: string | undefined;
+      s3Mock.on(GetObjectCommand).callsFake(async (_input, getClient) => {
+        observedRegion = await getClient().config.region();
+        return { Body: fakeBody(new Uint8Array([1])) as never, ETag: '"e"' };
+      });
+
+      // No getConfig region and no env vars set: falls back to the hardcoded default.
+      const storeNoEnv = new AwsRemoteFileStore(() => ({ bucket: 'my-bucket' }));
+      await storeNoEnv.get('a.txt');
+      expect(observedRegion).toBe('us-east-1');
+
+      // AWS_DEFAULT_REGION is honoured when set.
+      process.env['AWS_DEFAULT_REGION'] = 'ap-southeast-2';
+      const storeDefault = new AwsRemoteFileStore(() => ({ bucket: 'my-bucket' }));
+      await storeDefault.get('b.txt');
+      expect(observedRegion).toBe('ap-southeast-2');
+
+      // AWS_REGION takes priority over AWS_DEFAULT_REGION.
+      process.env['AWS_REGION'] = 'ca-central-1';
+      const storeRegion = new AwsRemoteFileStore(() => ({ bucket: 'my-bucket' }));
+      await storeRegion.get('c.txt');
+      expect(observedRegion).toBe('ca-central-1');
+
+      // AWS_REGION_ (Lambda's reserved-name workaround) takes priority over AWS_REGION.
+      process.env['AWS_REGION_'] = 'ap-northeast-1';
+      const storeUnderscore = new AwsRemoteFileStore(() => ({ bucket: 'my-bucket' }));
+      await storeUnderscore.get('d.txt');
+      expect(observedRegion).toBe('ap-northeast-1');
+    });
+  });
+});

--- a/app/packages/cloud-aws/src/AwsRemoteFileStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRemoteFileStore.test.ts
@@ -16,11 +16,13 @@ const s3Mock = mockClient(S3Client);
 
 /**
  * Build an {@link AwsRemoteFileStore} whose `getConfig` callback resolves to
- * the given bucket/region. Pass `undefined` to simulate a store constructed
- * with no `getConfig` callback at all (the zero-arg-constructible case).
+ * the given bucket/region. Pass `null` to simulate a store constructed with no
+ * `getConfig` callback at all (the zero-arg-constructible case) — a dedicated
+ * `null` sentinel is used (rather than `undefined`) because an explicit
+ * `undefined` argument would just fall through to the default parameter.
  */
-function makeStore(config: { bucket: string; region?: string } | undefined = { bucket: 'my-bucket' }) {
-  return new AwsRemoteFileStore(config === undefined ? undefined : () => config);
+function makeStore(config: { bucket: string; region?: string } | null = { bucket: 'my-bucket' }) {
+  return new AwsRemoteFileStore(config === null ? undefined : () => config);
 }
 
 /** Builds a fake S3 `Body` stream whose `transformToByteArray()` resolves to the given bytes. */
@@ -247,7 +249,7 @@ describe('AwsRemoteFileStore', () => {
 
   describe('bucket configuration', () => {
     it('should throw a clear error when constructed without a getConfig callback', async () => {
-      const store = new AwsRemoteFileStore();
+      const store = makeStore(null);
       await expect(store.get('foo.txt')).rejects.toThrow(
         'AwsRemoteFileStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
       );
@@ -259,7 +261,7 @@ describe('AwsRemoteFileStore', () => {
     });
 
     it('should throw a clear error from listVersions when no bucket is configured', async () => {
-      const store = new AwsRemoteFileStore();
+      const store = makeStore(null);
       await expect(store.listVersions('foo.txt')).rejects.toThrow('bucket not configured');
     });
   });

--- a/app/packages/cloud-aws/src/AwsRemoteFileStore.ts
+++ b/app/packages/cloud-aws/src/AwsRemoteFileStore.ts
@@ -1,40 +1,162 @@
-import type { RemoteFileStore } from '@hyveon/shared';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  ListObjectVersionsCommand,
+  NoSuchKey,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { RemoteFileConflictError, type RemoteFileStore } from '@hyveon/shared';
 
 /**
- * AWS implementation of the cloud-agnostic {@link RemoteFileStore} contract.
- *
- * This is currently a stub — every method throws until the AWS SDK-backed
- * logic (S3) lands in follow-up tasks. The class exists so the shape of the
- * store is fixed early and downstream wiring (DI, module registration) can
- * be built against a real type.
+ * HTTP status codes S3 returns when a conditional write's `If-Match` etag no
+ * longer matches the object currently stored at the key — either the
+ * standard `412 Precondition Failed`, or the `409 ConditionalRequestConflict`
+ * S3 can return when a competing write races the same key. Both map to
+ * {@link RemoteFileConflictError}.
+ */
+const CONFLICT_HTTP_STATUS_CODES = new Set([409, 412]);
+
+/**
+ * Strips the surrounding double quotes S3 always wraps `ETag` values in
+ * (e.g. `"9bb58f26192e4ba00f01e2e7b136bbd8"`), so callers of the
+ * cloud-agnostic {@link RemoteFileStore} contract see a plain token rather
+ * than a provider-specific quoting quirk.
+ */
+function unquoteEtag(etag: string): string {
+  return etag.replace(/^"|"$/g, '');
+}
+
+/**
+ * AWS implementation of the cloud-agnostic {@link RemoteFileStore} contract,
+ * backed by a versioned S3 bucket. No `@aws-sdk/*` shapes appear outside
+ * this class's private fields/method bodies, so callers depend only on
+ * {@link RemoteFileStore}.
  */
 export class AwsRemoteFileStore implements RemoteFileStore {
+  private client: S3Client | null = null;
+  private clientRegion: string | null = null;
+
   /**
-   * Retrieves the body and etag of a remote file.
-   *
-   * @param _path - The path of the file to retrieve.
+   * @param getConfig - Resolves the S3 bucket (and optional region) this
+   *   store reads/writes, on every call — so a bucket rename picked up
+   *   between calls (e.g. after a Terraform re-apply) isn't stuck targeting
+   *   a stale bucket. Optional so the class remains constructible with no
+   *   arguments, mirroring `AwsCloudProvider.getConfig`/`AwsSecretsStore`'s
+   *   zero-arg-constructible pattern. When omitted (or when it returns no
+   *   `bucket`), every method throws a clear "bucket not configured" error
+   *   rather than sending a malformed request. `region` falls back to
+   *   `AWS_REGION_` (Lambda's reserved-name workaround, see CLAUDE.md), then
+   *   `AWS_REGION`, then `AWS_DEFAULT_REGION`, then `us-east-1` when omitted.
    */
-  get(_path: string): Promise<{ body: Uint8Array; etag: string } | undefined> {
-    throw new Error('Not implemented: get — see Epic #137');
+  constructor(private readonly getConfig?: () => { bucket: string; region?: string }) {}
+
+  /**
+   * Resolves the configured bucket name, throwing a clear error instead of
+   * letting an unconfigured bucket fall through to a malformed S3 request.
+   */
+  private getBucketName(): string {
+    const bucket = this.getConfig?.()?.bucket;
+    if (!bucket) {
+      throw new Error(
+        'AwsRemoteFileStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
+      );
+    }
+    return bucket;
+  }
+
+  /**
+   * Lazily constructs the S3 client, recreating it whenever the
+   * freshly-resolved region differs from the region the cached client was
+   * built with — mirrors `AwsSecretsStore.getClient`'s rebuild-on-region-
+   * change pattern.
+   */
+  private getClient(): S3Client {
+    const region =
+      this.getConfig?.()?.region ??
+      process.env['AWS_REGION_'] ??
+      process.env['AWS_REGION'] ??
+      process.env['AWS_DEFAULT_REGION'] ??
+      'us-east-1';
+
+    if (!this.client || this.clientRegion !== region) {
+      this.client = new S3Client({ region });
+      this.clientRegion = region;
+    }
+    return this.client;
+  }
+
+  /**
+   * Retrieves the current version of a file by path.
+   *
+   * @param path - The store-relative path of the file to retrieve.
+   */
+  async get(path: string): Promise<{ body: Uint8Array; etag: string } | undefined> {
+    try {
+      const resp = await this.getClient().send(
+        new GetObjectCommand({ Bucket: this.getBucketName(), Key: path }),
+      );
+      const body = await resp.Body?.transformToByteArray();
+      if (!body || !resp.ETag) return undefined;
+      return { body, etag: unquoteEtag(resp.ETag) };
+    } catch (err) {
+      if (err instanceof NoSuchKey) return undefined;
+      if (err instanceof S3ServiceException && err.$metadata.httpStatusCode === 404) return undefined;
+      throw err;
+    }
   }
 
   /**
    * Writes a remote file, optionally conditioned on a matching etag.
    *
-   * @param _path - The path of the file to write.
-   * @param _body - The bytes to store.
-   * @param _opts - Optional write options, e.g. an `ifMatch` etag for optimistic concurrency.
+   * @param path - The path of the file to write.
+   * @param body - The bytes to store.
+   * @param opts - Optional write options, e.g. an `ifMatch` etag for optimistic concurrency.
+   * @throws {@link RemoteFileConflictError} when `opts.ifMatch` is provided but no longer
+   *   matches the etag currently stored at `path`.
    */
-  put(_path: string, _body: Uint8Array, _opts?: { ifMatch?: string }): Promise<{ etag: string }> {
-    throw new Error('Not implemented: put — see Epic #137');
+  async put(path: string, body: Uint8Array, opts?: { ifMatch?: string }): Promise<{ etag: string }> {
+    try {
+      const resp = await this.getClient().send(
+        new PutObjectCommand({
+          Bucket: this.getBucketName(),
+          Key: path,
+          Body: body,
+          ...(opts?.ifMatch ? { IfMatch: opts.ifMatch } : {}),
+        }),
+      );
+      if (!resp.ETag) {
+        throw new Error(`S3 PutObject for path "${path}" did not return an ETag.`);
+      }
+      return { etag: unquoteEtag(resp.ETag) };
+    } catch (err) {
+      if (
+        err instanceof S3ServiceException &&
+        err.$metadata.httpStatusCode !== undefined &&
+        CONFLICT_HTTP_STATUS_CODES.has(err.$metadata.httpStatusCode)
+      ) {
+        throw new RemoteFileConflictError(path, undefined, opts?.ifMatch);
+      }
+      throw err;
+    }
   }
 
   /**
    * Lists the known versions of a remote file.
    *
-   * @param _path - The path of the file whose versions should be listed.
+   * @param path - The path of the file whose versions should be listed.
    */
-  listVersions(_path: string): Promise<Array<{ versionId: string; lastModified: Date }>> {
-    throw new Error('Not implemented: listVersions — see Epic #137');
+  async listVersions(path: string): Promise<Array<{ versionId: string; lastModified: Date }>> {
+    const resp = await this.getClient().send(
+      new ListObjectVersionsCommand({ Bucket: this.getBucketName(), Prefix: path }),
+    );
+
+    return (resp.Versions ?? [])
+      .filter(
+        (v): v is typeof v & { Key: string; VersionId: string; LastModified: Date } =>
+          v.Key === path && v.VersionId !== undefined && v.LastModified !== undefined,
+      )
+      .map((v) => ({ versionId: v.VersionId, lastModified: v.LastModified }))
+      .sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime());
   }
 }

--- a/app/packages/cloud-aws/src/index.test.ts
+++ b/app/packages/cloud-aws/src/index.test.ts
@@ -25,6 +25,11 @@ import {
  * `AwsSecretsStore` is likewise a real Secrets-Manager-backed implementation
  * rather than a stub, so only its constructibility is asserted here — see
  * `AwsSecretsStore.test.ts` for behavioural coverage of `get`/`put`/`exists`.
+ * `AwsRemoteFileStore` is also a real S3-backed implementation rather than a
+ * stub; its "no bucket configured" guard is asserted here via `.rejects` (all
+ * three methods are `async` and reject rather than throw synchronously), and
+ * behavioural coverage of `get`/`put`/`listVersions` against a mocked S3
+ * client lives in `AwsRemoteFileStore.test.ts`.
  */
 describe('cloud-aws barrel export', () => {
   it('should export AwsCloudProvider as a constructible class', () => {
@@ -81,18 +86,20 @@ describe('cloud-aws barrel export', () => {
     expect(new AwsRemoteFileStore()).toBeInstanceOf(AwsRemoteFileStore);
   });
 
-  it('should throw a Not implemented error when get is called', () => {
-    expect(() => new AwsRemoteFileStore().get('path')).toThrow('Not implemented');
+  it('should reject with a "bucket not configured" error when get is called without config', async () => {
+    await expect(new AwsRemoteFileStore().get('path')).rejects.toThrow('bucket not configured');
   });
 
-  it('should throw a Not implemented error when put is called', () => {
-    expect(() => new AwsRemoteFileStore().put('path', new Uint8Array())).toThrow(
-      'Not implemented',
+  it('should reject with a "bucket not configured" error when put is called without config', async () => {
+    await expect(new AwsRemoteFileStore().put('path', new Uint8Array())).rejects.toThrow(
+      'bucket not configured',
     );
   });
 
-  it('should throw a Not implemented error when listVersions is called', () => {
-    expect(() => new AwsRemoteFileStore().listVersions('path')).toThrow('Not implemented');
+  it('should reject with a "bucket not configured" error when listVersions is called without config', async () => {
+    await expect(new AwsRemoteFileStore().listVersions('path')).rejects.toThrow(
+      'bucket not configured',
+    );
   });
 
   it('should export AwsSecretsStore as a constructible class', () => {

--- a/app/packages/shared/src/cloud.test.ts
+++ b/app/packages/shared/src/cloud.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { RemoteFileConflictError } from './cloud.js';
 import type {
   CloudProvider,
   CostBreakdown,
@@ -96,6 +97,39 @@ describe('RemoteFileStore', () => {
     } satisfies RemoteFileStore;
 
     expect(store).toBeDefined();
+  });
+});
+
+describe('RemoteFileConflictError', () => {
+  it('should be importable from cloud.ts and be an instance of Error', () => {
+    const error = new RemoteFileConflictError('games/minecraft/save.zip');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(RemoteFileConflictError);
+  });
+
+  it('should set name to RemoteFileConflictError and expose the conflicting path', () => {
+    const error = new RemoteFileConflictError('games/minecraft/save.zip');
+
+    expect(error.name).toBe('RemoteFileConflictError');
+    expect(error.path).toBe('games/minecraft/save.zip');
+    expect(error.message).toContain('games/minecraft/save.zip');
+  });
+
+  it('should use a custom message when one is provided', () => {
+    const error = new RemoteFileConflictError('games/minecraft/save.zip', 'etag mismatch');
+
+    expect(error.message).toBe('etag mismatch');
+  });
+
+  it('should propagate the stale ifMatch etag onto the error instance', () => {
+    const error = new RemoteFileConflictError(
+      'games/minecraft/save.zip',
+      'etag mismatch',
+      'stale-etag-123',
+    );
+
+    expect(error.ifMatch).toBe('stale-etag-123');
   });
 });
 

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -137,7 +137,7 @@ export interface RemoteFileStore {
  * concurrency guard (`opts.ifMatch`) is provided but no longer matches the
  * etag currently stored at `path` — i.e. the remote file was modified by
  * another writer since the caller last read it. Cloud-agnostic: providers
- * (e.g. `@hyveon/cloud-aws`'s `AwsS3Store`) must translate their SDK-specific
+ * (e.g. `@hyveon/cloud-aws`'s `AwsRemoteFileStore`) must translate their SDK-specific
  * precondition-failure errors into this type before surfacing them to callers.
  */
 export class RemoteFileConflictError extends Error {

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -133,6 +133,38 @@ export interface RemoteFileStore {
 }
 
 /**
+ * Thrown by `RemoteFileStore.put` implementations when an optimistic
+ * concurrency guard (`opts.ifMatch`) is provided but no longer matches the
+ * etag currently stored at `path` — i.e. the remote file was modified by
+ * another writer since the caller last read it. Cloud-agnostic: providers
+ * (e.g. `@hyveon/cloud-aws`'s `AwsS3Store`) must translate their SDK-specific
+ * precondition-failure errors into this type before surfacing them to callers.
+ */
+export class RemoteFileConflictError extends Error {
+  /** The store-relative path of the file that failed the conflict check. */
+  readonly path: string;
+
+  /** The stale `ifMatch` etag that was provided for the conflicting write, if any. */
+  readonly ifMatch?: string;
+
+  /**
+   * @param path - The store-relative path of the file that failed the
+   *   conflict check.
+   * @param message - Optional human-readable message; defaults to a message
+   *   derived from `path`.
+   * @param ifMatch - Optional stale `ifMatch` etag that was provided for the
+   *   conflicting write.
+   */
+  constructor(path: string, message?: string, ifMatch?: string) {
+    super(message ?? `Conflicting write detected for file at path: ${path}`);
+    this.name = 'RemoteFileConflictError';
+    this.path = path;
+    this.ifMatch = ifMatch;
+    Object.setPrototypeOf(this, RemoteFileConflictError.prototype);
+  }
+}
+
+/**
  * Cloud-agnostic interface for resolving the Discord interactions endpoint URL
  * from provider-managed configuration (e.g. an API Gateway invoke URL stored in
  * infrastructure state or a secrets store). Callers depend only on this contract;


### PR DESCRIPTION
Closes #180

## Summary

- Implements `AwsRemoteFileStore` using `@aws-sdk/client-s3`, providing `get`/`put`/`listVersions` with `IfMatch`-based optimistic locking and ETag propagation back to the caller.
- Adds `RemoteFileConflictError` to `@hyveon/shared`'s cloud contracts so a 412 (stale `ifMatch`) surfaces as a typed error instead of a raw SDK exception.
- Adds unit test coverage for `AwsRemoteFileStore` (including the 412 conflict path and `listVersions` behavior) and updates the `cloud-aws` barrel-export smoke test to reflect the new store.

## Changes

```
 .../cloud-aws/src/AwsRemoteFileStore.test.ts       | 332 +++++++++++++++++++++
 app/packages/cloud-aws/src/AwsRemoteFileStore.ts   | 160 ++++++++--
 app/packages/cloud-aws/src/index.test.ts           |  21 +-
 app/packages/shared/src/cloud.test.ts              |  34 +++
 app/packages/shared/src/cloud.ts                   |  32 ++
 5 files changed, 553 insertions(+), 26 deletions(-)
```

## Test plan

- [x] `AwsRemoteFileStore` implements `get`/`put` over S3 using `@aws-sdk/client-s3`
- [x] `put` uses `IfMatch` for optimistic locking and returns the resulting ETag
- [x] A 412 on stale `ifMatch` surfaces as a typed `RemoteFileConflictError`
- [x] `listVersions` returns the bucket's version metadata
- [x] New unit tests in `AwsRemoteFileStore.test.ts` cover get/put/conflict/listVersions behavior
- [x] `cloud-aws` barrel-export smoke test updated for the new store
- [ ] `npm run app:test` — all unit tests pass
- [ ] `npm run app:lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)