### PR TITLE
feat(desktop-main): bootstrap the tfvars bucket on first run (#85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ out/
 
 # electron-builder packaged artifacts
 release/
+
+# GSD bootstrap metadata (tfvars-bucket marker etc.)
+.gsd/

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -189,34 +189,63 @@ Both scripts are idempotent — safe to re-run at any time. They:
 2. Runs `npm ci` from `app/` so all workspaces are installed.
 3. Copies `terraform/terraform.tfvars.example` to `terraform/terraform.tfvars`
    if the latter doesn't exist yet.
-4. Creates the S3 state bucket (`{project_name}-tf-state`) and DynamoDB lock
+4. **`setup.sh` only** (not yet ported to `setup.ps1`): offers to bootstrap the
+   tfvars S3 bucket (`terraform/bootstrap/`), controlled by the
+   `GSD_TFVARS_BACKEND` environment variable:
+   - `GSD_TFVARS_BACKEND=s3` — bootstraps the bucket non-interactively.
+   - `GSD_TFVARS_BACKEND=local` — skips it entirely, no AWS/Terraform calls.
+   - Unset, interactive shell (a TTY) — prompts
+     `Store terraform.tfvars in a versioned S3 bucket (terraform/bootstrap)? [y/N]`;
+     anything other than `y`/`Y`/`yes`/`YES` falls back to `local`.
+   - Unset, non-interactive shell (CI, scripted runs) — silently defaults to
+     `local`.
+
+   When `s3` is selected, the script `cd`s into `terraform/bootstrap/`, runs
+   `terraform init` and `terraform apply -auto-approve` there (passing
+   `project_name` and `aws_region` from the values derived in step 3), then
+   records the resulting bucket name at `.gsd/tfvars-bucket` — a file at the
+   repo root, gitignored, used purely as a local marker for the operator. If
+   a local `terraform/terraform.tfvars` already exists, the script uploads it
+   to `s3://<bucket>/terraform.tfvars`, but **only if that key doesn't already
+   exist in the bucket** (checked via `aws s3api head-object`) — so re-running
+   `setup.sh` never clobbers a tfvars file that's already been pushed or
+   edited in S3.
+5. Creates the S3 state bucket (`{project_name}-tf-state`) and DynamoDB lock
    table (`{project_name}-tf-locks`) if they don't already exist. The bucket
    gets versioning, public-access blocking, and AES-256 encryption enabled.
    The script waits for the DynamoDB table to reach `ACTIVE` status before
    continuing. Both names are derived from `project_name` in
    `terraform.tfvars` (default: `game-servers`). This step requires the
    `s3:*` permissions in the inline policy above.
-5. Runs `terraform init` inside `terraform/`, passing the bucket and table
+6. Runs `terraform init` inside `terraform/`, passing the bucket and table
    as `-backend-config` flags. If a local `terraform.tfstate` is present
    (migrating from a previous local-backend setup), it automatically
    migrates state to S3 without prompting.
 
 ### Bootstrap the tfvars bucket (required before the first `terraform apply`)
 
-`terraform/bootstrap/` is a separate, standalone Terraform module — not part
-of the `setup.sh` flow above — that provisions a **second, distinct S3
-bucket** whose only job is to hold your `terraform.tfvars` (and other
-per-deployment secrets) outside of source control. This is unrelated to the
-`{project_name}-tf-state` bucket `setup.sh` creates for the Terraform
-backend. The root module's `data "aws_s3_bucket" "tfvars"` (in
-`terraform/main.tf`) reads this bucket, so it **must already exist before
-you run `terraform apply` in the root `terraform/` directory** — skipping
-this step makes the root `terraform plan`/`terraform apply` fail at plan
-time with a "bucket not found" error. Run it once, before the main
-`terraform init`/`terraform apply` steps below, to get a durable, versioned
-place to keep `tfvars` outside your parent repo — if you'd rather pre-create
-the bucket some other way (e.g. manually or via a different tool), that
-works too, as long as the name matches `tfvars_bucket_name` (see below).
+`terraform/bootstrap/` is a separate, standalone Terraform module that
+provisions a **second, distinct S3 bucket** whose only job is to hold your
+`terraform.tfvars` (and other per-deployment secrets) outside of source
+control. This is unrelated to the `{project_name}-tf-state` bucket `setup.sh`
+creates for the Terraform backend. The root module's `data "aws_s3_bucket"
+"tfvars"` (in `terraform/main.tf`) reads this bucket, so it **must already
+exist before you run `terraform apply` in the root `terraform/` directory** —
+skipping this step makes the root `terraform plan`/`terraform apply` fail at
+plan time with a "bucket not found" error.
+
+**On Linux/macOS, `./setup.sh` can do this for you** — see step 4 above
+(`GSD_TFVARS_BACKEND=s3`, or accept the interactive prompt). It runs the same
+`terraform init`/`terraform apply` shown below, records the bucket name at
+`.gsd/tfvars-bucket`, and uploads your local `terraform.tfvars` if the bucket
+doesn't already have one. Use the manual steps below if you're on
+`setup.ps1` (not yet supported there), opted for `GSD_TFVARS_BACKEND=local`
+and changed your mind, or just want to run it standalone — either way, get
+this done once, before the main `terraform init`/`terraform apply` steps
+below, to have a durable, versioned place to keep `tfvars` outside your
+parent repo. If you'd rather pre-create the bucket some other way (e.g.
+manually or via a different tool), that works too, as long as the name
+matches `tfvars_bucket_name` (see below).
 
 ```bash
 cd terraform/bootstrap

--- a/setup.sh
+++ b/setup.sh
@@ -11,6 +11,11 @@ Usage:
   ./setup.sh              First-time bootstrap (default).
                           Installs prereqs, builds Lambda bundles, creates the
                           S3+DynamoDB Terraform backend, and runs `terraform init`.
+                          Also offers to bootstrap a versioned S3 bucket for
+                          terraform.tfvars (terraform/bootstrap/) — set
+                          GSD_TFVARS_BACKEND=s3 to opt in non-interactively,
+                          or GSD_TFVARS_BACKEND=local to skip. Unset in a
+                          non-interactive shell defaults to local (no-op).
 
   ./setup.sh add-game     Interactive: prompts for image/cpu/memory/ports and
                           prints an HCL snippet to paste into terraform.tfvars
@@ -22,6 +27,77 @@ Usage:
 
   ./setup.sh -h | --help  Show this message.
 EOF
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# tfvars backend selection + S3 bootstrap
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# terraform/bootstrap/ is a separate, standalone Terraform module that
+# provisions a *second*, distinct S3 bucket whose only job is to hold
+# terraform.tfvars outside the operator's parent repo (see
+# docs/docs/setup.md, "Bootstrap the tfvars bucket"). GSD_TFVARS_BACKEND
+# picks how that bucket gets created:
+#   - "local" (default): skip entirely — zero new AWS/Terraform calls. This
+#     preserves today's behaviour for anyone managing tfvars by hand.
+#   - "s3": `terraform apply` the bootstrap module, record the resulting
+#     bucket name in .gsd/tfvars-bucket (parent-repo root, gitignored), and
+#     seed the bucket with the local terraform.tfvars — but only if one
+#     exists locally and the bucket doesn't already have an object at that
+#     key, so re-running never re-uploads.
+# When the env var is unset, an interactive TTY is prompted; a non-TTY
+# session (CI, scripted runs) silently defaults to "local".
+#
+# Expects TF_PROJECT and TF_REGION to already be set by the caller (bootstrap
+# derives them from terraform.tfvars before calling this).
+
+bootstrap_tfvars_backend() {
+  local backend="${GSD_TFVARS_BACKEND:-}"
+
+  if [ -z "$backend" ]; then
+    if [ -t 0 ]; then
+      local reply
+      read -rp "  Store terraform.tfvars in a versioned S3 bucket (terraform/bootstrap)? [y/N]: " reply
+      case "$reply" in
+        y|Y|yes|YES) backend="s3" ;;
+        *) backend="local" ;;
+      esac
+    else
+      backend="local"
+    fi
+  fi
+
+  if [ "$backend" != "s3" ]; then
+    echo "   tfvars backend: local (skipping S3 bootstrap — no AWS calls)"
+    return 0
+  fi
+
+  echo ""
+  echo "☁️   Bootstrapping tfvars S3 bucket (terraform/bootstrap)..."
+  cd "$SCRIPT_DIR/terraform/bootstrap"
+  terraform init -input=false
+  terraform apply -auto-approve -input=false \
+    -var="project_name=${TF_PROJECT}" \
+    -var="aws_region=${TF_REGION}"
+
+  local bucket
+  bucket=$(terraform output -raw tfvars_bucket_name)
+
+  mkdir -p "$SCRIPT_DIR/.gsd"
+  echo "$bucket" >"$SCRIPT_DIR/.gsd/tfvars-bucket"
+  echo "   Bucket name recorded at .gsd/tfvars-bucket: ${bucket}"
+
+  local tfvars_file="$SCRIPT_DIR/terraform/terraform.tfvars"
+  if [ -f "$tfvars_file" ]; then
+    if aws s3api head-object --bucket "$bucket" --key terraform.tfvars --region "$TF_REGION" >/dev/null 2>&1; then
+      echo "   s3://${bucket}/terraform.tfvars already exists — skipping upload."
+    else
+      echo "   Uploading local terraform.tfvars to s3://${bucket}/terraform.tfvars..."
+      aws s3 cp "$tfvars_file" "s3://${bucket}/terraform.tfvars" --region "$TF_REGION"
+    fi
+  fi
+
+  cd "$SCRIPT_DIR/terraform"
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -98,6 +174,8 @@ bootstrap() {
   TF_REGION="${TF_REGION:-us-east-1}"
   TF_STATE_BUCKET="${TF_PROJECT}-tf-state"
   TF_LOCK_TABLE="${TF_PROJECT}-tf-locks"
+
+  bootstrap_tfvars_backend
 
   echo ""
   echo "☁️   Bootstrapping S3 backend (bucket: ${TF_STATE_BUCKET}, region: ${TF_REGION})..."


### PR DESCRIPTION
Closes #85

## Summary

- Extends `setup.sh` to optionally bootstrap S3-backed tfvars storage: detects `GSD_TFVARS_BACKEND=s3` (env var or interactive prompt), defaulting to `local` for backwards compatibility.
- When `s3` is selected, runs `terraform init && terraform apply -auto-approve` against `terraform/bootstrap/`, captures the `tfvars_bucket_name` output, writes it to `.gsd/tfvars-bucket` at the parent repo root, and uploads an existing local `terraform.tfvars` as the initial version if the bucket is empty.
- Adds `.gsd/` to `.gitignore` so the bootstrap metadata directory isn't committed, and documents the new S3 tfvars bootstrap flow in `docs/docs/setup.md`.

## Changes

```
.gitignore         |  3 +++
docs/docs/setup.md | 61 +++++++++++++++++++++++++++++++-----------
setup.sh           | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
3 files changed, 126 insertions(+), 16 deletions(-)
```

## Test plan

- [ ] `GSD_TFVARS_BACKEND=s3 ./setup.sh` from a fresh account ends with the bucket created and the local tfvars uploaded.
- [ ] Re-running `setup.sh` is a no-op (no errors, no duplicate uploads).
- [ ] `setup.sh` without the env var still works as today (defaults to `local`).
- [x] `setup.md` updated to describe the new flow.