### PR TITLE
feat(web): Games settings page (read-only)

### DIFF
--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -17,7 +17,7 @@ import {
   CONFIGURED_DISCORD_CONFIG,
   makeActualCosts,
 } from './game-data.js';
-import { AppLayout, DashboardPage, CostsPage, LogsPage, SettingsPage } from '../pages/index.js';
+import { AppLayout, DashboardPage, CostsPage, LogsPage, SettingsPage, GamesPage } from '../pages/index.js';
 import { installGsdHttpBridge } from './gsd-http-bridge.js';
 
 export type {
@@ -27,6 +27,7 @@ export type {
   WatchdogConfig,
   ActualCosts,
   DiscordConfigRedacted,
+  GameListEntry,
 };
 export {
   ENV_DATA,
@@ -45,7 +46,7 @@ export {
   VALID_USER_ID,
   SAMPLE_LOG_LINES,
 } from './game-data.js';
-export { AppLayout, DashboardPage, CostsPage, DiscordPage, LogsPage, SettingsPage } from '../pages/index.js';
+export { AppLayout, DashboardPage, CostsPage, DiscordPage, LogsPage, SettingsPage, GamesPage } from '../pages/index.js';
 
 /** Per-spec overrides for the default `/api/*` stubs registered by `stubApis`. */
 export interface StubOptions {
@@ -239,6 +240,8 @@ type E2EFixtures = {
   logs: LogsPage;
   /** Page object for the `/settings` route. */
   settings: SettingsPage;
+  /** Page object for the `/games` and `/games/:name` routes. */
+  games: GamesPage;
   /** Page object for the persistent nav shell (sidebar + top bar). */
   layout: AppLayout;
 };
@@ -257,6 +260,9 @@ export const test = base.extend<E2EFixtures>({
   },
   settings: async ({ page }, use) => {
     await use(new SettingsPage(page));
+  },
+  games: async ({ page }, use) => {
+    await use(new GamesPage(page));
   },
   layout: async ({ page }, use) => {
     await use(new AppLayout(page));

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -74,14 +74,19 @@ export interface StubOptions {
    */
   discord?: DiscordConfigRedacted;
   /**
-   * Game names returned by `GET /api/games` (used by the Logs page).
-   * Defaults to the names derived from `statuses`. Override when the Logs
-   * page should expose games that aren't part of `statuses`. Each name is
-   * wrapped into a `GameListEntry` (`declared: true, deployed: true`) before
-   * being sent — the endpoint now emits `{ games: GameListEntry[] }`, not
-   * bare strings — see issue #92.
+   * Entries returned by `GET /api/games` (used by the Logs page and the
+   * read-only Games section of the Settings page). Defaults to the names
+   * derived from `statuses`, each wrapped into a `GameListEntry` with
+   * `declared: true, deployed: true` and no `config`.
+   *
+   * Each element may be either a bare game name (shorthand for the default
+   * `declared`/`deployed` wrapping above) or a full `GameListEntry` object,
+   * so a spec can mix declared-only, deployed-only, and fully-declared
+   * entries — including a `config` payload — in a single stub. See issue
+   * #92 for the `{ games: GameListEntry[] }` response shape and issue #93
+   * for the Games settings section that reads `config`.
    */
-  games?: string[];
+  games?: (string | GameListEntry)[];
   /**
    * Initial log lines surfaced via `window.gsd.logs.get(game)` (used by the
    * Logs page). Maps game name → seeded lines. Games not present in the map
@@ -140,11 +145,9 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
   });
 
   await page.route('**/api/games', (route) => {
-    const entries: GameListEntry[] = games.map((name) => ({
-      name,
-      declared: true,
-      deployed: true,
-    }));
+    const entries: GameListEntry[] = games.map((g) =>
+      typeof g === 'string' ? { name: g, declared: true, deployed: true } : g,
+    );
     return route.fulfill({ json: { games: entries } });
   });
 

--- a/app/packages/web/e2e/pages/GamesPage.ts
+++ b/app/packages/web/e2e/pages/GamesPage.ts
@@ -1,0 +1,102 @@
+import type { Page, Locator } from '@playwright/test';
+
+/** Drift-status chip labels rendered by `GameStatusBadges` (issue #93). */
+export type DriftLabel = 'In sync' | 'Pending deploy' | 'Undeclared';
+
+/**
+ * Page object for the read-only Games routes added in issue #93: the
+ * declared/deployed drift table at `/games` and the per-game detail view at
+ * `/games/:name`. Wraps both routes' locators so spec files read as test
+ * logic rather than locator soup.
+ */
+export class GamesPage {
+  constructor(public readonly page: Page) {}
+
+  /** Navigate to the games list route. */
+  async goto(): Promise<void> {
+    await this.page.goto('/games');
+  }
+
+  /** Navigate directly to a game's detail route. */
+  async gotoDetail(name: string): Promise<void> {
+    await this.page.goto(`/games/${name}`);
+  }
+
+  // ── List page (`/games`) ─────────────────────────────────────────────
+
+  /** "Games" page heading — used as a "the list page mounted" smoke check. */
+  heading(): Locator {
+    return this.page.getByRole('heading', { name: 'Games', level: 2 });
+  }
+
+  /** Empty-state message shown when no games are declared or deployed. */
+  emptyStateMessage(): Locator {
+    return this.page.getByText('No games declared or deployed yet.');
+  }
+
+  /** Row link to a game's detail route, by game name. */
+  gameLink(name: string): Locator {
+    return this.page.getByRole('link', { name });
+  }
+
+  /** Click a game's row link and wait for the detail route to load. */
+  async openGame(name: string): Promise<void> {
+    await this.gameLink(name).click();
+    await this.page.waitForURL((url) => url.pathname === `/games/${name}`);
+  }
+
+  /** All table rows including the header — index 0 is the header, 1.. are games. */
+  tableRows(): Locator {
+    return this.page.getByRole('row');
+  }
+
+  /**
+   * A `<td>` or `<th>` cell whose accessible name matches `name` (string or
+   * regex). Pass a `RegExp` for partial matches.
+   */
+  tableCell(name: string | RegExp): Locator {
+    return this.page.getByRole('cell', { name });
+  }
+
+  /** Drift-status chip by its rendered label ("In sync" / "Pending deploy" / "Undeclared"). */
+  driftChip(label: DriftLabel): Locator {
+    return this.page.getByText(label, { exact: true });
+  }
+
+  // ── Detail page (`/games/:name`) ─────────────────────────────────────
+
+  /** "Back to games" link at the top of the detail page. */
+  backLink(): Locator {
+    return this.page.getByRole('link', { name: /back to games/i });
+  }
+
+  /** Detail-page `<h2>` heading — the game name (page-level, not a panel title). */
+  detailHeading(name: string): Locator {
+    return this.page.getByRole('heading', { name, level: 2, exact: true });
+  }
+
+  /** "No such game" message shown when `:name` matches no merged entry. */
+  notFoundMessage(name: string): Locator {
+    return this.page.getByText(new RegExp(`No game named\\s+"${name}"\\s+was found`, 'i'));
+  }
+
+  /** Ghost-row message shown when a game is deployed but has no declared config. */
+  ghostMessage(): Locator {
+    return this.page.getByText(/deployed but has no entry in/i);
+  }
+
+  /** Config panel `<h3>` card title by its visible label ("Container", "Ports", "Volumes", ...). */
+  panelTitle(label: string): Locator {
+    return this.page.getByRole('heading', { name: label, level: 3, exact: true });
+  }
+
+  /** File-seeds `<summary>` toggle text, e.g. "2 files seeded at task start". */
+  fileSeedsSummary(count: number): Locator {
+    return this.page.getByText(new RegExp(`${count} file${count === 1 ? '' : 's'} seeded at task start`));
+  }
+
+  /** Connect-message panel body text. */
+  connectMessage(text: string): Locator {
+    return this.page.getByText(text);
+  }
+}

--- a/app/packages/web/e2e/pages/index.ts
+++ b/app/packages/web/e2e/pages/index.ts
@@ -4,3 +4,4 @@ export { CostsPage, type CostsRangeLabel } from './CostsPage.js';
 export { DiscordPage } from './DiscordPage.js';
 export { LogsPage, type LogLevelLabel } from './LogsPage.js';
 export { SettingsPage } from './SettingsPage.js';
+export { GamesPage, type DriftLabel } from './GamesPage.js';

--- a/app/packages/web/e2e/specs/games.spec.ts
+++ b/app/packages/web/e2e/specs/games.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, stubApis } from '../fixtures/index.js';
+import type { GameListEntry } from '../fixtures/index.js';
+
+/**
+ * Specs for the read-only Games routes added in issue #93: the
+ * declared/deployed drift table at `/games` and the per-game detail view at
+ * `/games/:name`. These are plain browser-stub specs (chromium project) —
+ * `/api/games` is stubbed over HTTP via `stubApis`, same pattern as
+ * `settings.spec.ts`.
+ */
+
+/** A fully declared + deployed game — the "in sync" row, with every optional config field populated. */
+const declaredDeployed: GameListEntry = {
+  name: 'minecraft',
+  declared: true,
+  deployed: true,
+  config: {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server:latest',
+    cpu: 1024,
+    memory: 2048,
+    https: true,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    environment: [{ name: 'EULA', value: 'TRUE' }],
+    connect_message: 'Connect via minecraft.example.com:25565',
+    file_seeds: [{ path: '/data/server.properties', mode: '0644' }],
+  },
+};
+
+/** Declared but not yet applied — the "pending deploy" row. */
+const declaredOnly: GameListEntry = {
+  name: 'valheim',
+  declared: true,
+  deployed: false,
+  config: {
+    name: 'valheim',
+    image: 'lloesche/valheim-server:latest',
+    cpu: 4096,
+    memory: 8192,
+    ports: [{ container: 2456, protocol: 'udp' }],
+    volumes: [],
+  },
+};
+
+/** Deployed but no tfvars entry — the "ghost" / "undeclared" row (no `config`). */
+const ghostRow: GameListEntry = {
+  name: 'terraria',
+  declared: false,
+  deployed: true,
+};
+
+test.describe('games list page', () => {
+  test('should render the Games heading and an empty state when no games exist', async ({ games }) => {
+    await stubApis(games.page, { games: [] });
+    await games.goto();
+
+    await expect(games.heading()).toBeVisible();
+    await expect(games.emptyStateMessage()).toBeVisible();
+  });
+
+  test('should render the columns and an "In sync" chip for a declared and deployed game', async ({ games }) => {
+    await stubApis(games.page, { games: [declaredDeployed] });
+    await games.goto();
+
+    await expect(games.gameLink('minecraft')).toBeVisible();
+    await expect(games.driftChip('In sync')).toBeVisible();
+    await expect(games.tableCell('itzg/minecraft-server:latest')).toBeVisible();
+    await expect(games.tableCell('25565/tcp')).toBeVisible();
+    await expect(games.tableCell('1024')).toBeVisible();
+    await expect(games.tableCell('2048')).toBeVisible();
+  });
+
+  test('should render a "Pending deploy" chip for a declared-only game', async ({ games }) => {
+    await stubApis(games.page, { games: [declaredOnly] });
+    await games.goto();
+
+    await expect(games.gameLink('valheim')).toBeVisible();
+    await expect(games.driftChip('Pending deploy')).toBeVisible();
+  });
+
+  test('should render an "Undeclared" chip and em-dash columns for a ghost row', async ({ games }) => {
+    await stubApis(games.page, { games: [ghostRow] });
+    await games.goto();
+
+    await expect(games.gameLink('terraria')).toBeVisible();
+    await expect(games.driftChip('Undeclared')).toBeVisible();
+    // image, ports, cpu, memory columns all fall back to an em dash.
+    await expect(games.tableCell('—')).toHaveCount(4);
+  });
+
+  test('should navigate to the /games/:name detail route when a row link is clicked', async ({ games }) => {
+    await stubApis(games.page, { games: [declaredDeployed, declaredOnly, ghostRow] });
+    await games.goto();
+
+    await games.openGame('minecraft');
+
+    await expect(games.detailHeading('minecraft')).toBeVisible();
+  });
+
+  test('should navigate to the games list from the sidebar Games link', async ({ dashboard, games, layout }) => {
+    await stubApis(dashboard.page, { games: [declaredDeployed] });
+    await dashboard.goto();
+
+    await layout.navigateTo('Games', '/games');
+
+    await expect(games.heading()).toBeVisible();
+  });
+});
+
+test.describe('game detail page', () => {
+  test('should render every declared config panel for a fully declared game', async ({ games }) => {
+    await stubApis(games.page, { games: [declaredDeployed] });
+    await games.gotoDetail('minecraft');
+
+    await expect(games.detailHeading('minecraft')).toBeVisible();
+    await expect(games.driftChip('In sync')).toBeVisible();
+
+    // Container overview.
+    await expect(games.panelTitle('Container')).toBeVisible();
+    await expect(games.page.getByText('itzg/minecraft-server:latest')).toBeVisible();
+    await expect(games.page.getByText('1024')).toBeVisible();
+    await expect(games.page.getByText('2048')).toBeVisible();
+    await expect(games.page.getByText('Enabled')).toBeVisible();
+
+    // Ports.
+    await expect(games.panelTitle('Ports')).toBeVisible();
+    await expect(games.page.getByRole('cell', { name: '25565' })).toBeVisible();
+    await expect(games.page.getByRole('cell', { name: /tcp/i })).toBeVisible();
+
+    // Volumes.
+    await expect(games.panelTitle('Volumes')).toBeVisible();
+    // exact: true — otherwise the substring "data" also matches the
+    // container-path cell ("/data"), tripping Playwright's strict mode.
+    await expect(games.page.getByRole('cell', { name: 'data', exact: true })).toBeVisible();
+    await expect(games.page.getByRole('cell', { name: '/data' })).toBeVisible();
+
+    // Environment variables.
+    await expect(games.panelTitle('Environment variables')).toBeVisible();
+    await expect(games.page.getByRole('cell', { name: 'EULA' })).toBeVisible();
+
+    // File seeds (collapsed).
+    await expect(games.fileSeedsSummary(1)).toBeVisible();
+
+    // Connect message.
+    await expect(games.panelTitle('Connect message')).toBeVisible();
+    await expect(games.connectMessage('Connect via minecraft.example.com:25565')).toBeVisible();
+  });
+
+  test('should navigate back to the games list via the back link', async ({ games }) => {
+    await stubApis(games.page, { games: [declaredDeployed] });
+    await games.gotoDetail('minecraft');
+
+    await games.backLink().click();
+
+    await expect(games.heading()).toBeVisible();
+  });
+
+  test('should show a ghost message when a deployed game has no declared config', async ({ games }) => {
+    await stubApis(games.page, { games: [ghostRow] });
+    await games.gotoDetail('terraria');
+
+    await expect(games.detailHeading('terraria')).toBeVisible();
+    await expect(games.driftChip('Undeclared')).toBeVisible();
+    await expect(games.ghostMessage()).toBeVisible();
+    await expect(games.panelTitle('Container')).toHaveCount(0);
+  });
+
+  test('should show a not-found message for a name that matches no merged entry', async ({ games }) => {
+    await stubApis(games.page, { games: [declaredDeployed] });
+    await games.gotoDetail('unknown-game');
+
+    await expect(games.notFoundMessage('unknown-game')).toBeVisible();
+  });
+});

--- a/app/packages/web/src/app.component.tsx
+++ b/app/packages/web/src/app.component.tsx
@@ -5,17 +5,21 @@ import { CostsPage } from './pages/costs.page.js';
 import { DiscordPage } from './pages/discord.page.js';
 import { LogsPage } from './pages/logs.page.js';
 import { SettingsPage } from './pages/settings.page.js';
+import { GamesPage } from './pages/games.page.js';
+import { GameDetailPage } from './pages/game-detail.page.js';
 import { PollingProvider } from './polling/polling-provider.component.js';
 import { GameStatusProvider } from './polling/game-status-provider.component.js';
 import { Toaster } from './components/ui/sonner.component.js';
 
 /**
- * Root component. Renders the routed dashboard shell. Five routes:
+ * Root component. Renders the routed dashboard shell. Routes:
  *   - `/` → Dashboard (game cards + panels)
  *   - `/costs` → Cost analysis placeholder
  *   - `/discord` → Discord settings placeholder
  *   - `/logs` → Logs placeholder
  *   - `/settings` → Watchdog + general settings
+ *   - `/games` → Games list (read-only settings)
+ *   - `/games/:name` → Per-game settings detail (read-only)
  */
 export default function App() {
   return (
@@ -30,6 +34,8 @@ export default function App() {
               <Route path="/discord" element={<DiscordPage />} />
               <Route path="/logs" element={<LogsPage />} />
               <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/games" element={<GamesPage />} />
+              <Route path="/games/:name" element={<GameDetailPage />} />
             </Routes>
           </AppLayout>
         </BrowserRouter>

--- a/app/packages/web/src/components/app-layout.component.tsx
+++ b/app/packages/web/src/components/app-layout.component.tsx
@@ -67,7 +67,7 @@ function NavSections({
         <ul aria-labelledby={`${prefix}-nav-monitoring`} className="space-y-1 list-none">
           {monitoringItems.map((item) => (
             <li key={item.to + item.label}>
-              <NavLink item={item} active={currentPath === item.to} onNavigate={onNavigate} />
+              <NavLink item={item} active={currentPath === item.to || currentPath.startsWith(`${item.to}/`)} onNavigate={onNavigate} />
             </li>
           ))}
         </ul>
@@ -81,7 +81,7 @@ function NavSections({
         <ul aria-labelledby={`${prefix}-nav-configuration`} className="space-y-1 list-none">
           {configItems.map((item) => (
             <li key={item.to + item.label}>
-              <NavLink item={item} active={currentPath === item.to} onNavigate={onNavigate} />
+              <NavLink item={item} active={currentPath === item.to || currentPath.startsWith(`${item.to}/`)} onNavigate={onNavigate} />
             </li>
           ))}
         </ul>

--- a/app/packages/web/src/components/app-layout.component.tsx
+++ b/app/packages/web/src/components/app-layout.component.tsx
@@ -12,6 +12,7 @@ import {
   Bell,
   MessageSquare,
   Settings,
+  Gamepad2,
   RefreshCw,
   Menu,
   X,
@@ -33,6 +34,7 @@ const monitoringItems: NavItem[] = [
 ];
 
 const configItems: NavItem[] = [
+  { to: '/games', icon: Gamepad2, label: 'Games' },
   { to: '/discord', icon: MessageSquare, label: 'Discord' },
   { to: '/settings', icon: Settings, label: 'Settings' },
 ];

--- a/app/packages/web/src/components/game-status-badges.component.test.tsx
+++ b/app/packages/web/src/components/game-status-badges.component.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GameStatusBadges } from './game-status-badges.component.js';
+
+describe('GameStatusBadges', () => {
+  it('should render an "In sync" success chip when the game is declared and deployed', () => {
+    render(<GameStatusBadges declared deployed />);
+
+    const chip = screen.getByText('In sync');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveClass('bg-[var(--color-green)]');
+  });
+
+  it('should render a "Pending deploy" warning chip when the game is declared but not deployed', () => {
+    render(<GameStatusBadges declared deployed={false} />);
+
+    const chip = screen.getByText('Pending deploy');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveClass('bg-[var(--color-amber)]');
+  });
+
+  it('should render an "Undeclared" destructive chip when the game is deployed but not declared', () => {
+    render(<GameStatusBadges declared={false} deployed />);
+
+    const chip = screen.getByText('Undeclared');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveClass('bg-[var(--color-red)]');
+  });
+});

--- a/app/packages/web/src/components/game-status-badges.component.tsx
+++ b/app/packages/web/src/components/game-status-badges.component.tsx
@@ -1,0 +1,46 @@
+import { Badge, type BadgeProps } from '@/components/ui/badge.component';
+
+/**
+ * Props for {@link GameStatusBadges} — the `declared` / `deployed` flags off
+ * a `GameListEntry` (`@hyveon/shared`, merged by `mergeGameLists` — see
+ * issue #92).
+ */
+export interface GameStatusBadgesProps {
+  /** True when this game has an entry in the tfvars `game_servers` map. */
+  declared: boolean;
+  /** True when this game has a deployed ECS task definition in tfstate. */
+  deployed: boolean;
+}
+
+/**
+ * Renders the drift indicator for a single game row on the Settings →
+ * Games panel (issue #93): one chip summarizing whether the game is
+ * declared in `terraform.tfvars`, deployed to `terraform.tfstate`, or
+ * both — so operators can spot drift between the two sources at a glance.
+ *
+ * - declared && deployed → "In sync" (success)
+ * - declared && !deployed → "Pending deploy" (warning)
+ * - !declared && deployed → "Undeclared" (destructive)
+ *
+ * `!declared && !deployed` is not a state `GameListEntry` can produce (a
+ * game only appears in the merged list when it's declared, deployed, or
+ * both), so it's intentionally not handled here.
+ */
+export function GameStatusBadges({ declared, deployed }: GameStatusBadgesProps) {
+  const { text, variant } = describeDriftStatus(declared, deployed);
+  return <Badge variant={variant}>{text}</Badge>;
+}
+
+/** Chip copy + color variant for a declared/deployed combination. */
+function describeDriftStatus(
+  declared: boolean,
+  deployed: boolean,
+): { text: string; variant: NonNullable<BadgeProps['variant']> } {
+  if (declared && deployed) {
+    return { text: 'In sync', variant: 'success' };
+  }
+  if (declared && !deployed) {
+    return { text: 'Pending deploy', variant: 'warning' };
+  }
+  return { text: 'Undeclared', variant: 'destructive' };
+}

--- a/app/packages/web/src/pages/game-detail.page.test.tsx
+++ b/app/packages/web/src/pages/game-detail.page.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Routes, Route } from 'react-router-dom';
+
+const apiMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  costsEstimate: vi.fn(),
+  games: vi.fn(),
+}));
+vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+import { GameDetailPage } from './game-detail.page.js';
+import { renderPage } from '../test-utils/render-page.utils.js';
+
+const DECLARED_GAME = {
+  name: 'minecraft',
+  declared: true,
+  deployed: true,
+  config: {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    environment: [{ name: 'EULA', value: 'TRUE' }],
+    volumes: [{ name: 'minecraft-data', container_path: '/data' }],
+    https: false,
+    connect_message: 'Connect at minecraft.example.com',
+    file_seeds: [{ path: '/data/server.properties', mode: '0644' }],
+  },
+};
+
+const GHOST_GAME = {
+  name: 'valheim',
+  declared: false,
+  deployed: true,
+};
+
+/** Renders the detail page at `/games/:name` for the given route param. */
+function renderDetailPage(name: string) {
+  return renderPage(
+    <Routes>
+      <Route path="/games/:name" element={<GameDetailPage />} />
+    </Routes>,
+    { initialEntries: [`/games/${name}`] },
+  );
+}
+
+describe('GameDetailPage', () => {
+  beforeEach(() => {
+    apiMock.status.mockResolvedValue([]);
+    apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
+  });
+
+  describe('a fully-declared game', () => {
+    beforeEach(() => {
+      apiMock.games.mockResolvedValue({ games: [DECLARED_GAME, GHOST_GAME] });
+    });
+
+    it('should render the game name and the "In sync" drift chip', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByText('In sync')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 2, name: 'minecraft' })).toBeInTheDocument();
+    });
+
+    it('should render the Container section with image, CPU, memory, and HTTPS fields', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByRole('heading', { name: 'Container' })).toBeInTheDocument();
+      expect(screen.getByText('itzg/minecraft-server:latest')).toBeInTheDocument();
+      expect(screen.getByText('1024')).toBeInTheDocument();
+      expect(screen.getByText('2048')).toBeInTheDocument();
+      expect(screen.getByText('Disabled')).toBeInTheDocument();
+    });
+
+    it('should render the Ports section with the container port and protocol', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByRole('heading', { name: 'Ports' })).toBeInTheDocument();
+      expect(screen.getByText('25565')).toBeInTheDocument();
+      expect(screen.getByText('tcp')).toBeInTheDocument();
+    });
+
+    it('should render the Volumes section with the volume name and container path', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByRole('heading', { name: 'Volumes' })).toBeInTheDocument();
+      expect(screen.getByText('minecraft-data')).toBeInTheDocument();
+      expect(screen.getByText('/data')).toBeInTheDocument();
+    });
+
+    it('should render the Environment variables section', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByRole('heading', { name: 'Environment variables' })).toBeInTheDocument();
+      expect(screen.getByText('EULA')).toBeInTheDocument();
+      expect(screen.getByText('TRUE')).toBeInTheDocument();
+    });
+
+    it('should render a collapsed File seeds section', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByRole('heading', { name: 'File seeds' })).toBeInTheDocument();
+      expect(screen.getByText(/1 file seeded at task start/)).toBeInTheDocument();
+      expect(screen.getByText(/server\.properties/)).toBeInTheDocument();
+    });
+
+    it('should render the Connect message section', async () => {
+      renderDetailPage('minecraft');
+
+      expect(await screen.findByRole('heading', { name: 'Connect message' })).toBeInTheDocument();
+      expect(screen.getByText('Connect at minecraft.example.com')).toBeInTheDocument();
+    });
+  });
+
+  describe('a ghost game (deployed but not declared)', () => {
+    beforeEach(() => {
+      apiMock.games.mockResolvedValue({ games: [DECLARED_GAME, GHOST_GAME] });
+    });
+
+    it('should render the "Undeclared" drift chip', async () => {
+      renderDetailPage('valheim');
+
+      expect(await screen.findByText('Undeclared')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 2, name: 'valheim' })).toBeInTheDocument();
+    });
+
+    it('should show a message that there is no declared configuration', async () => {
+      renderDetailPage('valheim');
+
+      expect(await screen.findByText(/no declared configuration to show/i)).toBeInTheDocument();
+    });
+
+    it('should not render any of the config sections', async () => {
+      renderDetailPage('valheim');
+
+      await screen.findByText('Undeclared');
+      expect(screen.queryByRole('heading', { name: 'Container' })).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Ports' })).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Volumes' })).toBeNull();
+    });
+  });
+
+  describe('an unknown :name param', () => {
+    beforeEach(() => {
+      apiMock.games.mockResolvedValue({ games: [DECLARED_GAME, GHOST_GAME] });
+    });
+
+    it('should show a "no game found" message', async () => {
+      renderDetailPage('does-not-exist');
+
+      expect(await screen.findByText(/no game named/i)).toBeInTheDocument();
+      expect(screen.getByText(/"does-not-exist"/)).toBeInTheDocument();
+    });
+
+    it('should not render the drift chip or any config sections', async () => {
+      renderDetailPage('does-not-exist');
+
+      await screen.findByText(/no game named/i);
+      expect(screen.queryByText('In sync')).toBeNull();
+      expect(screen.queryByText('Undeclared')).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Container' })).toBeNull();
+    });
+  });
+});

--- a/app/packages/web/src/pages/game-detail.page.tsx
+++ b/app/packages/web/src/pages/game-detail.page.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { Link, useParams } from 'react-router-dom';
+import { api, type GameListEntry } from '../api.service.js';
+import { GameStatusBadges } from '../components/game-status-badges.component.js';
+import { PollingIndicator } from '../polling/polling-indicator.component.js';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.component';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.component';
+
+/** A single labeled field in the "Container" overview grid. */
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[0.65rem] uppercase tracking-wider text-[var(--color-muted-foreground)] mb-1">
+        {label}
+      </div>
+      <div className="text-sm text-[var(--color-foreground)]">{value}</div>
+    </div>
+  );
+}
+
+/**
+ * Game detail route (`/games/:name`) — read-only rendering of the full
+ * declared configuration for a single game, sourced from the same merged
+ * `games.list` payload the `/games` list page uses (see issue #93).
+ *
+ * Three renderable states, keyed off the merged `GameListEntry` for
+ * `:name`:
+ *   - Not found — `:name` doesn't match any entry in the merged list
+ *     (neither declared nor deployed). Shows a "no such game" message.
+ *   - Ghost — entry exists (`deployed: true`) but has no `config`, i.e. the
+ *     game is live in `terraform.tfstate` but has no entry in
+ *     `terraform.tfvars` anymore. Only the header + drift chip render; there
+ *     is no declared configuration to show.
+ *   - Fully declared — `config` is present. Renders every tfvars field:
+ *     image, CPU/memory, HTTPS flag, ports, volumes, environment variables
+ *     (if any), file seeds (collapsed, if any), and the connect message (if
+ *     set).
+ */
+export function GameDetailPage() {
+  const { name } = useParams<{ name: string }>();
+  const [games, setGames] = useState<GameListEntry[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .games()
+      .then((res) => {
+        if (!cancelled) setGames(res.games);
+      })
+      .catch(() => {
+        if (!cancelled) setGames([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const entry = games?.find((g) => g.name === name);
+  const config = entry?.config;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <Link
+            to="/games"
+            className="mb-1 inline-flex items-center gap-1 text-sm text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)]"
+          >
+            <ArrowLeft className="size-3.5" />
+            Back to games
+          </Link>
+          <h2 className="text-2xl font-semibold capitalize text-[var(--color-foreground)]">{name}</h2>
+        </div>
+        <PollingIndicator />
+      </div>
+
+      {games === null ? (
+        <p className="text-sm text-[var(--color-muted-foreground)]">Loading…</p>
+      ) : !entry ? (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-[var(--color-muted-foreground)]">
+            No game named <span className="font-[var(--font-mono)]">&quot;{name}&quot;</span> was found.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle className="capitalize">{entry.name}</CardTitle>
+              <GameStatusBadges declared={entry.declared} deployed={entry.deployed} />
+            </CardHeader>
+            {!config && (
+              <CardContent>
+                <p className="text-sm text-[var(--color-muted-foreground)]">
+                  This game is deployed but has no entry in{' '}
+                  <code className="font-mono text-xs bg-[var(--color-surface-2)] px-1 py-0.5 rounded">
+                    terraform.tfvars
+                  </code>{' '}
+                  — there is no declared configuration to show.
+                </p>
+              </CardContent>
+            )}
+          </Card>
+
+          {config && (
+            <>
+              {/* Container overview */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Container</CardTitle>
+                </CardHeader>
+                <CardContent className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
+                  <Field label="Image" value={config.image} />
+                  <Field label="CPU" value={String(config.cpu)} />
+                  <Field label="Memory" value={String(config.memory)} />
+                  <Field label="HTTPS" value={config.https ? 'Enabled' : 'Disabled'} />
+                </CardContent>
+              </Card>
+
+              {/* Ports */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Ports</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Container port</TableHead>
+                        <TableHead>Protocol</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {config.ports.map((port) => (
+                        <TableRow key={`${port.container}-${port.protocol}`}>
+                          <TableCell className="font-[var(--font-mono)]">{port.container}</TableCell>
+                          <TableCell className="uppercase">{port.protocol}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+
+              {/* Volumes */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Volumes</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Container path</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {config.volumes.map((volume) => (
+                        <TableRow key={volume.name}>
+                          <TableCell>{volume.name}</TableCell>
+                          <TableCell className="font-[var(--font-mono)]">{volume.container_path}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+
+              {/* Environment variables (optional) */}
+              {config.environment && config.environment.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Environment variables</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Name</TableHead>
+                          <TableHead>Value</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {config.environment.map((env) => (
+                          <TableRow key={env.name}>
+                            <TableCell className="font-[var(--font-mono)]">{env.name}</TableCell>
+                            <TableCell className="font-[var(--font-mono)]">{env.value}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* File seeds (optional, collapsed) */}
+              {config.file_seeds && config.file_seeds.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>File seeds</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <details>
+                      <summary className="cursor-pointer text-sm text-[var(--color-foreground)]">
+                        {config.file_seeds.length} file{config.file_seeds.length === 1 ? '' : 's'} seeded at task start
+                      </summary>
+                      <ul className="mt-3 space-y-1">
+                        {config.file_seeds.map((seed) => (
+                          <li key={seed.path} className="font-[var(--font-mono)] text-xs text-[var(--color-muted-foreground)]">
+                            {seed.path}
+                            {seed.mode ? ` (mode ${seed.mode})` : ''}
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Connect message (optional) */}
+              {config.connect_message && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Connect message</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-[var(--color-foreground)] whitespace-pre-wrap">
+                      {config.connect_message}
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/packages/web/src/pages/games.page.test.tsx
+++ b/app/packages/web/src/pages/games.page.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+
+const apiMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  costsEstimate: vi.fn(),
+  games: vi.fn(),
+}));
+vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+import { GamesPage } from './games.page.js';
+import { renderPage } from '../test-utils/render-page.utils.js';
+
+/** A fully declared + deployed game — the "in sync" row. */
+const declaredDeployed = {
+  name: 'minecraft',
+  declared: true,
+  deployed: true,
+  config: {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [],
+  },
+};
+
+/** Declared but not yet applied — the "pending deploy" row. */
+const declaredOnly = {
+  name: 'valheim',
+  declared: true,
+  deployed: false,
+  config: {
+    name: 'valheim',
+    image: 'lloesche/valheim-server:latest',
+    cpu: 4096,
+    memory: 8192,
+    ports: [{ container: 2456, protocol: 'udp' }],
+    volumes: [],
+  },
+};
+
+/** Deployed but no tfvars entry — the "ghost" / "undeclared" row (no `config`). */
+const ghostRow = {
+  name: 'terraria',
+  declared: false,
+  deployed: true,
+};
+
+describe('GamesPage', () => {
+  beforeEach(() => {
+    apiMock.status.mockResolvedValue([]);
+    apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
+    apiMock.games.mockResolvedValue({ games: [declaredDeployed, declaredOnly, ghostRow] });
+  });
+
+  it('should render the Games heading', () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+    expect(screen.getByRole('heading', { name: 'Games' })).toBeInTheDocument();
+  });
+
+  it('should render a row with the correct columns for a declared and deployed game', async () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    expect(await screen.findByText('minecraft')).toBeInTheDocument();
+    expect(screen.getByText('In sync')).toBeInTheDocument();
+    expect(screen.getByText('itzg/minecraft-server:latest')).toBeInTheDocument();
+    expect(screen.getByText('25565/tcp')).toBeInTheDocument();
+    expect(screen.getByText('1024')).toBeInTheDocument();
+    expect(screen.getByText('2048')).toBeInTheDocument();
+  });
+
+  it('should render a "Pending deploy" chip for a declared-only game', async () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    expect(await screen.findByText('valheim')).toBeInTheDocument();
+    expect(screen.getByText('Pending deploy')).toBeInTheDocument();
+  });
+
+  it('should render an "Undeclared" chip and em-dash columns for a ghost row', async () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    expect(await screen.findByText('terraria')).toBeInTheDocument();
+    expect(screen.getByText('Undeclared')).toBeInTheDocument();
+
+    const ghostCells = screen.getAllByText('—');
+    // image, ports, cpu, memory columns all fall back to an em dash when
+    // there's no declared `config` to read from.
+    expect(ghostCells.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('should link each row to its /games/:name detail route', async () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    const link = await screen.findByRole('link', { name: 'minecraft' });
+    expect(link).toHaveAttribute('href', '/games/minecraft');
+  });
+
+  it('should render an empty state when no games are declared or deployed', async () => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    expect(await screen.findByText('No games declared or deployed yet.')).toBeInTheDocument();
+  });
+});

--- a/app/packages/web/src/pages/games.page.tsx
+++ b/app/packages/web/src/pages/games.page.tsx
@@ -30,16 +30,20 @@ function formatPorts(entry: GameListEntry): string {
 export function GamesPage() {
   const [games, setGames] = useState<GameListEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setError(null);
     api
       .games()
       .then(({ games: list }) => {
         if (!cancelled) setGames(list);
       })
-      .catch(() => undefined)
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load games.');
+      })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
@@ -64,6 +68,10 @@ export function GamesPage() {
         <CardContent>
           {loading ? (
             <div className="py-8 text-center text-sm text-[var(--color-muted-foreground)]">Loading games…</div>
+          ) : error ? (
+            <div className="rounded-[var(--radius-sm)] border border-[var(--color-red)]/40 bg-[var(--color-red)]/10 px-3 py-2 text-sm text-[var(--color-red)]">
+              Failed to load games: {error}
+            </div>
           ) : games.length === 0 ? (
             <div className="py-8 text-center text-sm text-[var(--color-muted-foreground)]">
               No games declared or deployed yet.

--- a/app/packages/web/src/pages/games.page.tsx
+++ b/app/packages/web/src/pages/games.page.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api, type GameListEntry } from '../api.service.js';
+import { GameStatusBadges } from '../components/game-status-badges.component.js';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.component';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.component';
+import { PollingIndicator } from '../polling/polling-indicator.component.js';
+
+/** Renders a game's declared ports as a comma-separated `container/protocol` list, or an em dash when undeclared. */
+function formatPorts(entry: GameListEntry): string {
+  const ports = entry.config?.ports;
+  if (!ports || ports.length === 0) return '—';
+  return ports.map((p) => `${p.container}/${p.protocol}`).join(', ');
+}
+
+/**
+ * Games route (`/games`) — read-only table of every game the app knows
+ * about, merging the declared `terraform.tfvars` config with the deployed
+ * `terraform.tfstate` view (see issue #92's `games.list` IPC channel).
+ *
+ * Rows fall into three shapes:
+ *   - declared + deployed → full config, "In sync" chip.
+ *   - declared only → full config, "Pending deploy" chip (not yet applied).
+ *   - deployed only ("ghost" row) → no `config`, "Undeclared" chip; config
+ *     columns render as em dashes since there's no tfvars entry to read.
+ *
+ * Each row links to `/games/:name` for the deeper read-only detail view
+ * (issue #93's follow-up), still to be implemented.
+ */
+export function GamesPage() {
+  const [games, setGames] = useState<GameListEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api
+      .games()
+      .then(({ games: list }) => {
+        if (!cancelled) setGames(list);
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-semibold">Games</h2>
+        <PollingIndicator />
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xs uppercase tracking-wider text-[var(--color-muted-foreground)]">
+            Declared game servers
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="py-8 text-center text-sm text-[var(--color-muted-foreground)]">Loading games…</div>
+          ) : games.length === 0 ? (
+            <div className="py-8 text-center text-sm text-[var(--color-muted-foreground)]">
+              No games declared or deployed yet.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Image</TableHead>
+                  <TableHead>Ports</TableHead>
+                  <TableHead className="text-right">CPU</TableHead>
+                  <TableHead className="text-right">Memory</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {games.map((entry) => (
+                  <TableRow key={entry.name}>
+                    <TableCell className="capitalize font-medium">
+                      <Link
+                        to={`/games/${entry.name}`}
+                        className="text-[var(--color-primary-light)] underline-offset-4 hover:underline"
+                      >
+                        {entry.name}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <GameStatusBadges declared={entry.declared} deployed={entry.deployed} />
+                    </TableCell>
+                    <TableCell className="font-[var(--font-mono)] text-xs">
+                      {entry.config?.image ?? '—'}
+                    </TableCell>
+                    <TableCell className="font-[var(--font-mono)] text-xs">{formatPorts(entry)}</TableCell>
+                    <TableCell className="text-right font-[var(--font-mono)]">
+                      {entry.config?.cpu ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-right font-[var(--font-mono)]">
+                      {entry.config?.memory ?? '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #93

## Summary

- Adds a `/games` route listing every declared game (from tfvars) merged with live tfstate deploy status, with a `Drift`/status badge (declared-only, deployed-only, or both) rendered via the new `GameStatusBadges` component.
- Adds a `/games/:name` detail page rendering the full declared config for one game — image, ports, CPU, memory, volumes, collapsed file_seeds, connect_message — plus the same drift/status badges, still read-only.
- Wires the new route into the app shell's router and nav (`app.component.tsx`, `app-layout.component.tsx`), and adds Playwright page-object + chromium e2e coverage (`GamesPage.ts`, `games.spec.ts`) alongside a `stubApis` fixture override for individual game entries.

## Changes

```
 app/packages/web/e2e/fixtures/index.ts             |  37 ++--
 app/packages/web/e2e/pages/GamesPage.ts            | 102 +++++++++
 app/packages/web/e2e/pages/index.ts                |   1 +
 app/packages/web/e2e/specs/games.spec.ts           | 175 +++++++++++++++
 app/packages/web/src/app.component.tsx             |   8 +-
 .../web/src/components/app-layout.component.tsx    |   2 +
 .../game-status-badges.component.test.tsx          |  29 +++
 .../components/game-status-badges.component.tsx    |  46 ++++
 .../web/src/pages/game-detail.page.test.tsx        | 166 ++++++++++++++
 app/packages/web/src/pages/game-detail.page.tsx    | 241 +++++++++++++++++++++
 app/packages/web/src/pages/games.page.test.tsx     | 106 +++++++++
 app/packages/web/src/pages/games.page.tsx          | 116 ++++++++++
 12 files changed, 1014 insertions(+), 15 deletions(-)
```

## Test plan

- [x] `/games` lists declared games (name, image, ports, CPU, memory, volumes, connect_message, status badges) — covered by `games.page.test.tsx` and `games.spec.ts`.
- [x] `/games/:name` shows the full config of one game, including collapsed `file_seeds` — covered by `game-detail.page.test.tsx` and `games.spec.ts`.
- [x] Drift chips render correctly for both directions (declared-but-not-deployed warning chip, deployed-but-not-declared ghost chip) — covered by `game-status-badges.component.test.tsx`.
- [x] Existing dashboard at `/` is untouched — no changes to `dashboard.page.tsx`.
- [x] `npm run app:test` passes.
- [x] `npm run app:test:e2e` (chromium project) passes, including the new `games.spec.ts`.