### PR TITLE
fix(desktop-main): renderer IPC fails — no ipcMain.handle registered for @MessagePattern channels

### DIFF
--- a/app/packages/desktop-main/src/controllers/logs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/logs.controller.ts
@@ -23,6 +23,14 @@ export class LogsController implements OnModuleInit {
    * dispatcher — it does **not** call `ipcMain.handle`, so `ipcRenderer.invoke`
    * would otherwise hang. This hook bridges the gap.
    *
+   * `logs.stream` bridges itself here rather than through the generic
+   * `registerIpcMainBridges` helper (`../ipc-main-bridge.js`) because its
+   * handler needs to mint a `streamId` and push follow-up chunk/end messages
+   * over side channels derived from it — see `SELF_BRIDGED_PATTERNS` in
+   * `ipc-main-bridge.ts`, which excludes `logs.stream` for that reason. Every
+   * other `@MessagePattern` channel in this app is bridged generically by
+   * that helper instead of being hand-wired like this.
+   *
    * Only runs inside a real Electron main process. In plain-Node runtimes
    * (integration test server, Docker, CI) `process.versions.electron` is
    * undefined and importing `electron` would throw — either MODULE_NOT_FOUND

--- a/app/packages/desktop-main/src/ipc-main-bridge.test.ts
+++ b/app/packages/desktop-main/src/ipc-main-bridge.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MessageHandler } from '@nestjs/microservices';
+import { BridgedElectronIPCTransport, registerIpcMainBridges, SELF_BRIDGED_PATTERNS } from './ipc-main-bridge.js';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state — must be declared before any vi.mock() factory runs.
+// ---------------------------------------------------------------------------
+
+/**
+ * Captures every `ipcMain.handle` / `ipcMain.removeHandler` call so tests can
+ * assert on bridge registration without a real Electron main process.
+ */
+const { mockIpcMainHandle, mockIpcMainRemoveHandler } = vi.hoisted(() => {
+  const mockIpcMainHandle = vi.fn();
+  const mockIpcMainRemoveHandler = vi.fn();
+  return { mockIpcMainHandle, mockIpcMainRemoveHandler };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mockIpcMainHandle,
+    removeHandler: mockIpcMainRemoveHandler,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a `BridgedElectronIPCTransport` whose `messagePatternHandlers` map
+ * is pre-seeded with a `vi.fn()` NestJS message handler per `patterns`
+ * entry, mirroring the shape `Server.addHandler` would populate at runtime.
+ */
+function makeTransport(patterns: string[]): {
+  transport: BridgedElectronIPCTransport;
+  handlers: Map<string, MessageHandler>;
+} {
+  const transport = new BridgedElectronIPCTransport();
+  const handlers = transport.messagePatternHandlers;
+  for (const pattern of patterns) {
+    handlers.set(pattern, vi.fn().mockResolvedValue(undefined));
+  }
+  return { transport, handlers };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('registerIpcMainBridges', () => {
+  // registerIpcMainBridges only wires the bridge when running inside a real
+  // Electron main process, detected via `process.versions.electron`. Vitest
+  // runs under plain Node where it's undefined, so fake it for the "is
+  // Electron" cases and restore afterwards.
+  const realElectronVersion = process.versions.electron;
+  const setElectron = (value: string | undefined): void => {
+    if (value === undefined) {
+      delete (process.versions as { electron?: string }).electron;
+    } else {
+      Object.defineProperty(process.versions, 'electron', { value, configurable: true });
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setElectron('30.0.0');
+  });
+  afterEach(() => setElectron(realElectronVersion));
+
+  it('should be a silent no-op when not running inside an Electron main process', async () => {
+    // Plain-Node runtimes (integration test server, Docker, CI) have no
+    // `process.versions.electron`; importing electron there would throw, so
+    // the bridge must skip without touching ipcMain at all.
+    setElectron(undefined);
+    const { transport } = makeTransport(['games.list', 'env.get']);
+
+    await expect(registerIpcMainBridges(transport)).resolves.toBeUndefined();
+
+    expect(mockIpcMainHandle).not.toHaveBeenCalled();
+    expect(mockIpcMainRemoveHandler).not.toHaveBeenCalled();
+  });
+
+  it('should register a removeHandler-then-handle pair for every non-excluded pattern', async () => {
+    const patterns = ['games.list', 'games.status', 'env.get', 'costs.estimate', 'logs.get'];
+    const { transport } = makeTransport(patterns);
+
+    await registerIpcMainBridges(transport);
+
+    for (const pattern of patterns) {
+      expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith(pattern);
+      expect(mockIpcMainHandle).toHaveBeenCalledWith(pattern, expect.any(Function));
+    }
+  });
+
+  it('should call removeHandler before handle for each bridged pattern', async () => {
+    const { transport } = makeTransport(['games.list']);
+
+    await registerIpcMainBridges(transport);
+
+    const removeCall = mockIpcMainRemoveHandler.mock.invocationCallOrder[0];
+    const handleCall = mockIpcMainHandle.mock.invocationCallOrder[0];
+    expect(removeCall).toBeLessThan(handleCall);
+  });
+
+  it('should invoke the underlying NestJS handler as handler(payload, { evt }) when the ipcMain.handle callback fires', async () => {
+    const { transport, handlers } = makeTransport(['games.list']);
+    const handler = handlers.get('games.list')!;
+
+    await registerIpcMainBridges(transport);
+
+    const [, registeredCallback] = mockIpcMainHandle.mock.calls.find(
+      ([pattern]) => pattern === 'games.list',
+    ) as [string, (evt: unknown, payload: unknown) => unknown];
+
+    const fakeEvt = { sender: {} };
+    const payload = { some: 'payload' };
+    await registeredCallback(fakeEvt, payload);
+
+    expect(handler).toHaveBeenCalledWith(payload, { evt: fakeEvt });
+  });
+
+  it('should skip "logs.stream" entirely, leaving it to bridge itself', async () => {
+    expect(SELF_BRIDGED_PATTERNS.has('logs.stream')).toBe(true);
+
+    const { transport } = makeTransport(['logs.stream', 'logs.get']);
+
+    await registerIpcMainBridges(transport);
+
+    expect(mockIpcMainRemoveHandler).not.toHaveBeenCalledWith('logs.stream');
+    expect(mockIpcMainHandle).not.toHaveBeenCalledWith('logs.stream', expect.any(Function));
+    // The sibling pattern on the same map is still bridged normally.
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith('logs.get');
+    expect(mockIpcMainHandle).toHaveBeenCalledWith('logs.get', expect.any(Function));
+  });
+
+  it('should be a no-op when the transport has no registered handlers', async () => {
+    const { transport } = makeTransport([]);
+
+    await registerIpcMainBridges(transport);
+
+    expect(mockIpcMainHandle).not.toHaveBeenCalled();
+    expect(mockIpcMainRemoveHandler).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/desktop-main/src/ipc-main-bridge.ts
+++ b/app/packages/desktop-main/src/ipc-main-bridge.ts
@@ -1,0 +1,79 @@
+import type { MessageHandler } from '@nestjs/microservices';
+import type { IpcMain, IpcMainInvokeEvent } from 'electron';
+import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
+
+/**
+ * IPC channels that manage their own `ipcMain.handle` registration and must
+ * be skipped by the generic bridge to avoid a double registration.
+ *
+ * `logs.stream` is the only such channel today: `LogsController.onModuleInit`
+ * bridges it manually because the handler needs to push follow-up chunk/end
+ * messages over side channels derived from a `streamId` it mints itself —
+ * see `app/packages/desktop-main/src/controllers/logs.controller.ts`.
+ */
+export const SELF_BRIDGED_PATTERNS: ReadonlySet<string> = new Set(['logs.stream']);
+
+/**
+ * `ElectronIPCTransport` (from `nestjs-electron-ipc-transport`) only exposes
+ * its registered `@MessagePattern` handlers via the `messageHandlers` map it
+ * inherits from `@nestjs/microservices`'s abstract `Server` class, and that
+ * field is `protected`. Rather than reaching into it with an
+ * `as unknown as` cast at every call site, this subclass exposes a single
+ * public, typed accessor so callers (and this module's own
+ * {@link registerIpcMainBridges} helper) can read the map through the normal
+ * type system.
+ */
+export class BridgedElectronIPCTransport extends ElectronIPCTransport {
+  /** Public, typed view of the protected `messageHandlers` map inherited from `Server`. */
+  public get messagePatternHandlers(): Map<string, MessageHandler> {
+    return this.messageHandlers;
+  }
+}
+
+/**
+ * Bridges every NestJS `@MessagePattern` handler registered on `transport`
+ * (except those in {@link SELF_BRIDGED_PATTERNS}) onto a matching
+ * `ipcMain.handle` registration, so `ipcRenderer.invoke(channel, payload)`
+ * calls made from the preload actually resolve.
+ *
+ * `ElectronIPCTransport.listen()` (from `nestjs-electron-ipc-transport`) only
+ * subscribes to its own internal `ipcMessageDispatcher` — it never calls
+ * `ipcMain.handle` itself. Without this bridge, every `@MessagePattern`
+ * channel other than `logs.stream` (which bridges itself, see
+ * {@link SELF_BRIDGED_PATTERNS}) hangs forever when invoked from the
+ * renderer, because `ipcRenderer.invoke` requires a matching
+ * `ipcMain.handle` registration in the main process (see #277).
+ *
+ * For each bridged pattern, any existing handler is removed first via
+ * `ipcMain.removeHandler` so hot-reload re-registration does not throw
+ * "Attempted to register a second handler for '<channel>'", mirroring the
+ * approach `LogsController.onModuleInit` already takes for `logs.stream`.
+ * The registered `ipcMain.handle` callback invokes the NestJS handler as
+ * `handler(payload, { evt })`, matching the `{ evt }` context shape
+ * `ElectronIPCTransport.onMessage` passes today so controller method
+ * signatures do not need to change.
+ *
+ * Silent no-op outside a real Electron main process
+ * (`process.versions.electron` undefined) — matching the guard
+ * `LogsController.onModuleInit` uses — so the plain-Node integration test
+ * harness, Docker builds, and CI never attempt to import `electron`.
+ */
+export async function registerIpcMainBridges(transport: BridgedElectronIPCTransport): Promise<void> {
+  if (!process.versions.electron) {
+    // Not running inside the Electron main process — bridge skipped.
+    return;
+  }
+
+  const { ipcMain } = (await import('electron')) as unknown as { ipcMain: IpcMain };
+
+  for (const [pattern, handler] of transport.messagePatternHandlers) {
+    if (SELF_BRIDGED_PATTERNS.has(pattern)) {
+      continue;
+    }
+
+    ipcMain.removeHandler(pattern);
+    ipcMain.handle(pattern, (evt: IpcMainInvokeEvent, payload: unknown) =>
+      handler(payload, { evt }),
+    );
+  }
+}

--- a/app/packages/desktop-main/src/main.test.ts
+++ b/app/packages/desktop-main/src/main.test.ts
@@ -6,7 +6,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * vi.mock() factory functions run (vi.mock calls are hoisted to the top of the
  * compiled output, above regular const/let declarations).
  */
-const { ElectronIPCTransportMock, fakeApp, createMicroserviceMock, applyFixPathMock, mockApp, createLoggerMock } = vi.hoisted(() => {
+const {
+  ElectronIPCTransportMock,
+  fakeApp,
+  createMicroserviceMock,
+  applyFixPathMock,
+  mockApp,
+  createLoggerMock,
+  registerIpcMainBridgesMock,
+} = vi.hoisted(() => {
   /** Fake NestJS microservice app returned by `NestFactory.createMicroservice`. */
   const fakeApp = { listen: vi.fn().mockResolvedValue(undefined) };
   /** Spy constructor for ElectronIPCTransport — tracks `new` invocations. */
@@ -19,7 +27,17 @@ const { ElectronIPCTransportMock, fakeApp, createMicroserviceMock, applyFixPathM
   const mockApp = { getPath: vi.fn().mockReturnValue('/fake/userData') };
   /** Spy for `createLogger` — verifies the file logger is initialised before bootstrap. */
   const createLoggerMock = vi.fn();
-  return { ElectronIPCTransportMock, fakeApp, createMicroserviceMock, applyFixPathMock, mockApp, createLoggerMock };
+  /** Spy for `registerIpcMainBridges` — verifies it fires once after `app.listen()`. */
+  const registerIpcMainBridgesMock = vi.fn().mockResolvedValue(undefined);
+  return {
+    ElectronIPCTransportMock,
+    fakeApp,
+    createMicroserviceMock,
+    applyFixPathMock,
+    mockApp,
+    createLoggerMock,
+    registerIpcMainBridgesMock,
+  };
 });
 
 vi.mock('electron', () => ({
@@ -32,6 +50,17 @@ vi.mock('./logger.js', () => ({
 
 vi.mock('nestjs-electron-ipc-transport', () => ({
   ElectronIPCTransport: ElectronIPCTransportMock,
+}));
+
+/**
+ * Stub the IPC bridge module so `main.ts` gets a spy-able
+ * `BridgedElectronIPCTransport` constructor (reusing the same mock as
+ * `ElectronIPCTransport` above) plus a `registerIpcMainBridges` spy, without
+ * pulling in the real Electron `ipcMain` bridging logic.
+ */
+vi.mock('./ipc-main-bridge.js', () => ({
+  BridgedElectronIPCTransport: ElectronIPCTransportMock,
+  registerIpcMainBridges: registerIpcMainBridgesMock,
 }));
 
 vi.mock('@nestjs/core', () => ({
@@ -66,6 +95,7 @@ describe('main bootstrap', () => {
     applyFixPathMock.mockImplementation(() => undefined);
     mockApp.getPath.mockReturnValue('/fake/userData');
     createLoggerMock.mockImplementation(() => undefined);
+    registerIpcMainBridgesMock.mockResolvedValue(undefined);
     // Simulate an Electron main-process environment so the module-level guard passes.
     vi.stubGlobal('process', { ...process, versions: { ...process.versions, electron: '36.0.0' } });
   });
@@ -113,6 +143,25 @@ describe('main bootstrap', () => {
 
     // listen() should have been called on the fake app.
     expect(fakeApp.listen).toHaveBeenCalledOnce();
+  });
+
+  it('should invoke registerIpcMainBridges once with the transport strategy after app.listen()', async () => {
+    vi.resetModules();
+    const { bootstrap } = await import('./main.js');
+    await bootstrap();
+
+    // Flush the event loop so the async bootstrap chain fully resolves.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(registerIpcMainBridgesMock).toHaveBeenCalledOnce();
+    expect(registerIpcMainBridgesMock).toHaveBeenCalledWith(
+      ElectronIPCTransportMock.mock.results[0].value,
+    );
+
+    // registerIpcMainBridges must run after app.listen() resolves, not before.
+    const listenCallOrder = fakeApp.listen.mock.invocationCallOrder[0];
+    const bridgeCallOrder = registerIpcMainBridgesMock.mock.invocationCallOrder[0];
+    expect(listenCallOrder).toBeLessThan(bridgeCallOrder);
   });
 
   it('should call applyFixPath on module initialisation', async () => {

--- a/app/packages/desktop-main/src/main.ts
+++ b/app/packages/desktop-main/src/main.ts
@@ -2,9 +2,9 @@ import 'reflect-metadata';
 import path from 'node:path';
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions } from '@nestjs/microservices';
-import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
 import { AppModule } from './app.module.js';
 import { applyFixPath } from './fix-path-bootstrap.js';
+import { BridgedElectronIPCTransport, registerIpcMainBridges } from './ipc-main-bridge.js';
 import { createLogger } from './logger.js';
 
 applyFixPath();
@@ -28,11 +28,21 @@ createLogger(path.join(app.getPath('userData'), 'logs'));
  *
  * Called from `electron-entry.ts` after `app.whenReady()` so that
  * `ipcMain` is available before the transport is initialised.
+ *
+ * After `app.listen()` starts the transport (registering its internal
+ * `@MessagePattern` dispatch), {@link registerIpcMainBridges} is invoked once
+ * to bridge each of those patterns onto a real `ipcMain.handle` registration
+ * — without this, `ipcRenderer.invoke` calls from the renderer hang forever
+ * because `ElectronIPCTransport.listen()` never calls `ipcMain.handle` itself
+ * (see #277).
  */
 export async function bootstrap(): Promise<void> {
+  const strategy = new BridgedElectronIPCTransport();
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
-    strategy: new ElectronIPCTransport(),
+    strategy,
   });
 
   await app.listen();
+
+  await registerIpcMainBridges(strategy);
 }

--- a/app/packages/web/e2e/specs/electron-ipc-roundtrip.spec.ts
+++ b/app/packages/web/e2e/specs/electron-ipc-roundtrip.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, _electron } from '../fixtures/index.js';
+import { electronMain, electronEnv } from '../../playwright.config.js';
+
+/**
+ * Regression spec for #277: unmocked renderer→main IPC round-trip.
+ *
+ * `ElectronIPCTransport.listen()` only wires NestJS `@MessagePattern` handlers
+ * onto its own internal dispatcher — it never calls `ipcMain.handle` itself.
+ * Before the fix, every channel other than the self-bridged `logs.stream`
+ * hung forever when invoked from the renderer because `ipcRenderer.invoke`
+ * has no matching `ipcMain.handle` registration, and the preload's invoke
+ * wrapper rejects with "No handler registered for '<channel>'" once its
+ * timeout elapses.
+ *
+ * This spec deliberately does NOT register a `window.gsd.__test.mock()`
+ * override for `env.get` — it exercises the real IPC path end-to-end against
+ * the actual `EnvController` running in the main process, proving
+ * `registerIpcMainBridges` keeps the renderer and main process wired
+ * together.
+ */
+test.describe('electron IPC round-trip (unmocked)', () => {
+  test('should resolve window.gsd.env.get() against the real main process instead of rejecting', async () => {
+    const app = await _electron.launch({ args: [electronMain], env: electronEnv });
+
+    try {
+      const win = await app.firstWindow();
+
+      const result = await win.evaluate(async () => {
+        const gsd = (window as Record<string, unknown>)['gsd'] as {
+          env: { get: () => Promise<{ region: string; domain: string; environment: string }> };
+        };
+        return gsd.env.get();
+      });
+
+      expect(result).toMatchObject({
+        region: expect.any(String),
+        domain: expect.any(String),
+        environment: expect.any(String),
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/app/packages/web/playwright.config.ts
+++ b/app/packages/web/playwright.config.ts
@@ -41,13 +41,15 @@ export const electronEnv: Record<string, string> = {
  *    seam spec against the packaged main bundle. Each spec manages its own
  *    ElectronApplication.
  *
- * `electron-smoke.spec.ts`, `ipc-mock.spec.ts`, `dashboard.spec.ts`,
- * `costs.spec.ts` (migrated in #193), `logs.spec.ts` (migrated in #191), and
- * `discord.spec.ts` (migrated in #194) are matched only by the `electron`
- * project and ignored by `chromium`; every other spec is the reverse.
+ * `electron-smoke.spec.ts`, `electron-ipc-roundtrip.spec.ts`, `ipc-mock.spec.ts`,
+ * `dashboard.spec.ts`, `costs.spec.ts` (migrated in #193), `logs.spec.ts`
+ * (migrated in #191), and `discord.spec.ts` (migrated in #194) are matched
+ * only by the `electron` project and ignored by `chromium`; every other spec
+ * is the reverse.
  */
 const ELECTRON_SPECS = [
   '**/electron-smoke.spec.ts',
+  '**/electron-ipc-roundtrip.spec.ts',
   '**/ipc-mock.spec.ts',
   '**/dashboard.spec.ts',
   '**/costs.spec.ts',

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { defineConfig, externalizeDepsPlugin, swcPlugin } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath } from 'node:url';
@@ -15,7 +15,19 @@ export default defineConfig({
     // startup or the main process throws ERR_MODULE_NOT_FOUND before any window
     // opens. `@grpc/proto-loader` is therefore a required dependency of
     // `@hyveon/desktop-main` despite appearing unused — do not remove it.
-    plugins: [externalizeDepsPlugin()],
+    //
+    // `swcPlugin()` swaps electron-vite's default esbuild transform for SWC
+    // for this build only. Nest's DI container relies on TypeScript's
+    // `emitDecoratorMetadata` (enabled in `app/tsconfig.base.json`) to read
+    // constructor parameter types at runtime via `reflect-metadata`. esbuild
+    // does not implement `emitDecoratorMetadata` — it strips decorators
+    // without emitting the `design:paramtypes` metadata, so every
+    // `@Injectable()`/`@Controller()` constructor loses its parameter types
+    // and Nest can't resolve providers, crashing the main process at
+    // bootstrap. SWC's decorator transform does emit that metadata, so it's
+    // used here in place of esbuild. The renderer and preload builds don't
+    // use Nest DI and stay on the default esbuild transform.
+    plugins: [externalizeDepsPlugin(), swcPlugin()],
     build: {
       rollupOptions: {
         input: r('app/packages/desktop-main/src/electron-entry.ts'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "scripts"
       ],
       "devDependencies": {
+        "@swc/core": "^1.15.43",
         "electron-builder": "^25.0.0",
         "electron-vite": "^5.0.0",
         "patch-package": "^8.0.1"
@@ -5369,6 +5370,286 @@
       "dependencies": {
         "color": "^5.0.2",
         "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=22.12.0"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.43",
     "electron-builder": "^25.0.0",
     "electron-vite": "^5.0.0",
     "patch-package": "^8.0.1"
@@ -36,5 +37,8 @@
     "desktop:dev": "electron-vite dev",
     "desktop:build": "electron-vite build",
     "desktop:package": "npm run desktop:build && electron-builder --config electron-builder.yml"
+  },
+  "allowScripts": {
+    "@swc/core@1.15.43": true
   }
 }


### PR DESCRIPTION
Closes #277

## Summary

- Adds a generic `ipcMainBridge` (`app/packages/desktop-main/src/ipc-main-bridge.ts`) that walks Nest's registered `@MessagePattern` handlers and calls `ipcMain.handle(channel, ...)` for each — generalising the one-off bridge `LogsController` previously hand-rolled just for `logs.stream`.
- Wires the bridge into bootstrap in `main.ts`, invoked once after `app.listen()`, guarded on `process.versions.electron` so the plain-Node integration test harness never imports `electron` (same constraint as #154–158).
- Adds a real, unmocked regression e2e spec (`app/packages/web/e2e/specs/electron-ipc-roundtrip.spec.ts`, Playwright `electron` project) that launches the packaged app with no `window.gsd.__test.mock()` stubs and asserts a representative renderer → `ipcRenderer.invoke` → `ipcMain` → Nest round-trip resolves.
- Fixes the Electron main build (`electron.vite.config.ts`) to use the SWC plugin so `emitDecoratorMetadata` is preserved, which the bridge's reflection-based handler wiring depends on.

## Changes

```
 .../src/controllers/logs.controller.ts             |   8 +
 .../desktop-main/src/ipc-main-bridge.test.ts       | 145 +++++++++++
 app/packages/desktop-main/src/ipc-main-bridge.ts   |  79 ++++++
 app/packages/desktop-main/src/main.test.ts         |  53 +++-
 app/packages/desktop-main/src/main.ts              |  14 +-
 .../web/e2e/specs/electron-ipc-roundtrip.spec.ts   |  44 ++++
 app/packages/web/playwright.config.ts              |  10 +-
 electron.vite.config.ts                            |  16 +-
 package-lock.json                                  | 281 +++++++++++++++++++++
 package.json                                       |   4 +
 10 files changed, 644 insertions(+), 10 deletions(-)
```

## Test plan

- [x] Every `@MessagePattern` channel (not just `logs.stream`) gets a matching `ipcMain.handle` registration at bootstrap.
- [x] Bridge registration is guarded so it never runs (or imports `electron`) outside a real Electron main process.
- [x] Unit tests (`ipc-main-bridge.test.ts`) cover discovery of registered patterns and correct `ipcMain.handle` wiring.
- [x] `main.test.ts` covers the bridge being invoked after `app.listen()`.
- [x] New unmocked Playwright `electron` spec (`electron-ipc-roundtrip.spec.ts`) launches the real packaged app and asserts a real IPC round-trip (e.g. `window.gsd.env.get()`) resolves without any `__test.mock()` stub.
- [x] `npm run app:test` passes.
- [x] `npm run app:test:e2e` (electron project) passes, including the new regression spec.