### PR TITLE
feat(terraform): top-level composer (main.tf + variables.tf)

### DIFF
--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -14,14 +14,21 @@ blocks, a `module "cloud"` (source `./aws`) that carries every AWS resource,
 and passthrough `outputs.tf`/`variables.tf`. All AWS-specific HCL lives in the
 `terraform/aws/` module — that's where you'll find the actual resources.
 
+Composition is keyed on `var.active_cloud`: the `module "cloud"` block carries
+`count = var.active_cloud == "aws" ? 1 : 0`, so root outputs read from
+`module.cloud[0]`. Only `"aws"` is supported in v1 — the variable's
+`validation` block rejects anything else — but the count makes room for a
+future `gcp`/`azure` module to sit alongside `./aws` without restructuring
+the composer.
+
 ## Files
 
 | File | What it provisions |
 |---|---|
-| `main.tf` | Root composer: `terraform`/`backend "s3"` block, both `provider "aws"` blocks (default + `us_east_1` alias for CloudFront ACM certs), and the `module "cloud"` block wiring all 16 inputs through to `./aws`. |
-| `variables.tf` | Every configurable input (passed straight through to the module). See the table below. |
-| `outputs.tf` | Re-exports every `module.cloud.*` output by the same name — `ConfigService.getTfOutputs()` reads these from root-level `terraform.tfstate`, where module outputs don't appear. |
-| `moved.tf` | One `moved` block per resource living in `terraform/aws/`, mapping its pre-split root address to `module.cloud.<type>.<name>` so existing deployments `plan` cleanly instead of proposing a destroy/recreate. |
+| `main.tf` | Root composer: `terraform`/`backend "s3"` block, both `provider "aws"` blocks (default + `us_east_1` alias for CloudFront ACM certs), and the `module "cloud"` block — conditionally counted on `var.active_cloud` — wiring all 16 inputs through to `./aws`. |
+| `variables.tf` | Every configurable input (passed straight through to the module), plus `active_cloud` which selects the composed cloud module and isn't forwarded to `./aws`. See the table below. |
+| `outputs.tf` | Re-exports every `module.cloud[0].*` output by the same name — `ConfigService.getTfOutputs()` reads these from root-level `terraform.tfstate`, where module outputs don't appear. |
+| `moved.tf` | A module-level `moved` block mapping `module.cloud` → `module.cloud[0]` (added when the module gained `count`), plus one `moved` block per resource living in `terraform/aws/`, mapping its pre-split root address to `module.cloud.<type>.<name>` so existing deployments `plan` cleanly instead of proposing a destroy/recreate. |
 | `terraform.tfvars.example` | Starting point for your `terraform.tfvars`. |
 | `aws/main.tf` | VPC, Internet Gateway, two public subnets across AZs, route table, IAM execution role, EFS filesystem + mount targets + **per-game access points**, ECS cluster, **one Fargate task definition per game**, CloudWatch log groups, game-server + file-manager + EFS security groups. |
 | `aws/versions.tf` | Module-local `required_providers` (aws, archive), including the `aws.us_east_1` `configuration_aliases` entry the root passes in. |
@@ -39,6 +46,7 @@ and passthrough `outputs.tf`/`variables.tf`. All AWS-specific HCL lives in the
 
 | Name | Type | Default | Purpose |
 |---|---|---|---|
+| `active_cloud` | `string` | `aws` | Selects which cloud module the root composes. Only `"aws"` is supported in v1 — the variable's `validation` block rejects anything else. |
 | `aws_region` | `string` | `us-east-1` | AWS region for all resources. |
 | `project_name` | `string` | `game-servers` | Prefix for named resources and the Secrets Manager paths. |
 | `vpc_cidr` | `string` | `10.0.0.0/16` | Parent CIDR; subnets are /24s within it. |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,8 +42,13 @@ provider "aws" {
 # All AWS infrastructure lives in the "./aws" module — this root composes the
 # backend/provider config with the module and re-exports its outputs
 # (outputs.tf) so ConfigService.getTfOutputs() keeps reading root-level state.
+#
+# Composition is keyed on var.active_cloud: v1 only supports "aws" (enforced
+# by the variable's validation, so count is always 1 today). A future gcp/azure
+# module gets its own conditionally-counted module block alongside this one.
 module "cloud" {
   source = "./aws"
+  count  = var.active_cloud == "aws" ? 1 : 0
 
   providers = {
     aws           = aws

--- a/terraform/moved.tf
+++ b/terraform/moved.tf
@@ -2,6 +2,14 @@
 # HCL was split out (issue #185). Keeps existing deployed state mapped to its new
 # address instead of terraform proposing destroy/recreate of the whole stack.
 
+# module "cloud" gained a count meta-argument keyed on var.active_cloud
+# (issue #187). This chains with the per-resource moves below so an existing
+# deployment plans without destroy/recreate.
+moved {
+  from = module.cloud
+  to   = module.cloud[0]
+}
+
 # ── alb.tf ──
 moved {
   from = aws_acm_certificate.game_servers

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,111 +1,111 @@
 output "vpc_id" {
   description = "VPC ID"
-  value       = module.cloud.vpc_id
+  value       = module.cloud[0].vpc_id
 }
 
 output "ecs_cluster_name" {
   description = "ECS cluster name"
-  value       = module.cloud.ecs_cluster_name
+  value       = module.cloud[0].ecs_cluster_name
 }
 
 output "ecs_cluster_arn" {
   description = "ECS cluster ARN"
-  value       = module.cloud.ecs_cluster_arn
+  value       = module.cloud[0].ecs_cluster_arn
 }
 
 output "subnet_ids" {
   description = "Public subnet IDs (comma-separated for Lambda env vars)"
-  value       = module.cloud.subnet_ids
+  value       = module.cloud[0].subnet_ids
 }
 
 output "security_group_id" {
   description = "Security group ID for game server tasks"
-  value       = module.cloud.security_group_id
+  value       = module.cloud[0].security_group_id
 }
 
 output "efs_file_system_id" {
   description = "EFS file system ID for persistent game saves"
-  value       = module.cloud.efs_file_system_id
+  value       = module.cloud[0].efs_file_system_id
 }
 
 output "game_names" {
   description = "List of configured game server names"
-  value       = module.cloud.game_names
+  value       = module.cloud[0].game_names
 }
 
 output "task_definitions" {
   description = "Map of game name → ECS task definition family name"
-  value       = module.cloud.task_definitions
+  value       = module.cloud[0].task_definitions
 }
 
 output "hosted_zone_id" {
   description = "Route 53 hosted zone ID"
-  value       = module.cloud.hosted_zone_id
+  value       = module.cloud[0].hosted_zone_id
 }
 
 output "domain_name" {
   description = "Base domain name"
-  value       = module.cloud.domain_name
+  value       = module.cloud[0].domain_name
 }
 
 output "aws_region" {
   description = "AWS region"
-  value       = module.cloud.aws_region
+  value       = module.cloud[0].aws_region
 }
 
 output "file_manager_security_group_id" {
   description = "Security group ID for FileBrowser file manager tasks"
-  value       = module.cloud.file_manager_security_group_id
+  value       = module.cloud[0].file_manager_security_group_id
 }
 
 output "efs_access_points" {
   description = "Map of game name → first volume's EFS access point ID (consumed by FileManagerService)"
-  value       = module.cloud.efs_access_points
+  value       = module.cloud[0].efs_access_points
 }
 
 output "alb_dns_name" {
   description = "ALB DNS name (only when HTTPS games exist)"
-  value       = module.cloud.alb_dns_name
+  value       = module.cloud[0].alb_dns_name
 }
 
 output "acm_certificate_arn" {
   description = "ACM certificate ARN (only when HTTPS games exist)"
-  value       = module.cloud.acm_certificate_arn
+  value       = module.cloud[0].acm_certificate_arn
 }
 
 # ── Discord serverless outputs ───────────────────────────────────────────────
 
 output "discord_table_name" {
   description = "DynamoDB table holding DiscordConfig + pending interactions"
-  value       = module.cloud.discord_table_name
+  value       = module.cloud[0].discord_table_name
 }
 
 output "discord_bot_token_secret_arn" {
   description = "Secrets Manager ARN for the Discord bot token"
-  value       = module.cloud.discord_bot_token_secret_arn
+  value       = module.cloud[0].discord_bot_token_secret_arn
 }
 
 output "discord_public_key_secret_arn" {
   description = "Secrets Manager ARN for the Discord application Ed25519 public key"
-  value       = module.cloud.discord_public_key_secret_arn
+  value       = module.cloud[0].discord_public_key_secret_arn
 }
 
 output "interactions_invoke_url" {
   description = "Paste this into the 'Interactions Endpoint URL' field in the Discord Developer Portal"
-  value       = module.cloud.interactions_invoke_url
+  value       = module.cloud[0].interactions_invoke_url
 }
 
 output "discord_interactions_url" {
   description = "Custom domain URL for the Discord interactions endpoint"
-  value       = module.cloud.discord_interactions_url
+  value       = module.cloud[0].discord_interactions_url
 }
 
 output "dns_records" {
   description = "DNS hostnames for each game server (active when server is running)"
-  value       = module.cloud.dns_records
+  value       = module.cloud[0].dns_records
 }
 
 output "watchdog_function_name" {
   description = "Watchdog Lambda function name"
-  value       = module.cloud.watchdog_function_name
+  value       = module.cloud[0].watchdog_function_name
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,6 +1,10 @@
 # Copy this file to terraform.tfvars and customize.
 # terraform.tfvars is gitignored — safe to put passwords here.
 
+# Cloud provider backing this deployment. Only "aws" is currently supported
+# (default shown below) — the validation on the variable rejects anything else.
+# active_cloud = "aws"
+
 aws_region   = "us-east-1"
 project_name = "game-servers"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,14 @@
+variable "active_cloud" {
+  description = "Cloud provider backing this deployment. Only \"aws\" is currently supported."
+  type        = string
+  default     = "aws"
+
+  validation {
+    condition     = var.active_cloud == "aws"
+    error_message = "active_cloud must be \"aws\" — no other cloud providers are supported yet."
+  }
+}
+
 variable "aws_region" {
   description = "AWS region to deploy into"
   type        = string


### PR DESCRIPTION
Closes #187

## Summary

- Adds an `active_cloud` variable to root `terraform/variables.tf` (v1: defaults to/validates only `"aws"`) so the top-level composer can conditionally select the cloud module.
- Makes `terraform/main.tf` conditionally compose `module "cloud"` (count = active_cloud == "aws" ? 1 : 0) against `./aws`, keeping the root composer cloud-agnostic while only `aws` is implemented.
- Re-points `terraform/outputs.tf` at `module.cloud[0]` so downstream consumers (`ConfigService.getTfOutputs()`) keep reading outputs from the same paths, with a module-level `moved` block covering the count-based migration so existing state doesn't propose destroy/recreate.
- Documents `active_cloud` in `terraform.tfvars.example` and `docs/docs/components/terraform.md`.

## Changes

```
 docs/docs/components/terraform.md  | 16 ++++++++++----
 terraform/main.tf                  |  5 +++++
 terraform/moved.tf                 |  8 +++++++
 terraform/outputs.tf               | 44 +++++++++++++++++++-------------------
 terraform/terraform.tfvars.example |  4 ++++
 terraform/variables.tf             | 11 ++++++++++
 6 files changed, 62 insertions(+), 26 deletions(-)
```

## Test plan

- [x] `terraform/variables.tf` declares cloud-agnostic `active_cloud` input alongside existing `game_servers` / `project_name`
- [x] `terraform/main.tf` conditionally composes `module "cloud"` sourced from `./aws` based on `active_cloud`
- [x] `terraform/outputs.tf` re-exposes per-cloud outputs at the same paths the desktop app consumes
- [x] `moved` block added so existing state doesn't propose destroy/recreate for the count migration
- [x] `terraform.tfvars.example` and `docs/docs/components/terraform.md` updated for `active_cloud`
- [ ] `cd terraform && terraform init` — succeeds
- [ ] `cd terraform && terraform plan` — succeeds, no destroy/recreate for existing resources
- [ ] `terraform fmt -check -recursive` and `terraform validate` — pass
- [ ] `tflint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)