### PR TITLE
feat(cloud-aws): AwsLambdaDiscordReceiver implementation

### DIFF
--- a/app/packages/cloud-aws/src/AwsDiscordEventReceiver.test.ts
+++ b/app/packages/cloud-aws/src/AwsDiscordEventReceiver.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { AwsDiscordEventReceiver } from './AwsDiscordEventReceiver.js';
+
+describe('AwsDiscordEventReceiver', () => {
+  describe('getInteractionEndpointUrl', () => {
+    it('should return the interactionsInvokeUrl from the resolved config', async () => {
+      const receiver = new AwsDiscordEventReceiver(() => ({
+        interactionsInvokeUrl: 'https://example.execute-api.us-east-1.amazonaws.com/interactions',
+      }));
+
+      await expect(receiver.getInteractionEndpointUrl()).resolves.toBe(
+        'https://example.execute-api.us-east-1.amazonaws.com/interactions',
+      );
+    });
+
+    it('should return null when no getConfig callback was supplied', async () => {
+      const receiver = new AwsDiscordEventReceiver();
+
+      await expect(receiver.getInteractionEndpointUrl()).resolves.toBeNull();
+    });
+
+    it('should return null when the getConfig callback itself returns null', async () => {
+      const receiver = new AwsDiscordEventReceiver(() => null);
+
+      await expect(receiver.getInteractionEndpointUrl()).resolves.toBeNull();
+    });
+
+    it('should return null when the resolved config\'s interactionsInvokeUrl is undefined', async () => {
+      const receiver = new AwsDiscordEventReceiver(() => ({ interactionsInvokeUrl: undefined }));
+
+      await expect(receiver.getInteractionEndpointUrl()).resolves.toBeNull();
+    });
+
+    it('should resolve the config freshly on every call, picking up a value change between calls', async () => {
+      const urls: Array<string | null | undefined> = [
+        null,
+        'https://example.execute-api.us-east-1.amazonaws.com/interactions',
+      ];
+      let call = 0;
+      const receiver = new AwsDiscordEventReceiver(() => ({
+        interactionsInvokeUrl: urls[call++],
+      }));
+
+      await expect(receiver.getInteractionEndpointUrl()).resolves.toBeNull();
+      await expect(receiver.getInteractionEndpointUrl()).resolves.toBe(
+        'https://example.execute-api.us-east-1.amazonaws.com/interactions',
+      );
+    });
+  });
+});

--- a/app/packages/cloud-aws/src/AwsDiscordEventReceiver.ts
+++ b/app/packages/cloud-aws/src/AwsDiscordEventReceiver.ts
@@ -1,19 +1,46 @@
 import type { DiscordEventReceiver } from '@hyveon/shared';
 
 /**
+ * Minimal subset of Terraform-derived configuration this receiver needs.
+ */
+export interface AwsDiscordEventReceiverConfig {
+  /** The API Gateway/Lambda invoke URL Discord should POST interactions to,
+   *  or `null`/`undefined` when no endpoint has been provisioned yet. */
+  interactionsInvokeUrl: string | null | undefined;
+}
+
+/**
  * AWS implementation of the cloud-agnostic {@link DiscordEventReceiver} contract.
  *
- * This is currently a stub — the method throws until the AWS-backed logic
- * (resolving the Lambda/API Gateway interactions endpoint) lands in
- * follow-up tasks. The class exists so the shape of the receiver is fixed
- * early and downstream wiring (DI, module registration) can be built
- * against a real type.
+ * Resolves the interactions endpoint URL from a `getConfig` callback,
+ * mirroring `AwsCloudProvider`/`AwsSecretsStore`'s `getConfig` callback
+ * pattern so a value that changes between calls (e.g. re-applied Terraform
+ * state) is always read fresh rather than captured once at construction.
+ * Callers typically source `interactionsInvokeUrl` from
+ * `ConfigService.getTfOutputs()`'s `interactions_invoke_url` field (parsed
+ * from `terraform.tfstate`, S3 backend), the same Terraform-derived value
+ * `DiscordConfigService` reads elsewhere.
  */
 export class AwsDiscordEventReceiver implements DiscordEventReceiver {
   /**
-   * Resolves the public URL Discord should send interaction events to.
+   * @param getConfig - Resolves the current Terraform-derived configuration
+   *   on every call. Omit when no interactions endpoint is available yet
+   *   (e.g. before `terraform apply` has run) — {@link getInteractionEndpointUrl}
+   *   resolves to `null` rather than throwing in that case.
    */
-  getInteractionEndpointUrl(): Promise<string | null> {
-    throw new Error('Not implemented: getInteractionEndpointUrl — see Epic #137');
+  constructor(
+    private readonly getConfig?: () => AwsDiscordEventReceiverConfig | null | undefined,
+  ) {}
+
+  /**
+   * Resolves the public URL Discord should send interaction events to.
+   *
+   * @returns A promise that resolves to the interactions endpoint URL, or
+   *   `null` when no `getConfig` callback was supplied, the callback itself
+   *   returns `null`/`undefined`, or the resolved config's
+   *   `interactionsInvokeUrl` field is `null`/`undefined`. Never throws.
+   */
+  async getInteractionEndpointUrl(): Promise<string | null> {
+    return this.getConfig?.()?.interactionsInvokeUrl ?? null;
   }
 }

--- a/app/packages/cloud-aws/src/index.test.ts
+++ b/app/packages/cloud-aws/src/index.test.ts
@@ -29,7 +29,11 @@ import {
  * stub; its "no bucket configured" guard is asserted here via `.rejects` (all
  * three methods are `async` and reject rather than throw synchronously), and
  * behavioural coverage of `get`/`put`/`listVersions` against a mocked S3
- * client lives in `AwsRemoteFileStore.test.ts`.
+ * client lives in `AwsRemoteFileStore.test.ts`. `AwsDiscordEventReceiver` is
+ * also a real implementation rather than a stub; its "no `getConfig`
+ * supplied" branch is asserted here via `.resolves` since
+ * `getInteractionEndpointUrl` is a real `async` method that resolves to
+ * `null` rather than throwing.
  */
 describe('cloud-aws barrel export', () => {
   it('should export AwsCloudProvider as a constructible class', () => {
@@ -76,10 +80,8 @@ describe('cloud-aws barrel export', () => {
     expect(new AwsDiscordEventReceiver()).toBeInstanceOf(AwsDiscordEventReceiver);
   });
 
-  it('should throw a Not implemented error when getInteractionEndpointUrl is called', () => {
-    expect(() => new AwsDiscordEventReceiver().getInteractionEndpointUrl()).toThrow(
-      'Not implemented',
-    );
+  it('should resolve to null when getInteractionEndpointUrl is called without a getConfig callback', async () => {
+    await expect(new AwsDiscordEventReceiver().getInteractionEndpointUrl()).resolves.toBeNull();
   });
 
   it('should export AwsRemoteFileStore as a constructible class', () => {


### PR DESCRIPTION
Closes #181

## Summary

- Implements `AwsDiscordEventReceiver.getInteractionEndpointUrl()` by resolving the interactions endpoint from a `getConfig` callback, mirroring the `AwsCloudProvider`/`AwsSecretsStore` `getConfig` callback pattern so a value that can change between calls (e.g. re-applied Terraform state) is always read fresh rather than captured once at construction.
- Adds the `AwsDiscordEventReceiverConfig` interface describing the minimal Terraform-derived shape the receiver needs (`interactionsInvokeUrl`), sourced from `ConfigService.getTfOutputs()`'s `interactions_invoke_url` field.
- Adds unit test coverage for `AwsDiscordEventReceiver` (present/absent config, present/absent callback) and updates the `cloud-aws` barrel-export smoke test to reflect the implemented receiver.

## Changes

```
 .../cloud-aws/src/AwsDiscordEventReceiver.test.ts  | 50 ++++++++++++++++++++++
 .../cloud-aws/src/AwsDiscordEventReceiver.ts       | 41 +++++++++++++++---
 app/packages/cloud-aws/src/index.test.ts           | 12 +++---
 3 files changed, 91 insertions(+), 12 deletions(-)
```

## Test plan

- [x] `getInteractionEndpointUrl()` returns the Lambda Function URL when `interactionsInvokeUrl` is present (i.e. after a successful `terraform apply`)
- [x] `getInteractionEndpointUrl()` returns `null` when not yet provisioned (no `getConfig` callback, callback returns `null`/`undefined`, or `interactionsInvokeUrl` is `null`/`undefined`)
- [x] New unit tests in `AwsDiscordEventReceiver.test.ts` cover all of the above paths
- [x] `cloud-aws` barrel-export smoke test updated for the implemented receiver
- [ ] `npm run app:test` — all unit tests pass
- [ ] `npm run app:lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)