### PR TITLE
docs: document S3 tfvars workflow

### DIFF
--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -70,6 +70,61 @@ module has no remote backend of its own (it creates the bucket other things
 eventually read from, so storing its own state there would be
 chicken-and-egg); its state stays local and is gitignored.
 
+### Bucket layout
+
+The bucket holds exactly one object: the key `terraform.tfvars` (overridable
+via `tfvars-sync.ts --key`, e.g. if a parent repo wants to store the file
+under a different name). There is no per-environment prefixing or additional
+objects — one bucket maps to one `terraform.tfvars`. S3 **versioning**
+(`aws_s3_bucket_versioning.tfvars`, `Enabled`) keeps every prior revision of
+that object under its own `versionId`, which doubles as the change history
+and the substrate for the conflict-detection scheme below — there is no
+separate DynamoDB lock table for this bucket the way the Terraform state
+backend uses one. The **lifecycle rule**
+(`aws_s3_bucket_lifecycle_configuration.tfvars`) expires noncurrent versions
+after 90 days, so history isn't kept forever, but recent revisions remain
+recoverable via `aws s3api list-object-versions` / `get-object --version-id`
+if a bad push needs to be rolled back.
+
+### Optimistic locking (version/etag conflict semantics)
+
+Nothing in this bucket takes a blocking lock. Instead, `scripts/tfvars-sync.ts`
+(the CLI the parent-repo Makefile's `tfvars-pull` / `tfvars-push` / `tfvars-diff`
+targets wrap — see `renderMakefile()` in `scripts/init-parent.ts`) coordinates
+concurrent edits with **optimistic locking** against the object's S3 version
+id and etag:
+
+- **`pull`** downloads the object and writes a sidecar lock file
+  `terraform.tfvars.lock` next to it, recording the `versionId`, `etag`,
+  size, and `lastModified` observed at pull time (plus a local `pulledAt`
+  timestamp). This lock file is machine-local and gitignored — see
+  `renderGitignore()`'s `*.tfvars.lock` entry — it is never committed.
+- **`push`** refuses to upload unless the local lock's `versionId` still
+  matches the object's *current* `versionId` (checked via `HeadObject`
+  immediately before the write): a missing lock (never pulled) or a
+  stale one (someone else pushed since your last pull) both raise
+  `VersionMismatchError`, and the fix is the same either way — run `pull`
+  again to refresh, resolve any diff, then retry `push`.
+- **The check-then-write race is closed with a conditional `PutObject`.**
+  Between the `HeadObject` check and the actual upload there's a window
+  where a concurrent push could slip in; `push` guards it with `IfMatch:
+  "<locked etag>"` for an existing object (or `IfNoneMatch: '*'` for a
+  brand-new one). If S3 rejects the write with `412 Precondition Failed`
+  because the object changed in that window, `tfvars-sync.ts` surfaces the
+  same `VersionMismatchError` rather than silently overwriting the other
+  side's change.
+- **`BucketNotVersionedError`** is thrown instead if `HeadObject` reports no
+  `VersionId` for an existing object — i.e. the bucket lost (or never had)
+  versioning enabled. The version-based conflict check has nothing to
+  compare against in that case, so `push` refuses outright rather than
+  guessing; versioning must be restored on the bucket before pushing again.
+- **`diff`** and **`check`** are read-only: `diff` byte-compares the local
+  file against the current remote object (used by `migrate --to-local` to
+  confirm it's safe to drop the S3 marker), and `check` compares the local
+  lock's `versionId` against the remote `HeadObject` `versionId` as a fast
+  drift gate — this is what the Makefile's `apply` target runs before every
+  `terraform apply` (skippable with `FORCE_APPLY=1`).
+
 ## Variables
 
 | Name | Type | Default | Purpose |

--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -18,6 +18,10 @@ Role-oriented walkthroughs for the three people most likely to open this site:
   submodule inside a private parent repo that holds `terraform.tfvars`,
   state, and anything else secret. Includes an interactive scaffolder that
   generates the wrapper Makefile and config files for you.
+- **[S3 tfvars storage guide](/guides/s3-tfvars)** — the
+  optional versioned S3 backend for `terraform.tfvars`: bootstrapping,
+  day-to-day pull/push/diff, migrating an existing parent repo, and
+  troubleshooting sync failures.
 
 The [Setup guide](/setup) is still the first stop if
 none of the above has happened yet.

--- a/docs/docs/guides/s3-tfvars.md
+++ b/docs/docs/guides/s3-tfvars.md
@@ -1,0 +1,245 @@
+---
+title: S3 tfvars storage
+sidebar_position: 5
+---
+
+# S3 tfvars storage
+
+`terraform.tfvars` holds your hosted zone, Discord credentials, and the
+`game_servers` map — everything a deployment needs but nothing you want to
+lose or hand-edit blind on a second machine. This guide covers the optional
+**versioned S3 backend** for that one file: bootstrapping it, the day-to-day
+CLI and `make` targets that keep a local copy and the remote object in sync,
+migrating an existing parent repo onto (or off) it, and what to do when the
+sync check fails.
+
+If you haven't set up a [submodule-based parent repo](/guides/submodule) yet,
+start there — this page assumes the wrapper `Makefile` it generates already
+exists. Everything here also works standalone via `scripts/tfvars-sync.ts`
+if you're not using the submodule pattern.
+
+## Why bother
+
+Local-file `terraform.tfvars` works fine for a single operator on a single
+machine. The S3 backend earns its keep once more than one of these is true:
+
+- More than one person (or CI job) needs to run `terraform plan`/`apply`.
+- You want version history / recoverability for tfvars edits, independent of
+  git (tfvars is deliberately gitignored — see
+  [What NOT to do](/guides/submodule#what-not-to-do)).
+- You want `terraform apply` to refuse to run against a stale local copy.
+
+If none of that applies, skip this page — `local` mode (the default) needs
+no S3 bucket and no extra commands.
+
+## Bootstrapping the S3 backend
+
+`terraform/bootstrap/` is a small, standalone Terraform module that
+provisions a dedicated, versioned S3 bucket (default name
+`{project_name}-tfvars`) whose only job is to hold `terraform.tfvars`. It's
+unrelated to the `{project_name}-tf-state` bucket the main `setup.sh`
+bootstrap creates for the Terraform state backend.
+
+Three ways to bootstrap it, in order of convenience:
+
+1. **`./setup.sh` (Linux/macOS)** — prompts interactively
+   (`Store terraform.tfvars in a versioned S3 bucket (terraform/bootstrap)? [y/N]`)
+   unless `GSD_TFVARS_BACKEND` is already set:
+   - `GSD_TFVARS_BACKEND=s3` — bootstraps non-interactively.
+   - `GSD_TFVARS_BACKEND=local` — skips entirely, no AWS/Terraform calls.
+   - Unset + non-interactive shell (CI) — silently defaults to `local`.
+
+   On `s3`, it runs `terraform init`/`terraform apply` inside
+   `terraform/bootstrap/`, records the bucket name at `.gsd/tfvars-bucket`
+   (repo root, gitignored), and uploads the local `terraform.tfvars` to the
+   bucket — but only if that key doesn't already exist remotely, so
+   re-running `setup.sh` never clobbers a tfvars file someone else already
+   pushed or edited in S3.
+
+2. **`init-parent.ts bootstrap --s3-tfvars`** — when scaffolding a fresh
+   [submodule parent repo](/guides/submodule#quick-start-interactive-scaffolder),
+   pre-answers the same prompt up front and writes the `.gsd/tfvars-bucket`
+   marker at the *parent repo root* before `setup.sh` ever runs, so `make
+   setup` bootstraps the S3 backend on its first run without asking.
+
+3. **Manual** — for `setup.ps1` users (not yet ported) or anyone who wants
+   to run it standalone:
+
+   ```bash
+   cd terraform/bootstrap
+   terraform init
+   terraform apply
+   ```
+
+   The resulting bucket has versioning enabled, AES-256 server-side
+   encryption, all four public-access-block settings on, and a lifecycle
+   rule that expires noncurrent object versions after 90 days. Its own
+   Terraform state stays local (`terraform/bootstrap/terraform.tfstate`,
+   already gitignored) — it can't use the S3 backend it's bootstrapping, so
+   keep a personal backup of that state file.
+
+Already have a tfvars bucket some other way? That's fine too, as long as its
+name matches `tfvars_bucket_name` (defaults to `{project_name}-tfvars`) so
+the root module's `data "aws_s3_bucket" "tfvars"` resolves correctly.
+
+See [Bootstrap the tfvars bucket](/setup#bootstrap-the-tfvars-bucket-required-before-the-first-terraform-apply)
+in the setup guide for the full walkthrough, including IAM permissions.
+
+## Day-to-day: the `tfvars-sync` CLI
+
+`scripts/tfvars-sync.ts` is the CLI that actually talks to S3. It pulls,
+pushes, diffs, and reports status for a local `terraform.tfvars` against the
+bucket:
+
+```bash
+tsx scripts/tfvars-sync.ts pull   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts push   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts diff   [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts status [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+tsx scripts/tfvars-sync.ts check  [--bucket <name>] [--path <file>] [--key <key>] [--region <region>]
+```
+
+| Command | What it does |
+|---|---|
+| `pull` | Downloads the remote object to `--path` (default `terraform/terraform.tfvars`), creating parent directories as needed, and writes a sidecar lock file (`<path>.lock`) recording the version just pulled. |
+| `push` | Uploads the local file to the bucket/key. Refuses to overwrite the remote object if the local lock is missing or stale — see [Troubleshooting](#troubleshooting) below. |
+| `diff` | Prints a unified diff (`remote → local`). Exits `0` and prints `✓ local and remote match` when byte-identical; otherwise exits `1` and prints `✗ local and remote differ`. |
+| `status` | Prints bucket/key/path, the local lock's recorded version/etag/pulled-at, the remote object's current version/etag/last-modified, and whether the two agree. |
+| `check` | Drift gate for CI/`make apply`: exits `0` (`✓ in sync: ...`) when the local lock's version id matches the remote's current version id, `1` (`✗ drift detected: <reason>`) otherwise. |
+
+`--bucket` is resolved through a fallback chain when omitted: the flag
+itself, then the `GSD_TFVARS_BUCKET` environment variable, then the nearest
+`.gsd/tfvars-bucket` marker file found walking up from the current
+directory. The CLI errors out if none of these resolve. `--key` always
+defaults to the fixed key `terraform.tfvars` regardless of `--path` — pass
+it explicitly only if the bucket should hold the object under a different
+name.
+
+Run it directly from this repo's own workspace via
+`npm run scripts:tfvars-sync -- <command> [flags]`.
+
+### The lock file
+
+Every successful `pull` or `push` (re)writes `<path>.lock` — JSON recording
+the S3 `bucket`, `key`, `versionId`, `etag`, `size`, `lastModified`, and
+`pulledAt`. It's the optimistic-concurrency check `push` uses before
+uploading: if the remote object exists but no lock is present, or the lock's
+`versionId` doesn't match the remote's *current* `versionId`, `push` refuses
+to run rather than silently clobbering someone else's newer write. It's
+safe to inspect, and safe to delete — a deleted lock just means the next
+`push` will require a fresh `pull` first.
+
+## Day-to-day: `make` targets
+
+If you're using the [submodule parent-repo pattern](/guides/submodule), the
+generated wrapper `Makefile` drives the same CLI for you, plus wires it into
+`plan`/`apply` automatically:
+
+| Target | What it does |
+|---|---|
+| `make tfvars-pull` | Pulls `terraform.tfvars` from the configured S3 backend. Refuses to run if the local file has uncommitted git changes, so a pull can never silently discard edits you haven't committed. Fails fast with a pointer to `GSD_TFVARS_BACKEND`/`setup.sh` if no backend is detected. |
+| `make tfvars-push` | Pushes the local `terraform.tfvars` to the configured S3 backend. Same fail-fast behavior when no backend is detected. |
+| `make tfvars-diff` | Prints a unified diff between local and remote. Same fail-fast behavior when no backend is detected. |
+| `make plan` | Auto-pulls the latest tfvars from S3 first (when a backend is detected), so a stale local copy can't silently drive the plan. Set `NO_PULL=1` to skip the pull for one invocation. |
+| `make apply` | Asserts the local tfvars are still in sync with S3 first (`tfvars-sync check`), refusing to apply against drifted vars. Set `FORCE_APPLY=1` to skip the check for one invocation. |
+| `make setup` | If `setup.sh` bootstrapped an S3 backend, also pulls `terraform.tfvars` afterwards. On a first bootstrap against an empty bucket the pull can't find anything yet — it prints a warning suggesting `make tfvars-push` to seed the bucket instead of failing `make setup`. |
+
+Whether these targets treat you as being in S3 mode or local mode is decided
+by `TFVARS_BACKEND`, resolved in this order:
+
+1. `GSD_TFVARS_BACKEND=s3` or `GSD_TFVARS_BACKEND=local` — explicit override,
+   wins regardless of any marker file.
+2. The **parent-root** `.gsd/tfvars-bucket` marker (written by
+   `init-parent bootstrap --s3-tfvars` or `migrate --to-s3`, before
+   `setup.sh` ever runs) — takes priority if present.
+3. The **submodule-local** `.gsd/tfvars-bucket` marker (written by
+   `setup.sh`'s own bootstrap) — checked next.
+4. Otherwise: `local`.
+
+In `local` mode the gates inside `setup`/`plan`/`apply` are silent no-ops —
+nothing changes for a deployment that has never touched the S3 backend.
+`make tfvars-pull`/`push`/`diff` behave differently: they're
+operator-invoked, so they always fail fast (rather than silently no-opping)
+when no backend is detected.
+
+## Migrating an existing parent repo's backend
+
+Started on `local` and want to move to S3 later (or vice versa), without
+re-running the whole interactive scaffolder? `init-parent.ts migrate`
+rewires an already-scaffolded parent repo (one where `bootstrap` has already
+run and a `Makefile` exists) in place:
+
+```bash
+npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts migrate --to-s3
+# or
+npx --prefix Hyveon/scripts tsx Hyveon/scripts/init-parent.ts migrate --to-local
+```
+
+Exactly one of `--to-s3` / `--to-local` is required — passing both, or
+neither, is a usage error. Both directions prompt for confirmation before
+touching anything; pass `--yes` to skip the prompt (e.g. for scripting/CI).
+
+### `migrate --to-s3`
+
+1. Reads `project_name` out of the parent repo's existing
+   `terraform.tfvars` and derives the bucket name `${project_name}-tfvars` —
+   the same convention `bootstrap --s3-tfvars` uses.
+2. Writes the `.gsd/tfvars-bucket` marker at the parent repo root.
+3. Rewrites the `Makefile` with the S3-aware targets (the same output a
+   fresh `bootstrap` renders — the Makefile is always S3-aware; only the
+   marker's presence flips `TFVARS_BACKEND` to `s3`).
+4. Runs `make setup` with `GSD_TFVARS_BACKEND=s3` so `terraform/bootstrap/`
+   provisions the bucket.
+
+`terraform.tfvars` itself is left untouched — pull the now-remote copy down
+explicitly with `make tfvars-pull` afterwards for confirmation it
+round-tripped (or push it up with `make tfvars-push` if the bucket comes
+back empty).
+
+### `migrate --to-local`
+
+1. Resolves the target bucket the same way the generated Makefile does:
+   `GSD_TFVARS_BUCKET` env var, else the parent-root marker, else the
+   submodule-local one. Exits `1` with no changes if none resolve (already
+   local — nothing to migrate).
+2. Pulls `terraform.tfvars` down from S3 first if it's missing locally (a
+   parent repo that's been in S3 mode a while may have no local copy at
+   all).
+3. Diffs the local file against the remote object byte-for-byte (the same
+   comparison `make tfvars-diff`/`tfvars-sync.ts diff` uses) and **aborts,
+   leaving every file untouched**, if they've drifted — reconcile with
+   `make tfvars-pull` or `make tfvars-push` first, then re-run the
+   migration. If the remote object was never seeded at all, this comparison
+   is skipped and migration proceeds straight to step 4.
+4. On a clean match (or an unseeded remote), deletes both the parent-root
+   and submodule-local `.gsd/tfvars-bucket` markers, plus the
+   `terraform.tfvars.lock` sidecar. `terraform.tfvars` itself stays in
+   place — it's already the correct source of truth for local mode once the
+   markers are gone.
+
+`migrate --to-local` **never deletes the S3 bucket** — tear it down yourself
+once you're done with it:
+
+```bash
+terraform -chdir=Hyveon/terraform/bootstrap destroy
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `push` fails with `Local lock version "..." does not match remote version "..." for s3://<bucket>/terraform.tfvars. Run "pull" to refresh before pushing.` — i.e. **the remote object changed since your last pull** | Someone else (or another machine you use) pushed a newer `terraform.tfvars` after your last `pull`. Your local lock file is now stale, so `push` refuses to silently overwrite their change. | Run `tfvars-sync.ts pull` (or `make tfvars-pull`) to fetch the latest version and refresh the lock. If your local edits still need to land, reconcile the two files by hand (or re-apply your edits on top of the freshly-pulled copy), then `push` again. Never blindly force-overwrite — you'd destroy whatever the other operator/machine just wrote. |
+| `push` fails with `Remote object s3://<bucket>/terraform.tfvars changed after the version check (concurrent push detected). Run "pull" to refresh before pushing.` | A second `push` slipped in between this `push`'s own version check and its upload (a true race, not just a stale lock) — the S3 conditional write (`IfMatch`) caught it. | Same fix as above: `pull`, reconcile if needed, `push` again. This is rarer than the plain stale-lock case above but resolved identically. |
+| `push` fails with `Remote object ... already exists but no local lock file was found at terraform.tfvars.lock. Run "pull" first.` | You've never pulled on this machine/checkout, so there's no lock to validate against — `push` won't guess whether it's safe to overwrite. | Run `pull` once to establish a baseline lock, then `push`. |
+| `push` fails with `Bucket "<bucket>" does not appear to have S3 versioning enabled...` | The bucket was created or modified outside `terraform/bootstrap/` and has versioning off or suspended. The whole conflict-detection scheme (`versionId` comparisons) depends on a versioned bucket. | Enable versioning on the bucket (or re-provision it via `terraform/bootstrap/`, which enables it by default), then retry. |
+| `check` fails (`make apply` aborts) with `no local lock file found ... — run "pull" first` | Fresh checkout, or the lock file was deleted/gitignored-and-never-restored. | `make tfvars-pull` once, then retry `make apply`. Or set `FORCE_APPLY=1` if you're intentionally applying without syncing (not recommended). |
+| `check`/`make apply` fails with a version-id mismatch reason | Same root cause as the `push` conflict above, just caught earlier by the pre-apply gate instead of at push time. | `make tfvars-pull`, review the diff, `make apply` again. |
+| `pull`/`push`/`diff`/`status`/`check` all fail with `--bucket is required (or set GSD_TFVARS_BUCKET, or create a .gsd/tfvars-bucket marker file)` | No backend configured, or you're running the CLI from a directory where the marker-file walk-up can't find `.gsd/tfvars-bucket`. | Pass `--bucket` explicitly, set `GSD_TFVARS_BUCKET`, or run from within the repo/parent-repo tree so the marker file is found. If you haven't bootstrapped a backend yet, see [Bootstrapping the S3 backend](#bootstrapping-the-s3-backend) above. |
+| `make tfvars-pull`/`push`/`diff` fail with `No S3 tfvars backend detected (TFVARS_BACKEND=local) — set GSD_TFVARS_BACKEND=s3 ... or bootstrap one via setup.sh.` | No `.gsd/tfvars-bucket` marker exists anywhere in the resolution chain, and `GSD_TFVARS_BACKEND` isn't set to `s3`. | Bootstrap a backend (see above) or set `GSD_TFVARS_BACKEND=s3` with `GSD_TFVARS_BUCKET` pointing at an existing bucket. |
+| `make tfvars-pull` (or the automatic `plan`/`setup` pull) refuses with `terraform.tfvars has uncommitted changes — commit or stash them before pulling from S3.` | A pull overwrites the local file in place; the guard won't let it discard uncommitted edits git can see. | Commit or `git stash` the local changes, then retry. Or `NO_PULL=1 make plan` to skip the auto-pull for one invocation. |
+| `migrate --to-local` aborts with a drift message, no files changed | The local `terraform.tfvars` and the remote object have diverged — see the diff step in [`migrate --to-local`](#migrate---to-local) above. | Run `make tfvars-pull` or `make tfvars-push` to reconcile, then re-run the migration. |
+| First-ever `push` to a brand-new bucket succeeds even though you never `pull`ed | Expected: `push` only requires a prior `pull` when the remote object already exists. A first push to an empty bucket has nothing to conflict with. | Nothing to fix — this is the intended "seed the bucket" path (`setup.sh`'s post-bootstrap pull warns and suggests exactly this when the bucket comes back empty). |
+
+For issues with the bootstrap step itself (bucket creation, IAM
+permissions), see the [setup guide's IAM section](/setup#1-create-and-authorise-an-iam-user)
+and its own [Troubleshooting](/setup#troubleshooting) table.

--- a/docs/docs/guides/s3-tfvars.md
+++ b/docs/docs/guides/s3-tfvars.md
@@ -30,7 +30,12 @@ machine. The S3 backend earns its keep once more than one of these is true:
 - You want `terraform apply` to refuse to run against a stale local copy.
 
 If none of that applies, skip this page — `local` mode (the default) needs
-no S3 bucket and no extra commands.
+no `tfvars-sync` commands. It still needs the `{project_name}-tfvars` bucket
+to exist once, though: the root module's `data "aws_s3_bucket" "tfvars"`
+(`terraform/main.tf`) reads it unconditionally on every `terraform
+plan`/`apply`, regardless of `GSD_TFVARS_BACKEND`. See
+[Bootstrap the tfvars bucket](/setup#bootstrap-the-tfvars-bucket-required-before-the-first-terraform-apply)
+in the setup guide for the one-time step.
 
 ## Bootstrapping the S3 backend
 
@@ -80,7 +85,9 @@ Three ways to bootstrap it, in order of convenience:
 
 Already have a tfvars bucket some other way? That's fine too, as long as its
 name matches `tfvars_bucket_name` (defaults to `{project_name}-tfvars`) so
-the root module's `data "aws_s3_bucket" "tfvars"` resolves correctly.
+the root module's `data "aws_s3_bucket" "tfvars"` resolves correctly, and
+versioning is enabled on it — `scripts/tfvars-sync.ts` checks this on every
+run and throws `BucketNotVersionedError` if it isn't.
 
 See [Bootstrap the tfvars bucket](/setup#bootstrap-the-tfvars-bucket-required-before-the-first-terraform-apply)
 in the setup guide for the full walkthrough, including IAM permissions.
@@ -127,7 +134,10 @@ uploading: if the remote object exists but no lock is present, or the lock's
 `versionId` doesn't match the remote's *current* `versionId`, `push` refuses
 to run rather than silently clobbering someone else's newer write. It's
 safe to inspect, and safe to delete — a deleted lock just means the next
-`push` will require a fresh `pull` first.
+`push` will require a fresh `pull` first, *if* the remote object already
+exists. A first push to an empty/unseeded bucket doesn't need a prior pull
+at all (the `IfNoneMatch: '*'` seed path — see the
+[Troubleshooting](#troubleshooting) row below).
 
 ## Day-to-day: `make` targets
 
@@ -137,12 +147,25 @@ generated wrapper `Makefile` drives the same CLI for you, plus wires it into
 
 | Target | What it does |
 |---|---|
-| `make tfvars-pull` | Pulls `terraform.tfvars` from the configured S3 backend. Refuses to run if the local file has uncommitted git changes, so a pull can never silently discard edits you haven't committed. Fails fast with a pointer to `GSD_TFVARS_BACKEND`/`setup.sh` if no backend is detected. |
+| `make tfvars-pull` | Pulls `terraform.tfvars` from the configured S3 backend. Refuses to run if `git status --porcelain` reports the local file as changed, so a pull won't overwrite an edit git can see. See the caveat right below the table — this is *not* a full guarantee against clobbering local edits. Fails fast with a pointer to `GSD_TFVARS_BACKEND`/`setup.sh` if no backend is detected. |
 | `make tfvars-push` | Pushes the local `terraform.tfvars` to the configured S3 backend. Same fail-fast behavior when no backend is detected. |
 | `make tfvars-diff` | Prints a unified diff between local and remote. Same fail-fast behavior when no backend is detected. |
-| `make plan` | Auto-pulls the latest tfvars from S3 first (when a backend is detected), so a stale local copy can't silently drive the plan. Set `NO_PULL=1` to skip the pull for one invocation. |
+| `make plan` | Auto-pulls the latest tfvars from S3 first (when a backend is detected), gated behind the same git-dirty check as `make tfvars-pull` above (and subject to the same caveat). Set `NO_PULL=1` to skip the pull for one invocation. |
 | `make apply` | Asserts the local tfvars are still in sync with S3 first (`tfvars-sync check`), refusing to apply against drifted vars. Set `FORCE_APPLY=1` to skip the check for one invocation. |
-| `make setup` | If `setup.sh` bootstrapped an S3 backend, also pulls `terraform.tfvars` afterwards. On a first bootstrap against an empty bucket the pull can't find anything yet — it prints a warning suggesting `make tfvars-push` to seed the bucket instead of failing `make setup`. |
+| `make setup` | If `setup.sh` bootstrapped an S3 backend, also pulls `terraform.tfvars` afterwards, gated behind the same git-dirty check (and caveat) as `make tfvars-pull`. On a first bootstrap against an empty bucket the pull can't find anything yet — it prints a warning suggesting `make tfvars-push` to seed the bucket instead of failing `make setup`. |
+
+> **The git-dirty guard is not a full safety net.** `tfvars-pull`, `plan`'s
+> auto-pull, and `setup`'s post-bootstrap pull all shell out to
+> `git status --porcelain -- terraform.tfvars` and refuse to overwrite the
+> file if that reports anything. But `terraform.tfvars` is normally
+> gitignored (see [Why bother](#why-bother) above) — git doesn't diff
+> gitignored or never-`git add`ed files at all, so an edit sitting only in a
+> gitignored or untracked local copy is invisible to this check and **can
+> still be silently overwritten** by the pull. The guard only helps in the
+> unusual case where the file happens to be tracked by git (e.g.
+> deliberately `git add -f`d). Don't rely on it as your only safeguard — run
+> `make tfvars-diff` (or `tfvars-sync.ts diff`) first if you have local edits
+> you're not sure are reflected in S3 yet.
 
 Whether these targets treat you as being in S3 mode or local mode is decided
 by `TFVARS_BACKEND`, resolved in this order:
@@ -204,16 +227,22 @@ back empty).
    local — nothing to migrate).
 2. Pulls `terraform.tfvars` down from S3 first if it's missing locally (a
    parent repo that's been in S3 mode a while may have no local copy at
-   all).
-3. Diffs the local file against the remote object byte-for-byte (the same
+   all). If the remote object was never seeded either, this pull fails and
+   the whole migration **aborts right here, leaving every file
+   untouched** — including the `.gsd/tfvars-bucket` marker(s) — since
+   there'd be nothing left to source `terraform.tfvars` from once those
+   markers were deleted. Reconcile with `make tfvars-push` (from whichever
+   machine still has a good local copy) before re-running the migration.
+3. Otherwise — a local `terraform.tfvars` was already present, so step 2
+   was a no-op — diffs it against the remote object byte-for-byte (the same
    comparison `make tfvars-diff`/`tfvars-sync.ts diff` uses) and **aborts,
    leaving every file untouched**, if they've drifted — reconcile with
    `make tfvars-pull` or `make tfvars-push` first, then re-run the
    migration. If the remote object was never seeded at all, this comparison
    is skipped and migration proceeds straight to step 4.
-4. On a clean match (or an unseeded remote), deletes both the parent-root
-   and submodule-local `.gsd/tfvars-bucket` markers, plus the
-   `terraform.tfvars.lock` sidecar. `terraform.tfvars` itself stays in
+4. On a clean match (or an unseeded remote reached via step 3), deletes both
+   the parent-root and submodule-local `.gsd/tfvars-bucket` markers, plus
+   the `terraform.tfvars.lock` sidecar. `terraform.tfvars` itself stays in
    place — it's already the correct source of truth for local mode once the
    markers are gone.
 
@@ -236,8 +265,9 @@ terraform -chdir=Hyveon/terraform/bootstrap destroy
 | `check`/`make apply` fails with a version-id mismatch reason | Same root cause as the `push` conflict above, just caught earlier by the pre-apply gate instead of at push time. | `make tfvars-pull`, review the diff, `make apply` again. |
 | `pull`/`push`/`diff`/`status`/`check` all fail with `--bucket is required (or set GSD_TFVARS_BUCKET, or create a .gsd/tfvars-bucket marker file)` | No backend configured, or you're running the CLI from a directory where the marker-file walk-up can't find `.gsd/tfvars-bucket`. | Pass `--bucket` explicitly, set `GSD_TFVARS_BUCKET`, or run from within the repo/parent-repo tree so the marker file is found. If you haven't bootstrapped a backend yet, see [Bootstrapping the S3 backend](#bootstrapping-the-s3-backend) above. |
 | `make tfvars-pull`/`push`/`diff` fail with `No S3 tfvars backend detected (TFVARS_BACKEND=local) — set GSD_TFVARS_BACKEND=s3 ... or bootstrap one via setup.sh.` | No `.gsd/tfvars-bucket` marker exists anywhere in the resolution chain, and `GSD_TFVARS_BACKEND` isn't set to `s3`. | Bootstrap a backend (see above) or set `GSD_TFVARS_BACKEND=s3` with `GSD_TFVARS_BUCKET` pointing at an existing bucket. |
-| `make tfvars-pull` (or the automatic `plan`/`setup` pull) refuses with `terraform.tfvars has uncommitted changes — commit or stash them before pulling from S3.` | A pull overwrites the local file in place; the guard won't let it discard uncommitted edits git can see. | Commit or `git stash` the local changes, then retry. Or `NO_PULL=1 make plan` to skip the auto-pull for one invocation. |
+| `make tfvars-pull` (or the automatic `plan`/`setup` pull) refuses with `terraform.tfvars has uncommitted changes — commit or stash them before pulling from S3.` | A pull overwrites the local file in place; the guard won't let it discard uncommitted edits *that git can see*. Remember this guard is `git status --porcelain`-based, so it only catches this if the file happens to be tracked — see the caveat under [Day-to-day: `make` targets](#day-to-day-make-targets). | Commit or `git stash` the local changes, then retry. Or `NO_PULL=1 make plan` to skip the auto-pull for one invocation. If the file is normally gitignored on your setup, run `make tfvars-diff` first to check for drift before pulling, since this guard won't warn you. |
 | `migrate --to-local` aborts with a drift message, no files changed | The local `terraform.tfvars` and the remote object have diverged — see the diff step in [`migrate --to-local`](#migrate---to-local) above. | Run `make tfvars-pull` or `make tfvars-push` to reconcile, then re-run the migration. |
+| `migrate --to-local` aborts with `failed to pull s3://<bucket>/terraform.tfvars`, no files changed (markers still present) | There's no local `terraform.tfvars` *and* the remote object was never seeded — this parent repo has never had a working copy anywhere, so the migration refuses to delete the `.gsd/tfvars-bucket` marker(s) and strand you with no `terraform.tfvars` at all. | Get a good copy of `terraform.tfvars` onto this machine (e.g. from another checkout) and `make tfvars-push` it up first, then re-run the migration. |
 | First-ever `push` to a brand-new bucket succeeds even though you never `pull`ed | Expected: `push` only requires a prior `pull` when the remote object already exists. A first push to an empty bucket has nothing to conflict with. | Nothing to fix — this is the intended "seed the bucket" path (`setup.sh`'s post-bootstrap pull warns and suggests exactly this when the bucket comes back empty). |
 
 For issues with the bootstrap step itself (bucket creation, IAM

--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -146,9 +146,9 @@ parent's `terraform.tfvars` between runs.
 ## S3 tfvars backend detection
 
 See [S3 tfvars storage](/guides/s3-tfvars) for the full guide to bootstrapping,
-day-to-day syncing, and migrating an existing parent repo onto (or off) this
-backend. The rest of this section covers how the generated Makefile detects
-which backend is active.
+day-to-day syncing, migrating an existing parent repo onto (or off) this
+backend, and troubleshooting sync conflicts. The rest of this section covers
+how the generated Makefile detects which backend is active.
 
 The three `tfvars-*` targets, and the automatic gating baked into
 `setup`/`plan`/`apply` above, all key off the same `TFVARS_BACKEND`

--- a/docs/docs/guides/submodule.md
+++ b/docs/docs/guides/submodule.md
@@ -145,6 +145,11 @@ parent's `terraform.tfvars` between runs.
 
 ## S3 tfvars backend detection
 
+See [S3 tfvars storage](/guides/s3-tfvars) for the full guide to bootstrapping,
+day-to-day syncing, and migrating an existing parent repo onto (or off) this
+backend. The rest of this section covers how the generated Makefile detects
+which backend is active.
+
 The three `tfvars-*` targets, and the automatic gating baked into
 `setup`/`plan`/`apply` above, all key off the same `TFVARS_BACKEND`
 resolution in the generated Makefile:

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -222,6 +222,48 @@ Both scripts are idempotent — safe to re-run at any time. They:
    (migrating from a previous local-backend setup), it automatically
    migrates state to S3 without prompting.
 
+### tfvars storage: local vs S3
+
+`terraform.tfvars` can live purely as a local file — the default, and all
+you need for a single operator on a single machine, with no S3 bucket and no
+extra commands. Switch to the optional **S3 backend** once any of these
+apply: more than one person (or a CI job) needs to run `terraform
+plan`/`apply`, you want version history/recoverability for tfvars edits
+independent of git, you want `terraform apply` to refuse to run against a
+stale local copy, or you want the desktop app's remote tfvars editing
+(`RemoteTfvarsStore`'s pull/push/diff/lock flow) to be able to read and write
+`terraform.tfvars` without SSH/file-share access to whichever machine last
+ran `terraform apply`. If none of that applies to you, stay on `local` and
+skip ahead to [step 4](#4-configure-your-servers) — everything below this
+subsection is about the S3 option.
+
+Which mode `setup.sh` sets up is controlled by the `GSD_TFVARS_BACKEND`
+environment variable (see step 4 above):
+
+- `GSD_TFVARS_BACKEND=s3` — bootstraps the tfvars bucket non-interactively
+  (the steps below) and leaves a `.gsd/tfvars-bucket` marker so later
+  `make`/CLI tooling knows it's in S3 mode.
+- `GSD_TFVARS_BACKEND=local` — skips the bucket entirely; no AWS/Terraform
+  calls related to tfvars storage, and `terraform.tfvars` stays a plain
+  local file.
+- Unset — `setup.sh` prompts interactively on a TTY
+  (`Store terraform.tfvars in a versioned S3 bucket (terraform/bootstrap)? [y/N]`),
+  or silently falls back to `local` in a non-interactive shell (CI).
+
+> **IAM warning:** the S3 backend needs bucket access on top of the core
+> deploy policy. Confirm the `GameServerTfvarsBucket` statement from
+> [step 1](#1-create-and-authorise-an-iam-user) is attached to whatever
+> IAM user/role runs `setup.sh`/`terraform apply`/`terraform/bootstrap`
+> *before* you opt into `GSD_TFVARS_BACKEND=s3` — without it, bootstrapping
+> the bucket and every subsequent `pull`/`push`/`plan`/`apply` against it
+> will fail with an S3 `AccessDenied` error.
+
+For the full day-to-day S3 workflow — the `tfvars-sync` CLI, the generated
+`make tfvars-pull`/`push`/`diff` targets, migrating an existing parent repo
+between `local` and `s3`, and a troubleshooting table — see the dedicated
+[S3 tfvars storage guide](/guides/s3-tfvars). The rest of this section
+covers only the one-time bootstrap step.
+
 ### Bootstrap the tfvars bucket (required before the first `terraform apply`)
 
 `terraform/bootstrap/` is a separate, standalone Terraform module that

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -193,7 +193,15 @@ Both scripts are idempotent — safe to re-run at any time. They:
    tfvars S3 bucket (`terraform/bootstrap/`), controlled by the
    `GSD_TFVARS_BACKEND` environment variable:
    - `GSD_TFVARS_BACKEND=s3` — bootstraps the bucket non-interactively.
-   - `GSD_TFVARS_BACKEND=local` — skips it entirely, no AWS/Terraform calls.
+   - `GSD_TFVARS_BACKEND=local` — skips this automatic step, no AWS/Terraform
+     calls from `setup.sh` itself. **This does not make the bucket optional**:
+     the root module's `data "aws_s3_bucket" "tfvars"` (`terraform/main.tf`)
+     reads it unconditionally, regardless of `GSD_TFVARS_BACKEND`, so you must
+     still create a `{project_name}-tfvars` bucket yourself (see
+     [Bootstrap the tfvars bucket](#bootstrap-the-tfvars-bucket-required-before-the-first-terraform-apply)
+     below) before the root `terraform plan`/`apply` will succeed. `local`
+     only means you won't use the `tfvars-sync` CLI to keep `terraform.tfvars`
+     itself in sync with S3.
    - Unset, interactive shell (a TTY) — prompts
      `Store terraform.tfvars in a versioned S3 bucket (terraform/bootstrap)? [y/N]`;
      anything other than `y`/`Y`/`yes`/`YES` falls back to `local`.
@@ -225,8 +233,8 @@ Both scripts are idempotent — safe to re-run at any time. They:
 ### tfvars storage: local vs S3
 
 `terraform.tfvars` can live purely as a local file — the default, and all
-you need for a single operator on a single machine, with no S3 bucket and no
-extra commands. Switch to the optional **S3 backend** once any of these
+you need for a single operator on a single machine, with no `tfvars-sync`
+commands to run. Switch to the optional **S3 backend** once any of these
 apply: more than one person (or a CI job) needs to run `terraform
 plan`/`apply`, you want version history/recoverability for tfvars edits
 independent of git, you want `terraform apply` to refuse to run against a
@@ -234,8 +242,11 @@ stale local copy, or you want the desktop app's remote tfvars editing
 (`RemoteTfvarsStore`'s pull/push/diff/lock flow) to be able to read and write
 `terraform.tfvars` without SSH/file-share access to whichever machine last
 ran `terraform apply`. If none of that applies to you, stay on `local` and
-skip ahead to [step 4](#4-configure-your-servers) — everything below this
-subsection is about the S3 option.
+skip ahead to [step 4](#4-configure-your-servers) once you've completed the
+[one-time bucket bootstrap](#bootstrap-the-tfvars-bucket-required-before-the-first-terraform-apply)
+below — `local` mode skips the day-to-day S3 sync workflow, **not** the
+bucket itself: the root module reads it unconditionally, so it must exist
+before the first `terraform apply` no matter which mode you choose.
 
 Which mode `setup.sh` sets up is controlled by the `GSD_TFVARS_BACKEND`
 environment variable (see step 4 above):
@@ -243,9 +254,12 @@ environment variable (see step 4 above):
 - `GSD_TFVARS_BACKEND=s3` — bootstraps the tfvars bucket non-interactively
   (the steps below) and leaves a `.gsd/tfvars-bucket` marker so later
   `make`/CLI tooling knows it's in S3 mode.
-- `GSD_TFVARS_BACKEND=local` — skips the bucket entirely; no AWS/Terraform
-  calls related to tfvars storage, and `terraform.tfvars` stays a plain
-  local file.
+- `GSD_TFVARS_BACKEND=local` — skips `setup.sh`'s automatic bucket bootstrap
+  and the `tfvars-sync` day-to-day workflow; `terraform.tfvars` stays a plain
+  local file you edit and `terraform apply` directly. The bucket itself is
+  **not** skipped: it still must exist (see
+  [Bootstrap the tfvars bucket](#bootstrap-the-tfvars-bucket-required-before-the-first-terraform-apply)
+  below) before the root `terraform plan`/`apply` will succeed.
 - Unset — `setup.sh` prompts interactively on a TTY
   (`Store terraform.tfvars in a versioned S3 bucket (terraform/bootstrap)? [y/N]`),
   or silently falls back to `local` in a non-interactive shell (CI).
@@ -268,8 +282,7 @@ covers only the one-time bootstrap step.
 
 `terraform/bootstrap/` is a separate, standalone Terraform module that
 provisions a **second, distinct S3 bucket** whose only job is to hold your
-`terraform.tfvars` (and other per-deployment secrets) outside of source
-control. This is unrelated to the `{project_name}-tf-state` bucket `setup.sh`
+`terraform.tfvars` outside of source control. This is unrelated to the `{project_name}-tf-state` bucket `setup.sh`
 creates for the Terraform backend. The root module's `data "aws_s3_bucket"
 "tfvars"` (in `terraform/main.tf`) reads this bucket, so it **must already
 exist before you run `terraform apply` in the root `terraform/` directory** —


### PR DESCRIPTION
Closes #90

## Summary

- Adds `docs/docs/guides/s3-tfvars.md` — a standalone walkthrough covering bootstrap, day-to-day `make tfvars-*` usage, migrate flow, and troubleshooting (e.g. "remote changed since last pull").
- Documents the S3 tfvars backend across `docs/docs/setup.md` (when to choose S3, `GSD_TFVARS_BACKEND=s3 ./setup.sh` walkthrough, IAM scope warning) and `docs/docs/components/terraform.md` (bootstrap module, bucket layout, versioning + lifecycle, optimistic locking, `tfvars_bucket_name` variable row).
- Cross-links the new guide from `docs/docs/guides/index.md` and `docs/docs/guides/submodule.md`, and preserves the existing local-file workflow documentation alongside the new S3 material.

## Changes

```
 docs/docs/components/terraform.md |  55 +++++++++
 docs/docs/guides/index.md         |   4 +
 docs/docs/guides/s3-tfvars.md     | 245 ++++++++++++++++++++++++++++++++++++++
 docs/docs/guides/submodule.md     |   5 +
 docs/docs/setup.md                |  42 +++++++
 5 files changed, 351 insertions(+)
```

## Test plan

- [x] `setup.md` has a tfvars-storage section.
- [x] `terraform.md` covers the bootstrap module and variables.
- [x] Standalone `s3-tfvars.md` walkthrough exists.
- [x] Local-file workflow documentation is preserved.