### PR TITLE
feat(desktop-main): TfvarsService — parse and cache S3-backed tfvars

### DIFF
--- a/app/packages/desktop-main/package.json
+++ b/app/packages/desktop-main/package.json
@@ -17,6 +17,7 @@
     "@aws-sdk/client-ecs": "^3.600.0",
     "@aws-sdk/client-secrets-manager": "^3.600.0",
     "@aws-sdk/lib-dynamodb": "^3.600.0",
+    "@cdktf/hcl2json": "^0.21.0",
     "@grpc/proto-loader": "^0.8.1",
     "@hyveon/cloud-aws": "*",
     "@hyveon/shared": "*",

--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'module';
 import { Module } from '@nestjs/common';
 import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
+import { TfvarsModule } from './modules/tfvars.module.js';
 import { GamesController } from './controllers/games.controller.js';
 import { GamesHttpController } from './controllers/games-http.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
@@ -24,11 +25,11 @@ import { SafeStorageService } from './services/SafeStorageService.js';
 import { ElectronStoreService } from './services/ElectronStoreService.js';
 
 /**
- * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`) to
- * the IPC controllers.
+ * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`,
+ * `TfvarsModule`) to the IPC controllers.
  */
 @Module({
-  imports: [AwsModule, DiscordModule],
+  imports: [AwsModule, DiscordModule, TfvarsModule],
   controllers: [
     GamesController,
     GamesHttpController,

--- a/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { GamesHttpController } from './games-http.controller.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
+import type { TfvarsService } from '../services/TfvarsService.js';
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -33,21 +34,34 @@ function makeEcs(): EcsService {
   } as unknown as EcsService;
 }
 
+/** Build a TfvarsService stub with `invalidateCache` pre-wired. */
+function makeTfvars(): TfvarsService {
+  return {
+    invalidateCache: vi.fn(),
+  } as unknown as TfvarsService;
+}
+
 describe('GamesHttpController', () => {
   describe('listGames', () => {
     it('should invalidate the tfstate cache before reading game names', () => {
       const config = makeConfig();
-      new GamesHttpController(config, makeEcs()).listGames();
+      new GamesHttpController(config, makeEcs(), makeTfvars()).listGames();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
+    it('should invalidate the TfvarsService cache before reading game names', () => {
+      const tfvars = makeTfvars();
+      new GamesHttpController(makeConfig(), makeEcs(), tfvars).listGames();
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
+    });
+
     it('should return game names from Terraform outputs', () => {
-      const result = new GamesHttpController(makeConfig(), makeEcs()).listGames();
+      const result = new GamesHttpController(makeConfig(), makeEcs(), makeTfvars()).listGames();
       expect(result).toEqual({ games: ['minecraft', 'valheim'] });
     });
 
     it('should return an empty games array when Terraform has not been applied yet', () => {
-      const result = new GamesHttpController(makeConfig(null), makeEcs()).listGames();
+      const result = new GamesHttpController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
       expect(result).toEqual({ games: [] });
     });
   });
@@ -55,26 +69,32 @@ describe('GamesHttpController', () => {
   describe('listStatus', () => {
     it('should invalidate cache before querying ECS', async () => {
       const config = makeConfig();
-      await new GamesHttpController(config, makeEcs()).listStatus();
+      await new GamesHttpController(config, makeEcs(), makeTfvars()).listStatus();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
+    });
+
+    it('should invalidate the TfvarsService cache before querying ECS', async () => {
+      const tfvars = makeTfvars();
+      await new GamesHttpController(makeConfig(), makeEcs(), tfvars).listStatus();
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should query ECS status for every game in the Terraform outputs', async () => {
       const ecs = makeEcs();
-      await new GamesHttpController(makeConfig(), ecs).listStatus();
+      await new GamesHttpController(makeConfig(), ecs, makeTfvars()).listStatus();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
       expect(ecs.getStatus).toHaveBeenCalledWith('valheim');
     });
 
     it('should return an empty array when tfstate is absent', async () => {
-      const result = await new GamesHttpController(makeConfig(null), makeEcs()).listStatus();
+      const result = await new GamesHttpController(makeConfig(null), makeEcs(), makeTfvars()).listStatus();
       expect(result).toEqual([]);
     });
 
     it('should return status entries in the same order as game_names', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockImplementation(async (g) => ({ game: g, state: 'stopped' as const }));
-      const result = await new GamesHttpController(makeConfig(), ecs).listStatus();
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).listStatus();
       expect(result.map((s) => s.game)).toEqual(['minecraft', 'valheim']);
     });
   });
@@ -83,7 +103,7 @@ describe('GamesHttpController', () => {
     it('should delegate to EcsService without invalidating the tfstate cache', async () => {
       const config = makeConfig();
       const ecs = makeEcs();
-      await new GamesHttpController(config, ecs).getStatus('minecraft');
+      await new GamesHttpController(config, ecs, makeTfvars()).getStatus('minecraft');
       expect(config.invalidateCache).not.toHaveBeenCalled();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
     });
@@ -91,7 +111,7 @@ describe('GamesHttpController', () => {
     it('should return the status provided by EcsService', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running' });
-      const result = await new GamesHttpController(makeConfig(), ecs).getStatus('minecraft');
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).getStatus('minecraft');
       expect(result).toEqual({ game: 'minecraft', state: 'running' });
     });
   });
@@ -99,14 +119,14 @@ describe('GamesHttpController', () => {
   describe('start', () => {
     it('should delegate to EcsService.start with the requested game name', async () => {
       const ecs = makeEcs();
-      await new GamesHttpController(makeConfig(), ecs).start('valheim');
+      await new GamesHttpController(makeConfig(), ecs, makeTfvars()).start('valheim');
       expect(ecs.start).toHaveBeenCalledWith('valheim');
     });
 
     it('should return the result from EcsService.start', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.start).mockResolvedValue({ success: true, message: 'running', taskArn: 'arn:task' });
-      const result = await new GamesHttpController(makeConfig(), ecs).start('minecraft');
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).start('minecraft');
       expect(result).toMatchObject({ success: true, taskArn: 'arn:task' });
     });
   });
@@ -114,14 +134,14 @@ describe('GamesHttpController', () => {
   describe('stop', () => {
     it('should delegate to EcsService.stop with the requested game name', async () => {
       const ecs = makeEcs();
-      await new GamesHttpController(makeConfig(), ecs).stop('minecraft');
+      await new GamesHttpController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
       expect(ecs.stop).toHaveBeenCalledWith('minecraft');
     });
 
     it('should return the result from EcsService.stop', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.stop).mockResolvedValue({ success: true, message: 'stopped' });
-      const result = await new GamesHttpController(makeConfig(), ecs).stop('minecraft');
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
       expect(result).toMatchObject({ success: true, message: 'stopped' });
     });
   });

--- a/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
@@ -38,7 +38,7 @@ function makeEcs(): EcsService {
 function makeTfvars(): TfvarsService {
   return {
     invalidateCache: vi.fn(),
-  } as unknown as TfvarsService;
+  } as Partial<TfvarsService> as TfvarsService;
 }
 
 describe('GamesHttpController', () => {

--- a/app/packages/desktop-main/src/controllers/games-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Param, Post } from '@nestjs/common';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
+import { TfvarsService } from '../services/TfvarsService.js';
 
 /**
  * HTTP shim that exposes the game-server operations as plain REST endpoints
@@ -10,36 +11,42 @@ import { EcsService } from '../services/EcsService.js';
  * main-process host uses the IPC {@link GamesController} (`@MessagePattern`)
  * handlers instead.
  *
- * Both controllers delegate to the same {@link ConfigService} and
- * {@link EcsService} providers — there is no duplicated logic.
+ * Both controllers delegate to the same {@link ConfigService},
+ * {@link EcsService}, and {@link TfvarsService} providers — there is no
+ * duplicated logic.
  */
 @Controller()
 export class GamesHttpController {
   constructor(
     private readonly config: ConfigService,
     private readonly ecs: EcsService,
+    private readonly tfvars: TfvarsService,
   ) {}
 
   /**
    * Lists game keys from the Terraform `game_servers` map. Invalidates the
-   * tfstate cache first so a fresh `terraform apply` shows up without having
-   * to restart the server.
+   * tfstate cache and the `TfvarsService` cache first so a fresh
+   * `terraform apply` / tfvars edit shows up without having to restart the
+   * server.
    */
   @Get('games')
   listGames(): { games: string[] } {
     this.config.invalidateCache();
+    this.tfvars.invalidateCache();
     const outputs = this.config.getTfOutputs();
     return { games: outputs?.game_names ?? [] };
   }
 
   /**
    * Returns the current ECS status of every game in parallel. Also
-   * invalidates the tfstate cache — this is the endpoint the dashboard polls,
-   * so it's the natural place to pick up newly-added games.
+   * invalidates the tfstate cache and the `TfvarsService` cache — this is
+   * the endpoint the dashboard polls, so it's the natural place to pick up
+   * newly-added games.
    */
   @Get('status')
   async listStatus() {
     this.config.invalidateCache();
+    this.tfvars.invalidateCache();
     const outputs = this.config.getTfOutputs();
     if (!outputs) return [];
     return Promise.all(outputs.game_names.map((g) => this.ecs.getStatus(g)));

--- a/app/packages/desktop-main/src/controllers/games.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.test.ts
@@ -38,7 +38,7 @@ function makeEcs(): EcsService {
 function makeTfvars(): TfvarsService {
   return {
     invalidateCache: vi.fn(),
-  } as unknown as TfvarsService;
+  } as Partial<TfvarsService> as TfvarsService;
 }
 
 /**

--- a/app/packages/desktop-main/src/controllers/games.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { GamesController } from './games.controller.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
+import type { TfvarsService } from '../services/TfvarsService.js';
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -31,6 +32,13 @@ function makeEcs(): EcsService {
     start: vi.fn().mockResolvedValue({ success: true, message: 'Task launched' }),
     stop: vi.fn().mockResolvedValue({ success: true, message: 'Task stopped' }),
   } as unknown as EcsService;
+}
+
+/** Build a TfvarsService stub with `invalidateCache` pre-wired. */
+function makeTfvars(): TfvarsService {
+  return {
+    invalidateCache: vi.fn(),
+  } as unknown as TfvarsService;
 }
 
 /**
@@ -73,17 +81,23 @@ describe('GamesController', () => {
   describe('listGames', () => {
     it('should invalidate the tfstate cache before reading game names', () => {
       const config = makeConfig();
-      new GamesController(config, makeEcs()).listGames();
+      new GamesController(config, makeEcs(), makeTfvars()).listGames();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
+    it('should invalidate the TfvarsService cache before reading game names', () => {
+      const tfvars = makeTfvars();
+      new GamesController(makeConfig(), makeEcs(), tfvars).listGames();
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
+    });
+
     it('should return the game names from Terraform outputs', () => {
-      const result = new GamesController(makeConfig(), makeEcs()).listGames();
+      const result = new GamesController(makeConfig(), makeEcs(), makeTfvars()).listGames();
       expect(result).toEqual({ games: ['minecraft', 'palworld'] });
     });
 
     it('should return an empty games array when Terraform has not been applied yet', () => {
-      const result = new GamesController(makeConfig(null), makeEcs()).listGames();
+      const result = new GamesController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
       expect(result).toEqual({ games: [] });
     });
   });
@@ -91,26 +105,32 @@ describe('GamesController', () => {
   describe('listStatus', () => {
     it('should invalidate cache before querying ECS', async () => {
       const config = makeConfig();
-      await new GamesController(config, makeEcs()).listStatus();
+      await new GamesController(config, makeEcs(), makeTfvars()).listStatus();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
+    });
+
+    it('should invalidate the TfvarsService cache before querying ECS', async () => {
+      const tfvars = makeTfvars();
+      await new GamesController(makeConfig(), makeEcs(), tfvars).listStatus();
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should query ECS status for every game in the Terraform outputs', async () => {
       const ecs = makeEcs();
-      await new GamesController(makeConfig(), ecs).listStatus();
+      await new GamesController(makeConfig(), ecs, makeTfvars()).listStatus();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
       expect(ecs.getStatus).toHaveBeenCalledWith('palworld');
     });
 
     it('should return an empty array when tfstate is absent', async () => {
-      const result = await new GamesController(makeConfig(null), makeEcs()).listStatus();
+      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars()).listStatus();
       expect(result).toEqual([]);
     });
 
     it('should return status entries in the same order as game_names', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockImplementation(async (g) => ({ game: g, state: 'stopped' as const }));
-      const result = await new GamesController(makeConfig(), ecs).listStatus();
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).listStatus();
       expect(result.map((s) => s.game)).toEqual(['minecraft', 'palworld']);
     });
   });
@@ -120,7 +140,7 @@ describe('GamesController', () => {
       const config = makeConfig();
       const ecs = makeEcs();
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      await new GamesController(config, ecs).getStatus('minecraft');
+      await new GamesController(config, ecs, makeTfvars()).getStatus('minecraft');
       expect(config.invalidateCache).not.toHaveBeenCalled();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
     });
@@ -129,7 +149,7 @@ describe('GamesController', () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running' });
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      const result = await new GamesController(makeConfig(), ecs).getStatus('minecraft');
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).getStatus('minecraft');
       expect(result).toEqual({ game: 'minecraft', state: 'running' });
     });
   });
@@ -138,7 +158,7 @@ describe('GamesController', () => {
     it('should delegate to EcsService.start with the game name received via the IPC payload', async () => {
       const ecs = makeEcs();
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      await new GamesController(makeConfig(), ecs).start('palworld');
+      await new GamesController(makeConfig(), ecs, makeTfvars()).start('palworld');
       expect(ecs.start).toHaveBeenCalledWith('palworld');
     });
 
@@ -146,7 +166,7 @@ describe('GamesController', () => {
       const ecs = makeEcs();
       vi.mocked(ecs.start).mockResolvedValue({ success: true, message: 'running', taskArn: 'arn:task' });
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      const result = await new GamesController(makeConfig(), ecs).start('minecraft');
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).start('minecraft');
       expect(result).toMatchObject({ success: true, taskArn: 'arn:task' });
     });
   });
@@ -155,7 +175,7 @@ describe('GamesController', () => {
     it('should delegate to EcsService.stop with the game name received via the IPC payload', async () => {
       const ecs = makeEcs();
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      await new GamesController(makeConfig(), ecs).stop('minecraft');
+      await new GamesController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
       expect(ecs.stop).toHaveBeenCalledWith('minecraft');
     });
 
@@ -163,7 +183,7 @@ describe('GamesController', () => {
       const ecs = makeEcs();
       vi.mocked(ecs.stop).mockResolvedValue({ success: true, message: 'stopped' });
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      const result = await new GamesController(makeConfig(), ecs).stop('minecraft');
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
       expect(result).toMatchObject({ success: true, message: 'stopped' });
     });
   });

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -2,6 +2,7 @@ import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
+import { TfvarsService } from '../services/TfvarsService.js';
 
 /**
  * IPC-only game-server controller. Handles Electron main-process messages via
@@ -9,40 +10,46 @@ import { EcsService } from '../services/EcsService.js';
  *
  * The HTTP surface (`/api/games`, `/api/status`, `/api/start/:game`,
  * `/api/stop/:game`) is covered entirely by {@link GamesHttpController}.
- * Both controllers delegate to the same {@link ConfigService} and
- * {@link EcsService} providers — there is no duplicated logic.
+ * Both controllers delegate to the same {@link ConfigService},
+ * {@link EcsService}, and {@link TfvarsService} providers — there is no
+ * duplicated logic.
  */
 @Controller()
 export class GamesController {
   constructor(
     private readonly config: ConfigService,
     private readonly ecs: EcsService,
+    private readonly tfvars: TfvarsService,
   ) {}
 
   /**
    * Lists game keys from the Terraform `game_servers` map. Invalidates the
-   * tfstate cache first so a fresh `terraform apply` shows up without having
-   * to restart the server.
+   * tfstate cache and the `TfvarsService` cache first so a fresh
+   * `terraform apply` / tfvars edit shows up without having to restart the
+   * server.
    *
    * Reachable via the Electron IPC transport (`games.list`).
    */
   @MessagePattern('games.list')
   listGames(): { games: string[] } {
     this.config.invalidateCache();
+    this.tfvars.invalidateCache();
     const outputs = this.config.getTfOutputs();
     return { games: outputs?.game_names ?? [] };
   }
 
   /**
    * Returns the current ECS status of every game in parallel. Also
-   * invalidates the tfstate cache — this is the natural place to pick up
-   * newly-added games when called from the Electron renderer.
+   * invalidates the tfstate cache and the `TfvarsService` cache — this is
+   * the natural place to pick up newly-added games when called from the
+   * Electron renderer.
    *
    * Reachable via the Electron IPC transport (`games.status`).
    */
   @MessagePattern('games.status')
   async listStatus() {
     this.config.invalidateCache();
+    this.tfvars.invalidateCache();
     const outputs = this.config.getTfOutputs();
     if (!outputs) return [];
     return Promise.all(outputs.game_names.map((g) => this.ecs.getStatus(g)));

--- a/app/packages/desktop-main/src/modules/cloud-provider.module.test.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.module.test.ts
@@ -13,7 +13,12 @@ import type {
   CostBreakdown,
   DateRange,
 } from '@hyveon/shared';
-import { CLOUD_BINDINGS, resolveCloudBindings, type CloudBindings } from './cloud-provider.module.js';
+import {
+  CLOUD_BINDINGS,
+  resolveCloudBindings,
+  resolveTfvarsFileStoreConfig,
+  type CloudBindings,
+} from './cloud-provider.module.js';
 import type { ConfigService, ActiveCloud } from '../services/ConfigService.js';
 
 /**
@@ -22,10 +27,11 @@ import type { ConfigService, ActiveCloud } from '../services/ConfigService.js';
  * to be stubbed. The cast lets tests exercise an unregistered/fake cloud
  * value without widening `ActiveCloud` itself.
  */
-function makeConfig(activeCloud: ActiveCloud): ConfigService {
+function makeConfig(activeCloud: ActiveCloud, tfvarsBucket: string | null = 'test-tfvars-bucket'): ConfigService {
   const stub: Partial<ConfigService> = {
     getActiveCloud: () => activeCloud,
     getRegion: () => 'us-east-1',
+    getTfvarsBucket: () => tfvarsBucket,
   };
   return stub as ConfigService;
 }
@@ -131,6 +137,16 @@ describe('resolveCloudBindings', () => {
       const config = makeConfig('aws');
       const bindings = resolveCloudBindings(config);
       expect(bindings.remoteFileStore(config)).toBeInstanceOf(AwsRemoteFileStore);
+    });
+
+    it('should resolve the tfvars file store bucket from ConfigService.getTfvarsBucket() and region from getRegion()', () => {
+      const config = makeConfig('aws', 'my-tfvars-bucket');
+      expect(resolveTfvarsFileStoreConfig(config)).toEqual({ bucket: 'my-tfvars-bucket', region: 'us-east-1' });
+    });
+
+    it('should fall back to an empty bucket name when getTfvarsBucket() reports no bucket configured', () => {
+      const config = makeConfig('aws', null);
+      expect(resolveTfvarsFileStoreConfig(config)).toEqual({ bucket: '', region: 'us-east-1' });
     });
 
     it('should produce an AwsDiscordEventReceiver from the aws discordReceiver factory', () => {

--- a/app/packages/desktop-main/src/modules/cloud-provider.module.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.module.ts
@@ -28,6 +28,22 @@ export interface CloudBindings {
 }
 
 /**
+ * Resolves the `{ bucket, region }` config the AWS `RemoteFileStore`'s
+ * `getConfig` callback needs to target the tfvars bucket: the bucket comes
+ * from `ConfigService.getTfvarsBucket()` (falling back to `''` — an empty
+ * bucket name — when tfvars sync isn't configured, so `AwsRemoteFileStore`
+ * surfaces its own "bucket not configured" error rather than this factory
+ * silently defaulting somewhere), and the region from `getRegion()`.
+ * Exported as a standalone function (rather than inlined in
+ * {@link CLOUD_BINDINGS}) so a unit test can exercise the resolution logic
+ * directly without constructing an `@aws-sdk/client-s3`-backed store, which
+ * `@hyveon/desktop-main` tests aren't permitted to import.
+ */
+export function resolveTfvarsFileStoreConfig(config: ConfigService): { bucket: string; region: string } {
+  return { bucket: config.getTfvarsBucket() ?? '', region: config.getRegion() };
+}
+
+/**
  * Registry of per-cloud bindings, keyed by `ActiveCloud` (or any future cloud
  * string). Today only `'aws'` is populated; adding a new cloud provider
  * package means adding an entry here rather than touching the module's
@@ -38,7 +54,7 @@ export const CLOUD_BINDINGS: Record<string, CloudBindings> = {
   aws: {
     cloudProvider: (config) => createAwsCloudProvider(config),
     secretsStore: (config) => new AwsSecretsStore(() => config.getRegion()),
-    remoteFileStore: () => new AwsRemoteFileStore(),
+    remoteFileStore: (config) => new AwsRemoteFileStore(() => resolveTfvarsFileStoreConfig(config)),
     discordReceiver: () => new AwsDiscordEventReceiver(),
   },
 };

--- a/app/packages/desktop-main/src/modules/tfvars.module.ts
+++ b/app/packages/desktop-main/src/modules/tfvars.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from './config.module.js';
+import { CloudProviderModule } from './cloud-provider.module.js';
+import { TfvarsService } from '../services/TfvarsService.js';
+
+/**
+ * Feature module for `TfvarsService`, the local-vs-S3 `terraform.tfvars`
+ * reader/parser (see `TfvarsService`'s file-level doc comment for source
+ * resolution, parsing, and caching behaviour).
+ *
+ * `ConfigModule` is imported for `ConfigService` (tfvars source resolution)
+ * and `CloudProviderModule` for the `REMOTE_FILE_STORE` token (S3-mode
+ * reads), both re-exported alongside `TfvarsService` so any consumer that
+ * only needs `TfvarsModule` gets the full dependency chain without also
+ * importing `AwsModule`.
+ */
+@Module({
+  imports: [ConfigModule, CloudProviderModule],
+  providers: [TfvarsService],
+  exports: [ConfigModule, CloudProviderModule, TfvarsService],
+})
+export class TfvarsModule {}

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -248,11 +248,49 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('readEnvTfvarsCacheTtlMs', () => {
+    afterEach(() => {
+      delete process.env['TFVARS_CACHE_TTL_MS'];
+    });
+
+    it('should default to 30000 when TFVARS_CACHE_TTL_MS is unset', () => {
+      delete process.env['TFVARS_CACHE_TTL_MS'];
+      expect(service.readEnvTfvarsCacheTtlMs()).toBe(30000);
+    });
+
+    it('should default to 30000 when TFVARS_CACHE_TTL_MS is empty', () => {
+      process.env['TFVARS_CACHE_TTL_MS'] = '';
+      expect(service.readEnvTfvarsCacheTtlMs()).toBe(30000);
+    });
+
+    it('should parse a valid TFVARS_CACHE_TTL_MS value', () => {
+      process.env['TFVARS_CACHE_TTL_MS'] = '60000';
+      expect(service.readEnvTfvarsCacheTtlMs()).toBe(60000);
+    });
+
+    it('should default to 30000 and warn when TFVARS_CACHE_TTL_MS is not a number', () => {
+      process.env['TFVARS_CACHE_TTL_MS'] = 'not-a-number';
+      expect(service.readEnvTfvarsCacheTtlMs()).toBe(30000);
+    });
+
+    it('should default to 30000 when TFVARS_CACHE_TTL_MS is negative', () => {
+      process.env['TFVARS_CACHE_TTL_MS'] = '-1';
+      expect(service.readEnvTfvarsCacheTtlMs()).toBe(30000);
+    });
+
+    it('should default to 30000 when TFVARS_CACHE_TTL_MS is zero', () => {
+      process.env['TFVARS_CACHE_TTL_MS'] = '0';
+      expect(service.readEnvTfvarsCacheTtlMs()).toBe(30000);
+    });
+  });
+
   describe('path resolution', () => {
     afterEach(() => {
       vi.restoreAllMocks();
       delete process.env['TF_STATE_PATH'];
       delete process.env['SERVER_CONFIG_PATH'];
+      delete process.env['TFVARS_PATH'];
+      delete process.env['GSD_TFVARS_BUCKET'];
     });
 
     it('should return packaged tfstate path when readIsPackaged returns true', () => {
@@ -290,6 +328,70 @@ describe('ConfigService', () => {
       const result = service.getServerConfigPath();
       expect(result).toMatch(/server_config\.json$/);
       expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('should return the TFVARS_PATH env var value when set', () => {
+      process.env['TFVARS_PATH'] = '/custom/tfvars/terraform.tfvars';
+      expect(service.getTfvarsPath()).toBe('/custom/tfvars/terraform.tfvars');
+    });
+
+    it('should return packaged tfvars path when readIsPackaged returns true', () => {
+      type Internals = { readIsPackaged: () => boolean; readResourcesPath: () => string | undefined };
+      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(service as unknown as Internals, 'readResourcesPath').mockReturnValue('/fake/resources');
+      expect(service.getTfvarsPath()).toBe(
+        path.join('/fake/resources', 'terraform', 'terraform.tfvars'),
+      );
+    });
+
+    it('should return the repo-relative tfvars fallback when readIsPackaged returns false', () => {
+      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
+      const result = service.getTfvarsPath();
+      expect(result).toMatch(/terraform[/\\]terraform\.tfvars$/);
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('should return the GSD_TFVARS_BUCKET env var value when set', () => {
+      process.env['GSD_TFVARS_BUCKET'] = 'my-project-tfvars';
+      expect(service.getTfvarsBucket()).toBe('my-project-tfvars');
+    });
+
+    it('should return the marker file contents when GSD_TFVARS_BUCKET is unset', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('marker-bucket-name\n');
+      expect(service.getTfvarsBucket()).toBe('marker-bucket-name');
+    });
+
+    it('should walk up from a nested cwd to find the marker file at an ancestor directory', () => {
+      const repoRoot = path.join(path.sep, 'repo');
+      const nestedCwd = path.join(repoRoot, 'app', 'packages', 'desktop-main');
+      const markerPath = path.join(repoRoot, '.gsd', 'tfvars-bucket');
+
+      vi.spyOn(process, 'cwd').mockReturnValue(nestedCwd);
+      mockExists.mockImplementation((p) => p === markerPath);
+      mockRead.mockReturnValue('nested-bucket-name');
+
+      expect(service.getTfvarsBucket()).toBe('nested-bucket-name');
+      expect(mockRead).toHaveBeenCalledWith(markerPath, 'utf-8');
+    });
+
+    it('should return null when neither the env var nor the marker file resolve', () => {
+      mockExists.mockReturnValue(false);
+      expect(service.getTfvarsBucket()).toBeNull();
+    });
+
+    it('should return null when the marker file is empty', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('   ');
+      expect(service.getTfvarsBucket()).toBeNull();
+    });
+
+    it('should return null and warn when the marker file cannot be read', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockImplementation(() => {
+        throw new Error('EACCES');
+      });
+      expect(service.getTfvarsBucket()).toBeNull();
     });
   });
 });

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -59,6 +59,12 @@ const DEFAULT_CONFIG: WatchdogConfig = {
 };
 
 /**
+ * Default in-memory cache TTL (milliseconds) `TfvarsService` uses for the
+ * parsed tfvars payload when `TFVARS_CACHE_TTL_MS` is unset or invalid.
+ */
+const DEFAULT_TFVARS_CACHE_TTL_MS = 30000;
+
+/**
  * Identifier for the cloud provider the app is currently driving. A union
  * type (rather than a bare string) so additional providers can be added
  * without widening every consumer's type to `string`.
@@ -184,6 +190,27 @@ export class ConfigService {
   }
 
   /**
+   * Read the tfvars in-memory cache TTL override (milliseconds) from
+   * `TFVARS_CACHE_TTL_MS`. Extracted for test-stubbing, mirroring
+   * {@link readEnvRegion} / {@link readEnvApiToken}.
+   *
+   * Defaults to {@link DEFAULT_TFVARS_CACHE_TTL_MS} (30s) when the env var is
+   * unset, empty, not a finite number, or non-positive (zero included) — the
+   * default is applied here rather than pushed onto callers.
+   */
+  readEnvTfvarsCacheTtlMs(): number {
+    const raw = process.env['TFVARS_CACHE_TTL_MS'];
+    if (raw === undefined || raw.length === 0) return DEFAULT_TFVARS_CACHE_TTL_MS;
+
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      logger.warn('Invalid TFVARS_CACHE_TTL_MS value, using default', { raw });
+      return DEFAULT_TFVARS_CACHE_TTL_MS;
+    }
+    return parsed;
+  }
+
+  /**
    * Return `process.resourcesPath` when running inside an Electron packaged app,
    * or `undefined` otherwise. Extracted as a protected method so tests can stub
    * it via `vi.spyOn` without touching `process.resourcesPath` directly.
@@ -271,6 +298,84 @@ export class ConfigService {
     }
 
     return join(_APP_ROOT, 'server_config.json');
+  }
+
+  /**
+   * Resolve the absolute path to the local fallback copy of
+   * `terraform.tfvars`. This is the file `TfvarsService` reads/writes when
+   * running in "local" mode — i.e. no S3 tfvars backend is configured (see
+   * {@link getTfvarsBucket}). See `docs/docs/guides/s3-tfvars.md` for the
+   * local-vs-S3 tradeoff this mirrors.
+   *
+   * Resolution order (identical in structure to {@link getTfStatePath}):
+   *  1. `TFVARS_PATH` env var — wins when set.
+   *  2. Electron packaged app (`app.isPackaged`) — `<resourcesPath>/terraform/terraform.tfvars`.
+   *  3. Dev/test fallback — repo root `terraform/terraform.tfvars`.
+   */
+  getTfvarsPath(): string {
+    const envOverride = process.env['TFVARS_PATH'];
+    if (envOverride) return envOverride;
+
+    if (this.readIsPackaged()) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return join(this.readResourcesPath()!, 'terraform', 'terraform.tfvars');
+    }
+
+    // Dev fallback: repo root is one level above _APP_ROOT (app/)
+    return join(_APP_ROOT, '..', 'terraform', 'terraform.tfvars');
+  }
+
+  /**
+   * Resolve the S3 bucket name backing the optional versioned tfvars store
+   * described in `docs/docs/guides/s3-tfvars.md`. Returns `null` when no S3
+   * backend is configured, which callers treat as "local mode" — read/write
+   * {@link getTfvarsPath} directly instead.
+   *
+   * Resolution order (mirrors the `--bucket` fallback chain in
+   * `scripts/tfvars-sync.ts` and the `Makefile` targets it generates):
+   *  1. `GSD_TFVARS_BUCKET` env var — wins when set.
+   *  2. The nearest `.gsd/tfvars-bucket` marker file, found by walking up
+   *     from `process.cwd()` toward the filesystem root — written by
+   *     `setup.sh`'s S3 bootstrap or `init-parent.ts bootstrap --s3-tfvars`.
+   *     Matches `findBucketMarker()` in `scripts/tfvars-sync.ts` so the CLI
+   *     and the app agree on which marker file wins regardless of the
+   *     directory the app happens to be launched from.
+   *  3. `null` — no backend configured.
+   */
+  getTfvarsBucket(): string | null {
+    const envOverride = process.env['GSD_TFVARS_BUCKET'];
+    if (envOverride) return envOverride;
+
+    const markerPath = this.findTfvarsBucketMarker(process.cwd());
+    if (!markerPath) return null;
+
+    try {
+      const contents = readFileSync(markerPath, 'utf-8').trim();
+      return contents.length > 0 ? contents : null;
+    } catch (err) {
+      logger.warn('Could not read .gsd/tfvars-bucket marker file', { err, path: markerPath });
+      return null;
+    }
+  }
+
+  /**
+   * Walk up from `startDir` toward the filesystem root looking for a
+   * `.gsd/tfvars-bucket` marker file, one directory at a time. Mirrors
+   * `findBucketMarker()` in `scripts/tfvars-sync.ts` so both the CLI and the
+   * app resolve to the same marker file. Returns the marker file's absolute
+   * path once found, or `undefined` if the filesystem root is reached
+   * without a match.
+   */
+  private findTfvarsBucketMarker(startDir: string): string | undefined {
+    let dir = startDir;
+    while (true) {
+      const markerPath = join(dir, '.gsd', 'tfvars-bucket');
+      if (existsSync(markerPath)) return markerPath;
+
+      const parent = dirname(dir);
+      if (parent === dir) return undefined;
+      dir = parent;
+    }
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TfvarsService.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.test.ts
@@ -161,7 +161,7 @@ describe('TfvarsService', () => {
   });
 
   describe('getRawHcl', () => {
-    it('should return the raw HCL text without a versionId in local mode', async () => {
+    it('should return the raw HCL text without an etag in local mode', async () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(FIXTURE_TFVARS);
 
@@ -169,10 +169,10 @@ describe('TfvarsService', () => {
       const result = await service.getRawHcl();
 
       expect(result.hcl).toBe(FIXTURE_TFVARS);
-      expect(result.versionId).toBeUndefined();
+      expect(result.etag).toBeUndefined();
     });
 
-    it('should return the raw HCL text plus the RemoteFileStore etag as versionId in s3 mode', async () => {
+    it('should return the raw HCL text plus the RemoteFileStore etag in s3 mode', async () => {
       remoteFileStore.get.mockResolvedValue({
         body: new TextEncoder().encode(FIXTURE_TFVARS),
         etag: 'etag-1',
@@ -182,7 +182,7 @@ describe('TfvarsService', () => {
       const result = await service.getRawHcl();
 
       expect(result.hcl).toBe(FIXTURE_TFVARS);
-      expect(result.versionId).toBe('etag-1');
+      expect(result.etag).toBe('etag-1');
     });
 
     it('should reject when the tfvars source is unreadable, unlike getGameServers', async () => {

--- a/app/packages/desktop-main/src/services/TfvarsService.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.test.ts
@@ -81,11 +81,26 @@ const EXPECTED_GAME_SERVERS = [
 function makeRemoteFileStore(): RemoteFileStore & {
   get: ReturnType<typeof vi.fn>;
 } {
-  return {
+  const store: Partial<RemoteFileStore> = {
     get: vi.fn(),
     put: vi.fn(),
     listVersions: vi.fn(),
-  } as unknown as RemoteFileStore & { get: ReturnType<typeof vi.fn> };
+  };
+  return store as RemoteFileStore & { get: ReturnType<typeof vi.fn> };
+}
+
+/**
+ * Test-only subclass exposing a directly-controllable `now()` mock, so tests
+ * can simulate TTL expiry without real timers. Avoids reaching into
+ * `TfvarsService`'s protected `now()` via an `as unknown as { now }` cast.
+ */
+class TestableTfvarsService extends TfvarsService {
+  /** Mock backing `now()`; call `nowMock.mockReturnValue(...)` to control the clock. */
+  readonly nowMock = vi.fn<[], number>(() => Date.now());
+
+  protected override now(): number {
+    return this.nowMock();
+  }
 }
 
 /**
@@ -248,9 +263,8 @@ describe('TfvarsService', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue('this is not { valid hcl @@@');
 
-      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
-      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
-      nowSpy.mockReturnValue(1_000_000);
+      const service = new TestableTfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      service.nowMock.mockReturnValue(1_000_000);
 
       await expect(service.getGameServers()).resolves.toEqual([]);
       expect(mockRead).toHaveBeenCalledTimes(1);
@@ -258,7 +272,7 @@ describe('TfvarsService', () => {
       // Fix the underlying source, but stay within the TTL — the negatively
       // cached failure should still be served, not a fresh (now-valid) read.
       mockRead.mockReturnValue(FIXTURE_TFVARS);
-      nowSpy.mockReturnValue(1_010_000); // 10s later, well within a 30s TTL
+      service.nowMock.mockReturnValue(1_010_000); // 10s later, well within a 30s TTL
       await expect(service.getGameServers()).resolves.toEqual([]);
       expect(mockRead).toHaveBeenCalledTimes(1);
     });
@@ -267,14 +281,13 @@ describe('TfvarsService', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue('this is not { valid hcl @@@');
 
-      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
-      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
-      nowSpy.mockReturnValue(1_000_000);
+      const service = new TestableTfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      service.nowMock.mockReturnValue(1_000_000);
 
       await expect(service.getGameServers()).resolves.toEqual([]);
 
       mockRead.mockReturnValue(FIXTURE_TFVARS);
-      nowSpy.mockReturnValue(1_000_000 + 30001); // just past the 30s TTL
+      service.nowMock.mockReturnValue(1_000_000 + 30001); // just past the 30s TTL
       const result = await service.getGameServers();
 
       expect(result).toEqual(EXPECTED_GAME_SERVERS);
@@ -296,12 +309,11 @@ describe('TfvarsService', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(FIXTURE_TFVARS);
 
-      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
-      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
-      nowSpy.mockReturnValue(1_000_000);
+      const service = new TestableTfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      service.nowMock.mockReturnValue(1_000_000);
 
       const first = await service.getGameServers();
-      nowSpy.mockReturnValue(1_010_000); // 10s later, well within a 30s TTL
+      service.nowMock.mockReturnValue(1_010_000); // 10s later, well within a 30s TTL
       const second = await service.getGameServers();
 
       expect(mockRead).toHaveBeenCalledTimes(1);
@@ -312,12 +324,11 @@ describe('TfvarsService', () => {
       mockExists.mockReturnValue(true);
       mockRead.mockReturnValue(FIXTURE_TFVARS);
 
-      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
-      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
-      nowSpy.mockReturnValue(1_000_000);
+      const service = new TestableTfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      service.nowMock.mockReturnValue(1_000_000);
 
       await service.getGameServers();
-      nowSpy.mockReturnValue(1_000_000 + 30001); // just past the 30s TTL
+      service.nowMock.mockReturnValue(1_000_000 + 30001); // just past the 30s TTL
       await service.getGameServers();
 
       expect(mockRead).toHaveBeenCalledTimes(2);

--- a/app/packages/desktop-main/src/services/TfvarsService.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for `TfvarsService` — the local-vs-S3 tfvars reader/parser.
+ *
+ * `@cdktf/hcl2json` (the underlying HCL→JSON parser) is exercised for real
+ * here rather than mocked, since it's the whole point of the service; only
+ * the filesystem, the injected `RemoteFileStore`, and `ConfigService` are
+ * stubbed.
+ */
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RemoteFileStore } from '@hyveon/shared';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { readFileSync, existsSync } from 'fs';
+import { TfvarsService } from './TfvarsService.js';
+import { ConfigService } from './ConfigService.js';
+import { logger } from '../logger.js';
+
+/** Strongly-typed mock handles for the `fs` module. */
+const mockExists = vi.mocked(existsSync);
+const mockRead = vi.mocked(readFileSync);
+
+/** A minimal, valid `terraform.tfvars` fixture defining a single game server. */
+const FIXTURE_TFVARS = `
+aws_region   = "us-east-1"
+project_name = "game-servers"
+
+game_servers = {
+  palworld = {
+    image  = "thijsvanloef/palworld-server-docker:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 8211,  protocol = "udp" },
+      { container = 27015, protocol = "udp" },
+    ]
+    environment = [
+      { name = "PLAYERS", value = "16" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/palworld" },
+    ]
+    https           = false
+    connect_message = "Connect to {host}:{port}"
+  }
+}
+`;
+
+/** Expected `GameServer[]` produced by parsing `FIXTURE_TFVARS`. */
+const EXPECTED_GAME_SERVERS = [
+  {
+    name: 'palworld',
+    image: 'thijsvanloef/palworld-server-docker:latest',
+    cpu: 2048,
+    memory: 8192,
+    ports: [
+      { container: 8211, protocol: 'udp' },
+      { container: 27015, protocol: 'udp' },
+    ],
+    environment: [{ name: 'PLAYERS', value: '16' }],
+    volumes: [{ name: 'saves', container_path: '/palworld' }],
+    https: false,
+    connect_message: 'Connect to {host}:{port}',
+  },
+];
+
+/** Fake `RemoteFileStore` whose `get()` is a directly-controllable mock. */
+function makeRemoteFileStore(): RemoteFileStore & {
+  get: ReturnType<typeof vi.fn>;
+} {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  } as unknown as RemoteFileStore & { get: ReturnType<typeof vi.fn> };
+}
+
+/**
+ * Builds a `ConfigService` stub exposing just the methods `TfvarsService`
+ * reads. `bucket: null` selects local mode; any non-null string selects S3
+ * mode.
+ */
+function makeConfig(opts: {
+  bucket?: string | null;
+  path?: string;
+  ttlMs?: number;
+}): ConfigService {
+  const stub: Partial<ConfigService> = {
+    getTfvarsBucket: () => opts.bucket ?? null,
+    getTfvarsPath: () => opts.path ?? '/repo/terraform/terraform.tfvars',
+    readEnvTfvarsCacheTtlMs: () => opts.ttlMs ?? 30000,
+  };
+  return stub as ConfigService;
+}
+
+describe('TfvarsService', () => {
+  let remoteFileStore: RemoteFileStore & { get: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    remoteFileStore = makeRemoteFileStore();
+    vi.clearAllMocks();
+  });
+
+  describe('local mode', () => {
+    it('should parse a fixture tfvars file into a GameServer[] matching the terraform/variables.tf shape', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      const result = await service.getGameServers();
+
+      expect(result).toEqual(EXPECTED_GAME_SERVERS);
+      expect(remoteFileStore.get).not.toHaveBeenCalled();
+    });
+
+    it('should read from ConfigService.getTfvarsPath()', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(
+        makeConfig({ bucket: null, path: '/custom/terraform.tfvars' }),
+        remoteFileStore,
+      );
+      await service.getGameServers();
+
+      expect(mockExists).toHaveBeenCalledWith('/custom/terraform.tfvars');
+      expect(mockRead).toHaveBeenCalledWith('/custom/terraform.tfvars', 'utf-8');
+    });
+
+    it('should return an empty array and log when the local tfvars file does not exist', async () => {
+      mockExists.mockReturnValue(false);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should return an empty array and log when the tfvars file has no game_servers key', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('aws_region = "us-east-1"\n');
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('getRawHcl', () => {
+    it('should return the raw HCL text without a versionId in local mode', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      const result = await service.getRawHcl();
+
+      expect(result.hcl).toBe(FIXTURE_TFVARS);
+      expect(result.versionId).toBeUndefined();
+    });
+
+    it('should return the raw HCL text plus the RemoteFileStore etag as versionId in s3 mode', async () => {
+      remoteFileStore.get.mockResolvedValue({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-1',
+      });
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+      const result = await service.getRawHcl();
+
+      expect(result.hcl).toBe(FIXTURE_TFVARS);
+      expect(result.versionId).toBe('etag-1');
+    });
+
+    it('should reject when the tfvars source is unreadable, unlike getGameServers', async () => {
+      mockExists.mockReturnValue(false);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.getRawHcl()).rejects.toThrow(/not found/);
+    });
+  });
+
+  describe('s3 mode', () => {
+    it('should parse tfvars fetched from the stubbed RemoteFileStore into a GameServer[] matching the terraform/variables.tf shape', async () => {
+      remoteFileStore.get.mockResolvedValue({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-1',
+      });
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+      const result = await service.getGameServers();
+
+      expect(result).toEqual(EXPECTED_GAME_SERVERS);
+      expect(mockRead).not.toHaveBeenCalled();
+    });
+
+    it('should fetch the object keyed by the tfvars path basename', async () => {
+      remoteFileStore.get.mockResolvedValue({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-1',
+      });
+
+      const service = new TfvarsService(
+        makeConfig({ bucket: 'my-tfvars-bucket', path: '/repo/terraform/terraform.tfvars' }),
+        remoteFileStore,
+      );
+      await service.getGameServers();
+
+      expect(remoteFileStore.get).toHaveBeenCalledWith('terraform.tfvars');
+    });
+
+    it('should return an empty array and log when the remote tfvars object does not exist', async () => {
+      remoteFileStore.get.mockResolvedValue(undefined);
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('parse errors', () => {
+    it('should return an empty array and log when the tfvars text is malformed HCL', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('this is not { valid hcl @@@');
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should negatively cache a failed parse, so the next call within the TTL does not retry the source', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('this is not { valid hcl @@@');
+
+      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
+      nowSpy.mockReturnValue(1_000_000);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(mockRead).toHaveBeenCalledTimes(1);
+
+      // Fix the underlying source, but stay within the TTL — the negatively
+      // cached failure should still be served, not a fresh (now-valid) read.
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+      nowSpy.mockReturnValue(1_010_000); // 10s later, well within a 30s TTL
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(mockRead).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry the source once the TTL has elapsed after a failed parse', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('this is not { valid hcl @@@');
+
+      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
+      nowSpy.mockReturnValue(1_000_000);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+      nowSpy.mockReturnValue(1_000_000 + 30001); // just past the 30s TTL
+      const result = await service.getGameServers();
+
+      expect(result).toEqual(EXPECTED_GAME_SERVERS);
+    });
+  });
+
+  describe('caching', () => {
+    it('should be a cache miss on the first call, reading the source once', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      await service.getGameServers();
+
+      expect(mockRead).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be a cache hit on a second call within the TTL, not re-reading the source', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
+      nowSpy.mockReturnValue(1_000_000);
+
+      const first = await service.getGameServers();
+      nowSpy.mockReturnValue(1_010_000); // 10s later, well within a 30s TTL
+      const second = await service.getGameServers();
+
+      expect(mockRead).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
+    });
+
+    it('should re-read the source once the TTL has elapsed', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+      const nowSpy = vi.spyOn(service as unknown as { now: () => number }, 'now');
+      nowSpy.mockReturnValue(1_000_000);
+
+      await service.getGameServers();
+      nowSpy.mockReturnValue(1_000_000 + 30001); // just past the 30s TTL
+      await service.getGameServers();
+
+      expect(mockRead).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-read the source immediately after invalidateCache', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null, ttlMs: 30000 }), remoteFileStore);
+
+      await service.getGameServers();
+      service.invalidateCache();
+      await service.getGameServers();
+
+      expect(mockRead).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -67,6 +67,17 @@ export class TfvarsService {
   private cache: CachedGameServers | null = null;
 
   /**
+   * Monotonically incremented by {@link invalidateCache}. `getGameServers()`
+   * snapshots this value before starting a fetch and only commits the result
+   * to `this.cache` if the counter is unchanged when the fetch resolves —
+   * this stops a late-resolving fetch that was already in flight when
+   * `invalidateCache()` was called from resurrecting a stale, pre-invalidation
+   * parse with a fresh `cachedAt` (which would otherwise serve stale data for
+   * a full TTL window despite the explicit invalidation).
+   */
+  private cacheGeneration = 0;
+
+  /**
    * `remoteFileStore` is typed against the cloud-agnostic `RemoteFileStore`
    * contract (not a concrete AWS class) so this service depends only on the
    * interface; `@Inject(REMOTE_FILE_STORE)` tells Nest which concrete
@@ -95,6 +106,7 @@ export class TfvarsService {
    */
   invalidateCache(): void {
     this.cache = null;
+    this.cacheGeneration += 1;
   }
 
   /**
@@ -118,30 +130,40 @@ export class TfvarsService {
 
     logger.debug('tfvars cache miss — loading terraform.tfvars', {});
 
+    const generation = this.cacheGeneration;
+
     try {
       const { hcl } = await this.fetchRawTfvars();
       const value = this.parseGameServers(await this.parseHclContents(hcl));
-      this.cache = { value, cachedAt: this.now(), failed: false };
+      if (generation === this.cacheGeneration) {
+        this.cache = { value, cachedAt: this.now(), failed: false };
+      }
       logger.info('Loaded terraform.tfvars game_servers', { count: value.length });
       return value;
     } catch (err) {
       logger.error('Failed to load terraform.tfvars game_servers — returning empty list', { err });
-      this.cache = { value: [], cachedAt: this.now(), failed: true };
+      if (generation === this.cacheGeneration) {
+        this.cache = { value: [], cachedAt: this.now(), failed: true };
+      }
       return [];
     }
   }
 
   /**
    * Returns the raw, unparsed `terraform.tfvars` HCL text plus a source
-   * version marker: in S3 mode, the `RemoteFileStore.get()` etag (as
-   * `versionId`); in local mode, `versionId` is omitted since the local
-   * filesystem has no equivalent versioning concept. Unlike
-   * {@link getGameServers}, this bypasses the in-memory cache and rejects
-   * (rather than swallowing) a missing file/object — callers that need the
-   * raw text (e.g. an editor) want to know immediately if the source is
-   * unreadable rather than silently getting stale/empty data.
+   * integrity marker: in S3 mode, the `RemoteFileStore.get()` etag (as
+   * `etag`) — the same value `RemoteFileStore.put()` expects as its
+   * `ifMatch` guard, so callers can round-trip a conditional write; in local
+   * mode, `etag` is omitted since the local filesystem has no equivalent
+   * concept. This is distinct from `RemoteFileStore.listVersions()`'s
+   * `versionId`, which identifies a specific S3 object version rather than
+   * an etag — the two are not comparable. Unlike {@link getGameServers},
+   * this bypasses the in-memory cache and rejects (rather than swallowing) a
+   * missing file/object — callers that need the raw text (e.g. an editor)
+   * want to know immediately if the source is unreadable rather than
+   * silently getting stale/empty data.
    */
-  async getRawHcl(): Promise<{ hcl: string; versionId?: string }> {
+  async getRawHcl(): Promise<{ hcl: string; etag?: string }> {
     return this.fetchRawTfvars();
   }
 
@@ -153,7 +175,7 @@ export class TfvarsService {
    * Shared by {@link getGameServers} (which catches and swallows the error)
    * and {@link getRawHcl} (which lets it propagate).
    */
-  private async fetchRawTfvars(): Promise<{ hcl: string; versionId?: string }> {
+  private async fetchRawTfvars(): Promise<{ hcl: string; etag?: string }> {
     const bucket = this.config.getTfvarsBucket();
     const path = this.config.getTfvarsPath();
 
@@ -163,7 +185,7 @@ export class TfvarsService {
       if (!obj) {
         throw new Error(`tfvars object "${key}" not found in S3 bucket "${bucket}".`);
       }
-      return { hcl: new TextDecoder().decode(obj.body), versionId: obj.etag };
+      return { hcl: new TextDecoder().decode(obj.body), etag: obj.etag };
     }
 
     if (!existsSync(path)) {

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -1,0 +1,209 @@
+/**
+ * Reads and parses `terraform.tfvars` into the `GameServer[]` shape declared
+ * by `@hyveon/shared/tfvars.js` (which mirrors `terraform/variables.tf`'s
+ * `game_servers` map).
+ *
+ * Source resolution mirrors the local-vs-S3 tradeoff documented in
+ * `docs/docs/guides/s3-tfvars.md`:
+ *  - When `ConfigService.getTfvarsBucket()` resolves to a bucket name, the
+ *    raw tfvars text is fetched from that bucket via the injected
+ *    `RemoteFileStore` ("S3 mode").
+ *  - Otherwise the local file at `ConfigService.getTfvarsPath()` is read
+ *    directly ("local mode").
+ *
+ * The raw HCL text is converted to JSON via `@cdktf/hcl2json`'s `parse()`
+ * (a WASM-backed port of Terraform's own HCL parser), then the `game_servers`
+ * map is flattened into a `GameServer[]` with the map key attached as `name`.
+ *
+ * Parsed results are cached in-memory for `ConfigService.readEnvTfvarsCacheTtlMs()`
+ * milliseconds so frequent callers (e.g. polling endpoints) don't re-parse the
+ * file/re-fetch from S3 on every call. Call `invalidateCache()` to force a
+ * fresh read before the TTL elapses (e.g. after a tfvars edit). The cache
+ * mirrors `ConfigService.tfCache`'s tri-state approach: `undefined` means
+ * "never loaded" (always a miss), while a set `CachedGameServers` entry
+ * covers *both* a successful parse and a negatively-cached failed load (the
+ * `failed` flag distinguishes the two) — either way the entry's `cachedAt`
+ * governs the TTL, so a broken source isn't re-hit on every call within the
+ * TTL window.
+ *
+ * `getGameServers()` never rejects — a missing file/object, a missing
+ * `game_servers` key, or a malformed-HCL parse error are all logged via the
+ * shared Winston `logger` and resolve to `[]`, mirroring `ConfigService`'s
+ * graceful degradation for polling callers.
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { existsSync, readFileSync } from 'fs';
+import { basename } from 'path';
+import { parse as parseHcl } from '@cdktf/hcl2json';
+import type { GameServer, RemoteFileStore } from '@hyveon/shared';
+import { logger } from '../logger.js';
+import { ConfigService } from './ConfigService.js';
+import { REMOTE_FILE_STORE } from '../modules/cloud-provider.tokens.js';
+
+/**
+ * Raw JSON-decoded shape of a single `game_servers` map entry as produced by
+ * `@cdktf/hcl2json`, before the map key is flattened onto it as `name`.
+ * Structurally identical to `GameServer` minus the `name` field.
+ */
+type RawGameServerEntry = Omit<GameServer, 'name'>;
+
+/**
+ * In-memory cache entry: the resolved value (empty on failure), the
+ * timestamp it was resolved at, and whether that resolution was a failure
+ * (negatively cached) rather than a genuine successful parse.
+ */
+interface CachedGameServers {
+  value: GameServer[];
+  cachedAt: number;
+  failed: boolean;
+}
+
+/**
+ * Local-vs-S3 tfvars reader/parser — see the file-level doc comment above for
+ * source resolution, parsing, and caching behaviour.
+ */
+@Injectable()
+export class TfvarsService {
+  private cache: CachedGameServers | null = null;
+
+  /**
+   * `remoteFileStore` is typed against the cloud-agnostic `RemoteFileStore`
+   * contract (not a concrete AWS class) so this service depends only on the
+   * interface; `@Inject(REMOTE_FILE_STORE)` tells Nest which concrete
+   * provider (bound by `CloudProviderModule` for whichever cloud is active)
+   * to resolve for that parameter.
+   */
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(REMOTE_FILE_STORE) private readonly remoteFileStore: RemoteFileStore,
+  ) {}
+
+  /**
+   * Current time in milliseconds, extracted so tests can stub it via
+   * `vi.spyOn` to simulate TTL expiry without real timers (mirrors
+   * `ConfigService`'s protected `read*` accessors).
+   */
+  protected now(): number {
+    return Date.now();
+  }
+
+  /**
+   * Drop the in-memory cache so the next `getGameServers()` call re-reads
+   * from disk/S3 instead of returning a stale parse. Called after a tfvars
+   * write (e.g. via `scripts/tfvars-sync.ts pull`) and by tests between
+   * scenarios.
+   */
+  invalidateCache(): void {
+    this.cache = null;
+  }
+
+  /**
+   * Returns the `game_servers` map from `terraform.tfvars`, parsed into a
+   * `GameServer[]` (the map key is flattened onto each entry as `name`).
+   *
+   * Returns a cached result when the last resolution (success *or* failure)
+   * is younger than `ConfigService.readEnvTfvarsCacheTtlMs()`; otherwise
+   * reads/parses fresh (see the class doc for local-vs-S3 source resolution)
+   * and re-caches. Never rejects: a missing file/object, a missing
+   * `game_servers` key, or a malformed-HCL parse error are logged and
+   * resolved to `[]` (and negatively cached for the TTL window) rather than
+   * thrown, so polling callers degrade gracefully instead of crashing.
+   */
+  async getGameServers(): Promise<GameServer[]> {
+    const ttl = this.config.readEnvTfvarsCacheTtlMs();
+    if (this.cache && this.now() - this.cache.cachedAt < ttl) {
+      logger.debug('tfvars cache hit', { failed: this.cache.failed, cachedAt: this.cache.cachedAt });
+      return this.cache.value;
+    }
+
+    logger.debug('tfvars cache miss — loading terraform.tfvars', {});
+
+    try {
+      const { hcl } = await this.fetchRawTfvars();
+      const value = this.parseGameServers(await this.parseHclContents(hcl));
+      this.cache = { value, cachedAt: this.now(), failed: false };
+      logger.info('Loaded terraform.tfvars game_servers', { count: value.length });
+      return value;
+    } catch (err) {
+      logger.error('Failed to load terraform.tfvars game_servers — returning empty list', { err });
+      this.cache = { value: [], cachedAt: this.now(), failed: true };
+      return [];
+    }
+  }
+
+  /**
+   * Returns the raw, unparsed `terraform.tfvars` HCL text plus a source
+   * version marker: in S3 mode, the `RemoteFileStore.get()` etag (as
+   * `versionId`); in local mode, `versionId` is omitted since the local
+   * filesystem has no equivalent versioning concept. Unlike
+   * {@link getGameServers}, this bypasses the in-memory cache and rejects
+   * (rather than swallowing) a missing file/object — callers that need the
+   * raw text (e.g. an editor) want to know immediately if the source is
+   * unreadable rather than silently getting stale/empty data.
+   */
+  async getRawHcl(): Promise<{ hcl: string; versionId?: string }> {
+    return this.fetchRawTfvars();
+  }
+
+  /**
+   * Reads the raw tfvars text, preferring the S3 backend
+   * (`ConfigService.getTfvarsBucket()`) when configured, otherwise falling
+   * back to the local file at `ConfigService.getTfvarsPath()`. Throws a clear
+   * error when the source is configured but the file/object doesn't exist.
+   * Shared by {@link getGameServers} (which catches and swallows the error)
+   * and {@link getRawHcl} (which lets it propagate).
+   */
+  private async fetchRawTfvars(): Promise<{ hcl: string; versionId?: string }> {
+    const bucket = this.config.getTfvarsBucket();
+    const path = this.config.getTfvarsPath();
+
+    if (bucket) {
+      const key = basename(path);
+      const obj = await this.remoteFileStore.get(key);
+      if (!obj) {
+        throw new Error(`tfvars object "${key}" not found in S3 bucket "${bucket}".`);
+      }
+      return { hcl: new TextDecoder().decode(obj.body), versionId: obj.etag };
+    }
+
+    if (!existsSync(path)) {
+      throw new Error(`tfvars file not found at "${path}".`);
+    }
+    return { hcl: readFileSync(path, 'utf-8') };
+  }
+
+  /**
+   * Converts raw HCL tfvars text to JSON via `@cdktf/hcl2json`. Wraps parse
+   * failures (malformed HCL) in a clear, contextualized error rather than
+   * letting the library's raw error surface directly.
+   */
+  private async parseHclContents(contents: string): Promise<Record<string, unknown>> {
+    try {
+      return await parseHcl('terraform.tfvars', contents);
+    } catch (err) {
+      logger.error('Failed to parse terraform.tfvars', { err });
+      throw new Error(
+        `Failed to parse terraform.tfvars: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Flattens the `game_servers` map (if present) from the JSON-decoded
+   * tfvars payload into a `GameServer[]`. Returns `[]` (after logging a
+   * warning) when the key is absent or not an object, e.g. an
+   * empty/placeholder tfvars file.
+   */
+  private parseGameServers(parsed: Record<string, unknown>): GameServer[] {
+    const gameServers = parsed['game_servers'];
+    if (!gameServers || typeof gameServers !== 'object') {
+      logger.warn('terraform.tfvars has no game_servers map', {});
+      return [];
+    }
+
+    return Object.entries(gameServers as Record<string, RawGameServerEntry>).map(([name, entry]) => ({
+      name,
+      ...entry,
+    }));
+  }
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js';
+export * from './tfvars.js';
 export * from './cloud.js';
 export * from './sanitize.js';
 export * from './canRun.js';

--- a/app/packages/shared/src/tfvars.ts
+++ b/app/packages/shared/src/tfvars.ts
@@ -1,0 +1,58 @@
+/**
+ * TypeScript mirror of the `game_servers` map entry object type declared in
+ * `terraform/variables.tf`. Keep the fields (and their optionality) in sync
+ * with that Terraform variable — this is the shape parsed out of
+ * `terraform.tfvars` by `TfvarsService`.
+ */
+
+/** Single TCP/UDP port a game server container listens on. */
+export interface GameServerPort {
+  container: number;
+  protocol: string;
+}
+
+/** Environment variable injected into the game server container. */
+export interface GameServerEnvironmentVariable {
+  name: string;
+  value: string;
+}
+
+/** EFS-backed volume mount for a game server container. */
+export interface GameServerVolume {
+  name: string;
+  container_path: string;
+}
+
+/**
+ * File seeded into the container filesystem at task start (e.g. server
+ * config or mod files). Exactly one of `content` / `content_base64` is
+ * normally supplied.
+ */
+export interface GameServerFileSeed {
+  path: string;
+  content?: string;
+  content_base64?: string;
+  mode?: string;
+}
+
+/**
+ * Per-game container configuration, keyed by game name in the
+ * `game_servers` Terraform variable (`terraform/variables.tf`).
+ */
+export interface GameServer {
+  /**
+   * The `game_servers` map key for this entry. Not a Terraform object
+   * attribute — flattened onto the entry here so a list of `GameServer`
+   * values is self-describing without a separate keys array.
+   */
+  name: string;
+  image: string;
+  cpu: number;
+  memory: number;
+  ports: GameServerPort[];
+  environment?: GameServerEnvironmentVariable[];
+  volumes: GameServerVolume[];
+  https?: boolean;
+  connect_message?: string;
+  file_seeds?: GameServerFileSeed[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@aws-sdk/client-ecs": "^3.600.0",
         "@aws-sdk/client-secrets-manager": "^3.600.0",
         "@aws-sdk/lib-dynamodb": "^3.600.0",
+        "@cdktf/hcl2json": "^0.21.0",
         "@grpc/proto-loader": "^0.8.1",
         "@hyveon/cloud-aws": "*",
         "@hyveon/shared": "*",
@@ -1712,6 +1713,50 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@cdktf/hcl2json": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.21.0.tgz",
+      "integrity": "sha512-cwX3i/mSJI/cRrtqwEPRfawB7pXgNioriSlkvou8LWiCrrcDe9ZtTbAbu8W1tEJQpe1pnX9VEgpzf/BbM7xF8Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "fs-extra": "11.3.0"
+      }
+    },
+    "node_modules/@cdktf/hcl2json/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@cdktf/hcl2json/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@cdktf/hcl2json/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       ],
       "devDependencies": {
         "electron-builder": "^25.0.0",
-        "electron-vite": "^5.0.0"
+        "electron-vite": "^5.0.0",
+        "patch-package": "^8.0.1"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -6378,6 +6379,13 @@
         "node": ">=14.6"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
@@ -7254,6 +7262,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -10617,6 +10638,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -10665,6 +10699,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/fix-path": {
@@ -11758,6 +11802,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11867,6 +11927,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -12059,6 +12129,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -12313,6 +12396,26 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12347,6 +12450,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -12377,6 +12490,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kuler": {
@@ -13085,6 +13208,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -13950,6 +14100,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -14135,6 +14302,87 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -15547,6 +15795,16 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -16404,6 +16662,19 @@
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -18401,6 +18672,22 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   },
   "devDependencies": {
     "electron-builder": "^25.0.0",
-    "electron-vite": "^5.0.0"
+    "electron-vite": "^5.0.0",
+    "patch-package": "^8.0.1"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "app:dev": "npm run dev            -w game-server-manager",
     "app:build": "npm run build          -w game-server-manager",
     "app:start": "npm run start          -w game-server-manager",

--- a/patches/@cdktf+hcl2json+0.21.0.patch
+++ b/patches/@cdktf+hcl2json+0.21.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@cdktf/hcl2json/wasm/bridge_wasm_exec.js b/node_modules/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
+index 743a6b8..7f1edc0 100644
+--- a/node_modules/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
++++ b/node_modules/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
+@@ -11,7 +11,7 @@ globalThis.fs = require("fs");
+ globalThis.TextEncoder = require("util").TextEncoder;
+ globalThis.TextDecoder = require("util").TextDecoder;
+ 
+-globalThis.performance ??= require("performance");
++globalThis.performance ??= require("perf_hooks").performance;
+ 
+ // Node >= 19 has a crypto function object, lower node versions need this polyfill
+ if (!globalThis.crypto) {


### PR DESCRIPTION
Closes #91

## Summary

- Adds `TfvarsService` (`app/packages/desktop-main/src/services/TfvarsService.ts`), a `@Injectable()` service that parses S3-backed (or local-fallback) `terraform.tfvars` into a typed `GameServer[]`, mirroring `ConfigService`'s cloud-mode resolution.
- Exposes `getGameServers()`, `getRawHcl()` (raw HCL text + S3 ETag/version for the future write path), and `invalidateCache()`, backed by an in-memory cache with a configurable TTL (`TFVARS_CACHE_TTL_MS`, default 30s) and structured Winston logging.
- Registers the service via a new `TfvarsModule` and wires `invalidateCache()` into both `GamesController` (IPC) and `GamesHttpController` (HTTP) alongside the existing `ConfigService` cache invalidation on `/api/games` and `/api/status`.
- Adds the shared `GameServer` type (`@hyveon/shared/tfvars.ts`) matching `terraform/variables.tf`'s `game_servers` shape, `ConfigService` tfvars-resolution helpers (S3 bucket vs. local path), and a patch for `@cdktf/hcl2json`'s Node performance polyfill needed for HCL parsing in the Nest runtime.

## Changes

```
 app/packages/desktop-main/package.json             |   1 +
 app/packages/desktop-main/src/app.module.ts        |   7 +-
 .../src/controllers/games-http.controller.test.ts  |  46 ++-
 .../src/controllers/games-http.controller.ts       |  19 +-
 .../src/controllers/games.controller.test.ts       |  46 ++-
 .../src/controllers/games.controller.ts            |  19 +-
 .../src/modules/cloud-provider.module.test.ts      |  20 +-
 .../src/modules/cloud-provider.module.ts           |  18 +-
 .../desktop-main/src/modules/tfvars.module.ts      |  22 ++
 .../src/services/ConfigService.test.ts             | 102 +++++++
 .../desktop-main/src/services/ConfigService.ts     | 105 +++++++
 .../src/services/TfvarsService.test.ts             | 339 +++++++++++++++++++++
 .../desktop-main/src/services/TfvarsService.ts     | 231 ++++++++++++++
 app/packages/shared/src/index.ts                   |   1 +
 app/packages/shared/src/tfvars.ts                  |  58 ++++
 package-lock.json                                  | 334 +++++++++++++++++++-
 package.json                                       |   4 +-
 patches/@cdktf+hcl2json+0.21.0.patch               |  13 +
 18 files changed, 1339 insertions(+), 46 deletions(-)
```

## Test plan

- [x] `TfvarsService` registered in a new `TfvarsModule` (imported by `AppModule`).
- [x] `getGameServers()` returns `GameServer[]` matching the shape declared in `terraform/variables.tf`.
- [x] Cache invalidation (`invalidateCache()`) wired from `GamesController` / `GamesHttpController` and covered by controller tests.
- [x] Unit tests (`TfvarsService.test.ts`) cover S3 mode, local-file mode, HCL parse errors, and cache hit/miss behavior.
- [x] `ConfigService.test.ts` covers the new tfvars bucket/path resolution helpers.
- [ ] `npm run app:test` — full suite passes locally.
