### PR TITLE
feat(terraform): bootstrap module — versioned S3 bucket for tfvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ terraform/*.tfstate.backup
 terraform/*.tfvars
 !terraform/*.tfvars.example
 terraform/.terraform.lock.hcl
+terraform/**/.terraform/
+terraform/**/*.tfstate
+terraform/**/*.tfstate.backup
+terraform/**/.terraform.lock.hcl
 
 # App runtime
 app/server_config.json

--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -42,6 +42,34 @@ the composer.
 | `aws/followup.tf` | `followup` Lambda with IAM (`ecs:RunTask`, `StopTask`, `DescribeTasks`, `iam:PassRole`, `dynamodb:GetItem`/`PutItem`, `ec2:DescribeNetworkInterfaces`). Async-invoked by interactions. |
 | `aws/discord_store.tf` | DynamoDB table (pk+sk, TTL on `expiresAt`), two Secrets Manager secrets (`${project_name}/discord/bot-token`, `/discord/public-key`) with `recovery_window_in_days = 0` and `lifecycle.ignore_changes` on seeded secret values. Optional `CONFIG#discord` DynamoDB item seeded from tfvars. Optional `BASE#discord` item holding the Terraform-managed base allowlist/admins (see `base_allowed_guilds` / `base_admin_*` variables). When `discord_bot_token`, `discord_application_id`, and at least one `base_allowed_guilds` entry are set, a `null_resource` runs `curl` to register slash commands in each base guild during apply; re-runs on token rotation or command-descriptor changes. |
 
+## Bootstrap module (`terraform/bootstrap/`)
+
+Root `main.tf` reads the tfvars bucket via `data "aws_s3_bucket" "tfvars"`
+(keyed on `var.tfvars_bucket_name`), so that bucket must already exist before
+the root module is ever applied. `terraform/bootstrap/` is a small,
+standalone module — with no dependency on `terraform/aws/` or the root
+composer — whose only job is to create it. It provisions:
+
+- `aws_s3_bucket.tfvars` — named `coalesce(var.tfvars_bucket_name, "${var.project_name}-tfvars")`.
+- `aws_s3_bucket_versioning.tfvars` — versioning `Enabled`, which doubles as
+  the history/locking mechanism for `terraform.tfvars` (no separate DynamoDB
+  lock table for this bucket).
+- `aws_s3_bucket_server_side_encryption_configuration.tfvars` — AES256 SSE by default.
+- `aws_s3_bucket_public_access_block.tfvars` — blocks all public ACLs/policies.
+- `aws_s3_bucket_lifecycle_configuration.tfvars` — expires noncurrent versions
+  after 90 days.
+
+Outputs (`terraform/bootstrap/outputs.tf`): `tfvars_bucket_name` and
+`tfvars_bucket_arn`.
+
+**Apply-before-main ordering:** run `terraform init` and `terraform apply`
+inside `terraform/bootstrap/` first — before the first `terraform apply` in
+the root `terraform/` module. If the bucket doesn't exist yet, the root's
+`data "aws_s3_bucket" "tfvars"` source fails at plan time. The bootstrap
+module has no remote backend of its own (it creates the bucket other things
+eventually read from, so storing its own state there would be
+chicken-and-egg); its state stays local and is gitignored.
+
 ## Variables
 
 | Name | Type | Default | Purpose |
@@ -63,6 +91,7 @@ the composer.
 | `base_allowed_guilds` | `list(string)` | `[]` | Guild IDs written to the `BASE#discord` row on every apply. The management UI shows these as locked; they cannot be removed via the UI. Update in tfvars + re-apply to change. |
 | `base_admin_user_ids` | `list(string)` | `[]` | Discord user IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
 | `base_admin_role_ids` | `list(string)` | `[]` | Discord role IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
+| `tfvars_bucket_name` | `string` | `null` → `{project_name}-tfvars` | Name of the versioned S3 bucket created by the [bootstrap module](#bootstrap-module-terraformbootstrap) to hold `terraform.tfvars` outside the operator's parent repo. Read via a `data "aws_s3_bucket" "tfvars"` source in root `main.tf`; must resolve to a bucket that already exists (see apply-before-main ordering below). |
 | `tags` | `map(string)` | defaults | Merged into `default_tags` for cost allocation (`Project`). |
 
 ### `game_servers[].file_seeds` (optional)

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -164,16 +164,22 @@ Both scripts are idempotent — safe to re-run at any time. They:
    (migrating from a previous local-backend setup), it automatically
    migrates state to S3 without prompting.
 
-### Bootstrap the tfvars bucket (optional but recommended)
+### Bootstrap the tfvars bucket (required before the first `terraform apply`)
 
 `terraform/bootstrap/` is a separate, standalone Terraform module — not part
 of the `setup.sh` flow above — that provisions a **second, distinct S3
 bucket** whose only job is to hold your `terraform.tfvars` (and other
 per-deployment secrets) outside of source control. This is unrelated to the
 `{project_name}-tf-state` bucket `setup.sh` creates for the Terraform
-backend; run it once, before the main `terraform init`/`terraform apply`
-steps below, if you want a durable, versioned place to keep `tfvars` outside
-your parent repo.
+backend. The root module's `data "aws_s3_bucket" "tfvars"` (in
+`terraform/main.tf`) reads this bucket, so it **must already exist before
+you run `terraform apply` in the root `terraform/` directory** — skipping
+this step makes the root `terraform plan`/`terraform apply` fail at plan
+time with a "bucket not found" error. Run it once, before the main
+`terraform init`/`terraform apply` steps below, to get a durable, versioned
+place to keep `tfvars` outside your parent repo — if you'd rather pre-create
+the bucket some other way (e.g. manually or via a different tool), that
+works too, as long as the name matches `tfvars_bucket_name` (see below).
 
 ```bash
 cd terraform/bootstrap

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -164,6 +164,46 @@ Both scripts are idempotent — safe to re-run at any time. They:
    (migrating from a previous local-backend setup), it automatically
    migrates state to S3 without prompting.
 
+### Bootstrap the tfvars bucket (optional but recommended)
+
+`terraform/bootstrap/` is a separate, standalone Terraform module — not part
+of the `setup.sh` flow above — that provisions a **second, distinct S3
+bucket** whose only job is to hold your `terraform.tfvars` (and other
+per-deployment secrets) outside of source control. This is unrelated to the
+`{project_name}-tf-state` bucket `setup.sh` creates for the Terraform
+backend; run it once, before the main `terraform init`/`terraform apply`
+steps below, if you want a durable, versioned place to keep `tfvars` outside
+your parent repo.
+
+```bash
+cd terraform/bootstrap
+terraform init
+terraform apply
+```
+
+The bucket it creates (default name `{project_name}-tfvars`) has:
+
+- **Versioning enabled** — every write to `terraform.tfvars` is recoverable.
+- **AES-256 server-side encryption** and a **public-access block** (all four
+  block-public settings on).
+- A **lifecycle rule** that expires noncurrent object versions after 90 days,
+  so old revisions don't accumulate forever.
+
+> **This module's own state stays local and is never committed.** It can't
+> use the S3 backend it's bootstrapping (chicken-and-egg), so `terraform
+> apply` writes a local `terraform.tfstate` under `terraform/bootstrap/` —
+> already covered by `.gitignore` (`terraform/**/*.tfstate`). Keep a personal
+> backup of that file; without it, a future `terraform apply` in this
+> directory won't recognize the bucket it already created.
+
+If you accept the default bucket name, no further action is needed — the
+root config's `tfvars_bucket_name` variable defaults to the same
+`{project_name}-tfvars` convention. If you pass a custom
+`-var="tfvars_bucket_name=..."` (or `project_name`) when applying this
+module, set the **same** value for `tfvars_bucket_name` in
+`terraform/terraform.tfvars` (see step 4 below) so the root module's
+`data "aws_s3_bucket" "tfvars"` resolves to the bucket you actually created.
+
 ## 4. Configure your servers
 
 Open `terraform/terraform.tfvars` in your editor and fill in:

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,54 @@
+locals {
+  tfvars_bucket_name = coalesce(var.tfvars_bucket_name, "${var.project_name}-tfvars")
+}
+
+# Versioned S3 bucket that holds terraform.tfvars outside the operator's
+# parent repo. Versioning plus the lifecycle rule below double as the
+# history/locking mechanism for this bucket.
+resource "aws_s3_bucket" "tfvars" {
+  bucket = local.tfvars_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "tfvars" {
+  bucket = aws_s3_bucket.tfvars.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfvars" {
+  bucket = aws_s3_bucket.tfvars.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfvars" {
+  bucket = aws_s3_bucket.tfvars.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tfvars" {
+  bucket = aws_s3_bucket.tfvars.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.tfvars]
+}

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "tfvars_bucket_name" {
+  description = "Name of the S3 bucket used to store terraform.tfvars"
+  value       = aws_s3_bucket.tfvars.id
+}
+
+output "tfvars_bucket_arn" {
+  description = "ARN of the S3 bucket used to store terraform.tfvars"
+  value       = aws_s3_bucket.tfvars.arn
+}

--- a/terraform/bootstrap/provider.tf
+++ b/terraform/bootstrap/provider.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # No remote backend on purpose: this module only exists to bootstrap the
+  # S3 bucket that the main `terraform/` module later reads via a
+  # `data "aws_s3_bucket"` source, so it can't store its own state there
+  # (chicken-and-egg). State stays local and is never committed.
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  description = "AWS region to provision the tfvars bucket in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "game-servers"
+}
+
+variable "tfvars_bucket_name" {
+  description = "Override for the tfvars bucket name (defaults to \"<project_name>-tfvars\")"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to all resources"
+  type        = map(string)
+  default = {
+    Project     = "game-servers-poc"
+    Environment = "poc"
+    ManagedBy   = "terraform"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,9 +41,10 @@ provider "aws" {
 
 # The versioned tfvars bucket is created out-of-band by the bootstrap module
 # (see terraform/bootstrap/) before this root config is ever applied. Reading
-# it here as a data source lets consumers (e.g. the desktop app) resolve the
-# bucket name without duplicating the "${project_name}-tfvars" naming
-# convention in multiple places.
+# it here as a data source both fails fast if the bootstrap bucket is missing
+# and lets consumers (e.g. the desktop app) resolve the bucket name — via the
+# `tfvars_bucket_name` output below — without duplicating the
+# "${project_name}-tfvars" naming convention in multiple places.
 data "aws_s3_bucket" "tfvars" {
   bucket = coalesce(var.tfvars_bucket_name, "${var.project_name}-tfvars")
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,6 +39,15 @@ provider "aws" {
   }
 }
 
+# The versioned tfvars bucket is created out-of-band by the bootstrap module
+# (see terraform/bootstrap/) before this root config is ever applied. Reading
+# it here as a data source lets consumers (e.g. the desktop app) resolve the
+# bucket name without duplicating the "${project_name}-tfvars" naming
+# convention in multiple places.
+data "aws_s3_bucket" "tfvars" {
+  bucket = coalesce(var.tfvars_bucket_name, "${var.project_name}-tfvars")
+}
+
 # All AWS infrastructure lives in the "./aws" module — this root composes the
 # backend/provider config with the module and re-exports its outputs
 # (outputs.tf) so ConfigService.getTfOutputs() keeps reading root-level state.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -109,3 +109,10 @@ output "watchdog_function_name" {
   description = "Watchdog Lambda function name"
   value       = module.cloud[0].watchdog_function_name
 }
+
+# ── Bootstrap-created resources ──────────────────────────────────────────────
+
+output "tfvars_bucket_name" {
+  description = "Name of the versioned tfvars bucket created by the bootstrap module (terraform/bootstrap/)"
+  value       = data.aws_s3_bucket.tfvars.id
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -8,6 +8,11 @@
 aws_region   = "us-east-1"
 project_name = "game-servers"
 
+# Name of the versioned S3 bucket created by the bootstrap module (terraform/bootstrap)
+# to hold terraform.tfvars outside your parent repo. Optional override — defaults to
+# "{project_name}-tfvars" when unset.
+# tfvars_bucket_name = "game-servers-tfvars"
+
 # Domain for server DNS records (must have a hosted zone in Route 53)
 # Creates: {game}.example.com for each entry in game_servers below.
 hosted_zone_name = "example.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -163,6 +163,14 @@ variable "discord_public_key" {
   sensitive   = true
 }
 
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+
+variable "tfvars_bucket_name" {
+  description = "Name of the versioned S3 bucket created by the bootstrap module to hold terraform.tfvars. Defaults to \"$${project_name}-tfvars\" when null."
+  type        = string
+  default     = null
+}
+
 # ── Tags ─────────────────────────────────────────────────────────────────────
 
 variable "tags" {


### PR DESCRIPTION
Closes #84

## Summary

- Adds a new `terraform/bootstrap/` module (own `main.tf` / `variables.tf` / `outputs.tf` / `provider.tf`, local state, no remote backend) that provisions the S3 bucket used to store `terraform.tfvars` outside the operator's parent repo.
- Bucket (`aws_s3_bucket.tfvars`, named `${project_name}-tfvars` or an override) has versioning, SSE-S3 (`AES256`) encryption, a public-access block with everything blocked, and a lifecycle rule expiring non-current versions after 90 days.
- Main module reads the bucket via `data "aws_s3_bucket" "tfvars"` keyed off a new `tfvars_bucket_name` variable (defaults to `${project_name}-tfvars`), avoiding a chicken-and-egg with the same state file declaring the bucket it's stored in.

## Changes

```
.gitignore                         |  4 +++
docs/docs/components/terraform.md  | 29 ++++++++++++++++++++
docs/docs/setup.md                 | 46 ++++++++++++++++++++++++++++++++
terraform/bootstrap/main.tf        | 54 ++++++++++++++++++++++++++++++++++++++
terraform/bootstrap/outputs.tf     |  9 +++++++
terraform/bootstrap/provider.tf    | 23 ++++++++++++++++
terraform/bootstrap/variables.tf   | 27 +++++++++++++++++++
terraform/main.tf                  | 10 +++++++
terraform/outputs.tf               |  7 +++++
terraform/terraform.tfvars.example |  5 ++++
terraform/variables.tf             |  8 ++++++
11 files changed, 222 insertions(+)
```

## Test plan

- [x] `terraform/bootstrap/` module created with own `main.tf`/`variables.tf`/`outputs.tf`/`provider.tf`, local state only
- [x] `aws_s3_bucket.tfvars` named `${project_name}-tfvars` (overridable)
- [x] `aws_s3_bucket_versioning` enabled
- [x] `aws_s3_bucket_server_side_encryption_configuration` with SSE-S3 (`AES256`)
- [x] `aws_s3_bucket_public_access_block` blocks everything
- [x] `aws_s3_bucket_lifecycle_configuration` expires non-current versions after 90 days
- [x] Outputs `tfvars_bucket_name` and `tfvars_bucket_arn` exposed
- [x] Main module's `data "aws_s3_bucket" "tfvars"` reads the bucket by name
- [x] `tfvars_bucket_name` added to `terraform/variables.tf` (defaults to `${project_name}-tfvars`)
- [x] Four-file Terraform-variable checklist applied (`variables.tf`, `terraform.tfvars.example`, `docs/docs/components/terraform.md`, `docs/docs/setup.md`)
- [ ] `cd terraform/bootstrap && terraform init && terraform apply` — applies cleanly from a fresh AWS account
- [ ] Re-running `terraform apply` in bootstrap is a no-op (idempotent)
- [ ] `cd terraform && terraform plan` — `data "aws_s3_bucket" "tfvars"` resolves without errors
- [ ] `terraform fmt -check -recursive` and `terraform validate` — pass
- [ ] `tflint` — passes