### PR TITLE
feat(iam): GameServerDeployAll entries for the tfvars bucket

### DIFF
--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -82,6 +82,27 @@ On the AWS side you need:
         "arn:aws:iam::*:role/game-servers-*",
         "arn:aws:iam::*:policy/game-servers-*"
       ]
+    },
+    {
+      "Sid": "GameServerTfvarsBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketLocation",
+        "s3:PutLifecycleConfiguration",
+        "s3:PutEncryptionConfiguration",
+        "s3:PutBucketPublicAccessBlock"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${project_name}-tfvars",
+        "arn:aws:s3:::${project_name}-tfvars/*"
+      ]
     }
   ]
 }
@@ -97,6 +118,22 @@ On the AWS side you need:
 > granting `iam:PassRole` on every role in the account. The `game-servers-*`
 > prefix matches the default `project_name`. If you change `project_name` in
 > `terraform.tfvars`, update the two ARN patterns in `GameServerIAM` to match.
+
+> **`GameServerTfvarsBucket` scopes access to the tfvars-bucket storage**
+> created by the [bootstrap module](#3-clone-and-bootstrap) (see the
+> "Bootstrap the tfvars bucket" step below) — the dedicated, versioned S3
+> bucket (default name `${project_name}-tfvars`) that holds `terraform.tfvars`
+> outside source control. It grants object read/write/list/versioning access
+> plus the bucket-config actions (`PutLifecycleConfiguration`,
+> `PutEncryptionConfiguration`, `PutBucketPublicAccessBlock`,
+> `PutBucketVersioning`/`GetBucketVersioning`, `GetBucketLocation`) the
+> bootstrap module needs to configure the bucket's lifecycle rule,
+> encryption, public-access block, and versioning. Although `s3:*` in
+> `GameServerDeploy` already covers these actions on every bucket, this
+> statement documents the specific permissions the tfvars-bucket workflow
+> depends on and scopes them to just the two tfvars ARNs. If you change
+> `project_name` or `tfvars_bucket_name`, update the two ARN patterns in
+> `GameServerTfvarsBucket` to match.
 
 Two permission areas used by Terraform are **not** covered by any AWS managed policy and are explicitly included above to avoid `AccessDenied` during `terraform apply`:
 


### PR DESCRIPTION
Closes #86

## Summary

- Adds a `GameServerTfvarsBucket` IAM statement to the `GameServerDeployAll` policy JSON in `docs/docs/setup.md`, scoped to the `${project_name}-tfvars` bucket + its objects.
- Grants `s3:GetObject`, `PutObject`, `DeleteObject`, `ListBucket`, `GetObjectVersion`, `GetBucketVersioning`, `PutBucketVersioning`, `GetBucketLocation`, `PutLifecycleConfiguration`, `PutEncryptionConfiguration`, and `PutBucketPublicAccessBlock` — the actions the bootstrap module needs to configure the bucket's versioning, SSE encryption, public-access block, and lifecycle rule.
- Adds surrounding prose explaining the statement's purpose, its link to the bootstrap module, and a note to update the ARN patterns if `project_name` or `tfvars_bucket_name` changes.

## Changes

```
docs/docs/setup.md | 37 +++++++++++++++++++++++++++++++++++++
1 file changed, 37 insertions(+)
```

## Test plan

- [x] `setup.md` policy JSON includes the `GameServerTfvarsBucket` statement covering both bucket and object ARNs.
- [x] Prose around the policy mentions tfvars storage and links to the bootstrap module.
- [ ] `terraform apply` of the bootstrap module + main module both succeed under the updated policy from a fresh account.