### PR TITLE
feat(desktop-main): wire RemoteTfvarsStore into bootstrap path

### DIFF
--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -108,20 +108,51 @@ make apply
 ## What the wrapper Makefile does
 
 The generated wrapper is a thin layer over the submodule's own Makefile.
-Five targets, no surprises:
+Eight targets, no surprises:
 
 | Target | What it does |
 |---|---|
-| `make setup` | One-time bootstrap. Runs `git submodule update --init --recursive`, executes `Hyveon/setup.sh` (installs Node/Terraform/AWS CLI on Debian/Ubuntu, npm-installs all workspaces, builds Lambda bundles, runs `terraform init` and bootstraps the S3 backend), then records the sha256 of `setup.sh` in `.make/setup.stamp`. |
-| `make plan` | Copies `terraform.tfvars` into `Hyveon/terraform/terraform.tfvars`, then runs `make -C Hyveon tf-plan` — which itself rebuilds the Lambda bundles before `terraform plan`. |
-| `make apply` | Same as `plan`, but delegates to `tf-apply`. The submodule's `tf-apply` recipe prints a post-deploy checklist with the Discord interactions URL when it finishes. |
+| `make setup` | One-time bootstrap. Runs `git submodule update --init --recursive`, executes `Hyveon/setup.sh` (installs Node/Terraform/AWS CLI on Debian/Ubuntu, npm-installs all workspaces, builds Lambda bundles, runs `terraform init` and bootstraps the S3 backend), then records the sha256 of `setup.sh` in `.make/setup.stamp`. If `setup.sh` bootstrapped a versioned S3 tfvars backend, `setup` also pulls `terraform.tfvars` down afterwards; on a first bootstrap against an empty bucket the pull can't find anything yet, so it prints a warning suggesting `make tfvars-push` to seed the bucket instead of failing `make setup`. |
+| `make plan` | Copies `terraform.tfvars` into `Hyveon/terraform/terraform.tfvars`, then runs `make -C Hyveon tf-plan` — which itself rebuilds the Lambda bundles before `terraform plan`. When an S3 tfvars backend is detected, it auto-pulls the latest tfvars first so a stale local copy can't silently drive the plan; set `NO_PULL=1` to skip the pull for one invocation. |
+| `make apply` | Same as `plan`, but delegates to `tf-apply`. The submodule's `tf-apply` recipe prints a post-deploy checklist with the Discord interactions URL when it finishes. When an S3 tfvars backend is detected, it first asserts the local tfvars are still in sync with S3 (via the `tfvars-sync` CLI's `check` subcommand), refusing to apply against drifted vars; set `FORCE_APPLY=1` to skip the check for one invocation. |
 | `make update` | Bumps the submodule to the tip of `main` (`git submodule update --remote --merge`). If the new `setup.sh` differs from the recorded sha, clears `.terraform/` and re-runs `setup.sh` automatically; otherwise leaves it alone. Reminds you to commit the new submodule pointer. |
 | `make dev` | Pulls live tfstate into `.make/tfstate.json` (so ConfigService can read it via `TF_STATE_PATH`), wipes stale TS build info under the submodule's `app/packages/*/`, then runs `make -C Hyveon dev`, exporting `API_TOKEN` and `TF_STATE_PATH` to the child make. |
+| `make tfvars-pull` | Pulls `terraform.tfvars` from the configured S3 backend (requires one to be detected — see below). Refuses to run if the local file has uncommitted git changes, so a pull can never silently discard edits you haven't committed. |
+| `make tfvars-push` | Pushes the local `terraform.tfvars` to the configured S3 backend (requires one to be detected). |
+| `make tfvars-diff` | Prints a unified diff between the local and remote `terraform.tfvars` (requires a backend to be detected). |
 
 The `tfvars` copy is **always fresh** on plan/apply — the recipe `cp`s
 unconditionally, not just when the file is older than the destination. This
 prevents stale variables from sneaking into a deploy when you've edited the
 parent's `terraform.tfvars` between runs.
+
+## S3 tfvars backend detection
+
+The three `tfvars-*` targets, and the automatic gating baked into
+`setup`/`plan`/`apply` above, all key off the same `TFVARS_BACKEND`
+resolution in the generated Makefile:
+
+- `GSD_TFVARS_BACKEND=s3` forces S3 mode, even if the marker file below is
+  missing.
+- `GSD_TFVARS_BACKEND=local` forces local-file mode, even if a marker file
+  is present.
+- Otherwise: S3 if `Hyveon/.gsd/tfvars-bucket` exists — the marker
+  file `setup.sh`'s `bootstrap_tfvars_backend()` writes recording the
+  bucket name it just created — local otherwise.
+
+`GSD_TFVARS_BUCKET`, if set, wins over the marker file's contents when the
+wrapper needs to display or pass along the bucket name; otherwise it reads
+the marker file.
+
+`make tfvars-pull`, `make tfvars-push`, and `make tfvars-diff` fail fast
+with a pointer to `GSD_TFVARS_BACKEND`/`setup.sh` when no backend is
+detected — they're operator-driven, so they never silently no-op.
+
+The gates inside `setup`/`plan`/`apply` behave differently: in **local
+mode** (no marker file and `GSD_TFVARS_BACKEND` isn't `s3`) they're silent
+no-ops, so `make setup`, `make plan`, and `make apply` behave exactly as
+they did before S3 tfvars sync existed. Nothing changes for a single-file,
+no-remote-backend deployment.
 
 ## Submodule update with idempotent setup.sh re-run
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,7 @@ tsx scripts/tfvars-sync.ts pull   [--bucket <name>] [--path <file>] [--key <key>
 tsx scripts/tfvars-sync.ts push   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
 tsx scripts/tfvars-sync.ts diff   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
 tsx scripts/tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts check  [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
 ```
 
 ### Subcommands
@@ -77,6 +78,12 @@ tsx scripts/tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>
   never pulled"), the remote object's current version/etag/last-modified (or
   "object does not exist"), and whether the local lock is in sync with the
   remote version.
+- **`check`** — drift gate intended for `make apply` (or any CI/pre-flight
+  step): compares the local lock's recorded version id against the remote
+  object's current version id. Prints `✓ in sync: ...` and **exits `0`** when
+  they match; prints `✗ drift detected: <reason>` and **exits `1`** otherwise
+  (no lock file, remote object missing, or version mismatch), with a clear,
+  specific reason in each case.
 
 ### Flags
 
@@ -138,6 +145,19 @@ against it.
 - **`0`** — local and remote are byte-for-byte identical (`matches: true`).
 - **`1`** — local and remote differ (`matches: false`); the unified diff is
   printed to stdout before the exit code is set.
+
+### Check exit codes
+
+`check` sets `process.exitCode`:
+
+- **`0`** — the local lock's version id matches the remote object's current
+  version id (`inSync: true`).
+- **`1`** — the versions don't match, printing the specific reason: no local
+  lock file was found, the remote object doesn't exist, or the lock's
+  recorded version id differs from the remote's current version id. Wire
+  this into `make apply` (or CI) as a pre-flight drift gate so an apply never
+  runs against a `terraform.tfvars` that has silently drifted from the
+  version stored in S3.
 
 ### Requirements
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,8 @@ Interactive scaffolder for the [private parent + submodule deployment
 pattern](https://codercoco.github.io/Hyveon/guides/submodule/). It
 generates a `Makefile`, `terraform.tfvars`, `.env`, and `.gitignore` in your
 parent repo, all wired to the wrapper Make targets (`setup`, `plan`, `apply`,
-`update`, `dev`) so you can drive the whole stack from the parent repo root.
+`update`, `dev`, `tfvars-pull`, `tfvars-push`, `tfvars-diff`) so you can drive
+the whole stack from the parent repo root.
 
 ### Usage
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,8 +83,8 @@ tsx scripts/tfvars-sync.ts check  [--bucket <name>] [--path <file>] [--key <key>
   step): compares the local lock's recorded version id against the remote
   object's current version id. Prints `✓ in sync: ...` and **exits `0`** when
   they match; prints `✗ drift detected: <reason>` and **exits `1`** otherwise
-  (no lock file, remote object missing, or version mismatch), with a clear,
-  specific reason in each case.
+  (no lock file, remote object missing, the bucket lacking S3 versioning, or
+  a version mismatch), with a clear, specific reason in each case.
 
 ### Flags
 
@@ -154,11 +154,13 @@ against it.
 - **`0`** — the local lock's version id matches the remote object's current
   version id (`inSync: true`).
 - **`1`** — the versions don't match, printing the specific reason: no local
-  lock file was found, the remote object doesn't exist, or the lock's
-  recorded version id differs from the remote's current version id. Wire
-  this into `make apply` (or CI) as a pre-flight drift gate so an apply never
-  runs against a `terraform.tfvars` that has silently drifted from the
-  version stored in S3.
+  lock file was found, the remote object doesn't exist, the bucket doesn't
+  appear to have S3 versioning enabled (`HeadObject` returned no
+  `VersionId`, so drift can't be detected), or the lock's recorded version
+  id differs from the remote's current version id. Wire this into
+  `make apply` (or CI) as a pre-flight drift gate so an apply never runs
+  against a `terraform.tfvars` that has silently drifted from the version
+  stored in S3.
 
 ### Requirements
 

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -36,6 +36,59 @@ expect('Makefile copy-tfvars uses cp', mk.includes('cp $(TFVARS) $(TF_DIR)/terra
 expect('Makefile uses bash shell', mk.startsWith('SHELL      := /usr/bin/env bash'));
 expect('Makefile does NOT inline API_TOKEN', !/API_TOKEN\s*:?=\s*[a-f0-9]{40,}/.test(mk));
 
+// ── S3 tfvars backend detection block ───────────────────────────────────────
+expect('Makefile defines TFVARS_MARKER', mk.includes('TFVARS_MARKER := $(SUBMODULE)/.gsd/tfvars-bucket'));
+expect('Makefile defines TFVARS_LOCK', mk.includes('TFVARS_LOCK   := $(TFVARS).lock'));
+expect(
+  'Makefile defines TFVARS_BACKEND gated on GSD_TFVARS_BACKEND override then the marker file',
+  mk.includes(
+    'TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(TFVARS_MARKER)),s3,local)))',
+  ),
+);
+expect('Makefile routes TFVARS_SYNC --bucket through TFVARS_MARKER', mk.includes('cat $(TFVARS_MARKER)'));
+
+// ── Gated tfvars-* targets ───────────────────────────────────────────────────
+expect('Makefile phonies list tfvars-pull/push/diff (not tfvars-status)', mk.includes('tfvars-pull tfvars-push tfvars-diff'));
+expect('Makefile has tfvars-pull target', /^tfvars-pull:$/m.test(mk));
+expect('Makefile has tfvars-push target', /^tfvars-push:$/m.test(mk));
+expect('Makefile has tfvars-diff target wired to tfvars-sync.ts diff', /^tfvars-diff:$/m.test(mk) && mk.includes('$(TFVARS_SYNC) diff'));
+expect('Makefile does NOT have a tfvars-status target', !/^tfvars-status:$/m.test(mk));
+expect('Makefile tfvars-* targets gate on TFVARS_BACKEND != s3', mk.includes('if [ "$(TFVARS_BACKEND)" != s3 ]'));
+expect(
+  'Makefile tfvars-pull aborts on a dirty TFVARS before pulling',
+  /tfvars-pull:\n(?:\t.*\n)*?\t@if \[ -n "\$\$\(git -C \$\(REPO_ROOT\) status --porcelain -- \$\(TFVARS\)\)" \]; then echo .* >&2; exit 1; fi\n\t\$\(TFVARS_SYNC\) pull/.test(mk),
+);
+
+// ── plan/apply/setup gating ──────────────────────────────────────────────────
+expect(
+  'Makefile gates plan auto-pull on TFVARS_BACKEND and NO_PULL',
+  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${NO_PULL:-}" ]; then $(TFVARS_SYNC) pull; fi'),
+);
+expect('Makefile plan depends on pull-tfvars-if-needed', mk.includes('plan: pull-tfvars-if-needed copy-tfvars'));
+expect(
+  'Makefile gates apply check on TFVARS_BACKEND and FORCE_APPLY',
+  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check; fi'),
+);
+expect('Makefile apply depends on check-tfvars-if-needed', mk.includes('apply: check-tfvars-if-needed copy-tfvars'));
+expect(
+  'Makefile setup runtime-pulls tfvars post-bootstrap when TFVARS_BACKEND is s3',
+  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ]; then') && mk.includes('$(TFVARS_SYNC) pull ||'),
+);
+expect(
+  'Makefile setup tolerates a first-time pull against an empty bucket instead of aborting',
+  /\$\(TFVARS_SYNC\) pull \|\| echo ".*run 'make tfvars-push' to seed the bucket"/.test(mk),
+);
+
+// ── Updated help text ────────────────────────────────────────────────────────
+expect('Makefile help mentions tfvars-diff', mk.includes('make tfvars-diff'));
+expect('Makefile help mentions GSD_TFVARS_BACKEND override', mk.includes('GSD_TFVARS_BACKEND=s3|local'));
+expect('Makefile help does NOT mention tfvars-status', !mk.includes('tfvars-status'));
+
+// ── Local-mode render: plan/apply/setup recipes stay functionally unchanged ──
+expect('Makefile plan still delegates to tf-plan after copy-tfvars', /plan: pull-tfvars-if-needed copy-tfvars\n\t\$\(MAKE\) -C \$\(SUBMODULE\) tf-plan/.test(mk));
+expect('Makefile apply still delegates to tf-apply after copy-tfvars', /apply: check-tfvars-if-needed copy-tfvars\n\t\$\(MAKE\) -C \$\(SUBMODULE\) tf-apply/.test(mk));
+expect('Makefile setup still runs git submodule update and setup.sh', mk.includes('git submodule update --init --recursive') && mk.includes('bash $(SUBMODULE)/setup.sh'));
+
 const tfv = renderTfvars(a);
 expect('tfvars sets project_name', tfv.includes('project_name = "mygames"'));
 expect('tfvars sets aws_region', tfv.includes('aws_region   = "us-west-2"'));
@@ -50,6 +103,7 @@ const gi = renderGitignore(a);
 expect('gitignore covers .env', gi.includes('.env\n'));
 expect('gitignore covers .make/', gi.includes('.make/'));
 expect('gitignore covers tfstate', gi.includes('terraform.tfstate'));
+expect('gitignore covers tfvars-sync.ts lock sidecar', gi.includes('*.tfvars.lock'));
 
 const aDiscord = { ...a, configureDiscord: true, discordApplicationId: '111', discordBotToken: 'btok', discordPublicKey: 'pkey' };
 const tfvD = renderTfvars(aDiscord);

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -62,7 +62,13 @@ expect(
 // ── plan/apply/setup gating ──────────────────────────────────────────────────
 expect(
   'Makefile gates plan auto-pull on TFVARS_BACKEND and NO_PULL',
-  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${NO_PULL:-}" ]; then $(TFVARS_SYNC) pull; fi'),
+  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${NO_PULL:-}" ]; then'),
+);
+expect(
+  'Makefile pull-tfvars-if-needed aborts on a dirty TFVARS before auto-pulling, same as tfvars-pull',
+  /pull-tfvars-if-needed:\n(?:\t.*\n)*?\t\s*if \[ -n "\$\$\(git -C \$\(REPO_ROOT\) status --porcelain -- \$\(TFVARS\)\)" \]; then echo .* >&2; exit 1; fi;/.test(
+    mk,
+  ),
 );
 expect('Makefile plan depends on pull-tfvars-if-needed', mk.includes('plan: pull-tfvars-if-needed copy-tfvars'));
 expect(
@@ -70,9 +76,21 @@ expect(
   mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check; fi'),
 );
 expect('Makefile apply depends on check-tfvars-if-needed', mk.includes('apply: check-tfvars-if-needed copy-tfvars'));
+// setup's post-bootstrap check must NOT reference the TFVARS_BACKEND/TFVARS_BUCKET make
+// variables: GNU Make expands a rule's whole recipe (including any $(wildcard ...)/
+// $(shell ...) calls hiding inside those variables) before running the recipe's first
+// line, so a make-variable-based check would still see the filesystem from before
+// setup.sh ran earlier in the same recipe. The check must be shell-native instead.
+const setupRecipeMatch = /^setup:.*\n(?:(?:\t|#).*\n?)*/m.exec(mk);
+const setupRecipe = setupRecipeMatch ? setupRecipeMatch[0] : '';
+expect('Makefile has a setup: recipe to inspect', setupRecipe !== '');
 expect(
-  'Makefile setup runtime-pulls tfvars post-bootstrap when TFVARS_BACKEND is s3',
-  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ]; then') && mk.includes('$(TFVARS_SYNC) pull ||'),
+  'Makefile setup runtime-pulls tfvars post-bootstrap via a shell-native (not make-variable) S3 backend check',
+  setupRecipe.includes(
+    '[ "$${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$${GSD_TFVARS_BACKEND:-}" != local ] && [ -f $(TFVARS_MARKER) ]; }',
+  ) &&
+    setupRecipe.includes('$(TFVARS_SYNC) pull ||') &&
+    !/if \[ "\$\(TFVARS_BACKEND\)" = s3 \]/.test(setupRecipe),
 );
 expect(
   'Makefile setup tolerates a first-time pull against an empty bucket instead of aborting',

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -73,7 +73,7 @@ expect(
 expect('Makefile plan depends on pull-tfvars-if-needed', mk.includes('plan: pull-tfvars-if-needed copy-tfvars'));
 expect(
   'Makefile gates apply check on TFVARS_BACKEND and FORCE_APPLY',
-  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check; fi'),
+  mk.includes('if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check $(TFVARS_SYNC_ARGS); fi'),
 );
 expect('Makefile apply depends on check-tfvars-if-needed', mk.includes('apply: check-tfvars-if-needed copy-tfvars'));
 // setup's post-bootstrap check must NOT reference the TFVARS_BACKEND/TFVARS_BUCKET make
@@ -89,12 +89,27 @@ expect(
   setupRecipe.includes(
     '[ "$${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$${GSD_TFVARS_BACKEND:-}" != local ] && [ -f $(TFVARS_MARKER) ]; }',
   ) &&
-    setupRecipe.includes('$(TFVARS_SYNC) pull ||') &&
+    setupRecipe.includes('$(TFVARS_SYNC) pull $(TFVARS_SYNC_ARGS) 2>&1') &&
     !/if \[ "\$\(TFVARS_BACKEND\)" = s3 \]/.test(setupRecipe),
 );
 expect(
   'Makefile setup tolerates a first-time pull against an empty bucket instead of aborting',
-  /\$\(TFVARS_SYNC\) pull \|\| echo ".*run 'make tfvars-push' to seed the bucket"/.test(mk),
+  /\$\(TFVARS_SYNC\) pull \$\(TFVARS_SYNC_ARGS\) 2>&1\); then[\s\S]*?run 'make tfvars-push' to seed the bucket/.test(mk),
+);
+// ── tfvars-sync.ts argv order: subcommand MUST be argv[0] (parseArgs()
+// throws its usage error otherwise) — every $(TFVARS_SYNC) call site must
+// render "<subcommand> $(TFVARS_SYNC_ARGS)", never flags before the
+// subcommand. Regression coverage for the blocker where --path/--bucket
+// were rendered ahead of pull|check|push|diff.
+expect(
+  'Makefile never renders TFVARS_SYNC flags before the subcommand',
+  !/\$\(TFVARS_SYNC\)\s+--(path|bucket|key|region)\b/.test(mk),
+);
+expect(
+  'Makefile renders TFVARS_SYNC_ARGS (--path/--bucket) after the pull|push|check|diff subcommand at every call site',
+  (mk.match(/\$\(TFVARS_SYNC\)\s+(pull|push|check|diff)\b/g) ?? []).length ===
+    (mk.match(/\$\(TFVARS_SYNC\)\s+(?:pull|push|check|diff)\s+\$\(TFVARS_SYNC_ARGS\)/g) ?? []).length &&
+    (mk.match(/\$\(TFVARS_SYNC\)\s+(pull|push|check|diff)\b/g) ?? []).length === 6,
 );
 
 // ── Updated help text ────────────────────────────────────────────────────────

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -177,7 +177,13 @@ TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,
 # TFVARS_BUCKET is display-only (used in log messages below); GSD_TFVARS_BUCKET
 # wins if already set, otherwise the marker file's contents.
 TFVARS_BUCKET = $(if $(GSD_TFVARS_BUCKET),$(GSD_TFVARS_BUCKET),$(shell cat $(TFVARS_MARKER) 2>/dev/null))
-TFVARS_SYNC   = npx --prefix $(SUBMODULE)/scripts tsx $(SUBMODULE)/scripts/tfvars-sync.ts --path $(TFVARS) --bucket "$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"
+# TFVARS_SYNC is deliberately just the interpreter invocation with no
+# subcommand or flags: tfvars-sync.ts's parseArgs() requires the subcommand
+# (pull/push/check/diff) to be argv[0], so every call site must render
+# "$(TFVARS_SYNC) <subcommand> $(TFVARS_SYNC_ARGS)" — never put flags before
+# the subcommand.
+TFVARS_SYNC      = npx --prefix $(SUBMODULE)/scripts tsx $(SUBMODULE)/scripts/tfvars-sync.ts
+TFVARS_SYNC_ARGS = --path $(TFVARS) --bucket "$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"
 
 .PHONY: help setup plan apply update dev copy-tfvars pull-tfvars-if-needed check-tfvars-if-needed tfvars-pull tfvars-push tfvars-diff
 
@@ -223,7 +229,15 @@ setup: | $(STAMP_DIR)
 \t  if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — skipping S3 pull to avoid clobbering them (commit or stash them, then run 'make tfvars-pull')." >&2; \\
 \t  else \\
 \t    echo "S3 tfvars backend detected (s3://$$bucket) — pulling terraform.tfvars..."; \\
-\t    $(TFVARS_SYNC) pull || echo "no tfvars object found in s3://$$bucket yet — run 'make tfvars-push' to seed the bucket" >&2; \\
+\t    if pull_out=$$($(TFVARS_SYNC) pull $(TFVARS_SYNC_ARGS) 2>&1); then \\
+\t      echo "$$pull_out"; \\
+\t    elif echo "$$pull_out" | grep -qi 'NoSuchKey\\|specified key does not exist'; then \\
+\t      echo "no tfvars object found in s3://$$bucket yet — run 'make tfvars-push' to seed the bucket" >&2; \\
+\t    else \\
+\t      echo "$$pull_out" >&2; \\
+\t      echo "tfvars pull failed — aborting setup; check credentials/network, then run 'make tfvars-pull' once resolved" >&2; \\
+\t      exit 1; \\
+\t    fi; \\
 \t  fi; \\
 \t fi
 
@@ -245,11 +259,11 @@ copy-tfvars: $(TFVARS)
 pull-tfvars-if-needed:
 \t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${NO_PULL:-}" ]; then \\
 \t  if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — commit or stash them before pulling from S3 (or rerun with NO_PULL=1)." >&2; exit 1; fi; \\
-\t  $(TFVARS_SYNC) pull; \\
+\t  $(TFVARS_SYNC) pull $(TFVARS_SYNC_ARGS); \\
 \t fi
 
 check-tfvars-if-needed:
-\t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check; fi
+\t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check $(TFVARS_SYNC_ARGS); fi
 
 # plan auto-pulls the latest tfvars from S3 first (skip with NO_PULL=1), so a
 # stale local copy can't silently drive \`terraform plan\`. In local mode
@@ -272,15 +286,15 @@ apply: check-tfvars-if-needed copy-tfvars
 tfvars-pull:
 \t@if [ "$(TFVARS_BACKEND)" != s3 ]; then echo "No S3 tfvars backend detected (TFVARS_BACKEND=$(TFVARS_BACKEND)) — set GSD_TFVARS_BACKEND=s3 (with GSD_TFVARS_BUCKET) or bootstrap one via setup.sh." >&2; exit 1; fi
 \t@if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — commit or stash them before pulling from S3." >&2; exit 1; fi
-\t$(TFVARS_SYNC) pull
+\t$(TFVARS_SYNC) pull $(TFVARS_SYNC_ARGS)
 
 tfvars-push:
 \t@if [ "$(TFVARS_BACKEND)" != s3 ]; then echo "No S3 tfvars backend detected (TFVARS_BACKEND=$(TFVARS_BACKEND)) — set GSD_TFVARS_BACKEND=s3 (with GSD_TFVARS_BUCKET) or bootstrap one via setup.sh." >&2; exit 1; fi
-\t$(TFVARS_SYNC) push
+\t$(TFVARS_SYNC) push $(TFVARS_SYNC_ARGS)
 
 tfvars-diff:
 \t@if [ "$(TFVARS_BACKEND)" != s3 ]; then echo "No S3 tfvars backend detected (TFVARS_BACKEND=$(TFVARS_BACKEND)) — set GSD_TFVARS_BACKEND=s3 (with GSD_TFVARS_BUCKET) or bootstrap one via setup.sh." >&2; exit 1; fi
-\t$(TFVARS_SYNC) diff
+\t$(TFVARS_SYNC) diff $(TFVARS_SYNC_ARGS)
 
 # ── Submodule update with idempotent setup.sh re-run ─────────────────────────
 update: | $(STAMP_DIR)

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -220,8 +220,11 @@ setup: | $(STAMP_DIR)
 # see whatever setup.sh just wrote.
 \t@if [ "$\${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$\${GSD_TFVARS_BACKEND:-}" != local ] && [ -f $(TFVARS_MARKER) ]; }; then \\
 \t  bucket="$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"; \\
-\t  echo "S3 tfvars backend detected (s3://$$bucket) — pulling terraform.tfvars..."; \\
-\t  $(TFVARS_SYNC) pull || echo "no tfvars object found in s3://$$bucket yet — run 'make tfvars-push' to seed the bucket" >&2; \\
+\t  if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — skipping S3 pull to avoid clobbering them (commit or stash them, then run 'make tfvars-pull')." >&2; \\
+\t  else \\
+\t    echo "S3 tfvars backend detected (s3://$$bucket) — pulling terraform.tfvars..."; \\
+\t    $(TFVARS_SYNC) pull || echo "no tfvars object found in s3://$$bucket yet — run 'make tfvars-push' to seed the bucket" >&2; \\
+\t  fi; \\
 \t fi
 
 # ── Copy tfvars into the submodule terraform dir ─────────────────────────────

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -118,15 +118,17 @@ async function askRequired(rl: Interface, label: string, def?: string): Promise<
  *   dev   → pull live tfstate into .make/, then `make dev` in submodule
  *
  * Three extra targets — tfvars-pull, tfvars-push, tfvars-diff — wrap
- * scripts/tfvars-sync.ts for manual use. All tfvars-* behaviour (including
- * plan/apply's auto-pull/check and setup's post-bootstrap pull) is gated on
- * TFVARS_BACKEND, which resolves to "s3" or "local" in this order:
+ * scripts/tfvars-sync.ts for manual use. plan/apply's auto-pull/check are
+ * gated on TFVARS_BACKEND, which resolves to "s3" or "local" in this order:
  *   1. GSD_TFVARS_BACKEND=s3    — force s3, even without a marker file yet
  *   2. GSD_TFVARS_BACKEND=local — force local, even if a marker file exists
  *   3. otherwise: "s3" when the `.gsd/tfvars-bucket` marker file setup.sh
  *      writes inside the submodule directory exists, else "local"
  * When TFVARS_BACKEND is "local", plan/apply/setup behave exactly as
- * before — no S3 calls are made.
+ * before — no S3 calls are made. setup's post-bootstrap pull applies the
+ * same override semantics but re-implements them directly in its shell
+ * recipe rather than referencing TFVARS_BACKEND — see the comment on that
+ * recipe below for why.
  *
  * API_TOKEN is loaded from .env (gitignored) — never hardcoded.
  */
@@ -161,9 +163,15 @@ TFVARS_LOCK   := $(TFVARS).lock
 #   - GSD_TFVARS_BACKEND=s3    → force s3, even if the marker file is missing
 #   - GSD_TFVARS_BACKEND=local → force local, even if a marker file is present
 #   - unset                    → s3 when the marker file exists, else local
-# Recursive ('=', not ':='), and \$(wildcard ...) is re-checked on every
-# reference, so \`setup\`'s post-bootstrap pull (below) sees a marker that
-# setup.sh only just wrote earlier in the very same recipe.
+# Recursive ('=', not ':='), so \$(wildcard ...) is re-evaluated whenever this
+# variable is referenced from a *separate* \`make\` invocation (plan, apply,
+# tfvars-pull, etc. all see current marker-file state that way). It must NOT
+# be used to gate \`setup\`'s post-bootstrap pull: GNU Make expands a rule's
+# entire recipe before running the first line of that recipe, so a reference
+# to this variable inside the same \`setup\` recipe that runs setup.sh would
+# still see the pre-setup.sh filesystem state even though it appears later in
+# the recipe text. \`setup\` re-implements the same override logic directly in
+# its shell recipe instead — see below.
 TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(TFVARS_MARKER)),s3,local)))
 
 # TFVARS_BUCKET is display-only (used in log messages below); GSD_TFVARS_BUCKET
@@ -201,12 +209,19 @@ setup: | $(STAMP_DIR)
 \tgit submodule update --init --recursive
 \tbash $(SUBMODULE)/setup.sh
 \t@sha256sum $(SUBMODULE)/setup.sh | cut -d' ' -f1 > $(SETUP_STAMP)
-# Runtime (not parse-time) check: setup.sh may have just bootstrapped the S3
-# tfvars backend and written the marker file above, so pull the canonical
-# tfvars down now that it exists.
-\t@if [ "$(TFVARS_BACKEND)" = s3 ]; then \\
-\t  echo "S3 tfvars backend detected (s3://$(TFVARS_BUCKET)) — pulling terraform.tfvars..."; \\
-\t  $(TFVARS_SYNC) pull || echo "no tfvars object found in s3://$(TFVARS_BUCKET) yet — run 'make tfvars-push' to seed the bucket" >&2; \\
+# Runtime (not parse-time) check, evaluated entirely inside this shell
+# command: GNU Make expands a rule's whole recipe — including any
+# $(wildcard ...)/$(shell ...) calls hiding inside TFVARS_BACKEND/
+# TFVARS_BUCKET — before running the first line of that recipe, so a
+# make-variable-based check here would still see the filesystem from before
+# setup.sh (above) ran, even though it's written later in the recipe text.
+# Mirror TFVARS_BACKEND's own GSD_TFVARS_BACKEND override semantics by hand,
+# and defer both the marker-file test and its \`cat\` to the shell so they
+# see whatever setup.sh just wrote.
+\t@if [ "$\${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$\${GSD_TFVARS_BACKEND:-}" != local ] && [ -f $(TFVARS_MARKER) ]; }; then \\
+\t  bucket="$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"; \\
+\t  echo "S3 tfvars backend detected (s3://$$bucket) — pulling terraform.tfvars..."; \\
+\t  $(TFVARS_SYNC) pull || echo "no tfvars object found in s3://$$bucket yet — run 'make tfvars-push' to seed the bucket" >&2; \\
 \t fi
 
 # ── Copy tfvars into the submodule terraform dir ─────────────────────────────
@@ -220,8 +235,15 @@ copy-tfvars: $(TFVARS)
 # ── Terraform targets ────────────────────────────────────────────────────────
 # Internal gates: silently no-op in local mode (TFVARS_BACKEND=local) so
 # plan/apply behave exactly as they did before S3 sync existed.
+# pull-tfvars-if-needed guards against clobbering uncommitted local edits the
+# same way the manual tfvars-pull target does below: a pull overwrites
+# $(TFVARS) in place, so if git sees it as dirty we abort instead of silently
+# discarding the operator's changes (NO_PULL=1 still skips the pull entirely).
 pull-tfvars-if-needed:
-\t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${NO_PULL:-}" ]; then $(TFVARS_SYNC) pull; fi
+\t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${NO_PULL:-}" ]; then \\
+\t  if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — commit or stash them before pulling from S3 (or rerun with NO_PULL=1)." >&2; exit 1; fi; \\
+\t  $(TFVARS_SYNC) pull; \\
+\t fi
 
 check-tfvars-if-needed:
 \t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check; fi

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -108,11 +108,25 @@ async function askRequired(rl: Interface, label: string, def?: string): Promise<
 
 /**
  * Mirrors the structure documented in the Makefile-driven submodule pattern:
- *   setup → init submodule, run setup.sh, stamp its sha
- *   plan  → copy tfvars in, delegate to submodule's `make tf-plan`
- *   apply → same, delegate to `make tf-apply`
+ *   setup → init submodule, run setup.sh, stamp its sha, then pull tfvars
+ *            from S3 if setup.sh just bootstrapped a backend
+ *   plan  → auto-pull tfvars from S3 (unless NO_PULL=1), copy tfvars in,
+ *            delegate to submodule's `make tf-plan`
+ *   apply → check tfvars are in sync with S3 first (unless FORCE_APPLY=1),
+ *            copy tfvars in, delegate to `make tf-apply`
  *   update → bump submodule, rerun setup.sh only if its sha changed
  *   dev   → pull live tfstate into .make/, then `make dev` in submodule
+ *
+ * Three extra targets — tfvars-pull, tfvars-push, tfvars-diff — wrap
+ * scripts/tfvars-sync.ts for manual use. All tfvars-* behaviour (including
+ * plan/apply's auto-pull/check and setup's post-bootstrap pull) is gated on
+ * TFVARS_BACKEND, which resolves to "s3" or "local" in this order:
+ *   1. GSD_TFVARS_BACKEND=s3    — force s3, even without a marker file yet
+ *   2. GSD_TFVARS_BACKEND=local — force local, even if a marker file exists
+ *   3. otherwise: "s3" when the `.gsd/tfvars-bucket` marker file setup.sh
+ *      writes inside the submodule directory exists, else "local"
+ * When TFVARS_BACKEND is "local", plan/apply/setup behave exactly as
+ * before — no S3 calls are made.
  *
  * API_TOKEN is loaded from .env (gitignored) — never hardcoded.
  */
@@ -133,17 +147,50 @@ include $(REPO_ROOT)/.env
 export
 endif
 
-.PHONY: help setup plan apply update dev copy-tfvars
+# ── S3 tfvars backend detection ──────────────────────────────────────────────
+# TFVARS_MARKER is the bucket-name marker file setup.sh writes when it
+# bootstraps the versioned S3 tfvars backend (see setup.sh's
+# bootstrap_tfvars_backend()). TFVARS_LOCK is the sidecar lock file
+# tfvars-sync.ts writes after every successful pull/push, recording the S3
+# version id/etag last synced.
+TFVARS_MARKER := $(SUBMODULE)/.gsd/tfvars-bucket
+TFVARS_LOCK   := $(TFVARS).lock
+
+# TFVARS_BACKEND resolves the s3-vs-local decision explicitly, so an operator
+# can always force one or the other regardless of what's on disk:
+#   - GSD_TFVARS_BACKEND=s3    → force s3, even if the marker file is missing
+#   - GSD_TFVARS_BACKEND=local → force local, even if a marker file is present
+#   - unset                    → s3 when the marker file exists, else local
+# Recursive ('=', not ':='), and \$(wildcard ...) is re-checked on every
+# reference, so \`setup\`'s post-bootstrap pull (below) sees a marker that
+# setup.sh only just wrote earlier in the very same recipe.
+TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(TFVARS_MARKER)),s3,local)))
+
+# TFVARS_BUCKET is display-only (used in log messages below); GSD_TFVARS_BUCKET
+# wins if already set, otherwise the marker file's contents.
+TFVARS_BUCKET = $(if $(GSD_TFVARS_BUCKET),$(GSD_TFVARS_BUCKET),$(shell cat $(TFVARS_MARKER) 2>/dev/null))
+TFVARS_SYNC   = npx --prefix $(SUBMODULE)/scripts tsx $(SUBMODULE)/scripts/tfvars-sync.ts --path $(TFVARS) --bucket "$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"
+
+.PHONY: help setup plan apply update dev copy-tfvars pull-tfvars-if-needed check-tfvars-if-needed tfvars-pull tfvars-push tfvars-diff
 
 # ── Help ─────────────────────────────────────────────────────────────────────
 help:
 \t@echo "${a.projectName} — submodule deployment wrapper"
 \t@echo ""
-\t@echo "  make setup    One-time bootstrap: init submodule, install deps, terraform init"
-\t@echo "  make plan     Copy tfvars into submodule then terraform plan"
-\t@echo "  make apply    Copy tfvars into submodule then terraform apply"
-\t@echo "  make update   Pull latest ${a.submoduleDir}/main; rerun setup.sh if changed"
-\t@echo "  make dev      Start dev servers (Nest :3001 + Vite :5173)"
+\t@echo "  make setup         One-time bootstrap: init submodule, install deps, terraform init"
+\t@echo "                     (pulls terraform.tfvars from S3 afterwards if setup.sh bootstrapped a backend)"
+\t@echo "  make plan          Copy tfvars into submodule then terraform plan"
+\t@echo "                     (auto-pulls tfvars from S3 first when a backend is detected; NO_PULL=1 to skip)"
+\t@echo "  make apply         Copy tfvars into submodule then terraform apply"
+\t@echo "                     (checks tfvars are in sync with S3 first when a backend is detected; FORCE_APPLY=1 to skip)"
+\t@echo "  make update        Pull latest ${a.submoduleDir}/main; rerun setup.sh if changed"
+\t@echo "  make dev           Start dev servers (Nest :3001 + Vite :5173)"
+\t@echo "  make tfvars-pull   Pull terraform.tfvars from the S3 backend (requires one to be configured)"
+\t@echo "  make tfvars-push   Push terraform.tfvars to the S3 backend"
+\t@echo "  make tfvars-diff   Show a unified diff between local and remote terraform.tfvars"
+\t@echo ""
+\t@echo "  S3 tfvars backend detection: GSD_TFVARS_BACKEND=s3|local overrides;"
+\t@echo "  otherwise inferred from the $(TFVARS_MARKER) marker file."
 
 # ── Stamp dir ────────────────────────────────────────────────────────────────
 $(STAMP_DIR):
@@ -154,6 +201,13 @@ setup: | $(STAMP_DIR)
 \tgit submodule update --init --recursive
 \tbash $(SUBMODULE)/setup.sh
 \t@sha256sum $(SUBMODULE)/setup.sh | cut -d' ' -f1 > $(SETUP_STAMP)
+# Runtime (not parse-time) check: setup.sh may have just bootstrapped the S3
+# tfvars backend and written the marker file above, so pull the canonical
+# tfvars down now that it exists.
+\t@if [ "$(TFVARS_BACKEND)" = s3 ]; then \\
+\t  echo "S3 tfvars backend detected (s3://$(TFVARS_BUCKET)) — pulling terraform.tfvars..."; \\
+\t  $(TFVARS_SYNC) pull || echo "no tfvars object found in s3://$(TFVARS_BUCKET) yet — run 'make tfvars-push' to seed the bucket" >&2; \\
+\t fi
 
 # ── Copy tfvars into the submodule terraform dir ─────────────────────────────
 $(TF_DIR)/terraform.tfvars: $(TFVARS)
@@ -164,11 +218,44 @@ copy-tfvars: $(TFVARS)
 \tcp $(TFVARS) $(TF_DIR)/terraform.tfvars
 
 # ── Terraform targets ────────────────────────────────────────────────────────
-plan: copy-tfvars
+# Internal gates: silently no-op in local mode (TFVARS_BACKEND=local) so
+# plan/apply behave exactly as they did before S3 sync existed.
+pull-tfvars-if-needed:
+\t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${NO_PULL:-}" ]; then $(TFVARS_SYNC) pull; fi
+
+check-tfvars-if-needed:
+\t@if [ "$(TFVARS_BACKEND)" = s3 ] && [ -z "$\${FORCE_APPLY:-}" ]; then $(TFVARS_SYNC) check; fi
+
+# plan auto-pulls the latest tfvars from S3 first (skip with NO_PULL=1), so a
+# stale local copy can't silently drive \`terraform plan\`. In local mode
+# pull-tfvars-if-needed is a no-op and this is unchanged from before.
+plan: pull-tfvars-if-needed copy-tfvars
 \t$(MAKE) -C $(SUBMODULE) tf-plan
 
-apply: copy-tfvars
+# apply checks tfvars are still in sync with S3 first (skip with
+# FORCE_APPLY=1), so drift can't silently drive \`terraform apply\`. In local
+# mode check-tfvars-if-needed is a no-op and this is unchanged from before.
+apply: check-tfvars-if-needed copy-tfvars
 \t$(MAKE) -C $(SUBMODULE) tf-apply
+
+# ── Manual remote tfvars sync (gated on TFVARS_BACKEND) ─────────────────────
+# Unlike the internal gates above, these fail fast with a pointer to
+# configure a backend instead of silently no-opping — they're operator-driven.
+# tfvars-pull additionally refuses to clobber uncommitted local edits: a pull
+# overwrites $(TFVARS) in place, so if git sees it as dirty we abort instead
+# of silently discarding the operator's changes.
+tfvars-pull:
+\t@if [ "$(TFVARS_BACKEND)" != s3 ]; then echo "No S3 tfvars backend detected (TFVARS_BACKEND=$(TFVARS_BACKEND)) — set GSD_TFVARS_BACKEND=s3 (with GSD_TFVARS_BUCKET) or bootstrap one via setup.sh." >&2; exit 1; fi
+\t@if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — commit or stash them before pulling from S3." >&2; exit 1; fi
+\t$(TFVARS_SYNC) pull
+
+tfvars-push:
+\t@if [ "$(TFVARS_BACKEND)" != s3 ]; then echo "No S3 tfvars backend detected (TFVARS_BACKEND=$(TFVARS_BACKEND)) — set GSD_TFVARS_BACKEND=s3 (with GSD_TFVARS_BUCKET) or bootstrap one via setup.sh." >&2; exit 1; fi
+\t$(TFVARS_SYNC) push
+
+tfvars-diff:
+\t@if [ "$(TFVARS_BACKEND)" != s3 ]; then echo "No S3 tfvars backend detected (TFVARS_BACKEND=$(TFVARS_BACKEND)) — set GSD_TFVARS_BACKEND=s3 (with GSD_TFVARS_BUCKET) or bootstrap one via setup.sh." >&2; exit 1; fi
+\t$(TFVARS_SYNC) diff
 
 # ── Submodule update with idempotent setup.sh re-run ─────────────────────────
 update: | $(STAMP_DIR)
@@ -286,6 +373,10 @@ export function renderGitignore(a: Answers): string {
 terraform.tfstate
 terraform.tfstate.backup
 *.tfvars.local
+
+# tfvars-sync.ts sidecar lock file (S3 version/etag metadata, not a secret,
+# but machine-local and irrelevant to commit)
+*.tfvars.lock
 
 # Editor / OS noise
 .DS_Store

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -17,6 +17,7 @@ import {
   diffTfvars,
   lockStatus,
   checkTfvars,
+  parseArgs,
   VersionMismatchError,
   BucketNotVersionedError,
   type LockFile,
@@ -426,6 +427,45 @@ describe('tfvars-sync', () => {
 
       expect(result.inSync).toBe(false);
       expect(result.reason).toContain('versioning');
+    });
+  });
+
+  describe('parseArgs', () => {
+    /**
+     * The generated parent Makefile (see `renderMakefile()` in
+     * `init-parent.ts`) renders every call site as
+     * `$(TFVARS_SYNC) <subcommand> $(TFVARS_SYNC_ARGS)`, which Make expands
+     * to `... tfvars-sync.ts <subcommand> --path <file> --bucket <bucket>`
+     * — i.e. the subcommand always precedes the flags. This is the exact
+     * argv shape `parseArgs()` must accept.
+     */
+    it('should parse the subcommand-then-flags argv shape the generated Makefile emits', () => {
+      const { command, options } = parseArgs(['pull', '--path', '/tmp/parent/terraform.tfvars', '--bucket', 'my-bucket']);
+
+      expect(command).toBe('pull');
+      expect(options.path).toBe('/tmp/parent/terraform.tfvars');
+      expect(options.bucket).toBe('my-bucket');
+    });
+
+    it('should parse the subcommand-then-flags argv shape for every Makefile-driven subcommand (push/diff/check)', () => {
+      for (const command of ['push', 'diff', 'check'] as const) {
+        const parsed = parseArgs([command, '--path', '/tmp/parent/terraform.tfvars', '--bucket', 'my-bucket']);
+        expect(parsed.command).toBe(command);
+        expect(parsed.options.bucket).toBe('my-bucket');
+      }
+    });
+
+    it('should throw a usage error when flags precede the subcommand', () => {
+      // Regression pin: an earlier Makefile template baked --path/--bucket
+      // into the TFVARS_SYNC variable itself, so every call site rendered
+      // "--path <file> --bucket <bucket> <subcommand>" — flags before the
+      // subcommand. parseArgs() takes argv[0] as the command unconditionally,
+      // so that shape threw this exact usage error on every tfvars-pull/
+      // push/diff/check/setup invocation, yet no test exercised parseArgs()
+      // with the Makefile's actual emitted argv shape to catch it.
+      expect(() =>
+        parseArgs(['--path', '/tmp/parent/terraform.tfvars', '--bucket', 'my-bucket', 'pull']),
+      ).toThrow(/Usage: tfvars-sync\.ts <pull\|push\|diff\|status\|check>/);
     });
   });
 });

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -409,5 +409,23 @@ describe('tfvars-sync', () => {
       expect(result.inSync).toBe(false);
       expect(result.reason).toContain('does not exist');
     });
+
+    it('should report inSync: false when the remote object exists but the bucket returns no VersionId (unversioned bucket)', async () => {
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: null,
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ ETag: '"etag-1"' });
+
+      const result = await checkTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(false);
+      expect(result.reason).toContain('versioning');
+    });
   });
 });

--- a/scripts/tfvars-sync.test.ts
+++ b/scripts/tfvars-sync.test.ts
@@ -16,6 +16,7 @@ import {
   pushTfvars,
   diffTfvars,
   lockStatus,
+  checkTfvars,
   VersionMismatchError,
   BucketNotVersionedError,
   type LockFile,
@@ -341,6 +342,72 @@ describe('tfvars-sync', () => {
 
       expect(result.remote.exists).toBe(false);
       expect(result.inSync).toBe(false);
+    });
+  });
+
+  describe('checkTfvars', () => {
+    it('should report inSync: true with a clear reason when the local lock version matches the remote head version', async () => {
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'v1',
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+
+      const result = await checkTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(true);
+      expect(result.reason).toContain('v1');
+    });
+
+    it('should report inSync: false with a clear reason when the local lock version differs from the remote head version', async () => {
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'stale-version',
+        etag: 'stale-etag',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v2', ETag: '"etag-2"' });
+
+      const result = await checkTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(false);
+      expect(result.reason).toContain('stale-version');
+      expect(result.reason).toContain('v2');
+    });
+
+    it('should report inSync: false with a clear reason when no local lock file was found', async () => {
+      s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+
+      const result = await checkTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(false);
+      expect(result.reason).toContain('no local lock file found');
+    });
+
+    it('should report inSync: false with a clear reason when the remote object does not exist', async () => {
+      writeLockFile(localPath, {
+        bucket: 'my-bucket',
+        key: 'terraform.tfvars',
+        versionId: 'v1',
+        etag: 'etag-1',
+        size: 22,
+        lastModified: '2024-01-01T00:00:00.000Z',
+        pulledAt: '2024-01-01T00:00:01.000Z',
+      });
+      s3Mock.on(HeadObjectCommand).rejects({ name: 'NotFound', $metadata: { httpStatusCode: 404 } });
+
+      const result = await checkTfvars({ bucket: 'my-bucket', path: localPath, key: 'terraform.tfvars' });
+
+      expect(result.inSync).toBe(false);
+      expect(result.reason).toContain('does not exist');
     });
   });
 });

--- a/scripts/tfvars-sync.ts
+++ b/scripts/tfvars-sync.ts
@@ -12,6 +12,7 @@
  *   tsx tfvars-sync.ts push   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
  *   tsx tfvars-sync.ts diff   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
  *   tsx tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+ *   tsx tfvars-sync.ts check  [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
  *
  * `--path` defaults to `terraform/terraform.tfvars` and is the local file to
  * sync. `--key` defaults to `terraform.tfvars` and is the S3 object key —
@@ -135,6 +136,14 @@ export interface StatusReport {
   remote: RemoteHead;
   /** True when the local lock's version id matches the remote object's current version id. */
   inSync: boolean;
+}
+
+/** Result of `checkTfvars()` — a drift gate suitable for `make apply`. */
+export interface CheckResult {
+  /** True when the local lock's version id matches the remote object's current version id. */
+  inSync: boolean;
+  /** Human-readable explanation of `inSync`'s value — always present, even when `inSync` is true. */
+  reason: string;
 }
 
 /** Thrown by `pushTfvars()` when the local lock doesn't match (or is missing for) the current remote version. */
@@ -445,11 +454,41 @@ export async function lockStatus(opts: TfvarsSyncOptions): Promise<StatusReport>
   };
 }
 
+/**
+ * Drift gate for `make apply`: reports whether the local lock's version id
+ * matches the remote object's current version id, without touching the
+ * filesystem beyond reading the existing lock file. Unlike `lockStatus()`,
+ * this returns a single human-readable `reason` so callers (notably the CLI)
+ * can surface *why* the check failed without re-deriving it from the raw
+ * `LockFile`/`RemoteHead` shapes.
+ */
+export async function checkTfvars(opts: TfvarsSyncOptions): Promise<CheckResult> {
+  const status = await lockStatus(opts);
+
+  if (!status.lock) {
+    return { inSync: false, reason: `no local lock file found at ${lockPathFor(opts.path)} — run "pull" first` };
+  }
+  if (!status.remote.exists) {
+    return {
+      inSync: false,
+      reason: `remote object s3://${status.bucket}/${status.key} does not exist`,
+    };
+  }
+  if (status.lock.versionId !== status.remote.versionId) {
+    return {
+      inSync: false,
+      reason: `local lock version "${status.lock.versionId}" does not match remote version "${status.remote.versionId}" — run "pull" to refresh`,
+    };
+  }
+
+  return { inSync: true, reason: `local lock version "${status.lock.versionId}" matches remote` };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // CLI
 // ─────────────────────────────────────────────────────────────────────────────
 
-const COMMANDS = ['pull', 'push', 'diff', 'status'] as const;
+const COMMANDS = ['pull', 'push', 'diff', 'status', 'check'] as const;
 type Command = (typeof COMMANDS)[number];
 
 interface ParsedArgs {
@@ -577,6 +616,16 @@ async function main(): Promise<void> {
         output.write('  (object does not exist)\n');
       }
       output.write(`\nin sync: ${result.inSync ? 'yes' : 'no'}\n`);
+      return;
+    }
+    case 'check': {
+      const result = await checkTfvars(options);
+      if (result.inSync) {
+        output.write(`✓ in sync: ${result.reason}\n`);
+      } else {
+        output.write(`✗ drift detected: ${result.reason}\n`);
+        process.exitCode = 1;
+      }
       return;
     }
   }

--- a/scripts/tfvars-sync.ts
+++ b/scripts/tfvars-sync.ts
@@ -474,6 +474,12 @@ export async function checkTfvars(opts: TfvarsSyncOptions): Promise<CheckResult>
       reason: `remote object s3://${status.bucket}/${status.key} does not exist`,
     };
   }
+  if (status.remote.versionId === null) {
+    return {
+      inSync: false,
+      reason: `bucket "${status.bucket}" does not appear to have S3 versioning enabled (HeadObject returned no VersionId for s3://${status.bucket}/${status.key}) — drift cannot be detected without a versioned bucket`,
+    };
+  }
   if (status.lock.versionId !== status.remote.versionId) {
     return {
       inSync: false,


### PR DESCRIPTION
Closes #88

## Summary

- Wires the `tfvars-sync` S3 store into the parent repo's `Makefile` and setup flow: new `tfvars-pull`/`tfvars-push`/`tfvars-diff` targets, `make plan`/`make apply` pull-before-plan and drift-gate behavior, and a post-bootstrap pull in `make setup`, all gated on `GSD_TFVARS_BACKEND=s3`.
- Hardens the `tfvars-sync` CLI itself: adds a `check` subcommand (drift gate consumed by `make apply`), fixes subcommand-first argument parsing, fixes `lockStatus()` version comparison, fixes the post-bootstrap pull never firing on first-time setup, and guards the pull against clobbering local uncommitted changes.
- Updates `init-parent`'s `renderMakefile`/`renderGitignore` templates so newly-scaffolded parent repos get the s3-aware Makefile out of the box, and extends docs (`scripts/README.md`, `docs/docs/guides/submodule.md`) plus test coverage for both the CLI and the init-parent template.

## Changes

```
docs/docs/guides/submodule.md |  39 +++++++++--
scripts/README.md             |  25 ++++++-
scripts/init-parent.test.ts   |  87 ++++++++++++++++++++++++
scripts/init-parent.ts        | 152 +++++++++++++++++++++++++++++++++++++++---
scripts/tfvars-sync.test.ts   | 125 ++++++++++++++++++++++++++++++++++
scripts/tfvars-sync.ts        |  57 +++++++++++++++-
6 files changed, 468 insertions(+), 17 deletions(-)
```

## Test plan

- [ ] All four targets (`tfvars-pull`, `tfvars-push`, `tfvars-diff`, `make apply` drift check) work end-to-end against a real S3 bucket.
- [ ] `make plan` in s3 mode auto-pulls; emits a clear message if remote changed.
- [ ] `make apply` aborts with a helpful error if remote moved since last pull.
- [ ] Local-file mode is unchanged.
- [ ] Newly-scaffolded parent repos via `init-parent` get the s3-aware Makefile.
- [x] `scripts/tfvars-sync.test.ts` and `scripts/init-parent.test.ts` cover the new subcommand, lock-status fix, and template rendering.
