### PR TITLE
chore(lint): ban @aws-sdk/* imports outside @hyveon/cloud-aws and lambda packages

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -125,7 +125,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-restricted-imports': ['error', {
         patterns: [{
-          group: ['@aws-sdk/*'],
+          group: ['@aws-sdk/*', '@aws-sdk/**'],
           message: 'Import AWS SDK clients only within packages/cloud-aws or packages/lambda; depend on the cloud-agnostic interfaces from @hyveon/shared/cloud.js elsewhere.',
         }],
       }],

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -93,4 +93,42 @@ export default tseslint.config(
       },
     },
   },
+  {
+    // Ban direct @aws-sdk/* imports outside the cloud-aws implementation and
+    // the Lambda packages (which run standalone, without a DI-injected
+    // cloud provider). Everywhere else must depend on the cloud-agnostic
+    // interfaces in @hyveon/shared/cloud.js instead.
+    files: ['packages/**/*.{ts,tsx}'],
+    ignores: [
+      'packages/cloud-aws/**',
+      'packages/lambda/**',
+      // Legacy call sites predating the cloud-provider abstraction, pending
+      // migration onto the cloud-agnostic interfaces. Do not add new entries
+      // here — new code should depend on @hyveon/shared/cloud.js instead.
+      'packages/shared/src/ddb/client.ts',
+      'packages/shared/src/ddb/configStore.ts',
+      'packages/shared/src/ddb/configStore.test.ts',
+      'packages/shared/src/ddb/pendingStore.ts',
+      'packages/shared/src/ddb/pendingStore.test.ts',
+      'packages/shared/src/secrets/secretsStore.ts',
+      'packages/shared/src/secrets/secretsStore.test.ts',
+      'packages/desktop-main/src/services/LogsService.ts',
+      'packages/desktop-main/src/services/LogsService.test.ts',
+      'packages/desktop-main/src/services/Ec2Service.ts',
+      'packages/desktop-main/src/services/Ec2Service.test.ts',
+      'packages/desktop-main/src/services/FileManagerService.ts',
+      'packages/desktop-main/src/services/FileManagerService.test.ts',
+      'packages/desktop-main/src/services/EcsService.ts',
+      'packages/desktop-main/src/services/EcsService.test.ts',
+      'packages/desktop-main/src/test-mocks/ecs-mock.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['@aws-sdk/*'],
+          message: 'Import AWS SDK clients only within packages/cloud-aws or packages/lambda; depend on the cloud-agnostic interfaces from @hyveon/shared/cloud.js elsewhere.',
+        }],
+      }],
+    },
+  },
 );


### PR DESCRIPTION
Closes #195

## Summary

- Adds a `no-restricted-imports` ESLint rule to `app/eslint.config.js` that bans any `@aws-sdk/*` import from `packages/**/*.{ts,tsx}`.
- Scopes the ban to everywhere except `packages/cloud-aws/**` and `packages/lambda/**`, which are allowed to import AWS SDK clients directly (cloud-aws is the concrete implementation; the Lambdas run standalone without a DI-injected cloud provider).
- Carves out an explicit, commented `ignores` allowlist for legacy pre-abstraction call sites (`shared/src/ddb/*`, `shared/src/secrets/secretsStore.ts`, and several `desktop-main` services/mocks) so existing code isn't broken, with a note that new code should not be added to this list and should depend on `@hyveon/shared/cloud.js` instead.

## Changes

```
app/eslint.config.js | 38 ++++++++++++++++++++++++++++++++++++++
 1 file changed, 38 insertions(+)
```

## Test plan

- [x] `no-restricted-imports` rule bans `@aws-sdk/*` imports under `packages/**/*.{ts,tsx}`
- [x] `packages/cloud-aws/**` and `packages/lambda/**` are exempted from the rule
- [x] Legacy pre-abstraction call sites are carved out via an explicit, commented `ignores` list (no new entries expected)
- [ ] `npm run app:lint` — fails on a test `import { S3Client } from '@aws-sdk/client-s3'` added outside the allowed packages
- [ ] `npm run app:lint` — passes on the existing codebase as-is
