### PR TITLE
feat(desktop-main): migration path from pre-pivot local tfvars

### DIFF
--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
       // The tfvars-sync helper lives in the top-level @hyveon/scripts workspace
       // (outside packages/), so it needs its own explicit include entry.
       '../scripts/tfvars-sync.test.ts',
+      // Same rationale — the init-parent bootstrap/migrate CLI spec lives
+      // alongside tfvars-sync.test.ts, outside packages/.
+      '../scripts/init-parent.cli.test.ts',
     ],
     // Default environment for server-side and shared tests is Node.
     // React component tests under @hyveon/web override this via

--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -96,6 +96,23 @@ The script prompts for project name, AWS region, hosted zone, and
 `terraform.tfvars`, `.env`, and `.gitignore`. Existing files are skipped
 unless you pass `--force`.
 
+`init-parent.ts` dispatches on subcommands, with `bootstrap` (the flow
+above) implied when none is given:
+
+```bash
+init-parent.ts [--force] [--s3-tfvars] [--yes]            Interactive bootstrap (default)
+init-parent.ts migrate --to-s3 | --to-local [--yes]        Migrate an existing parent repo's tfvars backend
+```
+
+`--s3-tfvars` pre-answers the "bootstrap an S3-backed tfvars store now?"
+prompt with yes and writes `.gsd/tfvars-bucket` up front, so `make setup`
+provisions the S3 backend on its first run instead of asking interactively.
+`--yes` skips confirmation prompts generally (see [`scripts/README.md`](https://github.com/CoderCoco/Hyveon/blob/main/scripts/README.md#flags)
+for the exact per-subcommand semantics). Already have a scaffolded parent
+repo and want to switch its tfvars backend after the fact instead? See
+[Migrating an existing parent repo's tfvars backend](#migrating-an-existing-parent-repos-tfvars-backend)
+below.
+
 After it finishes:
 
 ```bash
@@ -136,13 +153,17 @@ resolution in the generated Makefile:
   missing.
 - `GSD_TFVARS_BACKEND=local` forces local-file mode, even if a marker file
   is present.
-- Otherwise: S3 if `Hyveon/.gsd/tfvars-bucket` exists — the marker
-  file `setup.sh`'s `bootstrap_tfvars_backend()` writes recording the
-  bucket name it just created — local otherwise.
+- Otherwise: S3 if either marker file exists — the **parent-root**
+  `.gsd/tfvars-bucket` (written by `bootstrap --s3-tfvars` or
+  `migrate --to-s3`) or the **submodule-local**
+  `Hyveon/.gsd/tfvars-bucket` (written by `setup.sh`'s
+  `bootstrap_tfvars_backend()`) — local otherwise.
 
-`GSD_TFVARS_BUCKET`, if set, wins over the marker file's contents when the
-wrapper needs to display or pass along the bucket name; otherwise it reads
-the marker file.
+`GSD_TFVARS_BUCKET`, if set, wins over both marker files' contents when the
+wrapper needs to display or pass along the bucket name. Otherwise it reads
+the parent-root marker first, falling back to the submodule-local marker if
+the parent-root one doesn't exist — see [Parent-root marker takes
+precedence](#parent-root-marker-takes-precedence) below for why.
 
 `make tfvars-pull`, `make tfvars-push`, and `make tfvars-diff` fail fast
 with a pointer to `GSD_TFVARS_BACKEND`/`setup.sh` when no backend is
@@ -153,6 +174,86 @@ mode** (no marker file and `GSD_TFVARS_BACKEND` isn't `s3`) they're silent
 no-ops, so `make setup`, `make plan`, and `make apply` behave exactly as
 they did before S3 tfvars sync existed. Nothing changes for a single-file,
 no-remote-backend deployment.
+
+## Migrating an existing parent repo's tfvars backend
+
+Started out on a local `terraform.tfvars` (or bootstrapped an S3 backend and
+want to drop it) and want to switch after the fact, without re-running the
+whole interactive scaffolder? `init-parent.ts migrate` rewires an
+already-scaffolded parent repo (one where `bootstrap` has already run and a
+`Makefile` exists) in place. Run it the same way as `bootstrap`, but from an
+existing parent repo checkout:
+
+```bash
+npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts migrate --to-s3
+# or
+npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts migrate --to-local
+```
+
+Exactly one of `--to-s3` / `--to-local` is required. Both directions prompt
+for confirmation before touching anything — pass `--yes` to skip the prompt
+(e.g. for scripting/CI).
+
+**`migrate --to-s3`** — moves a local-only parent repo onto a versioned S3
+backend:
+
+1. Reads `project_name` out of the parent repo's existing `terraform.tfvars`
+   and derives the bucket name `${project_name}-tfvars` — the same naming
+   `bootstrap --s3-tfvars` uses.
+2. Writes the `.gsd/tfvars-bucket` marker at the parent repo root.
+3. Rewrites the `Makefile` with the S3-aware targets (identical output to a
+   fresh `bootstrap` render — the Makefile is always S3-aware; only the
+   marker's presence flips `TFVARS_BACKEND` to `s3`).
+4. Runs `make setup` with `GSD_TFVARS_BACKEND=s3` so `terraform/bootstrap/`
+   provisions the bucket.
+
+`terraform.tfvars` itself is never read for anything beyond `project_name`,
+nor written by the migration — pull the now-remote copy down explicitly with
+`make tfvars-pull` if you want confirmation it round-tripped through S3 (or
+push it up with `make tfvars-push` if the bucket comes back empty).
+
+**`migrate --to-local`** — the reverse: drops an S3 backend and reverts to
+reading `terraform.tfvars` straight off disk:
+
+1. Resolves the target bucket the same way the generated Makefile's
+   `TFVARS_BUCKET` does — `GSD_TFVARS_BUCKET` env var wins if set, otherwise
+   the parent-root `.gsd/tfvars-bucket` marker, otherwise the submodule-local
+   one written by `setup.sh`. Exits `1` with no changes if none resolve
+   (already local, nothing to migrate).
+2. Pulls `terraform.tfvars` down from S3 first if it's missing locally — a
+   parent repo that migrated to S3 a while ago may have no local copy at
+   all.
+3. Diffs the local file against the remote object byte-for-byte (the same
+   comparison `make tfvars-diff` / `tfvars-sync.ts diff` uses) and **aborts,
+   leaving every file untouched**, if they've drifted — reconcile with
+   `make tfvars-pull` or `make tfvars-push` first, then re-run the
+   migration.
+4. On a clean match, deletes both the parent-root and submodule-local
+   `.gsd/tfvars-bucket` markers and the `terraform.tfvars.lock` sidecar.
+   `terraform.tfvars` itself is left in place — it's already the correct
+   source of truth for local mode once the markers are gone.
+
+`migrate --to-local` **never deletes the S3 bucket** — it only removes the
+markers that make the parent repo look at it. Tear the bucket down yourself
+once you're done with it:
+
+```bash
+terraform -chdir=Hyveon/terraform/bootstrap destroy
+```
+
+### Parent-root marker takes precedence
+
+Both migration directions, the generated Makefile's `TFVARS_BACKEND`/
+`TFVARS_BUCKET` resolution, and `setup.sh`'s post-bootstrap pull all agree on
+the same precedence when both marker files could theoretically exist: the
+**parent-root** marker (`<parent>/.gsd/tfvars-bucket`, written by
+`bootstrap --s3-tfvars` or `migrate --to-s3` before `setup.sh` ever runs)
+always wins over the **submodule-local** marker (`<parent>/Hyveon/.gsd/tfvars-bucket`,
+written by `setup.sh`'s own `bootstrap_tfvars_backend()`). An explicit
+parent-root marker reflects a deliberate operator choice, so it takes
+priority even before `setup.sh` gets a chance to write its own submodule-local
+marker. `GSD_TFVARS_BACKEND=s3|local` overrides both markers entirely when
+set.
 
 ## Submodule update with idempotent setup.sh re-run
 

--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -227,11 +227,15 @@ reading `terraform.tfvars` straight off disk:
    comparison `make tfvars-diff` / `tfvars-sync.ts diff` uses) and **aborts,
    leaving every file untouched**, if they've drifted — reconcile with
    `make tfvars-pull` or `make tfvars-push` first, then re-run the
-   migration.
-4. On a clean match, deletes both the parent-root and submodule-local
-   `.gsd/tfvars-bucket` markers and the `terraform.tfvars.lock` sidecar.
-   `terraform.tfvars` itself is left in place — it's already the correct
-   source of truth for local mode once the markers are gone.
+   migration. If `s3://<bucket>/terraform.tfvars` doesn't exist at all (the
+   bucket was created but never seeded), this comparison is skipped
+   entirely — there's nothing remote to reconcile against, so migration
+   proceeds straight to deleting the markers in step 4.
+4. On a clean match (or when the remote object was never seeded), deletes
+   both the parent-root and submodule-local `.gsd/tfvars-bucket` markers and
+   the `terraform.tfvars.lock` sidecar. `terraform.tfvars` itself is left in
+   place — it's already the correct source of truth for local mode once the
+   markers are gone.
 
 `migrate --to-local` **never deletes the S3 bucket** — it only removes the
 markers that make the parent repo look at it. Tear the bucket down yourself

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,11 +33,14 @@ npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts
 
 ### Subcommands
 
-`bootstrap` is the default and is implied whenever the first token isn't a
-recognized subcommand — existing invocations like `tsx init-parent.ts
---force` keep working unchanged.
+`bootstrap` has no subcommand token of its own — it is the implicit default,
+selected whenever the first argument is omitted or starts with `--` (e.g.
+`tsx init-parent.ts --force` keeps working unchanged). Passing the literal
+word `bootstrap` as an argument is **not** supported and exits `1` with
+`Unknown subcommand "bootstrap"` — the only recognized subcommand token is
+`migrate`.
 
-- **`bootstrap`** (default) — the interactive scaffolder described above:
+- **`bootstrap`** (default, invoked with no subcommand token) — the interactive scaffolder described above:
   prompts for parent-repo details and writes `Makefile`, `terraform.tfvars`,
   `.env`, and `.gitignore`, plus (only when requested) the
   `.gsd/tfvars-bucket` S3 backend marker.
@@ -57,11 +60,12 @@ recognized subcommand — existing invocations like `tsx init-parent.ts
   submodule-local marker), pulls `terraform.tfvars` down from S3 first if
   it's missing locally, aborts with no changes if the local file has
   drifted from the remote object (checked the same way `tfvars-sync.ts
-  diff` does), then deletes both `.gsd/tfvars-bucket` markers and the
-  `terraform.tfvars.lock` sidecar. `terraform.tfvars` itself is left in
-  place. The S3 bucket is **not** deleted — destroy it manually with
-  `terraform -chdir=<submodule>/terraform/bootstrap destroy` if you no
-  longer need it.
+  diff` does — skipped entirely if the remote object was never seeded, in
+  which case migration proceeds straight to deleting the markers), then
+  deletes both `.gsd/tfvars-bucket` markers and the `terraform.tfvars.lock`
+  sidecar. `terraform.tfvars` itself is left in place. The S3 bucket is
+  **not** deleted — destroy it manually with `terraform
+  -chdir=<submodule>/terraform/bootstrap destroy` if you no longer need it.
 
 ### Flags
 
@@ -73,11 +77,12 @@ recognized subcommand — existing invocations like `tsx init-parent.ts
 - `--to-s3` / `--to-local` — (`migrate` only) selects the migration
   direction. Exactly one is required; passing both or neither is a usage
   error.
-- `--yes` — (both subcommands) skips interactive confirmation prompts.
-  For `bootstrap`, this also skips the "bootstrap an S3-backed tfvars
-  store?" prompt and defaults it to no unless `--s3-tfvars` was also
-  passed. For `migrate`, this skips the "Proceed?" confirmation and runs
-  immediately.
+- `--yes` — for `migrate`, skips the "Proceed?" confirmation and runs
+  immediately. For `bootstrap`, it only pre-answers the "bootstrap an
+  S3-backed tfvars store?" prompt (defaulting to no unless `--s3-tfvars`
+  was also passed); all other bootstrap prompts (parent repo path,
+  submodule path, project name, AWS region, hosted zone, API token,
+  Discord credentials) still run interactively.
 
 An unrecognized subcommand, an unrecognized flag for the resolved
 subcommand, or (for `migrate`) anything other than exactly one of
@@ -93,8 +98,11 @@ npm run scripts:init-parent -- migrate --to-local
 npm run scripts:init-parent -- --force --s3-tfvars
 ```
 
-The script never reads or modifies anything inside the submodule. `bootstrap`
-is safe to re-run; without `--force` it leaves existing files alone.
+`bootstrap` never reads or modifies anything inside the submodule, and is
+safe to re-run; without `--force` it leaves existing files alone. `migrate`
+is the exception: `--to-local` may delete the submodule-local
+`.gsd/tfvars-bucket` marker (see above), and `--to-s3` runs `make setup`,
+which executes `setup.sh` inside the submodule.
 
 ### Requirements
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,11 @@ the whole stack from the parent repo root.
 
 ### Usage
 
+```bash
+init-parent.ts [--force] [--s3-tfvars] [--yes]            Interactive bootstrap (default)
+init-parent.ts migrate --to-s3 | --to-local [--yes]        Migrate an existing parent repo's tfvars backend
+```
+
 From the parent (private) repo root, after adding the submodule:
 
 ```bash
@@ -26,12 +31,70 @@ node --import tsx Hyveon/scripts/init-parent.ts
 npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts
 ```
 
-Flags:
+### Subcommands
 
-- `--force` — overwrite existing files instead of skipping them.
+`bootstrap` is the default and is implied whenever the first token isn't a
+recognized subcommand — existing invocations like `tsx init-parent.ts
+--force` keep working unchanged.
 
-The script never reads or modifies anything inside the submodule. Safe to
-re-run; without `--force` it leaves existing files alone.
+- **`bootstrap`** (default) — the interactive scaffolder described above:
+  prompts for parent-repo details and writes `Makefile`, `terraform.tfvars`,
+  `.env`, and `.gitignore`, plus (only when requested) the
+  `.gsd/tfvars-bucket` S3 backend marker.
+- **`migrate --to-s3`** — migrates an already-scaffolded parent repo (one
+  that already has a `Makefile`, i.e. `bootstrap` has already run) from a
+  local-file tfvars backend onto a versioned S3 bucket. Writes
+  `.gsd/tfvars-bucket` (`${project_name}-tfvars`, read out of the existing
+  `terraform.tfvars`'s `project_name` key), rewrites the `Makefile` with the
+  S3-aware targets, then runs `make setup` with `GSD_TFVARS_BACKEND=s3` so
+  `terraform/bootstrap/` provisions the bucket. `terraform.tfvars` itself is
+  left untouched — pull it back down from S3 afterwards with `make
+  tfvars-pull` if you want confirmation it round-tripped.
+- **`migrate --to-local`** — the reverse: drops an already-scaffolded parent
+  repo's S3 tfvars backend, reverting `make plan`/`make apply` to reading
+  `terraform.tfvars` straight off disk. Resolves the target bucket
+  (`GSD_TFVARS_BUCKET` env var, else the parent-root marker, else the
+  submodule-local marker), pulls `terraform.tfvars` down from S3 first if
+  it's missing locally, aborts with no changes if the local file has
+  drifted from the remote object (checked the same way `tfvars-sync.ts
+  diff` does), then deletes both `.gsd/tfvars-bucket` markers and the
+  `terraform.tfvars.lock` sidecar. `terraform.tfvars` itself is left in
+  place. The S3 bucket is **not** deleted — destroy it manually with
+  `terraform -chdir=<submodule>/terraform/bootstrap destroy` if you no
+  longer need it.
+
+### Flags
+
+- `--force` — (`bootstrap` only) overwrite existing files instead of
+  skipping them.
+- `--s3-tfvars` — (`bootstrap` only) pre-answers the "bootstrap an
+  S3-backed tfvars store?" prompt with yes, skipping it, and writes the
+  `.gsd/tfvars-bucket` marker up front.
+- `--to-s3` / `--to-local` — (`migrate` only) selects the migration
+  direction. Exactly one is required; passing both or neither is a usage
+  error.
+- `--yes` — (both subcommands) skips interactive confirmation prompts.
+  For `bootstrap`, this also skips the "bootstrap an S3-backed tfvars
+  store?" prompt and defaults it to no unless `--s3-tfvars` was also
+  passed. For `migrate`, this skips the "Proceed?" confirmation and runs
+  immediately.
+
+An unrecognized subcommand, an unrecognized flag for the resolved
+subcommand, or (for `migrate`) anything other than exactly one of
+`--to-s3`/`--to-local` prints a usage error to stderr and exits `1`.
+
+From inside this repo's own workspace (e.g. while developing the scaffolder
+itself), the `scripts:init-parent` npm script is an equivalent way to invoke
+it — pass subcommands/flags after `--`:
+
+```bash
+npm run scripts:init-parent -- migrate --to-s3
+npm run scripts:init-parent -- migrate --to-local
+npm run scripts:init-parent -- --force --s3-tfvars
+```
+
+The script never reads or modifies anything inside the submodule. `bootstrap`
+is safe to re-run; without `--force` it leaves existing files alone.
 
 ### Requirements
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,14 +33,14 @@ npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts
 
 ### Subcommands
 
-`bootstrap` has no subcommand token of its own — it is the implicit default,
-selected whenever the first argument is omitted or starts with `--` (e.g.
-`tsx init-parent.ts --force` keeps working unchanged). Passing the literal
-word `bootstrap` as an argument is **not** supported and exits `1` with
-`Unknown subcommand "bootstrap"` — the only recognized subcommand token is
-`migrate`.
+`bootstrap` is the implicit default, selected whenever the first argument is
+omitted or starts with `--` (e.g. `tsx init-parent.ts --force` keeps working
+unchanged). It can also be passed explicitly as the first token (e.g. `tsx
+init-parent.ts bootstrap --s3-tfvars`) — both forms parse identically. Only a
+genuinely unrecognized first token (one that isn't `bootstrap`, `migrate`, or
+a `--` flag) exits `1` with `Unknown subcommand "<token>"`.
 
-- **`bootstrap`** (default, invoked with no subcommand token) — the interactive scaffolder described above:
+- **`bootstrap`** (default; may be given explicitly or omitted) — the interactive scaffolder described above:
   prompts for parent-repo details and writes `Makefile`, `terraform.tfvars`,
   `.env`, and `.gitignore`, plus (only when requested) the
   `.gsd/tfvars-bucket` S3 backend marker.

--- a/scripts/init-parent.cli.test.ts
+++ b/scripts/init-parent.cli.test.ts
@@ -112,6 +112,23 @@ describe('parseCliArgs', () => {
   it('should throw CliUsageError when migrate is given both --to-s3 and --to-local', () => {
     expect(() => parseCliArgs(['migrate', '--to-s3', '--to-local'])).toThrow(CliUsageError);
   });
+
+  it('should throw CliUsageError for an unrecognized subcommand', () => {
+    expect(() => parseCliArgs(['frobnicate'])).toThrow(CliUsageError);
+    expect(() => parseCliArgs(['frobnicate'])).toThrow('Unknown subcommand "frobnicate".');
+  });
+
+  it('should throw CliUsageError for an unknown flag under the default bootstrap command', () => {
+    expect(() => parseCliArgs(['--to-s3'])).toThrow(CliUsageError);
+    expect(() => parseCliArgs(['--to-s3'])).toThrow(
+      'Unknown flag "--to-s3" for the default bootstrap command.',
+    );
+  });
+
+  it('should throw CliUsageError when migrate is given a bootstrap-only flag', () => {
+    expect(() => parseCliArgs(['migrate', '--force'])).toThrow(CliUsageError);
+    expect(() => parseCliArgs(['migrate', '--force'])).toThrow('Unknown flag "--force" for \'migrate\'.');
+  });
 });
 
 describe('runBootstrap --s3-tfvars', () => {
@@ -153,6 +170,29 @@ describe('runBootstrap --s3-tfvars', () => {
     expect(makefile).toContain('PARENT_TFVARS_MARKER := $(REPO_ROOT)/.gsd/tfvars-bucket');
     expect(existsSync(join(parentDir, 'terraform.tfvars'))).toBe(true);
     expect(existsSync(join(parentDir, '.env'))).toBe(true);
+  });
+
+  it('should write the .gsd/tfvars-bucket marker when --s3-tfvars is omitted but the operator answers "y" to the interactive prompt', async () => {
+    queueReadlineAnswers([
+      parentDir, // Parent repo path
+      'Hyveon', // Submodule path
+      'test-parent', // Project name
+      'us-east-1', // AWS region
+      'example.com', // Route 53 hosted zone
+      '', // API_TOKEN (accept generated)
+      'n', // Seed Discord credentials?
+      'y', // Bootstrap an S3-backed tfvars store now?
+    ]);
+
+    const { s3Tfvars, yes } = parseCliArgs([]);
+    expect(s3Tfvars).toBe(false);
+    expect(yes).toBe(false);
+
+    await runBootstrap({ s3Tfvars, yes });
+
+    const markerPath = join(parentDir, '.gsd', 'tfvars-bucket');
+    expect(existsSync(markerPath)).toBe(true);
+    expect(readFileSync(markerPath, 'utf8')).toBe('test-parent-tfvars\n');
   });
 
   it('should NOT write the .gsd/tfvars-bucket marker when --s3-tfvars is omitted and --yes defaults the prompt to no', async () => {
@@ -413,5 +453,132 @@ describe('runMigrate --to-local (bucket never seeded)', () => {
     expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
     expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(false);
     expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(tfvarsContent);
+  });
+});
+
+describe('runMigrate --to-local (confirmation declined)', () => {
+  let parentDir: string;
+  let originalCwd: string;
+  const tfvarsContent = 'project_name = "test-parent"\n';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), tfvarsContent);
+    mkdirSync(join(parentDir, '.gsd'), { recursive: true });
+    writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should make no changes and never contact S3 when the confirmation prompt is declined', async () => {
+    queueReadlineAnswers(['n']); // Declines the "Proceed?" prompt.
+
+    await runMigrate('to-local', { yes: false });
+
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(true);
+    expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(true);
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(tfvarsContent);
+    // The drift check (lockStatus/diffTfvars, both backed by the S3 client)
+    // only runs after the confirmation — a decline must short-circuit before
+    // any S3 call is made.
+    expect(s3Mock.calls()).toHaveLength(0);
+    expect(vi.mocked(exit)).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMigrate --to-local (no resolvable bucket)', () => {
+  let parentDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+    delete process.env.GSD_TFVARS_BUCKET;
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), 'project_name = "test-parent"\n');
+    // Deliberately no .gsd/tfvars-bucket marker anywhere (parent root or
+    // submodule) and no GSD_TFVARS_BUCKET env var — this parent repo was
+    // never migrated to S3, so there's nothing to resolve.
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should exit 1 without contacting S3 when neither GSD_TFVARS_BUCKET nor any marker file resolves a bucket', async () => {
+    await runMigrate('to-local', { yes: true });
+
+    expect(vi.mocked(exit)).toHaveBeenCalledWith(1);
+    expect(s3Mock.calls()).toHaveLength(0);
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe('project_name = "test-parent"\n');
+  });
+});
+
+describe('runMigrate --to-local (bucket resolution precedence)', () => {
+  let parentDir: string;
+  let originalCwd: string;
+  const tfvarsContent = 'project_name = "test-parent"\n';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+    delete process.env.GSD_TFVARS_BUCKET;
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), tfvarsContent);
+    writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
+
+    s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
+    s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(tfvarsContent) as never });
+  });
+
+  afterEach(() => {
+    delete process.env.GSD_TFVARS_BUCKET;
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should prefer GSD_TFVARS_BUCKET over the parent-root marker when both are set', async () => {
+    mkdirSync(join(parentDir, '.gsd'), { recursive: true });
+    writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'marker-bucket\n');
+    process.env.GSD_TFVARS_BUCKET = 'env-bucket';
+
+    await runMigrate('to-local', { yes: true });
+
+    expect(vi.mocked(exit)).not.toHaveBeenCalled();
+    expect(s3Mock.commandCalls(HeadObjectCommand)[0]?.args[0].input).toMatchObject({ Bucket: 'env-bucket' });
+    // The env var takes precedence for bucket resolution, but the marker
+    // deleted is still whichever one(s) exist on disk.
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+  });
+
+  it('should fall back to the submodule-local marker and delete it when no parent-root marker exists', async () => {
+    const submoduleMarkerDir = join(parentDir, 'Hyveon', '.gsd');
+    mkdirSync(submoduleMarkerDir, { recursive: true });
+    writeFileSync(join(submoduleMarkerDir, 'tfvars-bucket'), 'submodule-bucket\n');
+    // Deliberately no parent-root .gsd/tfvars-bucket marker.
+
+    await runMigrate('to-local', { yes: true });
+
+    expect(vi.mocked(exit)).not.toHaveBeenCalled();
+    expect(s3Mock.commandCalls(HeadObjectCommand)[0]?.args[0].input).toMatchObject({ Bucket: 'submodule-bucket' });
+    expect(existsSync(join(submoduleMarkerDir, 'tfvars-bucket'))).toBe(false);
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+    expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(false);
   });
 });

--- a/scripts/init-parent.cli.test.ts
+++ b/scripts/init-parent.cli.test.ts
@@ -13,7 +13,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -261,8 +261,10 @@ describe('runMigrate --to-local', () => {
     writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
     writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
 
-    // Remote content matches local, so diffTfvars() reports no drift and the
+    // Remote object exists (lockStatus()'s HeadObjectCommand check) and its
+    // content matches local, so diffTfvars() reports no drift and the
     // migration is allowed to delete the markers.
+    s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
     s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(tfvarsContent) as never });
   });
 
@@ -301,6 +303,7 @@ describe('runMigrate --to-local (terraform.tfvars missing locally)', () => {
     // sourcing it purely from S3, so runMigrateToLocal must pull one down
     // first (before the drift check can even run).
 
+    s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
     s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(remoteContent) as never });
   });
 
@@ -343,8 +346,10 @@ describe('runMigrate --to-local (drift abort)', () => {
     writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
     writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
 
-    // Remote content differs from local, so diffTfvars() reports drift and
-    // the migration must abort without touching any files.
+    // Remote object exists but its content differs from local, so
+    // diffTfvars() reports drift and the migration must abort without
+    // touching any files.
+    s3Mock.on(HeadObjectCommand).resolves({ VersionId: 'v1', ETag: '"etag-1"' });
     s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(remoteContent) as never });
   });
 
@@ -360,5 +365,44 @@ describe('runMigrate --to-local (drift abort)', () => {
     expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(true);
     expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(true);
     expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(localContent);
+  });
+});
+
+describe('runMigrate --to-local (bucket never seeded)', () => {
+  let parentDir: string;
+  let originalCwd: string;
+  const tfvarsContent = 'project_name = "test-parent"\n';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), tfvarsContent);
+    mkdirSync(join(parentDir, '.gsd'), { recursive: true });
+    writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
+
+    // The bucket marker exists (e.g. `bootstrap --s3-tfvars` ran) but the
+    // remote object was never seeded (the initial `make tfvars-push`/pull
+    // step was skipped) — lockStatus()'s HeadObjectCommand check reports the
+    // object missing, so there is nothing remote to diff against or strand.
+    s3Mock.on(HeadObjectCommand).rejects({ name: 'NotFound', $metadata: { httpStatusCode: 404 } });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should proceed with the migration instead of reporting drift when the remote object was never seeded', async () => {
+    await runMigrate('to-local', { yes: true });
+
+    expect(vi.mocked(exit)).not.toHaveBeenCalled();
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+    expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(false);
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(tfvarsContent);
   });
 });

--- a/scripts/init-parent.cli.test.ts
+++ b/scripts/init-parent.cli.test.ts
@@ -75,6 +75,15 @@ describe('parseCliArgs', () => {
     expect(parseCliArgs(['--s3-tfvars'])).toEqual({ command: 'bootstrap', force: false, s3Tfvars: true, yes: false });
   });
 
+  it('should accept an explicit "bootstrap" subcommand token identically to omitting it', () => {
+    expect(parseCliArgs(['bootstrap', '--s3-tfvars'])).toEqual({
+      command: 'bootstrap',
+      force: false,
+      s3Tfvars: true,
+      yes: false,
+    });
+  });
+
   it('should set direction "to-s3" for "migrate --to-s3"', () => {
     expect(parseCliArgs(['migrate', '--to-s3'])).toEqual({
       command: 'migrate',

--- a/scripts/init-parent.cli.test.ts
+++ b/scripts/init-parent.cli.test.ts
@@ -318,6 +318,10 @@ describe('runMigrate --to-local (terraform.tfvars missing locally)', () => {
     // missing/empty local file and aborted instead.
     expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(remoteContent);
     expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+    // pullTfvars() also writes terraform.tfvars.lock as a side effect of the
+    // pull-if-missing step — the migration must still delete it, not just the
+    // lock that existed (or didn't) before the pull ran.
+    expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(false);
   });
 });
 

--- a/scripts/init-parent.cli.test.ts
+++ b/scripts/init-parent.cli.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Vitest CLI spec for init-parent.ts's `bootstrap --s3-tfvars` flag and both
+ * `migrate --to-s3` / `migrate --to-local` directions (issue #89). Covers CLI
+ * argument parsing plus the actual file-system effects of each flow.
+ *
+ * `node:readline/promises` and `node:child_process`'s `spawnSync` are mocked
+ * so no real interactive prompts or `make` invocations happen; the S3 client
+ * is mocked via `aws-sdk-client-mock`, the same approach `tfvars-sync.test.ts`
+ * uses. `renderMakefile`/`renderTfvars`/etc.'s own render-shape checks live in
+ * `init-parent.test.ts` — this spec only asserts the CLI dispatch + IO
+ * behaviour layered on top of them.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Interface } from 'node:readline/promises';
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: vi.fn(),
+}));
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+// Preserves every other `node:process` export (cwd, stdin, stdout, argv, ...)
+// but replaces `exit` with a no-op mock, so the drift-abort / make-setup-failure
+// branches in init-parent.ts (which call `exit(1)` then `return;`) can be
+// exercised without actually killing the Vitest worker process.
+vi.mock('node:process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:process')>();
+  return { ...actual, exit: vi.fn() };
+});
+
+import { createInterface } from 'node:readline/promises';
+import { spawnSync } from 'node:child_process';
+import { exit } from 'node:process';
+import { CliUsageError, parseCliArgs, runBootstrap, runMigrate } from './init-parent.ts';
+
+/** Typed stand-in for the AWS S3 SDK client — patches every `new S3Client()` instance (shared by tfvars-sync.ts's pull/diff calls). */
+const s3Mock = mockClient(S3Client);
+
+/** Builds a fake `GetObjectCommand` `Body` whose `transformToString()` resolves to `content`. */
+function fakeBody(content: string): { transformToString: () => Promise<string> } {
+  return { transformToString: async () => content };
+}
+
+/**
+ * Wires the mocked `node:readline/promises` `createInterface` to hand back
+ * `answers` in order, one per `question()` call — mirroring the sequence of
+ * prompts `runBootstrap` asks. Throws if more questions are asked than
+ * answers were queued, so a spec fails loudly (instead of silently reading
+ * `undefined`) if a code change adds an unexpected prompt.
+ */
+function queueReadlineAnswers(answers: string[]): void {
+  const queue = [...answers];
+  const stub: Partial<Interface> = {
+    question: vi.fn(async () => {
+      if (queue.length === 0) throw new Error('queueReadlineAnswers: ran out of queued answers');
+      return queue.shift() as string;
+    }),
+    close: vi.fn(),
+  };
+  vi.mocked(createInterface).mockReturnValue(stub as Interface);
+}
+
+describe('parseCliArgs', () => {
+  it('should default to bootstrap with s3Tfvars false when no flags are given', () => {
+    expect(parseCliArgs([])).toEqual({ command: 'bootstrap', force: false, s3Tfvars: false, yes: false });
+  });
+
+  it('should set s3Tfvars true for "bootstrap --s3-tfvars"', () => {
+    expect(parseCliArgs(['--s3-tfvars'])).toEqual({ command: 'bootstrap', force: false, s3Tfvars: true, yes: false });
+  });
+
+  it('should set direction "to-s3" for "migrate --to-s3"', () => {
+    expect(parseCliArgs(['migrate', '--to-s3'])).toEqual({
+      command: 'migrate',
+      force: false,
+      s3Tfvars: false,
+      yes: false,
+      direction: 'to-s3',
+    });
+  });
+
+  it('should set direction "to-local" for "migrate --to-local"', () => {
+    expect(parseCliArgs(['migrate', '--to-local'])).toEqual({
+      command: 'migrate',
+      force: false,
+      s3Tfvars: false,
+      yes: false,
+      direction: 'to-local',
+    });
+  });
+
+  it('should throw CliUsageError when migrate is given neither --to-s3 nor --to-local', () => {
+    expect(() => parseCliArgs(['migrate'])).toThrow(CliUsageError);
+    expect(() => parseCliArgs(['migrate'])).toThrow('migrate requires exactly one of --to-s3 | --to-local.');
+  });
+
+  it('should throw CliUsageError when migrate is given both --to-s3 and --to-local', () => {
+    expect(() => parseCliArgs(['migrate', '--to-s3', '--to-local'])).toThrow(CliUsageError);
+  });
+});
+
+describe('runBootstrap --s3-tfvars', () => {
+  let parentDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should write the .gsd/tfvars-bucket marker (and the rest of the scaffold) when --s3-tfvars is passed', async () => {
+    queueReadlineAnswers([
+      parentDir, // Parent repo path
+      'Hyveon', // Submodule path
+      'test-parent', // Project name
+      'us-east-1', // AWS region
+      'example.com', // Route 53 hosted zone
+      '', // API_TOKEN (accept generated)
+      'n', // Seed Discord credentials?
+    ]);
+
+    const { s3Tfvars } = parseCliArgs(['--s3-tfvars']);
+    expect(s3Tfvars).toBe(true);
+
+    await runBootstrap({ s3Tfvars, yes: false });
+
+    const markerPath = join(parentDir, '.gsd', 'tfvars-bucket');
+    expect(existsSync(markerPath)).toBe(true);
+    expect(readFileSync(markerPath, 'utf8')).toBe('test-parent-tfvars\n');
+
+    const makefile = readFileSync(join(parentDir, 'Makefile'), 'utf8');
+    expect(makefile).toContain('PARENT_TFVARS_MARKER := $(REPO_ROOT)/.gsd/tfvars-bucket');
+    expect(existsSync(join(parentDir, 'terraform.tfvars'))).toBe(true);
+    expect(existsSync(join(parentDir, '.env'))).toBe(true);
+  });
+
+  it('should NOT write the .gsd/tfvars-bucket marker when --s3-tfvars is omitted and --yes defaults the prompt to no', async () => {
+    queueReadlineAnswers([
+      parentDir, // Parent repo path
+      'Hyveon', // Submodule path
+      'test-parent', // Project name
+      'us-east-1', // AWS region
+      'example.com', // Route 53 hosted zone
+      '', // API_TOKEN (accept generated)
+      'n', // Seed Discord credentials?
+      // No S3-tfvars prompt answer needed — `yes: true` without `s3Tfvars` skips it, defaulting to no.
+    ]);
+
+    const { s3Tfvars, yes } = parseCliArgs(['--yes']);
+    expect(s3Tfvars).toBe(false);
+
+    await runBootstrap({ s3Tfvars, yes });
+
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+  });
+});
+
+describe('runMigrate --to-s3', () => {
+  let parentDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+
+    // Minimal already-scaffolded parent repo: a Makefile with just the
+    // SUBMODULE line readExistingParent()/locateExistingParent() parse, and a
+    // terraform.tfvars carrying project_name.
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), 'project_name = "test-parent"\n');
+
+    const success: Partial<ReturnType<typeof spawnSync>> = { status: 0, error: undefined };
+    vi.mocked(spawnSync).mockReturnValue(success as ReturnType<typeof spawnSync>);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should write the tfvars-bucket marker, rewrite the Makefile with s3-aware targets, and run `make setup` with GSD_TFVARS_BACKEND=s3', async () => {
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const { direction } = parseCliArgs(['migrate', '--to-s3']);
+    expect(direction).toBe('to-s3');
+
+    await runMigrate('to-s3', { yes: true });
+
+    const markerPath = join(parentDir, '.gsd', 'tfvars-bucket');
+    expect(existsSync(markerPath)).toBe(true);
+    expect(readFileSync(markerPath, 'utf8')).toBe('test-parent-tfvars\n');
+
+    const makefile = readFileSync(join(parentDir, 'Makefile'), 'utf8');
+    expect(makefile).toContain('PARENT_TFVARS_MARKER := $(REPO_ROOT)/.gsd/tfvars-bucket');
+    // terraform.tfvars itself is left untouched by migrate --to-s3.
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe('project_name = "test-parent"\n');
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'make',
+      ['setup'],
+      expect.objectContaining({ cwd: parentDir, env: expect.objectContaining({ GSD_TFVARS_BACKEND: 's3' }) }),
+    );
+
+    // One-time note pointing operators at `make tfvars-pull` to fetch
+    // terraform.tfvars back down, since migrate --to-s3 never writes it itself.
+    const written = writeSpy.mock.calls.map((args) => String(args[0])).join('');
+    expect(written).toContain('make tfvars-pull');
+  });
+
+  it('should make no changes and never call spawnSync when the confirmation prompt is declined', async () => {
+    queueReadlineAnswers(['n']); // Declines the "Proceed?" prompt.
+
+    await runMigrate('to-s3', { yes: false });
+
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+    expect(readFileSync(join(parentDir, 'Makefile'), 'utf8')).toBe('SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('should exit 1 without rolling back the marker/Makefile when `make setup` fails', async () => {
+    const failure: Partial<ReturnType<typeof spawnSync>> = { status: 1, error: undefined };
+    vi.mocked(spawnSync).mockReturnValue(failure as ReturnType<typeof spawnSync>);
+
+    await runMigrate('to-s3', { yes: true });
+
+    expect(vi.mocked(exit)).toHaveBeenCalledWith(1);
+    // Marker + Makefile are written before `make setup` runs — a failed
+    // `make setup` doesn't roll them back, so a re-run only needs to retry it.
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(true);
+    expect(readFileSync(join(parentDir, 'Makefile'), 'utf8')).toContain('PARENT_TFVARS_MARKER := $(REPO_ROOT)/.gsd/tfvars-bucket');
+  });
+});
+
+describe('runMigrate --to-local', () => {
+  let parentDir: string;
+  let originalCwd: string;
+  const tfvarsContent = 'project_name = "test-parent"\n';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), tfvarsContent);
+    mkdirSync(join(parentDir, '.gsd'), { recursive: true });
+    writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
+
+    // Remote content matches local, so diffTfvars() reports no drift and the
+    // migration is allowed to delete the markers.
+    s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(tfvarsContent) as never });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should delete the tfvars-bucket marker and lock sidecar, leaving terraform.tfvars untouched, when local and remote match', async () => {
+    const { direction } = parseCliArgs(['migrate', '--to-local']);
+    expect(direction).toBe('to-local');
+
+    await runMigrate('to-local', { yes: true });
+
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+    expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(false);
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(tfvarsContent);
+  });
+});
+
+describe('runMigrate --to-local (terraform.tfvars missing locally)', () => {
+  let parentDir: string;
+  let originalCwd: string;
+  const remoteContent = 'project_name = "test-parent"\n';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    mkdirSync(join(parentDir, '.gsd'), { recursive: true });
+    writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
+    // Deliberately no terraform.tfvars written — this parent repo is currently
+    // sourcing it purely from S3, so runMigrateToLocal must pull one down
+    // first (before the drift check can even run).
+
+    s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(remoteContent) as never });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should pull terraform.tfvars from S3 before the drift check runs when it is missing locally', async () => {
+    await runMigrate('to-local', { yes: true });
+
+    // pullTfvars() wrote the local file before diffTfvars() compared it —
+    // proven by the migration completing cleanly (markers deleted): if the
+    // pull hadn't happened first, diffTfvars would have compared against a
+    // missing/empty local file and aborted instead.
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(remoteContent);
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(false);
+  });
+});
+
+describe('runMigrate --to-local (drift abort)', () => {
+  let parentDir: string;
+  let originalCwd: string;
+  const localContent = 'project_name = "test-parent"\n';
+  const remoteContent = 'project_name = "test-parent-DRIFTED"\n';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    process.chdir(mkdtempSync(join(tmpdir(), 'init-parent-cli-test-')));
+    parentDir = process.cwd();
+    s3Mock.reset();
+
+    writeFileSync(join(parentDir, 'Makefile'), 'SUBMODULE   := $(REPO_ROOT)/Hyveon\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars'), localContent);
+    mkdirSync(join(parentDir, '.gsd'), { recursive: true });
+    writeFileSync(join(parentDir, '.gsd', 'tfvars-bucket'), 'test-parent-tfvars\n');
+    writeFileSync(join(parentDir, 'terraform.tfvars.lock'), '{}\n');
+
+    // Remote content differs from local, so diffTfvars() reports drift and
+    // the migration must abort without touching any files.
+    s3Mock.on(GetObjectCommand).resolves({ Body: fakeBody(remoteContent) as never });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it('should abort without deleting markers/lock or touching terraform.tfvars when local and remote have drifted', async () => {
+    await runMigrate('to-local', { yes: true });
+
+    expect(vi.mocked(exit)).toHaveBeenCalledWith(1);
+    expect(existsSync(join(parentDir, '.gsd', 'tfvars-bucket'))).toBe(true);
+    expect(existsSync(join(parentDir, 'terraform.tfvars.lock'))).toBe(true);
+    expect(readFileSync(join(parentDir, 'terraform.tfvars'), 'utf8')).toBe(localContent);
+  });
+});

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -110,6 +110,17 @@ expect('Makefile apply depends on check-tfvars-if-needed', mk.includes('apply: c
 const setupRecipeMatch = /^setup:.*\n(?:(?:\t|#).*\n?)*/m.exec(mk);
 const setupRecipe = setupRecipeMatch ? setupRecipeMatch[0] : '';
 expect('Makefile has a setup: recipe to inspect', setupRecipe !== '');
+// Regression coverage: setup.sh's bootstrap_tfvars_backend() derives
+// TF_PROJECT from $(TF_DIR)/terraform.tfvars, not from the parent-root
+// $(TFVARS)/PARENT_TFVARS_MARKER. Without copying the parent's tfvars into
+// the submodule first, a first-ever `make setup` would see the
+// "game-servers" default from terraform.tfvars.example and bootstrap a
+// differently-named bucket than the one PARENT_TFVARS_MARKER records.
+expect(
+  'Makefile setup copies the parent tfvars into the submodule before running setup.sh, so TF_PROJECT (and the bucket setup.sh bootstraps) matches the project name PARENT_TFVARS_MARKER was derived from',
+  setupRecipe.includes('cp $(TFVARS) $(TF_DIR)/terraform.tfvars') &&
+    setupRecipe.indexOf('cp $(TFVARS) $(TF_DIR)/terraform.tfvars') < setupRecipe.indexOf('bash $(SUBMODULE)/setup.sh'),
+);
 expect(
   'Makefile setup runtime-pulls tfvars post-bootstrap via a shell-native (not make-variable) S3 backend check that also honors the parent-root marker',
   setupRecipe.includes(

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -120,11 +120,18 @@ expect(
 );
 
 // ── setup exports GSD_TFVARS_BACKEND=s3 when the parent-root marker exists ──
+// (but only when GSD_TFVARS_BACKEND is not already set — an explicit
+// GSD_TFVARS_BACKEND=local override must survive into setup.sh's environment
+// too, per TFVARS_BACKEND's own override precedence)
 expect(
-  'Makefile setup exports GSD_TFVARS_BACKEND=s3 into setup.sh\'s environment when the parent-root marker exists',
-  /if \[ -f \$\(PARENT_TFVARS_MARKER\) \]; then export GSD_TFVARS_BACKEND=s3; fi; \\\n\tbash \$\(SUBMODULE\)\/setup\.sh/.test(
+  'Makefile setup exports GSD_TFVARS_BACKEND=s3 into setup.sh\'s environment when the parent-root marker exists and GSD_TFVARS_BACKEND is unset',
+  /if \[ -z "\$\$\{GSD_TFVARS_BACKEND:-\}" \] && \[ -f \$\(PARENT_TFVARS_MARKER\) \]; then export GSD_TFVARS_BACKEND=s3; fi; \\\n\tbash \$\(SUBMODULE\)\/setup\.sh/.test(
     setupRecipe,
   ),
+);
+expect(
+  'Makefile setup\'s parent-marker export does not clobber an explicit GSD_TFVARS_BACKEND=local override',
+  setupRecipe.includes('if [ -z "$${GSD_TFVARS_BACKEND:-}" ] && [ -f $(PARENT_TFVARS_MARKER) ]; then export GSD_TFVARS_BACKEND=s3; fi;'),
 );
 expect(
   'Makefile setup\'s parent-marker export line precedes the bash setup.sh invocation within the same recipe',

--- a/scripts/init-parent.test.ts
+++ b/scripts/init-parent.test.ts
@@ -39,13 +39,39 @@ expect('Makefile does NOT inline API_TOKEN', !/API_TOKEN\s*:?=\s*[a-f0-9]{40,}/.
 // ── S3 tfvars backend detection block ───────────────────────────────────────
 expect('Makefile defines TFVARS_MARKER', mk.includes('TFVARS_MARKER := $(SUBMODULE)/.gsd/tfvars-bucket'));
 expect('Makefile defines TFVARS_LOCK', mk.includes('TFVARS_LOCK   := $(TFVARS).lock'));
+expect('Makefile defines PARENT_TFVARS_MARKER at the parent repo root', mk.includes('PARENT_TFVARS_MARKER := $(REPO_ROOT)/.gsd/tfvars-bucket'));
 expect(
-  'Makefile defines TFVARS_BACKEND gated on GSD_TFVARS_BACKEND override then the marker file',
+  'Makefile defines TFVARS_BACKEND gated on GSD_TFVARS_BACKEND override, then the parent-root marker, then the submodule marker',
   mk.includes(
-    'TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(TFVARS_MARKER)),s3,local)))',
+    'TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(PARENT_TFVARS_MARKER)),s3,$(if $(wildcard $(TFVARS_MARKER)),s3,local))))',
   ),
 );
 expect('Makefile routes TFVARS_SYNC --bucket through TFVARS_MARKER', mk.includes('cat $(TFVARS_MARKER)'));
+
+// ── Parent-root marker precedence (prefers parent, falls back to submodule) ─
+expect(
+  'Makefile TFVARS_BACKEND checks the parent-root marker before the submodule marker',
+  mk.indexOf('$(wildcard $(PARENT_TFVARS_MARKER))') < mk.indexOf('$(wildcard $(TFVARS_MARKER))') &&
+    mk.indexOf('$(wildcard $(PARENT_TFVARS_MARKER))') !== -1,
+);
+expect(
+  'Makefile TFVARS_BACKEND falls back to the submodule marker when no parent-root marker exists',
+  mk.includes('$(if $(wildcard $(TFVARS_MARKER)),s3,local)'),
+);
+expect(
+  'Makefile TFVARS_BUCKET prefers the parent-root marker contents, falling back to the submodule marker',
+  mk.includes(
+    'TFVARS_BUCKET = $(if $(GSD_TFVARS_BUCKET),$(GSD_TFVARS_BUCKET),$(shell cat $(PARENT_TFVARS_MARKER) 2>/dev/null || cat $(TFVARS_MARKER) 2>/dev/null))',
+  ),
+);
+expect(
+  'Makefile TFVARS_SYNC_ARGS resolves --bucket from the parent-root marker before the submodule marker',
+  mk.includes('cat $(PARENT_TFVARS_MARKER) 2>/dev/null || cat $(TFVARS_MARKER) 2>/dev/null'),
+);
+expect(
+  'Makefile help text mentions the parent-root marker before the submodule marker fallback',
+  /otherwise inferred from \$\(PARENT_TFVARS_MARKER\), falling back to \$\(TFVARS_MARKER\)/.test(mk),
+);
 
 // ── Gated tfvars-* targets ───────────────────────────────────────────────────
 expect('Makefile phonies list tfvars-pull/push/diff (not tfvars-status)', mk.includes('tfvars-pull tfvars-push tfvars-diff'));
@@ -85,12 +111,26 @@ const setupRecipeMatch = /^setup:.*\n(?:(?:\t|#).*\n?)*/m.exec(mk);
 const setupRecipe = setupRecipeMatch ? setupRecipeMatch[0] : '';
 expect('Makefile has a setup: recipe to inspect', setupRecipe !== '');
 expect(
-  'Makefile setup runtime-pulls tfvars post-bootstrap via a shell-native (not make-variable) S3 backend check',
+  'Makefile setup runtime-pulls tfvars post-bootstrap via a shell-native (not make-variable) S3 backend check that also honors the parent-root marker',
   setupRecipe.includes(
-    '[ "$${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$${GSD_TFVARS_BACKEND:-}" != local ] && [ -f $(TFVARS_MARKER) ]; }',
+    '[ "$${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$${GSD_TFVARS_BACKEND:-}" != local ] && { [ -f $(PARENT_TFVARS_MARKER) ] || [ -f $(TFVARS_MARKER) ]; }; }',
   ) &&
     setupRecipe.includes('$(TFVARS_SYNC) pull $(TFVARS_SYNC_ARGS) 2>&1') &&
     !/if \[ "\$\(TFVARS_BACKEND\)" = s3 \]/.test(setupRecipe),
+);
+
+// ── setup exports GSD_TFVARS_BACKEND=s3 when the parent-root marker exists ──
+expect(
+  'Makefile setup exports GSD_TFVARS_BACKEND=s3 into setup.sh\'s environment when the parent-root marker exists',
+  /if \[ -f \$\(PARENT_TFVARS_MARKER\) \]; then export GSD_TFVARS_BACKEND=s3; fi; \\\n\tbash \$\(SUBMODULE\)\/setup\.sh/.test(
+    setupRecipe,
+  ),
+);
+expect(
+  'Makefile setup\'s parent-marker export line precedes the bash setup.sh invocation within the same recipe',
+  setupRecipe.indexOf('export GSD_TFVARS_BACKEND=s3') <
+    setupRecipe.indexOf('bash $(SUBMODULE)/setup.sh') &&
+    setupRecipe.indexOf('export GSD_TFVARS_BACKEND=s3') !== -1,
 );
 expect(
   'Makefile setup tolerates a first-time pull against an empty bucket instead of aborting',

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -615,10 +615,13 @@ export interface BootstrapOptions {
   s3Tfvars: boolean;
   /** Skips the interactive prompt entirely when `s3Tfvars` wasn't already passed, defaulting to no. */
   yes: boolean;
+  /** Overwrites existing Makefile/terraform.tfvars/.env/.gitignore instead of skipping them. Mirrors the module-level `FORCE` flag so callers of the exported API (not just the CLI entrypoint) can drive `--force` behaviour. */
+  force?: boolean;
 }
 
 /** The interactive bootstrap flow: prompts for parent-repo details and writes Makefile/terraform.tfvars/.env/.gitignore (and, when requested, the `.gsd/tfvars-bucket` S3 backend marker). Exported so the entrypoint guard below can invoke it after CLI parsing. */
 export async function runBootstrap(options: BootstrapOptions = { s3Tfvars: false, yes: false }): Promise<void> {
+  FORCE = options.force ?? FORCE;
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const guessedParent = findParentRepoRoot(cwd()) ?? findParentRepoRoot(scriptDir) ?? cwd();
 
@@ -1152,27 +1155,34 @@ const isEntrypoint =
   argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(argv[1]);
 
 if (isEntrypoint) {
-  let CLI: CliArgs;
-  try {
-    CLI = parseCliArgs(argv.slice(2));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`\n  ✗ ${message}\n\n${USAGE}`);
-    exit(1);
-  }
+  // Wrapped in an IIFE (rather than left as bare top-level statements) so the
+  // catch block below can `return;` immediately after `exit(1)` — top-level
+  // `return` isn't legal in an ES module, and without it a mocked `exit()` in
+  // tests would fall through to `CLI.command` while `CLI` is still
+  // unassigned.
+  (function dispatchCli(): void {
+    let CLI: CliArgs;
+    try {
+      CLI = parseCliArgs(argv.slice(2));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`\n  ✗ ${message}\n\n${USAGE}`);
+      exit(1);
+      return;
+    }
 
-  if (CLI.command === 'migrate') {
-    // parseCliArgs guarantees exactly one of --to-s3 | --to-local by the time
-    // command === 'migrate' is returned, so direction is always defined here.
-    runMigrate(CLI.direction as MigrateDirection, { yes: CLI.yes }).catch((err) => {
-      process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
-      exit(1);
-    });
-  } else {
-    FORCE = CLI.force;
-    runBootstrap({ s3Tfvars: CLI.s3Tfvars, yes: CLI.yes }).catch((err) => {
-      process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
-      exit(1);
-    });
-  }
+    if (CLI.command === 'migrate') {
+      // parseCliArgs guarantees exactly one of --to-s3 | --to-local by the time
+      // command === 'migrate' is returned, so direction is always defined here.
+      runMigrate(CLI.direction as MigrateDirection, { yes: CLI.yes }).catch((err) => {
+        process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
+        exit(1);
+      });
+    } else {
+      runBootstrap({ s3Tfvars: CLI.s3Tfvars, yes: CLI.yes, force: CLI.force }).catch((err) => {
+        process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
+        exit(1);
+      });
+    }
+  })();
 }

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -31,7 +31,7 @@ import { fileURLToPath } from 'node:url';
 import { stdin as input, stdout as output, argv, cwd, exit } from 'node:process';
 import { randomBytes } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
-import { diffTfvars, pullTfvars, type DiffResult } from './tfvars-sync.ts';
+import { diffTfvars, pullTfvars, lockStatus, type DiffResult, type StatusReport } from './tfvars-sync.ts';
 
 interface Answers {
   parentDir: string;
@@ -314,6 +314,16 @@ $(STAMP_DIR):
 # ── One-time setup ───────────────────────────────────────────────────────────
 setup: | $(STAMP_DIR)
 \tgit submodule update --init --recursive
+# Copy the parent's terraform.tfvars into the submodule *before* setup.sh
+# runs (mirroring the copy-tfvars target below), so setup.sh's
+# bootstrap_tfvars_backend() derives the bootstrap bucket name from the same
+# project_name this Makefile (and PARENT_TFVARS_MARKER, if written by
+# \`init-parent bootstrap --s3-tfvars\`/\`migrate --to-s3\`) was generated from.
+# Without this, setup.sh would see whatever project_name is already checked
+# into $(TF_DIR)/terraform.tfvars (e.g. the "game-servers" default seeded
+# from terraform.tfvars.example on a first run) and bootstrap a
+# differently-named bucket than the one PARENT_TFVARS_MARKER points at.
+\tcp $(TFVARS) $(TF_DIR)/terraform.tfvars
 # PARENT_TFVARS_MARKER is written by \`init-parent bootstrap --s3-tfvars\`
 # before setup.sh has ever run, so it reflects an operator's up-front choice
 # to run in S3 mode. Export GSD_TFVARS_BACKEND=s3 into setup.sh's own
@@ -937,11 +947,17 @@ export async function runMigrate(direction: MigrateDirection, options: MigrateOp
  *   2. If `terraform.tfvars` doesn't exist locally yet (the parent repo may
  *      currently be sourcing it purely from S3), pull it down via
  *      `pullTfvars()` first so there's something to compare/leave behind.
- *   3. Compare the (now-guaranteed-present) local `terraform.tfvars` against
- *      the remote S3 object byte-for-byte via `diffTfvars()` (the same
- *      comparison the `tfvars diff` subcommand uses) and abort — leaving
- *      every file untouched — if they've drifted, since deleting the markers
- *      would otherwise silently strand whichever side lost the race.
+ *   3. Check whether the remote S3 object exists at all via `lockStatus()`
+ *      first. If it was never seeded (a real state after `bootstrap
+ *      --s3-tfvars` + `make setup` when the initial push/pull was skipped),
+ *      there is nothing remote to strand — skip straight to deleting the
+ *      markers with a note instead of comparing against empty content.
+ *      Otherwise compare the (now-guaranteed-present) local
+ *      `terraform.tfvars` against the remote object byte-for-byte via
+ *      `diffTfvars()` (the same comparison the `tfvars diff` subcommand
+ *      uses) and abort — leaving every file untouched — if they've drifted,
+ *      since deleting the markers would otherwise silently strand whichever
+ *      side lost the race.
  *   4. On success, delete, if present: the `.gsd/tfvars-bucket` marker at the
  *      parent repo root, the sibling marker `setup.sh` writes inside the
  *      submodule directory, and the `terraform.tfvars.lock` sidecar
@@ -1039,27 +1055,51 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
     : '  Nothing was changed.\n\n';
 
   output.write('  Checking for drift against the remote tfvars object…\n');
-  let diff: DiffResult;
+  let remoteStatus: StatusReport;
   try {
-    diff = await diffTfvars({ bucket: bucketName, path: tfvarsPath });
+    remoteStatus = await lockStatus({ bucket: bucketName, path: tfvarsPath });
   } catch (err) {
     process.stderr.write(
-      `\n  ✗ failed to compare against s3://${bucketName}/terraform.tfvars: ${err instanceof Error ? err.message : String(err)}\n`,
+      `\n  ✗ failed to check s3://${bucketName}/terraform.tfvars: ${err instanceof Error ? err.message : String(err)}\n`,
     );
     process.stderr.write(recoveryMessage);
     exit(1);
     return;
   }
 
-  if (!diff.matches) {
-    process.stderr.write(`\n  ✗ local terraform.tfvars has drifted from s3://${bucketName}/terraform.tfvars — aborting.\n`);
-    process.stderr.write('  Run `make tfvars-pull` or `make tfvars-push` to reconcile them first, then re-run this migration.\n');
-    process.stderr.write(recoveryMessage);
-    exit(1);
-    return;
-  }
+  if (!remoteStatus.remote.exists) {
+    // The bucket was created but never seeded (e.g. `bootstrap --s3-tfvars`
+    // followed by `make setup` with the initial pull skipped). There is
+    // nothing remote to strand or reconcile — `make tfvars-pull` would just
+    // fail with NoSuchKey, and `make tfvars-push` would seed a bucket the
+    // operator is about to abandon. Proceed straight to deleting the
+    // markers.
+    output.write(
+      `  ✓ s3://${bucketName}/terraform.tfvars was never seeded — nothing remote to compare, safe to migrate.\n\n`,
+    );
+  } else {
+    let diff: DiffResult;
+    try {
+      diff = await diffTfvars({ bucket: bucketName, path: tfvarsPath });
+    } catch (err) {
+      process.stderr.write(
+        `\n  ✗ failed to compare against s3://${bucketName}/terraform.tfvars: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.stderr.write(recoveryMessage);
+      exit(1);
+      return;
+    }
 
-  output.write('  ✓ local and remote match — safe to migrate.\n\n');
+    if (!diff.matches) {
+      process.stderr.write(`\n  ✗ local terraform.tfvars has drifted from s3://${bucketName}/terraform.tfvars — aborting.\n`);
+      process.stderr.write('  Run `make tfvars-pull` or `make tfvars-push` to reconcile them first, then re-run this migration.\n');
+      process.stderr.write(recoveryMessage);
+      exit(1);
+      return;
+    }
+
+    output.write('  ✓ local and remote match — safe to migrate.\n\n');
+  }
   output.write('  Deleting files…\n');
   if (parentMarkerExists) {
     unlinkSync(parentMarkerPath);

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -21,7 +21,11 @@
  *   - .gsd/tfvars-bucket S3 backend marker (only when --s3-tfvars is passed,
  *                        or you answer yes to the interactive prompt)
  *
- * It NEVER reads or modifies anything inside the submodule.
+ * `bootstrap` (this default command) NEVER reads or modifies anything
+ * inside the submodule. `migrate --to-local` is the exception — it deletes
+ * the gitignored submodule-local .gsd/tfvars-bucket marker alongside the
+ * parent-root one, and `migrate --to-s3` runs `make setup`, which executes
+ * setup.sh inside the submodule.
  */
 
 import { createInterface, type Interface } from 'node:readline/promises';
@@ -81,11 +85,13 @@ export const USAGE = `Usage:
 /**
  * Parses `init-parent.ts`'s CLI args (i.e. `argv.slice(2)`) into a subcommand
  * plus its flags. `bootstrap` is implied when the first token isn't a known
- * subcommand, so existing invocations like `tsx init-parent.ts --force` keep
- * working unchanged. Throws {@link CliUsageError} for an unrecognized
- * subcommand, an unrecognized flag for the resolved subcommand, or (for
- * `migrate`) anything other than exactly one of `--to-s3` / `--to-local`.
- * Pure and side-effect free, so it's directly unit-testable.
+ * subcommand (so existing invocations like `tsx init-parent.ts --force` keep
+ * working unchanged), but it can also be given explicitly as the first token
+ * (`tsx init-parent.ts bootstrap --s3-tfvars`), matching the docs/Makefile
+ * comments that spell out the subcommand. Throws {@link CliUsageError} for an
+ * unrecognized subcommand, an unrecognized flag for the resolved subcommand,
+ * or (for `migrate`) anything other than exactly one of `--to-s3` /
+ * `--to-local`. Pure and side-effect free, so it's directly unit-testable.
  */
 export function parseCliArgs(args: string[]): CliArgs {
   const rest = [...args];
@@ -93,6 +99,9 @@ export function parseCliArgs(args: string[]): CliArgs {
 
   if (rest[0] === 'migrate') {
     command = 'migrate';
+    rest.shift();
+  } else if (rest[0] === 'bootstrap') {
+    command = 'bootstrap';
     rest.shift();
   } else if (rest[0] !== undefined && rest[0].startsWith('--') === false) {
     throw new CliUsageError(`Unknown subcommand "${rest[0]}".`);
@@ -323,7 +332,12 @@ setup: | $(STAMP_DIR)
 # into $(TF_DIR)/terraform.tfvars (e.g. the "game-servers" default seeded
 # from terraform.tfvars.example on a first run) and bootstrap a
 # differently-named bucket than the one PARENT_TFVARS_MARKER points at.
-\tcp $(TFVARS) $(TF_DIR)/terraform.tfvars
+# Guarded: a parent repo that migrated to S3 a while ago may have no local
+# $(TFVARS) at all (see docs/docs/guides/submodule.md) — a fresh clone of
+# such a parent must still be able to run \`make setup\` under -eu, falling
+# through to setup.sh (and its post-bootstrap S3 pull) to seed the file,
+# mirroring main's behavior when the file is missing.
+\tif [ -f $(TFVARS) ]; then cp $(TFVARS) $(TF_DIR)/terraform.tfvars; fi
 # PARENT_TFVARS_MARKER is written by \`init-parent bootstrap --s3-tfvars\`
 # before setup.sh has ever run, so it reflects an operator's up-front choice
 # to run in S3 mode. Export GSD_TFVARS_BACKEND=s3 into setup.sh's own
@@ -913,6 +927,10 @@ export async function runMigrate(direction: MigrateDirection, options: MigrateOp
 
   if (result.error) {
     process.stderr.write(`\n  ✗ failed to run \`make setup\`: ${result.error.message}\n`);
+    process.stderr.write(
+      `  .gsd/tfvars-bucket and the rewritten Makefile are already in place — no need to redo the\n` +
+        `  confirmation, marker, or Makefile steps. Fix the underlying issue and just re-run \`make setup\`.\n`,
+    );
     exit(1);
     return;
   }
@@ -1030,8 +1048,9 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
 
   // Tracks whether step 1 actually wrote terraform.tfvars, so the abort
   // messages below (steps 2 and 3) can accurately describe what's on disk —
-  // once the pull has run, "Nothing was changed." would be false: markers
-  // and the lock sidecar are still untouched, but terraform.tfvars is not.
+  // once the pull has run, "Nothing was changed." would be false:
+  // terraform.tfvars and its .lock sidecar were written by pullTfvars(),
+  // while the markers are still untouched.
   let pulled = false;
 
   if (!existsSync(tfvarsPath)) {
@@ -1051,7 +1070,7 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
   }
 
   const recoveryMessage = pulled
-    ? '  terraform.tfvars was pulled from S3; markers and the lock sidecar are unchanged.\n\n'
+    ? '  terraform.tfvars and its .lock sidecar were written by the pull from S3; markers are unchanged.\n\n'
     : '  Nothing was changed.\n\n';
 
   output.write('  Checking for drift against the remote tfvars object…\n');

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -43,7 +43,83 @@ interface Answers {
   discordPublicKey?: string;
 }
 
-const FORCE = argv.includes('--force');
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI dispatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Subcommands `init-parent.ts` dispatches on. `bootstrap` is the default when none is given. */
+export type CliCommand = 'bootstrap' | 'migrate';
+
+/** Direction for `migrate` — which way to move the parent repo's tfvars backend. */
+export type MigrateDirection = 'to-s3' | 'to-local';
+
+export interface CliArgs {
+  command: CliCommand;
+  force: boolean;
+  /** Pre-seeds an S3 tfvars backend during bootstrap. Only meaningful when `command === 'bootstrap'`. */
+  s3Tfvars: boolean;
+  /** Skips interactive confirmation prompts. Valid for both subcommands. */
+  yes: boolean;
+  /** Only meaningful when `command === 'migrate'`; always set once parsing succeeds (migrate requires exactly one direction). */
+  direction?: MigrateDirection;
+}
+
+/** Thrown by {@link parseCliArgs} for an unrecognized subcommand, an unrecognized flag, or an invalid flag combination. Callers should print `err.message` plus {@link USAGE} to stderr and exit 1. */
+export class CliUsageError extends Error {}
+
+export const USAGE = `Usage:
+  init-parent.ts [--force] [--s3-tfvars] [--yes]            Interactive bootstrap (default)
+  init-parent.ts migrate --to-s3 | --to-local [--yes]        Migrate an existing parent repo's tfvars backend
+`;
+
+/**
+ * Parses `init-parent.ts`'s CLI args (i.e. `argv.slice(2)`) into a subcommand
+ * plus its flags. `bootstrap` is implied when the first token isn't a known
+ * subcommand, so existing invocations like `tsx init-parent.ts --force` keep
+ * working unchanged. Throws {@link CliUsageError} for an unrecognized
+ * subcommand, an unrecognized flag for the resolved subcommand, or (for
+ * `migrate`) anything other than exactly one of `--to-s3` / `--to-local`.
+ * Pure and side-effect free, so it's directly unit-testable.
+ */
+export function parseCliArgs(args: string[]): CliArgs {
+  const rest = [...args];
+  let command: CliCommand = 'bootstrap';
+
+  if (rest[0] === 'migrate') {
+    command = 'migrate';
+    rest.shift();
+  } else if (rest[0] !== undefined && rest[0].startsWith('--') === false) {
+    throw new CliUsageError(`Unknown subcommand "${rest[0]}".`);
+  }
+
+  const knownFlags: readonly string[] =
+    command === 'bootstrap' ? ['--force', '--s3-tfvars', '--yes'] : ['--to-s3', '--to-local', '--yes'];
+
+  for (const token of rest) {
+    if (!knownFlags.includes(token)) {
+      throw new CliUsageError(`Unknown flag "${token}" for ${command === 'bootstrap' ? 'the default bootstrap command' : "'migrate'"}.`);
+    }
+  }
+
+  const force = rest.includes('--force');
+  const s3Tfvars = rest.includes('--s3-tfvars');
+  const yes = rest.includes('--yes');
+
+  if (command === 'bootstrap') {
+    return { command, force, s3Tfvars, yes };
+  }
+
+  const hasS3 = rest.includes('--to-s3');
+  const hasLocal = rest.includes('--to-local');
+  if (hasS3 === hasLocal) {
+    throw new CliUsageError('migrate requires exactly one of --to-s3 | --to-local.');
+  }
+
+  return { command, force, s3Tfvars, yes, direction: hasS3 ? 'to-s3' : 'to-local' };
+}
+
+/** Mutable so it can be set once `parseCliArgs` has run at entrypoint time; `writeIfSafe` reads it below. */
+let FORCE = false;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Path detection
@@ -468,10 +544,11 @@ function isValidDomain(s: string): boolean {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Main
+// Bootstrap (the pre-existing interactive flow, unchanged)
 // ─────────────────────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
+/** The interactive bootstrap flow: prompts for parent-repo details and writes Makefile/terraform.tfvars/.env/.gitignore. Exported so the entrypoint guard below can invoke it after CLI parsing. */
+export async function runBootstrap(): Promise<void> {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const guessedParent = findParentRepoRoot(cwd()) ?? findParentRepoRoot(scriptDir) ?? cwd();
 
@@ -577,6 +654,16 @@ async function main(): Promise<void> {
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Migrate (dispatch only — the migration itself lands in a follow-up task)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Runs the `migrate` subcommand for an already-validated `direction`. Migration itself lands in a follow-up task, so this only wires up dispatch: it prints a "not implemented yet" message and exits non-zero. */
+export function runMigrate(direction: MigrateDirection): void {
+  process.stderr.write(`\n  ✗ migrate --${direction} is not implemented yet.\n`);
+  exit(1);
+}
+
 // Only run when this file is the entry point — keeps the renderers importable
 // from tests without auto-launching the prompt loop. Compare normalized
 // absolute paths so relative invocations (e.g. `tsx init-parent.ts`) still
@@ -585,8 +672,24 @@ const isEntrypoint =
   argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(argv[1]);
 
 if (isEntrypoint) {
-  main().catch((err) => {
-    process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
+  let CLI: CliArgs;
+  try {
+    CLI = parseCliArgs(argv.slice(2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`\n  ✗ ${message}\n\n${USAGE}`);
     exit(1);
-  });
+  }
+
+  if (CLI.command === 'migrate') {
+    // parseCliArgs guarantees exactly one of --to-s3 | --to-local by the time
+    // command === 'migrate' is returned, so direction is always defined here.
+    runMigrate(CLI.direction as MigrateDirection);
+  } else {
+    FORCE = CLI.force;
+    runBootstrap().catch((err) => {
+      process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
+      exit(1);
+    });
+  }
 }

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -18,6 +18,8 @@
  *   - terraform.tfvars   skeleton populated from your answers
  *   - .env               API_TOKEN for the management app (gitignored)
  *   - .gitignore         covers .env, .make/, terraform.tfstate*, etc.
+ *   - .gsd/tfvars-bucket S3 backend marker (only when --s3-tfvars is passed,
+ *                        or you answer yes to the interactive prompt)
  *
  * It NEVER reads or modifies anything inside the submodule.
  */
@@ -41,6 +43,8 @@ interface Answers {
   discordApplicationId?: string;
   discordBotToken?: string;
   discordPublicKey?: string;
+  /** Whether an S3-backed tfvars store was requested (flag or interactive prompt), i.e. whether `.gsd/tfvars-bucket` was written. */
+  s3Tfvars?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -572,8 +576,16 @@ function isValidDomain(s: string): boolean {
 // Bootstrap (the pre-existing interactive flow, unchanged)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** The interactive bootstrap flow: prompts for parent-repo details and writes Makefile/terraform.tfvars/.env/.gitignore. Exported so the entrypoint guard below can invoke it after CLI parsing. */
-export async function runBootstrap(): Promise<void> {
+/** Flags from {@link parseCliArgs} that {@link runBootstrap} cares about. */
+export interface BootstrapOptions {
+  /** Pre-answers the "bootstrap an S3-backed tfvars store?" prompt with yes, skipping it. */
+  s3Tfvars: boolean;
+  /** Skips the interactive prompt entirely when `s3Tfvars` wasn't already passed, defaulting to no. */
+  yes: boolean;
+}
+
+/** The interactive bootstrap flow: prompts for parent-repo details and writes Makefile/terraform.tfvars/.env/.gitignore (and, when requested, the `.gsd/tfvars-bucket` S3 backend marker). Exported so the entrypoint guard below can invoke it after CLI parsing. */
+export async function runBootstrap(options: BootstrapOptions = { s3Tfvars: false, yes: false }): Promise<void> {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const guessedParent = findParentRepoRoot(cwd()) ?? findParentRepoRoot(scriptDir) ?? cwd();
 
@@ -628,6 +640,15 @@ export async function runBootstrap(): Promise<void> {
 
     const configureDiscord = await askBool(rl, 'Seed Discord credentials in tfvars now?', false);
 
+    // A --s3-tfvars flag pre-answers this and skips the prompt; --yes without
+    // --s3-tfvars also skips the prompt but defaults to "no" (an explicit
+    // opt-in is required to write the marker).
+    const wantsS3Tfvars = options.s3Tfvars
+      ? true
+      : options.yes
+        ? false
+        : await askBool(rl, 'Bootstrap an S3-backed tfvars store now? (records the target bucket for `make setup` to create)', false);
+
     let discordApplicationId: string | undefined;
     let discordBotToken: string | undefined;
     let discordPublicKey: string | undefined;
@@ -649,6 +670,7 @@ export async function runBootstrap(): Promise<void> {
       discordApplicationId,
       discordBotToken,
       discordPublicKey,
+      s3Tfvars: wantsS3Tfvars,
     };
 
     output.write('\n  Writing files…\n');
@@ -656,6 +678,17 @@ export async function runBootstrap(): Promise<void> {
     status(join(parentDir, 'terraform.tfvars'), writeIfSafe(join(parentDir, 'terraform.tfvars'), renderTfvars(answers)), parentDir);
     status(join(parentDir, '.env'), writeIfSafe(join(parentDir, '.env'), renderEnv(answers)), parentDir);
     status(join(parentDir, '.gitignore'), writeIfSafe(join(parentDir, '.gitignore'), renderGitignore(answers)), parentDir);
+    // The marker records the S3 bucket `setup.sh`'s bootstrap_tfvars_backend()
+    // will create (see terraform/bootstrap/main.tf's coalesce default) — it's
+    // written up-front, before setup.sh has ever run, so PARENT_TFVARS_MARKER
+    // in the generated Makefile can force GSD_TFVARS_BACKEND=s3 for `make setup`.
+    if (wantsS3Tfvars) {
+      status(
+        join(parentDir, '.gsd', 'tfvars-bucket'),
+        writeIfSafe(join(parentDir, '.gsd', 'tfvars-bucket'), `${projectName}-tfvars\n`),
+        parentDir,
+      );
+    }
 
     output.write('\n  ✓ Done.\n\n');
     output.write('  Next steps:\n');
@@ -663,6 +696,12 @@ export async function runBootstrap(): Promise<void> {
     output.write(`    2. Run \`make setup\` to bootstrap the submodule and Terraform.\n`);
     output.write(`    3. Run \`make plan\` then \`make apply\`.\n`);
     output.write(`    4. \`make dev\` to launch the management app on :5173.\n\n`);
+
+    if (wantsS3Tfvars) {
+      output.write(`  S3-backed tfvars store requested — .gsd/tfvars-bucket recorded (${projectName}-tfvars).\n`);
+      output.write(`  \`make setup\` will bootstrap that S3 bucket automatically before running terraform init,\n`);
+      output.write(`  and \`make tfvars-push\` to seed the bucket if setup reports it empty.\n\n`);
+    }
 
     if (existsSync(join(parentDir, '.gitmodules'))) {
       const gm = readFileSync(join(parentDir, '.gitmodules'), 'utf8');
@@ -712,7 +751,7 @@ if (isEntrypoint) {
     runMigrate(CLI.direction as MigrateDirection);
   } else {
     FORCE = CLI.force;
-    runBootstrap().catch((err) => {
+    runBootstrap({ s3Tfvars: CLI.s3Tfvars, yes: CLI.yes }).catch((err) => {
       process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
       exit(1);
     });

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -198,9 +198,13 @@ async function askRequired(rl: Interface, label: string, def?: string): Promise<
  * gated on TFVARS_BACKEND, which resolves to "s3" or "local" in this order:
  *   1. GSD_TFVARS_BACKEND=s3    — force s3, even without a marker file yet
  *   2. GSD_TFVARS_BACKEND=local — force local, even if a marker file exists
- *   3. otherwise: "s3" when the `.gsd/tfvars-bucket` marker file setup.sh
- *      writes inside the submodule directory exists, else "local"
- * When TFVARS_BACKEND is "local", plan/apply/setup behave exactly as
+ *   3. otherwise: "s3" when the `.gsd/tfvars-bucket` marker file at the
+ *      *parent repo root* exists (written up-front by `init-parent bootstrap
+ *      --s3-tfvars` / `migrate --to-s3`, before setup.sh has ever run)
+ *   4. otherwise: "s3" when the same-named marker file setup.sh writes
+ *      *inside the submodule directory* exists, else "local"
+ * The parent-root marker always wins over the submodule marker when both are
+ * present. When TFVARS_BACKEND is "local", plan/apply/setup behave exactly as
  * before — no S3 calls are made. setup's post-bootstrap pull applies the
  * same override semantics but re-implements them directly in its shell
  * recipe rather than referencing TFVARS_BACKEND — see the comment on that
@@ -228,9 +232,16 @@ endif
 # ── S3 tfvars backend detection ──────────────────────────────────────────────
 # TFVARS_MARKER is the bucket-name marker file setup.sh writes when it
 # bootstraps the versioned S3 tfvars backend (see setup.sh's
-# bootstrap_tfvars_backend()). TFVARS_LOCK is the sidecar lock file
+# bootstrap_tfvars_backend()). PARENT_TFVARS_MARKER is the sibling marker
+# \`init-parent bootstrap --s3-tfvars\` (and \`migrate --to-s3\`) write directly
+# at the parent repo root — before setup.sh has ever run — recording an
+# operator's up-front choice to run in S3 mode. It always takes priority over
+# TFVARS_MARKER: an explicit parent-root marker reflects a deliberate choice,
+# so it should win even before setup.sh gets a chance to write its own
+# submodule-local marker. TFVARS_LOCK is the sidecar lock file
 # tfvars-sync.ts writes after every successful pull/push, recording the S3
 # version id/etag last synced.
+PARENT_TFVARS_MARKER := $(REPO_ROOT)/.gsd/tfvars-bucket
 TFVARS_MARKER := $(SUBMODULE)/.gsd/tfvars-bucket
 TFVARS_LOCK   := $(TFVARS).lock
 
@@ -238,7 +249,9 @@ TFVARS_LOCK   := $(TFVARS).lock
 # can always force one or the other regardless of what's on disk:
 #   - GSD_TFVARS_BACKEND=s3    → force s3, even if the marker file is missing
 #   - GSD_TFVARS_BACKEND=local → force local, even if a marker file is present
-#   - unset                    → s3 when the marker file exists, else local
+#   - unset                    → s3 when the parent-root marker exists, else
+#                                 s3 when the submodule marker exists, else
+#                                 local
 # Recursive ('=', not ':='), so \$(wildcard ...) is re-evaluated whenever this
 # variable is referenced from a *separate* \`make\` invocation (plan, apply,
 # tfvars-pull, etc. all see current marker-file state that way). It must NOT
@@ -248,18 +261,19 @@ TFVARS_LOCK   := $(TFVARS).lock
 # still see the pre-setup.sh filesystem state even though it appears later in
 # the recipe text. \`setup\` re-implements the same override logic directly in
 # its shell recipe instead — see below.
-TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(TFVARS_MARKER)),s3,local)))
+TFVARS_BACKEND = $(if $(filter s3,$(GSD_TFVARS_BACKEND)),s3,$(if $(filter local,$(GSD_TFVARS_BACKEND)),local,$(if $(wildcard $(PARENT_TFVARS_MARKER)),s3,$(if $(wildcard $(TFVARS_MARKER)),s3,local))))
 
 # TFVARS_BUCKET is display-only (used in log messages below); GSD_TFVARS_BUCKET
-# wins if already set, otherwise the marker file's contents.
-TFVARS_BUCKET = $(if $(GSD_TFVARS_BUCKET),$(GSD_TFVARS_BUCKET),$(shell cat $(TFVARS_MARKER) 2>/dev/null))
+# wins if already set, otherwise the parent-root marker's contents, otherwise
+# the submodule marker's contents.
+TFVARS_BUCKET = $(if $(GSD_TFVARS_BUCKET),$(GSD_TFVARS_BUCKET),$(shell cat $(PARENT_TFVARS_MARKER) 2>/dev/null || cat $(TFVARS_MARKER) 2>/dev/null))
 # TFVARS_SYNC is deliberately just the interpreter invocation with no
 # subcommand or flags: tfvars-sync.ts's parseArgs() requires the subcommand
 # (pull/push/check/diff) to be argv[0], so every call site must render
 # "$(TFVARS_SYNC) <subcommand> $(TFVARS_SYNC_ARGS)" — never put flags before
 # the subcommand.
 TFVARS_SYNC      = npx --prefix $(SUBMODULE)/scripts tsx $(SUBMODULE)/scripts/tfvars-sync.ts
-TFVARS_SYNC_ARGS = --path $(TFVARS) --bucket "$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"
+TFVARS_SYNC_ARGS = --path $(TFVARS) --bucket "$\${GSD_TFVARS_BUCKET:-$$(cat $(PARENT_TFVARS_MARKER) 2>/dev/null || cat $(TFVARS_MARKER) 2>/dev/null)}"
 
 .PHONY: help setup plan apply update dev copy-tfvars pull-tfvars-if-needed check-tfvars-if-needed tfvars-pull tfvars-push tfvars-diff
 
@@ -280,7 +294,7 @@ help:
 \t@echo "  make tfvars-diff   Show a unified diff between local and remote terraform.tfvars"
 \t@echo ""
 \t@echo "  S3 tfvars backend detection: GSD_TFVARS_BACKEND=s3|local overrides;"
-\t@echo "  otherwise inferred from the $(TFVARS_MARKER) marker file."
+\t@echo "  otherwise inferred from $(PARENT_TFVARS_MARKER), falling back to $(TFVARS_MARKER)."
 
 # ── Stamp dir ────────────────────────────────────────────────────────────────
 $(STAMP_DIR):
@@ -289,6 +303,16 @@ $(STAMP_DIR):
 # ── One-time setup ───────────────────────────────────────────────────────────
 setup: | $(STAMP_DIR)
 \tgit submodule update --init --recursive
+# PARENT_TFVARS_MARKER is written by \`init-parent bootstrap --s3-tfvars\`
+# before setup.sh has ever run, so it reflects an operator's up-front choice
+# to run in S3 mode. Export GSD_TFVARS_BACKEND=s3 into setup.sh's own
+# environment when it's present — setup.sh's bootstrap_tfvars_backend()
+# already understands this variable — so it bootstraps the S3 backend
+# instead of defaulting to local mode. This must be a single shell line (via
+# \\) rather than two separate recipe lines: each recipe line runs in its own
+# fresh shell, so an \`export\` on one line would never be visible to the
+# \`bash setup.sh\` on the next.
+\tif [ -f $(PARENT_TFVARS_MARKER) ]; then export GSD_TFVARS_BACKEND=s3; fi; \\
 \tbash $(SUBMODULE)/setup.sh
 \t@sha256sum $(SUBMODULE)/setup.sh | cut -d' ' -f1 > $(SETUP_STAMP)
 # Runtime (not parse-time) check, evaluated entirely inside this shell
@@ -298,10 +322,11 @@ setup: | $(STAMP_DIR)
 # make-variable-based check here would still see the filesystem from before
 # setup.sh (above) ran, even though it's written later in the recipe text.
 # Mirror TFVARS_BACKEND's own GSD_TFVARS_BACKEND override semantics by hand,
-# and defer both the marker-file test and its \`cat\` to the shell so they
-# see whatever setup.sh just wrote.
-\t@if [ "$\${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$\${GSD_TFVARS_BACKEND:-}" != local ] && [ -f $(TFVARS_MARKER) ]; }; then \\
-\t  bucket="$\${GSD_TFVARS_BUCKET:-$$(cat $(TFVARS_MARKER) 2>/dev/null)}"; \\
+# and defer both marker-file tests and their \`cat\` to the shell so they see
+# whatever setup.sh just wrote. The parent-root marker (if any) is checked
+# first, same precedence as TFVARS_BACKEND/TFVARS_BUCKET above.
+\t@if [ "$\${GSD_TFVARS_BACKEND:-}" = s3 ] || { [ "$\${GSD_TFVARS_BACKEND:-}" != local ] && { [ -f $(PARENT_TFVARS_MARKER) ] || [ -f $(TFVARS_MARKER) ]; }; }; then \\
+\t  bucket="$\${GSD_TFVARS_BUCKET:-$$(cat $(PARENT_TFVARS_MARKER) 2>/dev/null || cat $(TFVARS_MARKER) 2>/dev/null)}"; \\
 \t  if [ -n "$$(git -C $(REPO_ROOT) status --porcelain -- $(TFVARS))" ]; then echo "$(TFVARS) has uncommitted changes — skipping S3 pull to avoid clobbering them (commit or stash them, then run 'make tfvars-pull')." >&2; \\
 \t  else \\
 \t    echo "S3 tfvars backend detected (s3://$$bucket) — pulling terraform.tfvars..."; \\

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -25,12 +25,13 @@
  */
 
 import { createInterface, type Interface } from 'node:readline/promises';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, unlinkSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stdin as input, stdout as output, argv, cwd, exit } from 'node:process';
 import { randomBytes } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
+import { diffTfvars, pullTfvars, type DiffResult } from './tfvars-sync.ts';
 
 interface Answers {
   parentDir: string;
@@ -549,14 +550,16 @@ function writeIfSafe(path: string, contents: string): 'wrote' | 'skipped' | 'ove
   return existed ? 'overwrote' : 'wrote';
 }
 
-function status(path: string, action: 'wrote' | 'skipped' | 'overwrote', parentDir: string): void {
+function status(path: string, action: 'wrote' | 'skipped' | 'overwrote' | 'deleted', parentDir: string): void {
   const rel = relative(parentDir, path) || path;
   const tag =
     action === 'wrote'
       ? '  +'
       : action === 'overwrote'
         ? '  ~'
-        : '  ·';
+        : action === 'deleted'
+          ? '  -'
+          : '  ·';
   const note = action === 'skipped' ? '  (exists — use --force to overwrite)' : '';
   output.write(`${tag} ${rel}${note}\n`);
 }
@@ -743,29 +746,58 @@ export interface MigrateOptions {
 type ExistingParentInfo = Pick<Answers, 'parentDir' | 'submoduleDir' | 'projectName'>;
 
 /**
- * Locates an already-scaffolded parent repo (a directory containing both
- * `Makefile` and `terraform.tfvars`, as written by `runBootstrap`) starting
- * from `cwd()` — walking up to the nearest `.gitmodules` first, same as
- * `runBootstrap`'s guess, and falling back to `cwd()` itself. Pulls
- * `submoduleDir` out of the existing Makefile's `SUBMODULE` line and
- * `projectName` out of the existing `terraform.tfvars`'s `project_name`.
- * Throws a plain `Error` (message intended for stderr) if either file is
- * missing or `project_name` can't be found.
+ * The subset of {@link ExistingParentInfo} recoverable from the Makefile
+ * alone, without requiring `terraform.tfvars` to already exist locally.
+ * `migrate --to-local` uses this looser lookup because its whole point is
+ * that the parent repo may currently be sourcing `terraform.tfvars` from S3
+ * with no local copy on disk yet — see {@link runMigrateToLocal}, which
+ * pulls one down first when needed.
  */
-function readExistingParent(scriptDir: string): ExistingParentInfo {
+type ParentLocation = Pick<Answers, 'parentDir' | 'submoduleDir'>;
+
+/**
+ * Locates an already-scaffolded parent repo (a directory containing a
+ * `Makefile`, as written by `runBootstrap`) starting from `cwd()` — walking
+ * up to the nearest `.gitmodules` first, same as `runBootstrap`'s guess, and
+ * falling back to `cwd()` itself. Pulls `submoduleDir` out of the existing
+ * Makefile's `SUBMODULE` line. Throws a plain `Error` (message intended for
+ * stderr) if the Makefile is missing.
+ */
+function locateExistingParent(scriptDir: string): ParentLocation {
   const parentDir = findParentRepoRoot(cwd()) ?? cwd();
   const makefilePath = join(parentDir, 'Makefile');
-  const tfvarsPath = join(parentDir, 'terraform.tfvars');
 
-  if (!existsSync(makefilePath) || !existsSync(tfvarsPath)) {
+  if (!existsSync(makefilePath)) {
     throw new Error(
-      `${parentDir} doesn't look like a scaffolded parent repo (missing Makefile and/or terraform.tfvars) — run \`init-parent.ts\` (bootstrap) first.`,
+      `${parentDir} doesn't look like a scaffolded parent repo (missing Makefile) — run \`init-parent.ts\` (bootstrap) first.`,
     );
   }
 
   const makefile = readFileSync(makefilePath, 'utf8');
   const submoduleMatch = makefile.match(/^SUBMODULE\s*:=\s*\$\(REPO_ROOT\)\/(.+)$/m);
   const submoduleDir = submoduleMatch ? submoduleMatch[1] : detectSubmodulePath(parentDir, scriptDir);
+
+  return { parentDir, submoduleDir };
+}
+
+/**
+ * Locates an already-scaffolded parent repo the same way
+ * {@link locateExistingParent} does, additionally requiring
+ * `terraform.tfvars` to exist locally and pulling `projectName` out of its
+ * `project_name` key. Used by `migrate --to-s3`, which needs a local
+ * `terraform.tfvars` as the source of truth to push up to the new bucket.
+ * `migrate --to-local` deliberately does *not* use this — see
+ * {@link ParentLocation}.
+ */
+function readExistingParent(scriptDir: string): ExistingParentInfo {
+  const { parentDir, submoduleDir } = locateExistingParent(scriptDir);
+  const tfvarsPath = join(parentDir, 'terraform.tfvars');
+
+  if (!existsSync(tfvarsPath)) {
+    throw new Error(
+      `${parentDir} doesn't look like a scaffolded parent repo (missing terraform.tfvars) — run \`init-parent.ts\` (bootstrap) first.`,
+    );
+  }
 
   const tfvars = readFileSync(tfvarsPath, 'utf8');
   const projectMatch = tfvars.match(/^project_name\s*=\s*"([^"]+)"/m);
@@ -790,16 +822,22 @@ function readExistingParent(scriptDir: string): ExistingParentInfo {
  * printed `make tfvars-pull` note (and to `make setup`'s own post-bootstrap
  * pull, which no-ops the first time since the bucket starts empty).
  *
- * `--to-local` is not implemented yet — lands in a follow-up task.
+ * `--to-local`: delegates to {@link runMigrateToLocal} — see its doc comment
+ * for the drift check and deletion behaviour.
  */
 export async function runMigrate(direction: MigrateDirection, options: MigrateOptions = { yes: false }): Promise<void> {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+
   if (direction === 'to-local') {
-    process.stderr.write(`\n  ✗ migrate --${direction} is not implemented yet.\n`);
-    exit(1);
+    // Deliberately uses the looser locateExistingParent (Makefile only, no
+    // terraform.tfvars requirement) — runMigrateToLocal pulls tfvars down
+    // from S3 itself when it's missing locally, so requiring it up front
+    // here would make that codepath unreachable.
+    const location = locateExistingParent(scriptDir);
+    await runMigrateToLocal(location, options);
     return;
   }
 
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
   const info = readExistingParent(scriptDir);
   const markerPath = join(info.parentDir, '.gsd', 'tfvars-bucket');
   const bucketName = `${info.projectName}-tfvars`;
@@ -871,6 +909,155 @@ export async function runMigrate(direction: MigrateDirection, options: MigrateOp
   output.write(`  Your tfvars are now in S3 (s3://${bucketName}) — this is a one-time note:\n`);
   output.write(`  run \`make tfvars-pull\` any time you need to refresh your local terraform.tfvars\n`);
   output.write(`  from the bucket (e.g. after editing it from another machine).\n\n`);
+}
+
+/**
+ * Implements `migrate --to-local`: drops an already-scaffolded parent repo's
+ * S3 tfvars backend markers, reverting `make plan`/`make apply` to reading
+ * `terraform.tfvars` straight off disk (the same behaviour as a parent repo
+ * that never opted into S3 at all).
+ *
+ * Steps:
+ *   1. Resolve the target bucket — `GSD_TFVARS_BUCKET` wins if set (matching
+ *      the Makefile's own `TFVARS_BUCKET` precedence and `resolveBucket()`'s
+ *      env-first behaviour in `tfvars-sync.ts`), otherwise the parent-root
+ *      `.gsd/tfvars-bucket` marker, otherwise the submodule-local one. If
+ *      none resolve, exit 1 — there's nothing to migrate.
+ *   2. If `terraform.tfvars` doesn't exist locally yet (the parent repo may
+ *      currently be sourcing it purely from S3), pull it down via
+ *      `pullTfvars()` first so there's something to compare/leave behind.
+ *   3. Compare the (now-guaranteed-present) local `terraform.tfvars` against
+ *      the remote S3 object byte-for-byte via `diffTfvars()` (the same
+ *      comparison the `tfvars diff` subcommand uses) and abort — leaving
+ *      every file untouched — if they've drifted, since deleting the markers
+ *      would otherwise silently strand whichever side lost the race.
+ *   4. On success, delete, if present: the `.gsd/tfvars-bucket` marker at the
+ *      parent repo root, the sibling marker `setup.sh` writes inside the
+ *      submodule directory, and the `terraform.tfvars.lock` sidecar
+ *      `tfvars-sync.ts` maintains. `terraform.tfvars` itself is never
+ *      written beyond the step-2 pull (if that ran) — it's already the
+ *      source of truth for local mode once the markers are gone.
+ *   5. Note that the S3 bucket itself is left standing (this command never
+ *      deletes it) and point at `terraform -chdir=<submodule>/terraform/bootstrap
+ *      destroy` for operators who want to tear it down.
+ */
+async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions): Promise<void> {
+  const parentMarkerPath = join(info.parentDir, '.gsd', 'tfvars-bucket');
+  const submoduleMarkerPath = join(info.parentDir, info.submoduleDir, '.gsd', 'tfvars-bucket');
+  const tfvarsPath = join(info.parentDir, 'terraform.tfvars');
+  const lockPath = `${tfvarsPath}.lock`;
+  const bootstrapDir = join(info.submoduleDir, 'terraform', 'bootstrap');
+
+  const parentMarkerExists = existsSync(parentMarkerPath);
+  const submoduleMarkerExists = existsSync(submoduleMarkerPath);
+  const lockExists = existsSync(lockPath);
+
+  output.write('\n');
+  output.write('  Hyveon — migrate tfvars backend to local\n');
+  output.write('  ────────────────────────────────────────────────────\n');
+  output.write('\n');
+  output.write(`  Parent repo:  ${info.parentDir}\n`);
+  output.write(`  Submodule:    ${info.submoduleDir}\n`);
+  output.write('\n');
+
+  // GSD_TFVARS_BUCKET wins over both marker files, then the parent-root
+  // marker wins over the submodule marker — same precedence resolveBucket()
+  // uses in tfvars-sync.ts and TFVARS_BUCKET uses in the generated Makefile
+  // (see renderMakefile's comment on PARENT_TFVARS_MARKER).
+  const bucketName =
+    (process.env.GSD_TFVARS_BUCKET || undefined) ??
+    (parentMarkerExists ? readFileSync(parentMarkerPath, 'utf8').trim() : undefined) ??
+    (submoduleMarkerExists ? readFileSync(submoduleMarkerPath, 'utf8').trim() : undefined);
+
+  if (!bucketName) {
+    process.stderr.write(
+      '  No GSD_TFVARS_BUCKET env var and no .gsd/tfvars-bucket marker found — already in local mode, nothing to migrate.\n\n',
+    );
+    exit(1);
+    return;
+  }
+
+  output.write(`  Bucket:       ${bucketName}\n`);
+  output.write('\n');
+  output.write('  This will:\n');
+  output.write(`    1. Pull terraform.tfvars from s3://${bucketName}/terraform.tfvars first if it's missing locally.\n`);
+  output.write(`    2. Compare local terraform.tfvars against s3://${bucketName}/terraform.tfvars — abort on drift.\n`);
+  output.write(`    3. Delete the .gsd/tfvars-bucket marker(s).\n`);
+  output.write(`    4. Delete the terraform.tfvars.lock sidecar, if present.\n`);
+  output.write('\n');
+  output.write('  terraform.tfvars itself is left in place (aside from the pull-if-missing step above).\n');
+  output.write('\n');
+
+  if (!options.yes) {
+    const rl = createInterface({ input, output });
+    let proceed: boolean;
+    try {
+      proceed = await askBool(rl, 'Proceed?', false);
+    } finally {
+      rl.close();
+    }
+    if (!proceed) {
+      output.write('\n  Aborted — no files were changed.\n\n');
+      return;
+    }
+  }
+
+  if (!existsSync(tfvarsPath)) {
+    output.write(`  terraform.tfvars not found locally — pulling from s3://${bucketName}/terraform.tfvars…\n`);
+    try {
+      await pullTfvars({ bucket: bucketName, path: tfvarsPath });
+    } catch (err) {
+      process.stderr.write(
+        `\n  ✗ failed to pull s3://${bucketName}/terraform.tfvars: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.stderr.write('  Nothing was changed.\n\n');
+      exit(1);
+      return;
+    }
+    status(tfvarsPath, 'wrote', info.parentDir);
+  }
+
+  output.write('  Checking for drift against the remote tfvars object…\n');
+  let diff: DiffResult;
+  try {
+    diff = await diffTfvars({ bucket: bucketName, path: tfvarsPath });
+  } catch (err) {
+    process.stderr.write(
+      `\n  ✗ failed to compare against s3://${bucketName}/terraform.tfvars: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.stderr.write('  Nothing was changed.\n\n');
+    exit(1);
+    return;
+  }
+
+  if (!diff.matches) {
+    process.stderr.write(`\n  ✗ local terraform.tfvars has drifted from s3://${bucketName}/terraform.tfvars — aborting.\n`);
+    process.stderr.write('  Run `make tfvars-pull` or `make tfvars-push` to reconcile them first, then re-run this migration.\n');
+    process.stderr.write('  Nothing was changed.\n\n');
+    exit(1);
+    return;
+  }
+
+  output.write('  ✓ local and remote match — safe to migrate.\n\n');
+  output.write('  Deleting files…\n');
+  if (parentMarkerExists) {
+    unlinkSync(parentMarkerPath);
+    status(parentMarkerPath, 'deleted', info.parentDir);
+  }
+  if (submoduleMarkerExists) {
+    unlinkSync(submoduleMarkerPath);
+    status(submoduleMarkerPath, 'deleted', info.parentDir);
+  }
+  if (lockExists) {
+    unlinkSync(lockPath);
+    status(lockPath, 'deleted', info.parentDir);
+  }
+
+  output.write('\n  ✓ Migrated to the local tfvars backend.\n\n');
+  output.write('  terraform.tfvars is unchanged — `make plan`/`make apply` will use it directly, with no S3 involved.\n\n');
+  output.write(`  Note: the S3 bucket (s3://${bucketName}) itself is retained — this command never deletes it.\n`);
+  output.write(`  If you no longer need it, destroy it with:\n`);
+  output.write(`    terraform -chdir=${bootstrapDir} destroy\n\n`);
 }
 
 // Only run when this file is the entry point — keeps the renderers importable

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -323,7 +323,7 @@ setup: | $(STAMP_DIR)
 # \\) rather than two separate recipe lines: each recipe line runs in its own
 # fresh shell, so an \`export\` on one line would never be visible to the
 # \`bash setup.sh\` on the next.
-\tif [ -f $(PARENT_TFVARS_MARKER) ]; then export GSD_TFVARS_BACKEND=s3; fi; \\
+\tif [ -z "$\${GSD_TFVARS_BACKEND:-}" ] && [ -f $(PARENT_TFVARS_MARKER) ]; then export GSD_TFVARS_BACKEND=s3; fi; \\
 \tbash $(SUBMODULE)/setup.sh
 \t@sha256sum $(SUBMODULE)/setup.sh | cut -d' ' -f1 > $(SETUP_STAMP)
 # Runtime (not parse-time) check, evaluated entirely inside this shell
@@ -811,8 +811,12 @@ function readExistingParent(scriptDir: string): ExistingParentInfo {
 /**
  * Migrates an already-scaffolded parent repo's tfvars backend.
  *
- * `--to-s3`: writes the `.gsd/tfvars-bucket` marker (same `${projectName}-tfvars`
- * naming `runBootstrap`'s `--s3-tfvars` path uses), rewrites the Makefile with
+ * `--to-s3`: (re)writes the `.gsd/tfvars-bucket` marker unconditionally (same
+ * `${projectName}-tfvars` naming `runBootstrap`'s `--s3-tfvars` path uses —
+ * unlike `runBootstrap`, this always overwrites any pre-existing marker
+ * rather than skipping, since `migrate` doesn't accept `--force` and the
+ * whole point of the command is to make the marker match the freshly
+ * computed bucket name), rewrites the Makefile with
  * the s3-aware targets (identical output to a fresh `runBootstrap` render —
  * the Makefile is always s3-aware, only the marker's presence flips
  * `TFVARS_BACKEND`), then runs `make setup` with `GSD_TFVARS_BACKEND=s3` so
@@ -873,11 +877,18 @@ export async function runMigrate(direction: MigrateDirection, options: MigrateOp
   }
 
   output.write('  Writing files…\n');
-  status(markerPath, writeIfSafe(markerPath, `${bucketName}\n`), info.parentDir);
+  // Migrate always (re)writes the marker and the Makefile it's migrating —
+  // that's the whole point of the command — regardless of the global
+  // --force flag, which only governs runBootstrap's skip-if-exists
+  // behaviour and isn't even accepted by the migrate subcommand (see
+  // parseCliArgs). Using writeIfSafe here would silently keep a
+  // pre-existing marker (possibly recording a different bucket) and print
+  // an unactionable "use --force" hint, so write unconditionally instead.
+  const markerExisted = existsSync(markerPath);
+  mkdirSync(dirname(markerPath), { recursive: true });
+  writeFileSync(markerPath, `${bucketName}\n`);
+  status(markerPath, markerExisted ? 'overwrote' : 'wrote', info.parentDir);
 
-  // Migrate always rewrites the Makefile it's migrating — that's the whole
-  // point of the command — regardless of the global --force flag, which only
-  // governs runBootstrap's skip-if-exists behaviour.
   const makefilePath = join(info.parentDir, 'Makefile');
   mkdirSync(dirname(makefilePath), { recursive: true });
   writeFileSync(makefilePath, renderMakefile({ submoduleDir: info.submoduleDir, projectName: info.projectName }));
@@ -950,7 +961,6 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
 
   const parentMarkerExists = existsSync(parentMarkerPath);
   const submoduleMarkerExists = existsSync(submoduleMarkerPath);
-  const lockExists = existsSync(lockPath);
 
   output.write('\n');
   output.write('  Hyveon — migrate tfvars backend to local\n');
@@ -1002,6 +1012,12 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
     }
   }
 
+  // Tracks whether step 1 actually wrote terraform.tfvars, so the abort
+  // messages below (steps 2 and 3) can accurately describe what's on disk —
+  // once the pull has run, "Nothing was changed." would be false: markers
+  // and the lock sidecar are still untouched, but terraform.tfvars is not.
+  let pulled = false;
+
   if (!existsSync(tfvarsPath)) {
     output.write(`  terraform.tfvars not found locally — pulling from s3://${bucketName}/terraform.tfvars…\n`);
     try {
@@ -1014,8 +1030,13 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
       exit(1);
       return;
     }
+    pulled = true;
     status(tfvarsPath, 'wrote', info.parentDir);
   }
+
+  const recoveryMessage = pulled
+    ? '  terraform.tfvars was pulled from S3; markers and the lock sidecar are unchanged.\n\n'
+    : '  Nothing was changed.\n\n';
 
   output.write('  Checking for drift against the remote tfvars object…\n');
   let diff: DiffResult;
@@ -1025,7 +1046,7 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
     process.stderr.write(
       `\n  ✗ failed to compare against s3://${bucketName}/terraform.tfvars: ${err instanceof Error ? err.message : String(err)}\n`,
     );
-    process.stderr.write('  Nothing was changed.\n\n');
+    process.stderr.write(recoveryMessage);
     exit(1);
     return;
   }
@@ -1033,7 +1054,7 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
   if (!diff.matches) {
     process.stderr.write(`\n  ✗ local terraform.tfvars has drifted from s3://${bucketName}/terraform.tfvars — aborting.\n`);
     process.stderr.write('  Run `make tfvars-pull` or `make tfvars-push` to reconcile them first, then re-run this migration.\n');
-    process.stderr.write('  Nothing was changed.\n\n');
+    process.stderr.write(recoveryMessage);
     exit(1);
     return;
   }
@@ -1048,7 +1069,11 @@ async function runMigrateToLocal(info: ParentLocation, options: MigrateOptions):
     unlinkSync(submoduleMarkerPath);
     status(submoduleMarkerPath, 'deleted', info.parentDir);
   }
-  if (lockExists) {
+  // Re-check at deletion time rather than trusting an up-front snapshot —
+  // pullTfvars() above writes this sidecar as a side effect when
+  // terraform.tfvars was missing locally, so a value captured before that
+  // pull would miss the freshly created lock and strand it behind.
+  if (existsSync(lockPath)) {
     unlinkSync(lockPath);
     status(lockPath, 'deleted', info.parentDir);
   }

--- a/scripts/init-parent.ts
+++ b/scripts/init-parent.ts
@@ -30,6 +30,7 @@ import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stdin as input, stdout as output, argv, cwd, exit } from 'node:process';
 import { randomBytes } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
 
 interface Answers {
   parentDir: string;
@@ -215,8 +216,13 @@ async function askRequired(rl: Interface, label: string, def?: string): Promise<
  * recipe below for why.
  *
  * API_TOKEN is loaded from .env (gitignored) — never hardcoded.
+ *
+ * Only reads `submoduleDir` and `projectName` off `a`, so it accepts a
+ * `Pick<Answers, ...>` rather than a full `Answers` — `runMigrate` re-renders
+ * the Makefile from an already-scaffolded parent repo without re-collecting
+ * every bootstrap answer.
  */
-export function renderMakefile(a: Answers): string {
+export function renderMakefile(a: Pick<Answers, 'submoduleDir' | 'projectName'>): string {
   return `SHELL      := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
 
@@ -719,13 +725,152 @@ export async function runBootstrap(options: BootstrapOptions = { s3Tfvars: false
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Migrate (dispatch only — the migration itself lands in a follow-up task)
+// Migrate
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Runs the `migrate` subcommand for an already-validated `direction`. Migration itself lands in a follow-up task, so this only wires up dispatch: it prints a "not implemented yet" message and exits non-zero. */
-export function runMigrate(direction: MigrateDirection): void {
-  process.stderr.write(`\n  ✗ migrate --${direction} is not implemented yet.\n`);
-  exit(1);
+/** Flags from {@link parseCliArgs} that {@link runMigrate} cares about. */
+export interface MigrateOptions {
+  /** Skips the interactive confirmation prompt, proceeding immediately. */
+  yes: boolean;
+}
+
+/**
+ * The subset of {@link Answers} `runMigrate` can recover by inspecting an
+ * already-scaffolded parent repo (as opposed to `runBootstrap`, which
+ * collects the full set interactively). `renderMakefile` only ever reads
+ * these two fields.
+ */
+type ExistingParentInfo = Pick<Answers, 'parentDir' | 'submoduleDir' | 'projectName'>;
+
+/**
+ * Locates an already-scaffolded parent repo (a directory containing both
+ * `Makefile` and `terraform.tfvars`, as written by `runBootstrap`) starting
+ * from `cwd()` — walking up to the nearest `.gitmodules` first, same as
+ * `runBootstrap`'s guess, and falling back to `cwd()` itself. Pulls
+ * `submoduleDir` out of the existing Makefile's `SUBMODULE` line and
+ * `projectName` out of the existing `terraform.tfvars`'s `project_name`.
+ * Throws a plain `Error` (message intended for stderr) if either file is
+ * missing or `project_name` can't be found.
+ */
+function readExistingParent(scriptDir: string): ExistingParentInfo {
+  const parentDir = findParentRepoRoot(cwd()) ?? cwd();
+  const makefilePath = join(parentDir, 'Makefile');
+  const tfvarsPath = join(parentDir, 'terraform.tfvars');
+
+  if (!existsSync(makefilePath) || !existsSync(tfvarsPath)) {
+    throw new Error(
+      `${parentDir} doesn't look like a scaffolded parent repo (missing Makefile and/or terraform.tfvars) — run \`init-parent.ts\` (bootstrap) first.`,
+    );
+  }
+
+  const makefile = readFileSync(makefilePath, 'utf8');
+  const submoduleMatch = makefile.match(/^SUBMODULE\s*:=\s*\$\(REPO_ROOT\)\/(.+)$/m);
+  const submoduleDir = submoduleMatch ? submoduleMatch[1] : detectSubmodulePath(parentDir, scriptDir);
+
+  const tfvars = readFileSync(tfvarsPath, 'utf8');
+  const projectMatch = tfvars.match(/^project_name\s*=\s*"([^"]+)"/m);
+  if (!projectMatch) {
+    throw new Error(`Couldn't find "project_name" in ${tfvarsPath} — is it a valid terraform.tfvars?`);
+  }
+
+  return { parentDir, submoduleDir, projectName: projectMatch[1] };
+}
+
+/**
+ * Migrates an already-scaffolded parent repo's tfvars backend.
+ *
+ * `--to-s3`: writes the `.gsd/tfvars-bucket` marker (same `${projectName}-tfvars`
+ * naming `runBootstrap`'s `--s3-tfvars` path uses), rewrites the Makefile with
+ * the s3-aware targets (identical output to a fresh `runBootstrap` render —
+ * the Makefile is always s3-aware, only the marker's presence flips
+ * `TFVARS_BACKEND`), then runs `make setup` with `GSD_TFVARS_BACKEND=s3` so
+ * `terraform/bootstrap/` provisions the bucket. `terraform.tfvars` itself is
+ * never read for anything other than `project_name`, nor written — the
+ * one-time pull to fetch it back down from S3 is left to the operator via the
+ * printed `make tfvars-pull` note (and to `make setup`'s own post-bootstrap
+ * pull, which no-ops the first time since the bucket starts empty).
+ *
+ * `--to-local` is not implemented yet — lands in a follow-up task.
+ */
+export async function runMigrate(direction: MigrateDirection, options: MigrateOptions = { yes: false }): Promise<void> {
+  if (direction === 'to-local') {
+    process.stderr.write(`\n  ✗ migrate --${direction} is not implemented yet.\n`);
+    exit(1);
+    return;
+  }
+
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const info = readExistingParent(scriptDir);
+  const markerPath = join(info.parentDir, '.gsd', 'tfvars-bucket');
+  const bucketName = `${info.projectName}-tfvars`;
+
+  output.write('\n');
+  output.write('  Hyveon — migrate tfvars backend to S3\n');
+  output.write('  ────────────────────────────────────────────────────\n');
+  output.write('\n');
+  output.write(`  Parent repo:  ${info.parentDir}\n`);
+  output.write(`  Submodule:    ${info.submoduleDir}\n`);
+  output.write(`  Bucket:       ${bucketName}\n`);
+  output.write('\n');
+  output.write('  This will:\n');
+  output.write(`    1. Write .gsd/tfvars-bucket recording the target bucket name.\n`);
+  output.write(`    2. Rewrite Makefile with the s3-aware targets.\n`);
+  output.write(`    3. Run \`make setup\` (GSD_TFVARS_BACKEND=s3) to bootstrap the bucket.\n`);
+  output.write('\n');
+  output.write('  terraform.tfvars itself is left untouched.\n');
+  output.write('\n');
+
+  if (!options.yes) {
+    const rl = createInterface({ input, output });
+    let proceed: boolean;
+    try {
+      proceed = await askBool(rl, 'Proceed?', false);
+    } finally {
+      rl.close();
+    }
+    if (!proceed) {
+      output.write('\n  Aborted — no files were changed.\n\n');
+      return;
+    }
+  }
+
+  output.write('  Writing files…\n');
+  status(markerPath, writeIfSafe(markerPath, `${bucketName}\n`), info.parentDir);
+
+  // Migrate always rewrites the Makefile it's migrating — that's the whole
+  // point of the command — regardless of the global --force flag, which only
+  // governs runBootstrap's skip-if-exists behaviour.
+  const makefilePath = join(info.parentDir, 'Makefile');
+  mkdirSync(dirname(makefilePath), { recursive: true });
+  writeFileSync(makefilePath, renderMakefile({ submoduleDir: info.submoduleDir, projectName: info.projectName }));
+  status(makefilePath, 'overwrote', info.parentDir);
+
+  output.write('\n  Running `make setup` (GSD_TFVARS_BACKEND=s3)…\n\n');
+  const result = spawnSync('make', ['setup'], {
+    cwd: info.parentDir,
+    stdio: 'inherit',
+    env: { ...process.env, GSD_TFVARS_BACKEND: 's3' },
+  });
+
+  if (result.error) {
+    process.stderr.write(`\n  ✗ failed to run \`make setup\`: ${result.error.message}\n`);
+    exit(1);
+    return;
+  }
+  if (result.status !== 0) {
+    process.stderr.write(`\n  ✗ \`make setup\` failed (exit ${result.status ?? 'unknown'}).\n`);
+    process.stderr.write(
+      `  .gsd/tfvars-bucket and the rewritten Makefile are already in place — no need to redo the\n` +
+        `  confirmation, marker, or Makefile steps. Fix the underlying issue and just re-run \`make setup\`.\n`,
+    );
+    exit(1);
+    return;
+  }
+
+  output.write('\n  ✓ Migrated to the S3 tfvars backend.\n\n');
+  output.write(`  Your tfvars are now in S3 (s3://${bucketName}) — this is a one-time note:\n`);
+  output.write(`  run \`make tfvars-pull\` any time you need to refresh your local terraform.tfvars\n`);
+  output.write(`  from the bucket (e.g. after editing it from another machine).\n\n`);
 }
 
 // Only run when this file is the entry point — keeps the renderers importable
@@ -748,7 +893,10 @@ if (isEntrypoint) {
   if (CLI.command === 'migrate') {
     // parseCliArgs guarantees exactly one of --to-s3 | --to-local by the time
     // command === 'migrate' is returned, so direction is always defined here.
-    runMigrate(CLI.direction as MigrateDirection);
+    runMigrate(CLI.direction as MigrateDirection, { yes: CLI.yes }).catch((err) => {
+      process.stderr.write(`\n  ✗ ${err instanceof Error ? err.message : String(err)}\n`);
+      exit(1);
+    });
   } else {
     FORCE = CLI.force;
     runBootstrap({ s3Tfvars: CLI.s3Tfvars, yes: CLI.yes }).catch((err) => {


### PR DESCRIPTION
Closes #89

## Summary

- Adds `--s3-tfvars` flag (and interactive prompt) to `init-parent bootstrap`, rendering the s3-aware Makefile targets, dropping a `.gsd/tfvars-bucket` marker, and pointing the operator at `make setup` to provision the bucket.
- Adds `init-parent migrate --to-s3` and `migrate --to-local` subcommands: `--to-s3` reads the existing local `terraform.tfvars`, confirms with the user, runs `make setup` to create the bucket and upload the file, and re-renders the Makefile with s3-aware targets; `--to-local` reverses the migration (pulls the remote tfvars back to disk, re-renders the local-mode Makefile, and removes the S3 marker) without losing the operator's `game_servers` definitions.
- Introduces `bootstrap`/`migrate` subcommand dispatch in `init-parent.ts`, extends the Makefile template with a parent-root marker, and documents both directions of the migration path in `scripts/README.md` and `docs/docs/guides/submodule.md`.

## Changes

```
 app/vitest.config.ts            |   3 +
 docs/docs/guides/submodule.md   | 119 +++++++-
 scripts/README.md               |  79 ++++-
 scripts/init-parent.cli.test.ts | 584 ++++++++++++++++++++++++++++++++++++
 scripts/init-parent.test.ts     |  66 ++++-
 scripts/init-parent.ts          | 636 ++++++++++++++++++++++++++++++++++++++--
 6 files changed, 1447 insertions(+), 40 deletions(-)
```

## Test plan

- [x] `init-parent bootstrap --s3-tfvars` produces a parent repo that uses s3 (covered by `scripts/init-parent.cli.test.ts`).
- [x] `init-parent migrate --to-s3` lifts an existing local-file parent repo into S3 cleanly (covered by `scripts/init-parent.cli.test.ts`).
- [x] `init-parent migrate --to-local` reverses the migration without data loss (covered by `scripts/init-parent.cli.test.ts`).
- [x] Tests cover both directions (`scripts/init-parent.cli.test.ts`, `scripts/init-parent.test.ts`).
- [ ] `npm run app:test` — full suite passes locally.
