### PR TITLE
feat(desktop-main): RemoteTfvarsStore service (pull/push/diff/lock)

### DIFF
--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -45,6 +45,9 @@ export default defineConfig({
       'packages/desktop-preload/**/*.test.{ts,tsx}',
       // Top-level test helpers (e.g. fake-terraform.mjs) live outside packages/.
       'test/**/*.test.{ts,tsx}',
+      // The tfvars-sync helper lives in the top-level @hyveon/scripts workspace
+      // (outside packages/), so it needs its own explicit include entry.
+      '../scripts/tfvars-sync.test.ts',
     ],
     // Default environment for server-side and shared tests is Node.
     // React component tests under @hyveon/web override this via

--- a/package-lock.json
+++ b/package-lock.json
@@ -5630,6 +5630,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -18497,13 +18504,28 @@
     "scripts": {
       "name": "@hyveon/scripts",
       "version": "0.0.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.600.0",
+        "diff": "^7.0.0"
+      },
       "devDependencies": {
+        "@types/diff": "^7.0.1",
         "@types/node": "^20.16.10",
+        "aws-sdk-client-mock": "^4.0.1",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "scripts/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "app:test:e2e": "npm run build -w @hyveon/shared && npm run build -w @hyveon/cloud-aws && npm run test:e2e -w @hyveon/web",
     "app:test:integration": "npm run build -w @hyveon/desktop-main && npm run test:integration -w @hyveon/web",
     "scripts:init-parent": "npm run init-parent  -w @hyveon/scripts",
+    "scripts:tfvars-sync": "npm run tfvars-sync  -w @hyveon/scripts",
     "desktop:dev": "electron-vite dev",
     "desktop:build": "electron-vite build",
     "desktop:package": "npm run desktop:build && electron-builder --config electron-builder.yml"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -107,9 +107,13 @@ these resolve.
 
 A sidecar lock file (`${path}.lock`, e.g. `terraform/terraform.tfvars.lock`)
 records the S3 version id, etag, size, last-modified timestamp, and
-pulled-at timestamp observed on the last successful `pull` or `push`. It is
-JSON and safe to inspect or commit-ignore alongside the tfvars file it
-tracks.
+pulled-at timestamp from the last successful `pull` or `push`. On `pull`,
+`lastModified` and `pulledAt` reflect the object's `LastModified` value as
+observed from S3. On `push`, both fields are instead the client-side write
+timestamp (`new Date().toISOString()` in `tfvars-sync.ts`, line ~393),
+recorded right after the upload completes rather than read back from S3.
+It is JSON and safe to inspect or commit-ignore alongside the tfvars file
+it tracks.
 
 `push` uses the lock as an optimistic-concurrency check before uploading:
 
@@ -123,8 +127,10 @@ tracks.
 - If the remote object doesn't exist yet, `push` proceeds without a lock
   check (first push).
 
-On success, both `pull` and `push` (re)write the lock file with the
-newly-observed version, so the next `push` is validated against it.
+On success, both `pull` and `push` (re)write the lock file with the new
+version — `pull` from the version it observed on S3, `push` from the
+response returned by its own upload — so the next `push` is validated
+against it.
 
 ### Diff exit codes
 
@@ -137,5 +143,7 @@ newly-observed version, so the next `push` is validated against it.
 ### Requirements
 
 - Node.js 20+.
-- AWS credentials resolvable by the AWS SDK v3's default provider chain
-  (env vars, shared config/credentials file, or `--region`/SDK defaults).
+- AWS credentials resolvable by the AWS SDK v3's default credential
+  provider chain (env vars, shared credentials file, IAM role, etc.).
+- A region, resolved via `--region` or the SDK's own region config —
+  this only selects the region and is unrelated to credential resolution.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,3 +40,100 @@ re-run; without `--force` it leaves existing files alone.
 Windows users should run this under WSL or Git Bash — the generated
 `Makefile` uses `bash`, `sha256sum`, and `cp`, which mirrors the upstream
 Makefile's shell expectations.
+
+## `tfvars-sync.ts`
+
+CLI mirror of the app's `RemoteTfvarsStore` service: pulls, pushes, diffs, and
+reports status for a `terraform.tfvars` file stored in the versioned S3 bucket
+provisioned by `terraform/bootstrap` (see `docs/docs/setup.md` for the
+bootstrap flow). Useful when you want to sync tfvars from a shell or CI job
+without going through the desktop app.
+
+### Usage
+
+```bash
+tsx scripts/tfvars-sync.ts pull   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts push   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts diff   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+```
+
+### Subcommands
+
+- **`pull`** — downloads the remote tfvars object to `--path`, creating parent
+  directories as needed, and writes a sidecar lock file recording the version
+  just pulled.
+- **`push`** — uploads the local `--path` file to the remote bucket/key.
+  Refuses to overwrite the remote object if the local lock is missing (never
+  pulled) or stale (the remote object's current version id doesn't match the
+  lock's recorded version) — run `pull` again to resolve, then retry `push`.
+- **`diff`** — prints a unified diff (`remote → local`) between the remote
+  object and the local file. Prints `✓ local and remote match` and exits `0`
+  when the contents are byte-for-byte identical; otherwise prints
+  `✗ local and remote differ` and **exits `1`**.
+- **`status`** — prints the bucket/key/path, whether the local file exists,
+  the sidecar lock's recorded version/etag/pulled-at timestamp (or "none —
+  never pulled"), the remote object's current version/etag/last-modified (or
+  "object does not exist"), and whether the local lock is in sync with the
+  remote version.
+
+### Flags
+
+- `--bucket <name>` — target S3 bucket. See resolution order below.
+- `--path <file>` — local file to read from / write to. Defaults to
+  `terraform/terraform.tfvars`.
+- `--key <key>` — S3 object key. Defaults to `terraform.tfvars` — pass it
+  explicitly if the bucket should hold the object under a different key than
+  the local file's basename.
+- `--region <region>` — AWS region override; falls back to the AWS SDK's
+  default provider chain when omitted.
+
+### `--bucket` resolution order
+
+`--bucket` is resolved through a fallback chain when the flag is omitted:
+
+1. The `--bucket` flag, if passed.
+2. The `GSD_TFVARS_BUCKET` environment variable.
+3. The contents of the nearest `.gsd/tfvars-bucket` marker file, found by
+   walking up from the current working directory.
+
+The CLI exits with an error (`--bucket is required (or set
+GSD_TFVARS_BUCKET, or create a .gsd/tfvars-bucket marker file)`) if none of
+these resolve.
+
+### Lock-file mechanism
+
+A sidecar lock file (`${path}.lock`, e.g. `terraform/terraform.tfvars.lock`)
+records the S3 version id, etag, size, last-modified timestamp, and
+pulled-at timestamp observed on the last successful `pull` or `push`. It is
+JSON and safe to inspect or commit-ignore alongside the tfvars file it
+tracks.
+
+`push` uses the lock as an optimistic-concurrency check before uploading:
+
+- If the remote object exists but no lock file is present locally, `push`
+  throws (`Run "pull" first.`) rather than overwriting an object it has
+  never seen.
+- If the remote object exists and the lock's `versionId` doesn't match the
+  remote object's current `versionId` (i.e. someone else pushed since the
+  last local `pull`), `push` throws (`Run "pull" to refresh before
+  pushing.`) instead of clobbering the newer remote version.
+- If the remote object doesn't exist yet, `push` proceeds without a lock
+  check (first push).
+
+On success, both `pull` and `push` (re)write the lock file with the
+newly-observed version, so the next `push` is validated against it.
+
+### Diff exit codes
+
+`diff` sets `process.exitCode`:
+
+- **`0`** — local and remote are byte-for-byte identical (`matches: true`).
+- **`1`** — local and remote differ (`matches: false`); the unified diff is
+  printed to stdout before the exit code is set.
+
+### Requirements
+
+- Node.js 20+.
+- AWS credentials resolvable by the AWS SDK v3's default provider chain
+  (env vars, shared config/credentials file, or `--region`/SDK defaults).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,11 +43,13 @@ Makefile's shell expectations.
 
 ## `tfvars-sync.ts`
 
-CLI mirror of the app's `RemoteTfvarsStore` service: pulls, pushes, diffs, and
-reports status for a `terraform.tfvars` file stored in the versioned S3 bucket
+Standalone CLI for syncing `terraform.tfvars` with the versioned S3 bucket
 provisioned by `terraform/bootstrap` (see `docs/docs/setup.md` for the
-bootstrap flow). Useful when you want to sync tfvars from a shell or CI job
-without going through the desktop app.
+bootstrap flow): pulls, pushes, diffs, and reports status. Useful when you
+want to sync tfvars from a shell or CI job without going through the desktop
+app. (A `RemoteTfvarsStore` service exposing the same pull/push/diff/status
+operations to `desktop-main` is planned as a follow-up; this CLI does not
+depend on it.)
 
 ### Usage
 
@@ -82,9 +84,9 @@ tsx scripts/tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>
 - `--bucket <name>` — target S3 bucket. See resolution order below.
 - `--path <file>` — local file to read from / write to. Defaults to
   `terraform/terraform.tfvars`.
-- `--key <key>` — S3 object key. Defaults to `terraform.tfvars` — pass it
-  explicitly if the bucket should hold the object under a different key than
-  the local file's basename.
+- `--key <key>` — S3 object key. Always defaults to the fixed key
+  `terraform.tfvars`, regardless of `--path` — pass it explicitly if the
+  bucket should hold the object under a different key.
 - `--region <region>` — AWS region override; falls back to the AWS SDK's
   default provider chain when omitted.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,10 +36,9 @@ re-run; without `--force` it leaves existing files alone.
 
 - Node.js 20+ (the same minimum the rest of the project enforces).
 - `git` on `$PATH` (used to detect `.gitmodules`).
-
-Windows users should run this under WSL or Git Bash — the generated
-`Makefile` uses `bash`, `sha256sum`, and `cp`, which mirrors the upstream
-Makefile's shell expectations.
+- Windows users should run this under WSL or Git Bash — the generated
+  `Makefile` uses `bash`, `sha256sum`, and `cp`, which mirrors the upstream
+  Makefile's shell expectations.
 
 ## `tfvars-sync.ts`
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,15 +6,22 @@
   "type": "module",
   "scripts": {
     "init-parent": "tsx init-parent.ts",
+    "tfvars-sync": "tsx tfvars-sync.ts",
     "test": "tsx init-parent.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "engines": {
     "node": ">=20"
   },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.600.0",
+    "diff": "^7.0.0"
+  },
   "devDependencies": {
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
-    "@types/node": "^20.16.10"
+    "@types/node": "^20.16.10",
+    "@types/diff": "^7.0.1",
+    "aws-sdk-client-mock": "^4.0.1"
   }
 }

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -108,6 +108,11 @@ describe('tfvars-sync', () => {
       const result = await pushTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
 
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+      // The conditional write is the actual race guard: assert PutObject was
+      // sent with `IfMatch` pinned to the locked etag, not just that some
+      // PutObject happened. A regression that drops the conditional write
+      // would otherwise still pass this test.
+      expect(s3Mock.commandCalls(PutObjectCommand)[0]!.args[0].input.IfMatch).toBe('"etag-1"');
       expect(result.lock.versionId).toBe('v2');
       expect(result.lock.etag).toBe('etag-2');
       expect(JSON.parse(readFileSync(result.lockPath, 'utf8'))).toMatchObject({ versionId: 'v2', etag: 'etag-2' });
@@ -204,6 +209,38 @@ describe('tfvars-sync', () => {
       expect(err).toBeInstanceOf(BucketNotVersionedError);
       expect(err).toHaveProperty('message', expect.stringContaining('does not appear to have S3 versioning enabled'));
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('should reject with VersionMismatchError when PutObject fails with a 412 precondition-failed response', async () => {
+      // The HeadObject check passes (lock matches remote at the time of the
+      // check), but a concurrent push slips in between the check and the
+      // PutObject call, so S3 rejects the conditional write with 412. This is
+      // the actual race guard the HeadObject check can't cover on its own.
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'v1',
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+      s3Mock.on(PutObjectCommand).rejects({ name: 'PreconditionFailed', $metadata: { httpStatusCode: 412 } });
+
+      const err: unknown = await pushTfvars({
+        bucket: 'my-bucket',
+        path: localPath,
+        key: 'terraform.tfvars',
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(VersionMismatchError);
+      expect((err as VersionMismatchError).localVersion).toBe('v1');
+      expect((err as VersionMismatchError).remoteVersion).toBeNull();
+      expect(err).toHaveProperty('message', expect.stringContaining('concurrent push detected'));
+      // The stale lock file must not have been overwritten with a failed push.
+      expect(JSON.parse(readFileSync(`${localPath}.lock`, 'utf8'))).toMatchObject({ versionId: 'v1' });
     });
   });
 

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -17,6 +17,7 @@ import {
   diffTfvars,
   lockStatus,
   VersionMismatchError,
+  BucketNotVersionedError,
   type LockFile,
 } from './tfvars-sync.ts';
 
@@ -176,6 +177,33 @@ describe('tfvars-sync', () => {
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
       // Nor should the (now-stale) lock file have been overwritten.
       expect(JSON.parse(readFileSync(`${localPath}.lock`, 'utf8'))).toMatchObject({ versionId: 'stale-version' });
+    });
+
+    it('should reject with BucketNotVersionedError and never call PutObject when the remote object exists but HeadObject reports no VersionId', async () => {
+      // Simulates an unversioned (or versioning-suspended) bucket: HeadObject
+      // omits VersionId even though the object exists.
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: null,
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ ETag: '"etag-1"' });
+      s3Mock.on(PutObjectCommand).resolves({ ETag: '"etag-2"' });
+
+      const err: unknown = await pushTfvars({
+        bucket: 'my-bucket',
+        path: localPath,
+        key: 'terraform.tfvars',
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(BucketNotVersionedError);
+      expect(err).toHaveProperty('message', expect.stringContaining('does not appear to have S3 versioning enabled'));
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
     });
   });
 

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -126,6 +126,10 @@ describe('tfvars-sync', () => {
       const result = await pushTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
 
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+      // The first-write guard is the actual TOCTOU protection here: assert
+      // PutObject was sent with `IfNoneMatch: '*'` so a concurrent create by
+      // another writer is rejected, not just that some PutObject happened.
+      expect(s3Mock.commandCalls(PutObjectCommand)[0]!.args[0].input.IfNoneMatch).toBe('*');
       expect(result.lock.versionId).toBe('v1');
     });
 

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for tfvars-sync.ts's public pull/push/diff/status API, backed by
+ * a mocked S3 client (via `aws-sdk-client-mock`) and a real, throwaway
+ * temp-directory filesystem (the module reads/writes files with plain
+ * `node:fs` calls, so faking `fs` would just re-implement it).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  pullTfvars,
+  pushTfvars,
+  diffTfvars,
+  lockStatus,
+  VersionMismatchError,
+  type LockFile,
+} from './tfvars-sync.ts';
+
+/** Typed stand-in for the AWS S3 SDK client — patches every `new S3Client()` instance. */
+const s3Mock = mockClient(S3Client);
+
+/** Builds a fake `GetObjectCommand` `Body` whose `transformToString()` resolves to `content`. */
+function fakeBody(content: string): { transformToString: () => Promise<string> } {
+  return { transformToString: async () => content };
+}
+
+/** Writes a `LockFile` sidecar directly to `${path}.lock`, bypassing `pullTfvars`/`pushTfvars`. */
+function writeLockFile(path: string, lock: LockFile): void {
+  writeFileSync(`${path}.lock`, JSON.stringify(lock, null, 2));
+}
+
+describe('tfvars-sync', () => {
+  let tmpDir: string;
+  let localPath: string;
+
+  beforeEach(() => {
+    s3Mock.reset();
+    tmpDir = mkdtempSync(join(tmpdir(), 'tfvars-sync-test-'));
+    localPath = join(tmpDir, 'terraform.tfvars');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('pullTfvars', () => {
+    it('should write the remote content to the local path and record a matching lock file', async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: fakeBody('project_name = "demo"\n') as never,
+        VersionId: 'v1',
+        ETag: '"etag-1"',
+        ContentLength: 22,
+        LastModified: new Date('2024-01-01T00:00:00Z'),
+      });
+
+      const result = await pullTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(readFileSync(localPath, 'utf8')).toBe('project_name = "demo"\n');
+      expect(result.lock).toMatchObject({
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'v1',
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+      });
+      expect(JSON.parse(readFileSync(result.lockPath, 'utf8'))).toMatchObject({ versionId: 'v1', etag: 'etag-1' });
+
+      const input = s3Mock.commandCalls(GetObjectCommand)[0]!.args[0].input;
+      expect(input.Bucket).toBe('my-bucket');
+      expect(input.Key).toBe('terraform.tfvars');
+    });
+
+    it('should create missing parent directories before writing the local file', async () => {
+      const nestedPath = join(tmpDir, 'nested', 'dir', 'terraform.tfvars');
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: fakeBody('a = 1\n') as never,
+        VersionId: 'v1',
+        ETag: '"e"',
+      });
+
+      await pullTfvars({ bucket: 'my-bucket', path: nestedPath, key: 'terraform.tfvars' });
+
+      expect(readFileSync(nestedPath, 'utf8')).toBe('a = 1\n');
+    });
+  });
+
+  describe('pushTfvars', () => {
+    it('should upload the local file and refresh the lock when the local lock matches the remote version', async () => {
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'v1',
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v2', ETag: '"etag-2"' });
+
+      const result = await pushTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+      expect(result.lock.versionId).toBe('v2');
+      expect(result.lock.etag).toBe('etag-2');
+      expect(JSON.parse(readFileSync(result.lockPath, 'utf8'))).toMatchObject({ versionId: 'v2', etag: 'etag-2' });
+    });
+
+    it('should upload without requiring a lock when the remote object does not exist yet', async () => {
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      s3Mock.on(HeadObjectCommand).rejects({ name: 'NotFound', $metadata: { httpStatusCode: 404 } });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+
+      const result = await pushTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+      expect(result.lock.versionId).toBe('v1');
+    });
+
+    it('should throw when the local file does not exist', async () => {
+      await expect(
+        pushTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' }),
+      ).rejects.toThrow(`Local file not found: ${localPath}`);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('should reject with VersionMismatchError and never call PutObject when the remote exists but no local lock was found', async () => {
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v2', ETag: '"etag-2"' });
+
+      const err: unknown = await pushTfvars({
+        bucket: 'my-bucket',
+        path: localPath,
+        key: 'terraform.tfvars',
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(VersionMismatchError);
+      expect((err as VersionMismatchError).localVersion).toBeNull();
+      expect((err as VersionMismatchError).remoteVersion).toBe('v1');
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('should reject a stale local lock with VersionMismatchError and never call PutObject', async () => {
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'stale-version',
+        etag: 'stale-etag',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      // Someone else pushed since the last pull — the remote has moved on to v2.
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v2', ETag: '"etag-2"' });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v3', ETag: '"etag-3"' });
+
+      const err: unknown = await pushTfvars({
+        bucket: 'my-bucket',
+        path: localPath,
+        key: 'terraform.tfvars',
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(VersionMismatchError);
+      expect((err as VersionMismatchError).localVersion).toBe('stale-version');
+      expect((err as VersionMismatchError).remoteVersion).toBe('v2');
+      expect(err).toHaveProperty('message', expect.stringContaining('Run "pull" to refresh before pushing.'));
+      // The whole point of the lock check: a stale lock must never reach PutObject.
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+      // Nor should the (now-stale) lock file have been overwritten.
+      expect(JSON.parse(readFileSync(`${localPath}.lock`, 'utf8'))).toMatchObject({ versionId: 'stale-version' });
+    });
+  });
+
+  describe('diffTfvars', () => {
+    it('should report matches: true when local and remote content are identical', async () => {
+      writeFileSync(localPath, 'project_name = "demo"\n');
+      s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody('project_name = "demo"\n') as never });
+
+      const result = await diffTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.matches).toBe(true);
+    });
+
+    it('should report matches: false and include a unified patch when local and remote content differ', async () => {
+      writeFileSync(localPath, 'project_name = "local"\n');
+      s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody('project_name = "remote"\n') as never });
+
+      const result = await diffTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.matches).toBe(false);
+      expect(result.patch).toContain('remote');
+      expect(result.patch).toContain('local');
+    });
+
+    it('should treat a missing remote object as empty content rather than throwing', async () => {
+      writeFileSync(localPath, 'project_name = "local"\n');
+      s3Mock.on(GetObjectCommand).rejects({ name: 'NoSuchKey', $metadata: { httpStatusCode: 404 } });
+
+      const result = await diffTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.matches).toBe(false);
+    });
+
+    it('should treat a missing local file as empty content rather than throwing', async () => {
+      s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody('project_name = "remote"\n') as never });
+
+      const result = await diffTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  describe('lockStatus', () => {
+    it('should report inSync: true when the local lock version matches the remote head version', async () => {
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'v1',
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+
+      const result = await lockStatus({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(true);
+      expect(result.lock?.versionId).toBe('v1');
+      expect(result.remote.exists).toBe(true);
+    });
+
+    it('should report inSync: false when the local lock version differs from the remote head version', async () => {
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'stale-version',
+        etag: 'stale-etag',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v2', ETag: '"etag-2"' });
+
+      const result = await lockStatus({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(false);
+    });
+
+    it('should report a null lock and inSync: false when the file was never pulled', async () => {
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+
+      const result = await lockStatus({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.lock).toBeNull();
+      expect(result.inSync).toBe(false);
+      expect(result.localExists).toBe(false);
+    });
+
+    it('should report remote.exists: false when the remote object does not exist', async () => {
+      s3Mock.on(HeadObjectCommand).rejects({ name: 'NotFound', $metadata: { httpStatusCode: 404 } });
+
+      const result = await lockStatus({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.remote.exists).toBe(false);
+      expect(result.inSync).toBe(false);
+    });
+  });
+});

--- a/scripts/tfvars-sync.ts
+++ b/scripts/tfvars-sync.ts
@@ -353,12 +353,15 @@ export async function pushTfvars(opts: TfvarsSyncOptions): Promise<PushResult> {
 
   const body = readFileSync(opts.path);
 
-  // Guard the window between the HeadObject check above and this write: pass
-  // `IfMatch` (S3 conditional write) whenever a lock is on file for an
-  // existing remote object, so a concurrent push that slips in between the
-  // head check and this PutObject fails with 412 instead of silently
-  // overwriting. The head check above still runs first purely to produce a
-  // friendlier, more specific error message for the common (non-racy) case.
+  // Guard the window between the HeadObject check above and this write with an
+  // S3 conditional write, so a concurrent push that slips in between the head
+  // check and this PutObject fails with 412 instead of silently overwriting.
+  // For an existing remote object, pass `IfMatch` whenever a lock is on file.
+  // For a brand-new object (no remote object observed above), pass
+  // `IfNoneMatch: '*'` so a concurrent first-ever push also fails with 412
+  // instead of one silently clobbering the other. The head check above still
+  // runs first purely to produce a friendlier, more specific error message
+  // for the common (non-racy) case.
   let put;
   try {
     put = await s3.send(
@@ -367,6 +370,7 @@ export async function pushTfvars(opts: TfvarsSyncOptions): Promise<PushResult> {
         Key: key,
         Body: body,
         ...(remote.exists && lock ? { IfMatch: `"${lock.etag}"` } : {}),
+        ...(!remote.exists ? { IfNoneMatch: '*' } : {}),
       }),
     );
   } catch (err) {

--- a/scripts/tfvars-sync.ts
+++ b/scripts/tfvars-sync.ts
@@ -1,0 +1,504 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * tfvars-sync.ts
+ *
+ * CLI mirror of the app's `RemoteTfvarsStore` service: pulls, pushes, diffs,
+ * and reports status for a `terraform.tfvars` file stored in the versioned
+ * S3 bucket provisioned by `terraform/bootstrap` (see
+ * `docs/docs/setup.md` for the bootstrap flow).
+ *
+ * Usage:
+ *   tsx tfvars-sync.ts pull   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+ *   tsx tfvars-sync.ts push   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+ *   tsx tfvars-sync.ts diff   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+ *   tsx tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+ *
+ * `--path` defaults to `terraform/terraform.tfvars` and is the local file to
+ * sync. `--key` defaults to `terraform.tfvars` and is the S3 object key —
+ * pass it explicitly if the bucket should hold the object under a different
+ * key than the local file's basename.
+ *
+ * `--bucket` is resolved through a fallback chain when the flag is omitted:
+ * the `GSD_TFVARS_BUCKET` environment variable, then the contents of the
+ * nearest `.gsd/tfvars-bucket` marker file found walking up from the current
+ * working directory. The CLI exits with an error if none of these resolve.
+ *
+ * A sidecar lock file (`${path}.lock`) records the S3 version id + etag
+ * observed on the last successful `pull` or `push`. `push` refuses to
+ * overwrite the remote object if the lock is missing (never pulled) or
+ * stale (someone else pushed since the last pull) — run `pull` again to
+ * resolve.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { argv, exit, stdout as output } from 'node:process';
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { createTwoFilesPatch } from 'diff';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Default local path when `--path` is omitted from the CLI. */
+const DEFAULT_PATH = 'terraform/terraform.tfvars';
+
+/** Default S3 object key when `--key` is omitted from the CLI (and no `opts.key` is set). */
+const DEFAULT_KEY = 'terraform.tfvars';
+
+/** Environment variable consulted by the `--bucket` fallback chain. */
+const BUCKET_ENV_VAR = 'GSD_TFVARS_BUCKET';
+
+/** Marker file (relative to a project root) holding the bucket name, as a last-resort fallback. */
+const BUCKET_MARKER_PATH = ['.gsd', 'tfvars-bucket'];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Options shared by every sync operation. */
+export interface TfvarsSyncOptions {
+  /** S3 bucket that holds the tfvars object. */
+  bucket: string;
+  /** Local file path to read from / write to. */
+  path: string;
+  /** S3 object key. Defaults to the local path's basename when omitted. */
+  key?: string;
+  /** Optional AWS region override; falls back to the SDK's default provider chain. */
+  region?: string;
+  /** Optional pre-built S3 client, so callers/tests can inject a mocked client. Defaults to `new S3Client({ region })`. */
+  client?: S3Client;
+}
+
+/** Sidecar metadata written to `${path}.lock` after a successful pull or push. */
+export interface LockFile {
+  bucket: string;
+  key: string;
+  versionId: string;
+  etag: string;
+  size: number;
+  lastModified: string | null;
+  pulledAt: string;
+}
+
+/** Metadata describing the current remote object, or its absence. */
+export interface RemoteHead {
+  exists: boolean;
+  versionId: string | null;
+  etag: string | null;
+  size: number | null;
+  lastModified: string | null;
+}
+
+export interface PullResult {
+  path: string;
+  lockPath: string;
+  lock: LockFile;
+}
+
+export interface PushResult {
+  path: string;
+  lockPath: string;
+  lock: LockFile;
+}
+
+export interface DiffResult {
+  /** True when the local file's contents are byte-for-byte identical to the remote object. */
+  matches: boolean;
+  /** Unified diff (remote → local), empty-hunk when `matches` is true. */
+  patch: string;
+}
+
+export interface StatusReport {
+  bucket: string;
+  key: string;
+  path: string;
+  localExists: boolean;
+  lock: LockFile | null;
+  remote: RemoteHead;
+  /** True when the local lock's version id matches the remote object's current version id. */
+  inSync: boolean;
+}
+
+/** Thrown by `pushTfvars()` when the local lock doesn't match (or is missing for) the current remote version. */
+export class VersionMismatchError extends Error {
+  constructor(
+    message: string,
+    public readonly localVersion: string | null,
+    public readonly remoteVersion: string | null,
+  ) {
+    super(message);
+    this.name = 'VersionMismatchError';
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Returns `opts.client` when provided, otherwise builds a fresh `S3Client` from `opts.region`. */
+function resolveClient(opts: Pick<TfvarsSyncOptions, 'region' | 'client'>): S3Client {
+  return opts.client ?? new S3Client({ region: opts.region });
+}
+
+/** Derives the S3 object key: `opts.key` when set, otherwise the local path's basename. */
+function keyFor(opts: Pick<TfvarsSyncOptions, 'path' | 'key'>): string {
+  return opts.key ?? basename(opts.path);
+}
+
+function lockPathFor(path: string): string {
+  return `${path}.lock`;
+}
+
+function stripQuotes(etag: string | undefined): string {
+  return (etag ?? '').replace(/^"|"$/g, '');
+}
+
+/** Reads the sidecar lock file, if present and parseable. */
+function readLock(path: string): LockFile | null {
+  const lockPath = lockPathFor(path);
+  if (!existsSync(lockPath)) return null;
+  try {
+    return JSON.parse(readFileSync(lockPath, 'utf8')) as LockFile;
+  } catch {
+    return null;
+  }
+}
+
+function writeLock(path: string, lock: LockFile): void {
+  writeFileSync(lockPathFor(path), `${JSON.stringify(lock, null, 2)}\n`);
+}
+
+/** True for the shapes the AWS SDK v3 uses to signal a missing S3 object. */
+function isNotFound(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const name = (err as { name?: string }).name;
+    if (name === 'NotFound' || name === 'NoSuchKey') return true;
+    const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+    if (status === 404) return true;
+  }
+  return false;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** HeadObject against the bucket/key, normalized to a `RemoteHead` (never throws on 404). */
+async function headRemote(s3: S3Client, bucket: string, key: string): Promise<RemoteHead> {
+  try {
+    const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+    return {
+      exists: true,
+      versionId: head.VersionId ?? null,
+      etag: stripQuotes(head.ETag) || null,
+      size: head.ContentLength ?? null,
+      lastModified: head.LastModified ? head.LastModified.toISOString() : null,
+    };
+  } catch (err) {
+    if (isNotFound(err)) {
+      return { exists: false, versionId: null, etag: null, size: null, lastModified: null };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Walks up from `startDir` looking for a `.gsd/tfvars-bucket` marker file.
+ * Returns its trimmed contents (the bucket name) if found and non-empty.
+ */
+function findBucketMarker(startDir: string): string | undefined {
+  let dir = resolve(startDir);
+  while (true) {
+    const markerPath = join(dir, ...BUCKET_MARKER_PATH);
+    if (existsSync(markerPath)) {
+      const content = readFileSync(markerPath, 'utf8').trim();
+      if (content) return content;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/**
+ * Resolves the target S3 bucket: an explicit value wins, then the
+ * `GSD_TFVARS_BUCKET` environment variable, then the contents of the
+ * nearest `.gsd/tfvars-bucket` marker file walking up from `startDir`.
+ */
+export function resolveBucket(explicit?: string, startDir: string = process.cwd()): string | undefined {
+  if (explicit) return explicit;
+  if (process.env[BUCKET_ENV_VAR]) return process.env[BUCKET_ENV_VAR];
+  return findBucketMarker(startDir);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Downloads the remote tfvars object to `opts.path` and writes a matching
+ * lock file recording the version just pulled.
+ */
+export async function pullTfvars(opts: TfvarsSyncOptions): Promise<PullResult> {
+  const s3 = resolveClient(opts);
+  const key = keyFor(opts);
+
+  let response;
+  try {
+    response = await s3.send(new GetObjectCommand({ Bucket: opts.bucket, Key: key }));
+  } catch (err) {
+    throw new Error(`Failed to pull s3://${opts.bucket}/${key}: ${errorMessage(err)}`);
+  }
+
+  const content = (await response.Body?.transformToString()) ?? '';
+  const dir = dirname(opts.path);
+  if (dir && dir !== '.') mkdirSync(dir, { recursive: true });
+  writeFileSync(opts.path, content);
+
+  const lock: LockFile = {
+    bucket: opts.bucket,
+    key,
+    versionId: response.VersionId ?? '',
+    etag: stripQuotes(response.ETag),
+    size: response.ContentLength ?? Buffer.byteLength(content),
+    lastModified: response.LastModified ? response.LastModified.toISOString() : null,
+    pulledAt: new Date().toISOString(),
+  };
+  writeLock(opts.path, lock);
+
+  return { path: opts.path, lockPath: lockPathFor(opts.path), lock };
+}
+
+/**
+ * Uploads the local tfvars file to the remote bucket, refusing to do so if
+ * the remote object has moved on since the last `pull` (or was never pulled
+ * at all). On success, refreshes the lock file with the newly-created
+ * version id.
+ */
+export async function pushTfvars(opts: TfvarsSyncOptions): Promise<PushResult> {
+  if (!existsSync(opts.path)) {
+    throw new Error(`Local file not found: ${opts.path}`);
+  }
+
+  const s3 = resolveClient(opts);
+  const key = keyFor(opts);
+  const lock = readLock(opts.path);
+  const remote = await headRemote(s3, opts.bucket, key);
+
+  if (remote.exists) {
+    if (!lock) {
+      throw new VersionMismatchError(
+        `Remote object s3://${opts.bucket}/${key} already exists but no local lock file was found at ${lockPathFor(opts.path)}. Run "pull" first.`,
+        null,
+        remote.versionId,
+      );
+    }
+    if (lock.versionId !== remote.versionId) {
+      throw new VersionMismatchError(
+        `Local lock version "${lock.versionId}" does not match remote version "${remote.versionId}" for s3://${opts.bucket}/${key}. Run "pull" to refresh before pushing.`,
+        lock.versionId,
+        remote.versionId,
+      );
+    }
+  }
+
+  const body = readFileSync(opts.path);
+  const put = await s3.send(new PutObjectCommand({ Bucket: opts.bucket, Key: key, Body: body }));
+
+  const newLock: LockFile = {
+    bucket: opts.bucket,
+    key,
+    versionId: put.VersionId ?? '',
+    etag: stripQuotes(put.ETag),
+    size: body.byteLength,
+    lastModified: new Date().toISOString(),
+    pulledAt: new Date().toISOString(),
+  };
+  writeLock(opts.path, newLock);
+
+  return { path: opts.path, lockPath: lockPathFor(opts.path), lock: newLock };
+}
+
+/**
+ * Compares the local file against the remote object and returns a unified
+ * diff (remote → local). `matches` is true only when both sides are
+ * byte-identical.
+ */
+export async function diffTfvars(opts: TfvarsSyncOptions): Promise<DiffResult> {
+  const s3 = resolveClient(opts);
+  const key = keyFor(opts);
+
+  const localContent = existsSync(opts.path) ? readFileSync(opts.path, 'utf8') : '';
+
+  let remoteContent = '';
+  try {
+    const response = await s3.send(new GetObjectCommand({ Bucket: opts.bucket, Key: key }));
+    remoteContent = (await response.Body?.transformToString()) ?? '';
+  } catch (err) {
+    if (!isNotFound(err)) throw err;
+  }
+
+  const matches = localContent === remoteContent;
+  const patch = createTwoFilesPatch(`remote:${key}`, `local:${opts.path}`, remoteContent, localContent);
+
+  return { matches, patch };
+}
+
+/**
+ * Reports the local lock metadata alongside the remote object's current
+ * head metadata, plus whether the two agree on version id.
+ */
+export async function lockStatus(opts: TfvarsSyncOptions): Promise<StatusReport> {
+  const s3 = resolveClient(opts);
+  const key = keyFor(opts);
+  const lock = readLock(opts.path);
+  const remote = await headRemote(s3, opts.bucket, key);
+  const inSync = Boolean(lock && remote.versionId && lock.versionId === remote.versionId);
+
+  return {
+    bucket: opts.bucket,
+    key,
+    path: opts.path,
+    localExists: existsSync(opts.path),
+    lock,
+    remote,
+    inSync,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COMMANDS = ['pull', 'push', 'diff', 'status'] as const;
+type Command = (typeof COMMANDS)[number];
+
+interface ParsedArgs {
+  command: Command;
+  options: TfvarsSyncOptions;
+}
+
+function isCommand(value: string | undefined): value is Command {
+  return value !== undefined && (COMMANDS as readonly string[]).includes(value);
+}
+
+/**
+ * Parses `<command> [--bucket <b>] [--path <p>] [--key <k>] [--region <r>]`
+ * argv (excluding node + script). `--path` defaults to
+ * `terraform/terraform.tfvars` and `--key` to `terraform.tfvars`. `--bucket`
+ * is resolved via `resolveBucket()` (flag > `GSD_TFVARS_BUCKET` env var >
+ * `.gsd/tfvars-bucket` marker file) and throws if nothing resolves.
+ */
+export function parseArgs(rawArgv: string[]): ParsedArgs {
+  const [command, ...rest] = rawArgv;
+  if (!isCommand(command)) {
+    throw new Error(
+      `Usage: tfvars-sync.ts <${COMMANDS.join('|')}> [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]`,
+    );
+  }
+
+  let bucket: string | undefined;
+  let path: string | undefined;
+  let key: string | undefined;
+  let region: string | undefined;
+
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === '--bucket') bucket = rest[++i];
+    else if (arg === '--path') path = rest[++i];
+    else if (arg === '--key') key = rest[++i];
+    else if (arg === '--region') region = rest[++i];
+  }
+
+  const resolvedBucket = resolveBucket(bucket);
+  if (!resolvedBucket) {
+    throw new Error(
+      `--bucket is required (or set ${BUCKET_ENV_VAR}, or create a ${join(...BUCKET_MARKER_PATH)} marker file)`,
+    );
+  }
+
+  return {
+    command,
+    options: {
+      bucket: resolvedBucket,
+      path: path ?? DEFAULT_PATH,
+      key: key ?? DEFAULT_KEY,
+      region,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const { command, options } = parseArgs(argv.slice(2));
+
+  switch (command) {
+    case 'pull': {
+      const result = await pullTfvars(options);
+      output.write(`✓ Pulled s3://${options.bucket}/${result.lock.key} → ${result.path}\n`);
+      output.write(`  lock written to ${result.lockPath} (version ${result.lock.versionId})\n`);
+      return;
+    }
+    case 'push': {
+      const result = await pushTfvars(options);
+      output.write(`✓ Pushed ${result.path} → s3://${options.bucket}/${result.lock.key}\n`);
+      output.write(`  lock written to ${result.lockPath} (version ${result.lock.versionId})\n`);
+      return;
+    }
+    case 'diff': {
+      const result = await diffTfvars(options);
+      if (result.patch.trim()) output.write(result.patch);
+      if (result.matches) {
+        output.write('✓ local and remote match\n');
+      } else {
+        output.write('✗ local and remote differ\n');
+        process.exitCode = 1;
+      }
+      return;
+    }
+    case 'status': {
+      const result = await lockStatus(options);
+      output.write(`bucket: ${result.bucket}\n`);
+      output.write(`key:    ${result.key}\n`);
+      output.write(`path:   ${result.path} (${result.localExists ? 'exists' : 'missing'})\n`);
+      output.write('\nlock:\n');
+      if (result.lock) {
+        output.write(`  version:       ${result.lock.versionId}\n`);
+        output.write(`  etag:          ${result.lock.etag}\n`);
+        output.write(`  pulled at:     ${result.lock.pulledAt}\n`);
+      } else {
+        output.write('  (none — never pulled)\n');
+      }
+      output.write('\nremote head:\n');
+      if (result.remote.exists) {
+        output.write(`  version:       ${result.remote.versionId}\n`);
+        output.write(`  etag:          ${result.remote.etag}\n`);
+        output.write(`  last modified: ${result.remote.lastModified}\n`);
+      } else {
+        output.write('  (object does not exist)\n');
+      }
+      output.write(`\nin sync: ${result.inSync ? 'yes' : 'no'}\n`);
+      return;
+    }
+  }
+}
+
+// Only run when this file is the entry point — keeps the exported functions
+// importable from tests without auto-launching the CLI. Compare normalized
+// absolute paths so relative invocations (e.g. `tsx tfvars-sync.ts`) still
+// match.
+const isEntrypoint =
+  argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(argv[1]);
+
+if (isEntrypoint) {
+  main().catch((err) => {
+    process.stderr.write(`\n✗ ${errorMessage(err)}\n`);
+    exit(1);
+  });
+}

--- a/scripts/tfvars-sync.ts
+++ b/scripts/tfvars-sync.ts
@@ -27,7 +27,11 @@
  * observed on the last successful `pull` or `push`. `push` refuses to
  * overwrite the remote object if the lock is missing (never pulled) or
  * stale (someone else pushed since the last pull) — run `pull` again to
- * resolve.
+ * resolve. That version check and the upload itself are also raced against
+ * each other with an S3 conditional write (`IfMatch: <locked etag>` on the
+ * `PutObject` call): if another push slips in between our `HeadObject`
+ * check and the write, S3 rejects it with 412 and we surface the same
+ * `VersionMismatchError` rather than silently overwriting.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -76,11 +80,18 @@ export interface TfvarsSyncOptions {
   client?: S3Client;
 }
 
-/** Sidecar metadata written to `${path}.lock` after a successful pull or push. */
+/**
+ * Sidecar metadata written to `${path}.lock` after a successful pull or push.
+ *
+ * `versionId` is `null` (never `''`) when S3 reports no `VersionId` — i.e.
+ * the bucket is unversioned or versioning is suspended — so it compares
+ * equal to `RemoteHead.versionId`'s own `null` in that same situation
+ * instead of tripping a spurious `VersionMismatchError`.
+ */
 export interface LockFile {
   bucket: string;
   key: string;
-  versionId: string;
+  versionId: string | null;
   etag: string;
   size: number;
   lastModified: string | null;
@@ -138,6 +149,21 @@ export class VersionMismatchError extends Error {
   }
 }
 
+/**
+ * Thrown by `pushTfvars()` when the remote object exists but S3 reports no
+ * `VersionId` for it — the bucket is unversioned or has versioning
+ * suspended, so the version-based conflict check that guards concurrent
+ * edits cannot function. This is distinct from `VersionMismatchError`
+ * because there is no stale/missing lock to fix by re-pulling; the bucket
+ * itself needs versioning enabled.
+ */
+export class BucketNotVersionedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BucketNotVersionedError';
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -182,6 +208,17 @@ function isNotFound(err: unknown): boolean {
     if (name === 'NotFound' || name === 'NoSuchKey') return true;
     const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
     if (status === 404) return true;
+  }
+  return false;
+}
+
+/** True for the shapes the AWS SDK v3 uses to signal a failed `IfMatch` conditional write (HTTP 412). */
+function isPreconditionFailed(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const name = (err as { name?: string }).name;
+    if (name === 'PreconditionFailed') return true;
+    const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+    if (status === 412) return true;
   }
   return false;
 }
@@ -265,7 +302,7 @@ export async function pullTfvars(opts: TfvarsSyncOptions): Promise<PullResult> {
   const lock: LockFile = {
     bucket: opts.bucket,
     key,
-    versionId: response.VersionId ?? '',
+    versionId: response.VersionId ?? null,
     etag: stripQuotes(response.ETag),
     size: response.ContentLength ?? Buffer.byteLength(content),
     lastModified: response.LastModified ? response.LastModified.toISOString() : null,
@@ -293,6 +330,11 @@ export async function pushTfvars(opts: TfvarsSyncOptions): Promise<PushResult> {
   const remote = await headRemote(s3, opts.bucket, key);
 
   if (remote.exists) {
+    if (remote.versionId === null) {
+      throw new BucketNotVersionedError(
+        `Bucket "${opts.bucket}" does not appear to have S3 versioning enabled (HeadObject returned no VersionId for s3://${opts.bucket}/${key}). The version-based conflict check that "push" relies on requires a versioned bucket — enable versioning on "${opts.bucket}" before pushing.`,
+      );
+    }
     if (!lock) {
       throw new VersionMismatchError(
         `Remote object s3://${opts.bucket}/${key} already exists but no local lock file was found at ${lockPathFor(opts.path)}. Run "pull" first.`,
@@ -310,12 +352,38 @@ export async function pushTfvars(opts: TfvarsSyncOptions): Promise<PushResult> {
   }
 
   const body = readFileSync(opts.path);
-  const put = await s3.send(new PutObjectCommand({ Bucket: opts.bucket, Key: key, Body: body }));
+
+  // Guard the window between the HeadObject check above and this write: pass
+  // `IfMatch` (S3 conditional write) whenever a lock is on file for an
+  // existing remote object, so a concurrent push that slips in between the
+  // head check and this PutObject fails with 412 instead of silently
+  // overwriting. The head check above still runs first purely to produce a
+  // friendlier, more specific error message for the common (non-racy) case.
+  let put;
+  try {
+    put = await s3.send(
+      new PutObjectCommand({
+        Bucket: opts.bucket,
+        Key: key,
+        Body: body,
+        ...(remote.exists && lock ? { IfMatch: `"${lock.etag}"` } : {}),
+      }),
+    );
+  } catch (err) {
+    if (isPreconditionFailed(err)) {
+      throw new VersionMismatchError(
+        `Remote object s3://${opts.bucket}/${key} changed after the version check (concurrent push detected). Run "pull" to refresh before pushing.`,
+        lock?.versionId ?? null,
+        null,
+      );
+    }
+    throw err;
+  }
 
   const newLock: LockFile = {
     bucket: opts.bucket,
     key,
-    versionId: put.VersionId ?? '',
+    versionId: put.VersionId ?? null,
     etag: stripQuotes(put.ETag),
     size: body.byteLength,
     lastModified: new Date().toISOString(),
@@ -409,12 +477,33 @@ export function parseArgs(rawArgv: string[]): ParsedArgs {
   let key: string | undefined;
   let region: string | undefined;
 
+  const KNOWN_FLAGS = ['--bucket', '--path', '--key', '--region'] as const;
+
+  /**
+   * Consumes the value following a recognized flag, throwing if it is
+   * missing or looks like another flag — guards against typos such as a
+   * trailing `--bucket` with no value silently falling through to the
+   * bucket-resolution fallback chain.
+   */
+  function readValue(flag: string, index: number): string {
+    const value = rest[index];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return value;
+  }
+
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
-    if (arg === '--bucket') bucket = rest[++i];
-    else if (arg === '--path') path = rest[++i];
-    else if (arg === '--key') key = rest[++i];
-    else if (arg === '--region') region = rest[++i];
+    if (arg === '--bucket') bucket = readValue(arg, ++i);
+    else if (arg === '--path') path = readValue(arg, ++i);
+    else if (arg === '--key') key = readValue(arg, ++i);
+    else if (arg === '--region') region = readValue(arg, ++i);
+    else {
+      throw new Error(
+        `Unrecognized argument '${arg}'. Known flags: ${KNOWN_FLAGS.join(', ')}`,
+      );
+    }
   }
 
   const resolvedBucket = resolveBucket(bucket);


### PR DESCRIPTION
Closes #87

## Summary

- Adds `scripts/tfvars-sync.ts` implementing a `RemoteTfvarsStore`-style CLI (`pull`/`push`/`diff`/`status`) that reads/writes `terraform.tfvars` from the S3 tfvars bucket, with optimistic locking via S3 object versioning + ETag stored in a local `.tfvars.lock` file.
- `push` rejects with a clear error when the remote object has moved since the last `pull` (stale-lock / TOCTOU-safe conditional write), and gracefully handles unversioned buckets.
- Adds `aws-sdk-client-mock`-based unit tests covering pull/push/diff/status and the stale-lock rejection path, wires the new spec into `app/vitest.config.ts`, documents CLI usage/bucket resolution in `scripts/README.md`, and declares the new script's dependencies/npm wiring in `scripts/package.json` and root `package.json`.

## Changes

```
 app/vitest.config.ts        |   3 +
 package-lock.json           |  22 ++
 package.json                |   1 +
 scripts/README.md           |  99 ++++++++
 scripts/package.json        |   9 +-
 scripts/tfvars-sync.test.ts | 342 +++++++++++++++++++++++++
 scripts/tfvars-sync.ts      | 597 ++++++++++++++++++++++++++++++++++++++++++++
 7 files changed, 1072 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `pull` writes `terraform.tfvars` and `.tfvars.lock` correctly.
- [x] `push` after `pull` succeeds; `push` from stale `.tfvars.lock` fails with a clear error.
- [x] `diff` prints a unified diff (no diff = exit 0).
- [x] Unit tests cover the four operations and the lock-mismatch path.
- [ ] `npm run app:test` — full suite passes locally.
