### PR TITLE
feat(desktop-main): gsd.games.list IPC — declared game_servers merged with live tfstate

### DIFF
--- a/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi } from 'vitest';
+import type { GameServer } from '@hyveon/shared';
 import { GamesHttpController } from './games-http.controller.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
@@ -13,6 +14,18 @@ vi.mock('../logger.js', () => ({
 const DEFAULT_OUTPUTS: Partial<TfOutputs> = {
   game_names: ['minecraft', 'valheim'],
 };
+
+/** Minimal, valid `GameServer` fixture for a single declared game. */
+function buildGameServer(name: string): GameServer {
+  return {
+    name,
+    image: 'example/image:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'saves', container_path: '/data' }],
+  };
+}
 
 /**
  * Build a ConfigService stub. Pass `null` to simulate a pre-apply state
@@ -34,34 +47,49 @@ function makeEcs(): EcsService {
   } as unknown as EcsService;
 }
 
-/** Build a TfvarsService stub with `invalidateCache` pre-wired. */
-function makeTfvars(): TfvarsService {
+/**
+ * Build a TfvarsService stub with `invalidateCache` and `getGameServers`
+ * pre-wired. Defaults to an empty declared list so `listGames` tests that
+ * don't care about the declared view can ignore it.
+ */
+function makeTfvars(declared: GameServer[] = []): TfvarsService {
   return {
     invalidateCache: vi.fn(),
+    getGameServers: vi.fn().mockResolvedValue(declared),
   } as Partial<TfvarsService> as TfvarsService;
 }
 
 describe('GamesHttpController', () => {
   describe('listGames', () => {
-    it('should invalidate the tfstate cache before reading game names', () => {
+    it('should invalidate the tfstate cache before reading game names', async () => {
       const config = makeConfig();
-      new GamesHttpController(config, makeEcs(), makeTfvars()).listGames();
+      await new GamesHttpController(config, makeEcs(), makeTfvars()).listGames();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
-    it('should invalidate the TfvarsService cache before reading game names', () => {
+    it('should invalidate the TfvarsService cache before reading game names', async () => {
       const tfvars = makeTfvars();
-      new GamesHttpController(makeConfig(), makeEcs(), tfvars).listGames();
+      await new GamesHttpController(makeConfig(), makeEcs(), tfvars).listGames();
       expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
-    it('should return game names from Terraform outputs', () => {
-      const result = new GamesHttpController(makeConfig(), makeEcs(), makeTfvars()).listGames();
-      expect(result).toEqual({ games: ['minecraft', 'valheim'] });
+    it('should return the merged declared/deployed games list', async () => {
+      const valheim = buildGameServer('valheim');
+      const result = await new GamesHttpController(
+        makeConfig(),
+        makeEcs(),
+        makeTfvars([valheim]),
+      ).listGames();
+      expect(result).toEqual({
+        games: [
+          { name: 'valheim', declared: true, deployed: true, config: valheim },
+          { name: 'minecraft', declared: false, deployed: true },
+        ],
+      });
     });
 
-    it('should return an empty games array when Terraform has not been applied yet', () => {
-      const result = new GamesHttpController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
+    it('should return an empty games array when Terraform has not been applied yet and nothing is declared', async () => {
+      const result = await new GamesHttpController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
       expect(result).toEqual({ games: [] });
     });
   });

--- a/app/packages/desktop-main/src/controllers/games-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Param, Post } from '@nestjs/common';
+import type { GameListEntry } from '@hyveon/shared';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
 import { TfvarsService } from '../services/TfvarsService.js';
+import { mergeGameLists } from '../services/mergeGameLists.js';
 
 /**
  * HTTP shim that exposes the game-server operations as plain REST endpoints
@@ -12,8 +14,8 @@ import { TfvarsService } from '../services/TfvarsService.js';
  * handlers instead.
  *
  * Both controllers delegate to the same {@link ConfigService},
- * {@link EcsService}, and {@link TfvarsService} providers — there is no
- * duplicated logic.
+ * {@link EcsService}, {@link TfvarsService}, and {@link mergeGameLists}
+ * providers — there is no duplicated logic.
  */
 @Controller()
 export class GamesHttpController {
@@ -24,17 +26,21 @@ export class GamesHttpController {
   ) {}
 
   /**
-   * Lists game keys from the Terraform `game_servers` map. Invalidates the
-   * tfstate cache and the `TfvarsService` cache first so a fresh
+   * Lists games by merging the declared view (`terraform.tfvars`
+   * `game_servers` map, via {@link TfvarsService}) with the deployed view
+   * (`terraform.tfstate` `game_names` output, via {@link ConfigService}) —
+   * see {@link mergeGameLists}. Invalidates both caches first so a fresh
    * `terraform apply` / tfvars edit shows up without having to restart the
    * server.
    */
   @Get('games')
-  listGames(): { games: string[] } {
+  async listGames(): Promise<{ games: GameListEntry[] }> {
     this.config.invalidateCache();
     this.tfvars.invalidateCache();
     const outputs = this.config.getTfOutputs();
-    return { games: outputs?.game_names ?? [] };
+    const declared = await this.tfvars.getGameServers();
+    const deployed = outputs?.game_names ?? [];
+    return { games: mergeGameLists(declared, deployed) };
   }
 
   /**

--- a/app/packages/desktop-main/src/controllers/games.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.test.ts
@@ -4,6 +4,7 @@ import { GamesController } from './games.controller.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
 import type { TfvarsService } from '../services/TfvarsService.js';
+import type { GameServer } from '@hyveon/shared';
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -34,10 +35,28 @@ function makeEcs(): EcsService {
   } as unknown as EcsService;
 }
 
-/** Build a TfvarsService stub with `invalidateCache` pre-wired. */
-function makeTfvars(): TfvarsService {
+/** Minimal, valid `GameServer` fixture for a single declared game. */
+function buildGameServer(name: string): GameServer {
+  return {
+    name,
+    image: 'example/image:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'saves', container_path: '/data' }],
+  };
+}
+
+/**
+ * Build a TfvarsService stub with `invalidateCache` and `getGameServers`
+ * pre-wired. Defaults `getGameServers()` to an empty declared list so
+ * existing specs that only care about the deployed (tfstate) view don't have
+ * to know about the declared merge.
+ */
+function makeTfvars(declared: GameServer[] = []): TfvarsService {
   return {
     invalidateCache: vi.fn(),
+    getGameServers: vi.fn().mockResolvedValue(declared),
   } as Partial<TfvarsService> as TfvarsService;
 }
 
@@ -79,26 +98,48 @@ describe('GamesController', () => {
   });
 
   describe('listGames', () => {
-    it('should invalidate the tfstate cache before reading game names', () => {
+    it('should invalidate the tfstate cache before reading game names', async () => {
       const config = makeConfig();
-      new GamesController(config, makeEcs(), makeTfvars()).listGames();
+      await new GamesController(config, makeEcs(), makeTfvars()).listGames();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
-    it('should invalidate the TfvarsService cache before reading game names', () => {
+    it('should invalidate the TfvarsService cache before reading game names', async () => {
       const tfvars = makeTfvars();
-      new GamesController(makeConfig(), makeEcs(), tfvars).listGames();
+      await new GamesController(makeConfig(), makeEcs(), tfvars).listGames();
       expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
-    it('should return the game names from Terraform outputs', () => {
-      const result = new GamesController(makeConfig(), makeEcs(), makeTfvars()).listGames();
-      expect(result).toEqual({ games: ['minecraft', 'palworld'] });
+    it('should return the deployed game names from Terraform outputs when nothing is declared in tfvars', async () => {
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars()).listGames();
+      expect(result).toEqual({
+        games: [
+          { name: 'minecraft', declared: false, deployed: true },
+          { name: 'palworld', declared: false, deployed: true },
+        ],
+      });
     });
 
-    it('should return an empty games array when Terraform has not been applied yet', () => {
-      const result = new GamesController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
+    it('should return an empty games array when Terraform has not been applied yet and nothing is declared', async () => {
+      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
       expect(result).toEqual({ games: [] });
+    });
+
+    it('should return a game that exists only in tfvars (declared but not yet applied)', async () => {
+      const ark = buildGameServer('ark');
+      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars([ark])).listGames();
+      expect(result).toEqual({ games: [{ name: 'ark', declared: true, deployed: false, config: ark }] });
+    });
+
+    it('should merge declared tfvars games with deployed tfstate games', async () => {
+      const palworld = buildGameServer('palworld');
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars([palworld])).listGames();
+      expect(result).toEqual({
+        games: [
+          { name: 'palworld', declared: true, deployed: true, config: palworld },
+          { name: 'minecraft', declared: false, deployed: true },
+        ],
+      });
     });
   });
 

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -1,8 +1,10 @@
 import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
+import type { GameListEntry } from '@hyveon/shared';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
 import { TfvarsService } from '../services/TfvarsService.js';
+import { mergeGameLists } from '../services/mergeGameLists.js';
 
 /**
  * IPC-only game-server controller. Handles Electron main-process messages via
@@ -23,19 +25,24 @@ export class GamesController {
   ) {}
 
   /**
-   * Lists game keys from the Terraform `game_servers` map. Invalidates the
-   * tfstate cache and the `TfvarsService` cache first so a fresh
-   * `terraform apply` / tfvars edit shows up without having to restart the
-   * server.
+   * Lists games merged from the declared view (`terraform.tfvars`
+   * `game_servers` map, via {@link TfvarsService}) and the deployed view
+   * (`terraform.tfstate` `game_names` output, via {@link ConfigService}) —
+   * see {@link mergeGameLists}. This surfaces games that are declared but not
+   * yet applied (`declared: true, deployed: false`) alongside live games, so
+   * the renderer can distinguish the two states. Invalidates the tfstate
+   * cache and the `TfvarsService` cache first so a fresh `terraform apply` /
+   * tfvars edit shows up without having to restart the server.
    *
    * Reachable via the Electron IPC transport (`games.list`).
    */
   @MessagePattern('games.list')
-  listGames(): { games: string[] } {
+  async listGames(): Promise<{ games: GameListEntry[] }> {
     this.config.invalidateCache();
     this.tfvars.invalidateCache();
+    const declared = await this.tfvars.getGameServers();
     const outputs = this.config.getTfOutputs();
-    return { games: outputs?.game_names ?? [] };
+    return { games: mergeGameLists(declared, outputs?.game_names ?? []) };
   }
 
   /**

--- a/app/packages/desktop-main/src/services/mergeGameLists.test.ts
+++ b/app/packages/desktop-main/src/services/mergeGameLists.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import type { GameServer } from '@hyveon/shared';
+import { mergeGameLists } from './mergeGameLists.js';
+
+/** Minimal, valid `GameServer` fixture for a single declared game. */
+function buildGameServer(name: string): GameServer {
+  return {
+    name,
+    image: 'example/image:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'saves', container_path: '/data' }],
+  };
+}
+
+describe('mergeGameLists', () => {
+  it('should mark a game declared-only when it appears only in tfvars', () => {
+    const palworld = buildGameServer('palworld');
+
+    const result = mergeGameLists([palworld], []);
+
+    expect(result).toEqual([{ name: 'palworld', declared: true, deployed: false, config: palworld }]);
+  });
+
+  it('should mark a game deployed-only when it appears only in tfstate', () => {
+    const result = mergeGameLists([], ['minecraft']);
+
+    expect(result).toEqual([{ name: 'minecraft', declared: false, deployed: true }]);
+  });
+
+  it('should mark a game as both declared and deployed when it appears in both sources', () => {
+    const valheim = buildGameServer('valheim');
+
+    const result = mergeGameLists([valheim], ['valheim']);
+
+    expect(result).toEqual([{ name: 'valheim', declared: true, deployed: true, config: valheim }]);
+  });
+
+  it('should merge a mix of declared-only, deployed-only, and both entries without duplicates', () => {
+    const declaredOnly = buildGameServer('ark');
+    const both = buildGameServer('rust');
+
+    const result = mergeGameLists([declaredOnly, both], ['rust', 'terraria']);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { name: 'ark', declared: true, deployed: false, config: declaredOnly },
+        { name: 'rust', declared: true, deployed: true, config: both },
+        { name: 'terraria', declared: false, deployed: true },
+      ]),
+    );
+  });
+
+  it('should return an empty array when both inputs are empty', () => {
+    expect(mergeGameLists([], [])).toEqual([]);
+  });
+
+  it('should order results as declared entries first (in tfvars order), then deployed-only entries (in tfstate order)', () => {
+    const ark = buildGameServer('ark');
+    const rust = buildGameServer('rust');
+
+    const result = mergeGameLists([ark, rust], ['zomboid', 'rust', 'terraria']);
+
+    expect(result).toEqual([
+      { name: 'ark', declared: true, deployed: false, config: ark },
+      { name: 'rust', declared: true, deployed: true, config: rust },
+      { name: 'zomboid', declared: false, deployed: true },
+      { name: 'terraria', declared: false, deployed: true },
+    ]);
+  });
+});

--- a/app/packages/desktop-main/src/services/mergeGameLists.ts
+++ b/app/packages/desktop-main/src/services/mergeGameLists.ts
@@ -1,0 +1,47 @@
+import type { GameListEntry, GameServer } from '@hyveon/shared';
+
+/**
+ * Merges the declared view of games (`terraform.tfvars` `game_servers` map,
+ * via {@link GameServer}) with the deployed view (`terraform.tfstate`
+ * `game_names` output) into the union `GameListEntry[]` shape returned by the
+ * `games.list` IPC channel / `/api/games` HTTP route — see issue #92.
+ *
+ * A game appears exactly once in the result, keyed by name, with `declared`
+ * and `deployed` flags set independently so callers can distinguish
+ * "declared but not yet applied" from "live but no longer declared" from
+ * "both". `config` is only populated for declared games.
+ *
+ * Pure function — no I/O, no side effects. Ordering is deterministic: entries
+ * appear in `declared` (tfvars) order first, followed by any deployed-only
+ * entries (present in `deployed` but not `declared`) in `deployed` order.
+ *
+ * @param declared - Games parsed from `terraform.tfvars` (`TfvarsService.getGameServers()`).
+ * @param deployed - Game names present in `terraform.tfstate` (`ConfigService.getTfOutputs()?.game_names`).
+ */
+export function mergeGameLists(declared: GameServer[], deployed: string[]): GameListEntry[] {
+  const entries = new Map<string, GameListEntry>();
+
+  for (const config of declared) {
+    entries.set(config.name, {
+      name: config.name,
+      declared: true,
+      deployed: false,
+      config,
+    });
+  }
+
+  for (const name of deployed) {
+    const existing = entries.get(name);
+    if (existing) {
+      existing.deployed = true;
+    } else {
+      entries.set(name, {
+        name,
+        declared: false,
+        deployed: true,
+      });
+    }
+  }
+
+  return Array.from(entries.values());
+}

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -168,14 +168,108 @@ export interface WatchdogConfigResult {
   config: WatchdogConfig;
 }
 
+/**
+ * Single TCP/UDP port a game server container listens on.
+ *
+ * Mirrors `GameServerPort` in `@hyveon/shared/src/tfvars.ts` — that file is
+ * the source of truth; keep this copy in sync with it.
+ */
+export interface GameServerPort {
+  container: number;
+  protocol: string;
+}
+
+/**
+ * Environment variable injected into the game server container.
+ *
+ * Mirrors `GameServerEnvironmentVariable` in `@hyveon/shared/src/tfvars.ts`
+ * — that file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameServerEnvironmentVariable {
+  name: string;
+  value: string;
+}
+
+/**
+ * EFS-backed volume mount for a game server container.
+ *
+ * Mirrors `GameServerVolume` in `@hyveon/shared/src/tfvars.ts` — that file
+ * is the source of truth; keep this copy in sync with it.
+ */
+export interface GameServerVolume {
+  name: string;
+  container_path: string;
+}
+
+/**
+ * File seeded into the container filesystem at task start (e.g. server
+ * config or mod files). Exactly one of `content` / `content_base64` is
+ * normally supplied.
+ *
+ * Mirrors `GameServerFileSeed` in `@hyveon/shared/src/tfvars.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameServerFileSeed {
+  path: string;
+  content?: string;
+  content_base64?: string;
+  mode?: string;
+}
+
+/**
+ * Per-game container configuration, keyed by game name in the
+ * `game_servers` Terraform variable (`terraform/variables.tf`).
+ *
+ * Mirrors `GameServer` in `@hyveon/shared/src/tfvars.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface GameServer {
+  name: string;
+  image: string;
+  cpu: number;
+  memory: number;
+  ports: GameServerPort[];
+  environment?: GameServerEnvironmentVariable[];
+  volumes: GameServerVolume[];
+  https?: boolean;
+  connect_message?: string;
+  file_seeds?: GameServerFileSeed[];
+}
+
+/**
+ * Response entry for the merged games list (the `games.list` IPC channel).
+ * Combines the declared view (`terraform.tfvars`, via {@link GameServer})
+ * with the deployed view (`terraform.tfstate`) so callers can tell
+ * "declared but not yet applied" apart from "live" games.
+ *
+ * Mirrors `GameListEntry` in `@hyveon/shared/src/tfvars.ts` — that file is
+ * the source of truth; keep this copy in sync with it.
+ */
+export interface GameListEntry {
+  /**
+   * Game key. Sourced from the tfvars `game_servers` map key when
+   * `declared` is true, otherwise from the tfstate game name.
+   */
+  name: string;
+  /** True when this game has an entry in the tfvars `game_servers` map. */
+  declared: boolean;
+  /** True when this game has a deployed ECS task definition in tfstate. */
+  deployed: boolean;
+  /**
+   * Full tfvars-parsed configuration for this game. Only present when
+   * `declared` is true.
+   */
+  config?: GameServer;
+}
+
 // ---------------------------------------------------------------------------
 // Per-namespace sub-interfaces
 // ---------------------------------------------------------------------------
 
 /** Game-server lifecycle: list games, query status, start/stop ECS tasks. */
 export interface GsdGamesApi {
-  /** Lists game keys from Terraform tfstate. */
-  list: () => Promise<{ games: string[] }>;
+  /** Lists games merged from tfvars (declared) and tfstate (deployed). */
+  list: () => Promise<{ games: GameListEntry[] }>;
   /** Returns ECS status for every game in parallel. */
   status: () => Promise<GameStatus[]>;
   /** Returns ECS status for a single game. */

--- a/app/packages/shared/src/tfvars.ts
+++ b/app/packages/shared/src/tfvars.ts
@@ -56,3 +56,27 @@ export interface GameServer {
   connect_message?: string;
   file_seeds?: GameServerFileSeed[];
 }
+
+/**
+ * Response entry for the merged games list (the `games.list` IPC channel /
+ * `/api/games` HTTP route). Combines the declared view (`terraform.tfvars`,
+ * via {@link GameServer}) with the deployed view (`terraform.tfstate`) so
+ * callers can tell "declared but not yet applied" apart from "live" games —
+ * see issue #92.
+ */
+export interface GameListEntry {
+  /**
+   * Game key. Sourced from the tfvars `game_servers` map key when
+   * `declared` is true, otherwise from the tfstate game name.
+   */
+  name: string;
+  /** True when this game has an entry in the tfvars `game_servers` map. */
+  declared: boolean;
+  /** True when this game has a deployed ECS task definition in tfstate. */
+  deployed: boolean;
+  /**
+   * Full tfvars-parsed configuration for this game. Only present when
+   * `declared` is true.
+   */
+  config?: GameServer;
+}

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -7,6 +7,7 @@ import type {
   WatchdogConfig,
   ActualCosts,
   DiscordConfigRedacted,
+  GameListEntry,
 } from '@/api.js';
 import {
   ENV_DATA,
@@ -75,7 +76,10 @@ export interface StubOptions {
   /**
    * Game names returned by `GET /api/games` (used by the Logs page).
    * Defaults to the names derived from `statuses`. Override when the Logs
-   * page should expose games that aren't part of `statuses`.
+   * page should expose games that aren't part of `statuses`. Each name is
+   * wrapped into a `GameListEntry` (`declared: true, deployed: true`) before
+   * being sent — the endpoint now emits `{ games: GameListEntry[] }`, not
+   * bare strings — see issue #92.
    */
   games?: string[];
   /**
@@ -135,7 +139,14 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
     return route.fulfill({ json: s });
   });
 
-  await page.route('**/api/games', (route) => route.fulfill({ json: { games } }));
+  await page.route('**/api/games', (route) => {
+    const entries: GameListEntry[] = games.map((name) => ({
+      name,
+      declared: true,
+      deployed: true,
+    }));
+    return route.fulfill({ json: { games: entries } });
+  });
 
   await page.route('**/api/costs/estimate', (route) => route.fulfill({ json: costs }));
 

--- a/app/packages/web/e2e/integration-specs/config-service.spec.ts
+++ b/app/packages/web/e2e/integration-specs/config-service.spec.ts
@@ -19,7 +19,13 @@ test.describe('ConfigService — tfstate fixture', () => {
 
   test('should return game names from tfstate fixture', async ({ ipc, serverMocks: _reset }) => {
     const body = await ipc.dispatch(GamesController, 'listGames');
-    expect(body.games).toEqual(['minecraft', 'valheim']);
+    // No terraform.tfvars is present in the test environment, so every game
+    // in the merged list is deployed-only (declared: false, deployed: true).
+    expect(body.games.map((g) => g.name).sort()).toEqual(['minecraft', 'valheim']);
+    body.games.forEach((g) => {
+      expect(g.declared).toBe(false);
+      expect(g.deployed).toBe(true);
+    });
   });
 
   test('should return status entries for all games in tfstate fixture', async ({ ipc, serverMocks: _reset }) => {

--- a/app/packages/web/e2e/integration-specs/start-stop.spec.ts
+++ b/app/packages/web/e2e/integration-specs/start-stop.spec.ts
@@ -18,7 +18,13 @@ test.describe('Start / Stop game server', () => {
     serverMocks: _reset,
   }) => {
     const { games } = await ipc.dispatch(GamesController, 'listGames');
-    expect(games.slice().sort()).toEqual(['minecraft', 'valheim']);
+    // No terraform.tfvars is present in the test environment, so every game
+    // in the merged list is deployed-only (declared: false, deployed: true).
+    expect(games.map((g) => g.name).sort()).toEqual(['minecraft', 'valheim']);
+    games.forEach((g) => {
+      expect(g.declared).toBe(false);
+      expect(g.deployed).toBe(true);
+    });
 
     const statuses = await ipc.dispatch(GamesController, 'listStatus');
     expect(statuses.map((s) => s.game).sort()).toEqual(['minecraft', 'valheim']);

--- a/app/packages/web/e2e/specs/discord.spec.ts
+++ b/app/packages/web/e2e/specs/discord.spec.ts
@@ -59,8 +59,15 @@ async function seedBaseMocks(
       Promise.resolve({ region: 'us-east-1', domain: 'example.com', environment: 'dev' }),
     );
     gsd.__test.mock('games.status', () => Promise.resolve(s));
+    // `games.list` resolves `GameListEntry[]`, not bare strings — see issue #92.
     gsd.__test.mock('games.list', () =>
-      Promise.resolve({ games: (s as Array<{ game: string }>).map((x) => x.game) }),
+      Promise.resolve({
+        games: (s as Array<{ game: string }>).map((x) => ({
+          name: x.game,
+          declared: true,
+          deployed: true,
+        })),
+      }),
     );
     gsd.__test.mock('config.get', () =>
       Promise.resolve({

--- a/app/packages/web/e2e/specs/logs.spec.ts
+++ b/app/packages/web/e2e/specs/logs.spec.ts
@@ -42,8 +42,11 @@ async function setupLogsPage(
       // Silence the background GameStatusProvider poller.
       gsd.__test.mock('games.status', () => Promise.resolve(statuses));
 
-      // Seed the game list for the combobox selector.
-      gsd.__test.mock('games.list', () => Promise.resolve({ games: g }));
+      // Seed the game list for the combobox selector. `games.list` resolves
+      // `GameListEntry[]`, not bare strings — see issue #92.
+      gsd.__test.mock('games.list', () =>
+        Promise.resolve({ games: g.map((name) => ({ name, declared: true, deployed: true })) }),
+      );
 
       // Seed the initial log snapshot for each game.
       gsd.__test.mock('logs.get', ({ game }: { game: string }) =>
@@ -70,13 +73,8 @@ test.describe('logs page', () => {
   });
 
   test.afterEach(async () => {
-    // Clear mocks so stale handlers do not bleed into later tests.
-    await win.evaluate(() => {
-      const gsd = (window as Record<string, unknown>)['gsd'] as {
-        __test: { clearMocks: () => void };
-      };
-      gsd.__test.clearMocks();
-    });
+    // Each test launches its own Electron app in `beforeEach`, so there is no
+    // shared mock registry to clear here — just tear down the app instance.
     await app.close();
   });
 

--- a/app/packages/web/src/api.service.test.ts
+++ b/app/packages/web/src/api.service.test.ts
@@ -195,8 +195,8 @@ describe('IPC bridge delegation', () => {
 
   it('should return the payload resolved by the bridge', async () => {
     const entries = [
-      { name: 'minecraft', declared: true, deployed: true },
-      { name: 'palworld', declared: true, deployed: false },
+      { name: 'minecraft', declared: false, deployed: true },
+      { name: 'palworld', declared: false, deployed: false },
     ];
     gsd.games.list.mockResolvedValueOnce({ games: entries });
     await expect(api.games()).resolves.toEqual({ games: entries });

--- a/app/packages/web/src/api.service.test.ts
+++ b/app/packages/web/src/api.service.test.ts
@@ -194,8 +194,12 @@ describe('IPC bridge delegation', () => {
   });
 
   it('should return the payload resolved by the bridge', async () => {
-    gsd.games.list.mockResolvedValueOnce({ games: ['minecraft', 'palworld'] });
-    await expect(api.games()).resolves.toEqual({ games: ['minecraft', 'palworld'] });
+    const entries = [
+      { name: 'minecraft', declared: true, deployed: true },
+      { name: 'palworld', declared: true, deployed: false },
+    ];
+    gsd.games.list.mockResolvedValueOnce({ games: entries });
+    await expect(api.games()).resolves.toEqual({ games: entries });
   });
 });
 

--- a/app/packages/web/src/api.service.ts
+++ b/app/packages/web/src/api.service.ts
@@ -51,6 +51,52 @@ export interface ActualCosts {
   error?: string;
 }
 
+/**
+ * Per-game container configuration, keyed by game name in the
+ * `game_servers` Terraform variable (`terraform/variables.tf`).
+ *
+ * Mirrors `GameServer` in `@hyveon/shared/src/tfvars.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface GameServer {
+  name: string;
+  image: string;
+  cpu: number;
+  memory: number;
+  ports: { container: number; protocol: string }[];
+  environment?: { name: string; value: string }[];
+  volumes: { name: string; container_path: string }[];
+  https?: boolean;
+  connect_message?: string;
+  file_seeds?: { path: string; content?: string; content_base64?: string; mode?: string }[];
+}
+
+/**
+ * Response entry for the merged games list (the `games.list` IPC channel).
+ * Combines the declared view (`terraform.tfvars`, via {@link GameServer})
+ * with the deployed view (`terraform.tfstate`) so callers can tell
+ * "declared but not yet applied" apart from "live" games — see issue #92.
+ *
+ * Mirrors `GameListEntry` in `@hyveon/shared/src/tfvars.ts` — that file is
+ * the source of truth; keep this copy in sync with it.
+ */
+export interface GameListEntry {
+  /**
+   * Game key. Sourced from the tfvars `game_servers` map key when
+   * `declared` is true, otherwise from the tfstate game name.
+   */
+  name: string;
+  /** True when this game has an entry in the tfvars `game_servers` map. */
+  declared: boolean;
+  /** True when this game has a deployed ECS task definition in tfstate. */
+  deployed: boolean;
+  /**
+   * Full tfvars-parsed configuration for this game. Only present when
+   * `declared` is true.
+   */
+  config?: GameServer;
+}
+
 /** Status of the FileBrowser helper task per game, returned by `GET /api/files/:game`. */
 export interface FileMgrStatus {
   game: string;
@@ -136,7 +182,7 @@ function gsd() {
 
 export const api = {
   env: async (): Promise<EnvInfo> => gsd().env.get(),
-  games: async (): Promise<{ games: string[] }> => gsd().games.list(),
+  games: async (): Promise<{ games: GameListEntry[] }> => gsd().games.list(),
   status: async (): Promise<GameStatus[]> => gsd().games.status(),
   statusGame: async (game: string): Promise<GameStatus> => gsd().games.getStatus(game),
   start: async (game: string): Promise<ActionResult> => gsd().games.start(game),

--- a/app/packages/web/src/pages/discord.page.test.tsx
+++ b/app/packages/web/src/pages/discord.page.test.tsx
@@ -38,7 +38,9 @@ describe('DiscordPage', () => {
   beforeEach(() => {
     apiMock.status.mockResolvedValue([]);
     apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
-    apiMock.games.mockResolvedValue({ games: ['minecraft'] });
+    apiMock.games.mockResolvedValue({
+      games: [{ name: 'minecraft', declared: true, deployed: true }],
+    });
     apiMock.discordConfig.mockResolvedValue(REDACTED_CONFIG);
     apiMock.discordSaveCredentials.mockResolvedValue(undefined);
     toastMock.success.mockClear();

--- a/app/packages/web/src/pages/discord.page.tsx
+++ b/app/packages/web/src/pages/discord.page.tsx
@@ -95,7 +95,9 @@ export function DiscordPage() {
   const [showWizard, setShowWizard] = useState(false);
 
   useEffect(() => {
-    api.games().then((g) => setGames(g.games)).catch(() => undefined);
+    // `api.games()` now resolves `GameListEntry[]` (declared + deployed view,
+    // see issue #92) — the permissions UI only needs the game keys.
+    api.games().then((g) => setGames(g.games.map((entry) => entry.name))).catch(() => undefined);
   }, []);
 
   /** Re-fetch the (redacted) Discord config from the API after mutations. */

--- a/app/packages/web/src/pages/logs.page.test.tsx
+++ b/app/packages/web/src/pages/logs.page.test.tsx
@@ -47,7 +47,9 @@ const SAMPLE_LINES = [
 
 describe('LogsPage', () => {
   beforeEach(() => {
-    apiMock.games.mockResolvedValue({ games: ['minecraft'] });
+    apiMock.games.mockResolvedValue({
+      games: [{ name: 'minecraft', declared: true, deployed: true }],
+    });
     gsdMock.logs.get.mockResolvedValue({ game: 'minecraft', lines: SAMPLE_LINES });
     // Default stream emits nothing and ends immediately — tests assert on the
     // seeded snapshot. Override per-test to drive live chunks through `for await`.

--- a/app/packages/web/src/pages/logs.page.tsx
+++ b/app/packages/web/src/pages/logs.page.tsx
@@ -200,8 +200,9 @@ export function LogsPage() {
       try {
         const res = await api.games();
         if (cancelled) return;
-        setGames(res.games);
-        if (res.games.length > 0) setSelectedGame((cur) => cur || res.games[0]!);
+        const names = res.games.map((g) => g.name);
+        setGames(names);
+        if (names.length > 0) setSelectedGame((cur) => cur || names[0]!);
       } catch {
         if (!cancelled) setError('Could not load games.');
       }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,6 +9,17 @@ directories:
 
 files:
   - out/**
+  # @cdktf/hcl2json is deliberately NOT bundled into out/main (see the
+  # `external` entry in electron.vite.config.ts) — its wasm bridge must load
+  # main.wasm.gz relative to its own module file, and its bundled copy breaks
+  # Electron's quit path. Ship the module and its transitive runtime deps
+  # (fs-extra → graceful-fs/jsonfile/universalify) so the packaged main
+  # process can resolve the bare `import '@cdktf/hcl2json'`.
+  - node_modules/@cdktf/hcl2json/**
+  - node_modules/fs-extra/**
+  - node_modules/graceful-fs/**
+  - node_modules/jsonfile/**
+  - node_modules/universalify/**
 
 extraResources:
   - from: terraform/terraform.tfstate

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -19,6 +19,21 @@ export default defineConfig({
     build: {
       rollupOptions: {
         input: r('app/packages/desktop-main/src/electron-entry.ts'),
+        // `@cdktf/hcl2json` must stay external (loaded from node_modules at
+        // runtime), never bundled, for two reasons:
+        //  1. Its wasm bridge reads `main.wasm.gz` relative to its own module
+        //     file (`join(__dirname, '..', 'main.wasm.gz')`). Bundled, that
+        //     resolves to `out/main.wasm.gz`, which doesn't exist — the read
+        //     rejects and every later `parse()` call awaits a `ready` flag
+        //     that never flips, so `games.list` would hang forever.
+        //  2. The bundled copy of its Go `wasm_exec` glue runs module-scope
+        //     side effects at app startup that prevent Electron from ever
+        //     quitting — `app.close()` in Playwright's electron project then
+        //     hangs until the worker teardown timeout, failing every spec.
+        // The external package also keeps the patch-package fix
+        // (patches/@cdktf+hcl2json+0.21.0.patch) in effect. electron-builder.yml
+        // packages the module (and its transitive deps) into the installer.
+        external: ['@cdktf/hcl2json'],
         output: {
           format: 'es',
           entryFileNames: 'index.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "hyveon",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "workspaces": [
         "app",
         "app/packages/*",


### PR DESCRIPTION
Closes #92

## Summary

- Adds `mergeGameLists` (`app/packages/desktop-main/src/services/mergeGameLists.ts`), a pure helper that unions tfvars-declared `GameServer[]` with tfstate-derived deployed games into a `GameListEntry[]`, each entry carrying `declared: boolean`, `deployed: boolean`, and the full tfvars config when declared.
- Wires the merge into both `GamesController` (IPC `games.list`) and `GamesHttpController` (`/api/games`), calling `TfvarsService.getGameServers()` alongside the existing tfstate lookup so declared-but-not-yet-applied games show up in both surfaces.
- Adds the `GameListEntry` API type to `@hyveon/shared` and extends the preload `GsdGamesApi.list`/`api.service.ts` web client to consume the new shape.
- Updates consuming pages (`logs.page.tsx`, `discord.page.tsx`) so they don't crash on the new merged shape, plus unit, integration, and e2e coverage for the merge logic and downstream consumers.

## Changes

```
 .../src/controllers/games-http.controller.test.ts  | 50 ++++++++---
 .../src/controllers/games-http.controller.ts       | 18 ++--
 .../src/controllers/games.controller.test.ts       | 63 +++++++++++---
 .../src/controllers/games.controller.ts            | 19 +++--
 .../src/services/mergeGameLists.test.ts            | 73 ++++++++++++++++
 .../desktop-main/src/services/mergeGameLists.ts    | 47 +++++++++++
 app/packages/desktop-preload/src/gsd-api.ts        | 98 +++++++++++++++++++++-
 app/packages/shared/src/tfvars.ts                  | 24 ++++++
 app/packages/web/e2e/fixtures/index.ts             | 15 +++-
 .../e2e/integration-specs/config-service.spec.ts   |  8 +-
 .../web/e2e/integration-specs/start-stop.spec.ts   |  8 +-
 app/packages/web/e2e/specs/discord.spec.ts         |  9 +-
 app/packages/web/e2e/specs/logs.spec.ts            | 16 ++--
 app/packages/web/src/api.service.test.ts           |  8 +-
 app/packages/web/src/api.service.ts                | 48 ++++++++++-
 app/packages/web/src/pages/discord.page.test.tsx   |  4 +-
 app/packages/web/src/pages/discord.page.tsx        |  4 +-
 app/packages/web/src/pages/logs.page.test.tsx      |  4 +-
 app/packages/web/src/pages/logs.page.tsx           |  5 +-
 package-lock.json                                  |  1 +
 20 files changed, 464 insertions(+), 58 deletions(-)
```

## Test plan

- [x] `/api/games` (and IPC `games.list`) return games that are declared but not yet applied (`declared: true, deployed: false`).
- [x] Existing UI (`logs.page.tsx`, `discord.page.tsx`) doesn't crash on the new `GameListEntry[]` shape — covered by page unit tests and e2e specs.
- [x] Unit tests cover merge logic for declared-only, deployed-only, and both-declared-and-deployed cases (`mergeGameLists.test.ts`).
- [x] Controller tests updated for both `GamesController` (IPC) and `GamesHttpController` (HTTP) covering the merged shape.
- [x] Tier-2 integration specs assert the merged `games.list` shape end-to-end against the in-process `AppModule`.
- [x] E2E stubs (chromium `/api/games` stub, Electron `games.list` IPC mock) emit `GameListEntry[]`.