### PR TITLE
feat(desktop-main): drift detection — declared-vs-live mismatches

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -20,7 +20,10 @@ import { EnvController } from './controllers/env.controller.js';
 import { EnvHttpController } from './controllers/env-http.controller.js';
 import { DiagnosticsController } from './controllers/diagnostics.controller.js';
 import { DiagnosticsHttpController } from './controllers/diagnostics-http.controller.js';
+import { DriftController } from './controllers/drift.controller.js';
+import { DriftHttpController } from './controllers/drift-http.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
+import { DriftService } from './services/DriftService.js';
 import { SafeStorageService } from './services/SafeStorageService.js';
 import { ElectronStoreService } from './services/ElectronStoreService.js';
 
@@ -46,6 +49,8 @@ import { ElectronStoreService } from './services/ElectronStoreService.js';
     EnvHttpController,
     DiagnosticsController,
     DiagnosticsHttpController,
+    DriftController,
+    DriftHttpController,
   ],
   providers: [
     {
@@ -60,6 +65,7 @@ import { ElectronStoreService } from './services/ElectronStoreService.js';
       },
     },
     DiagnosticsService,
+    DriftService,
     SafeStorageService,
     ElectronStoreService,
   ],

--- a/app/packages/desktop-main/src/controllers/drift-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/drift-http.controller.test.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import type { DriftReport } from '@hyveon/shared';
+import { DriftHttpController } from './drift-http.controller.js';
+import type { DriftService } from '../services/DriftService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Default drift report used by most tests. */
+const DEFAULT_REPORT: DriftReport = {
+  entries: [{ game: 'minecraft', kind: 'config_drift', changedFields: ['cpu'] }],
+};
+
+/** Build a DriftService stub with `getDrift` pre-wired to resolve `report`. */
+function makeDrift(report: DriftReport = DEFAULT_REPORT): DriftService {
+  return {
+    getDrift: vi.fn().mockResolvedValue(report),
+  } as unknown as DriftService;
+}
+
+describe('DriftHttpController', () => {
+  describe('get', () => {
+    it('should return the DriftReport from DriftService', async () => {
+      const result = await new DriftHttpController(makeDrift()).get();
+      expect(result).toEqual(DEFAULT_REPORT);
+    });
+
+    it('should delegate to DriftService.getDrift', async () => {
+      const drift = makeDrift();
+      await new DriftHttpController(drift).get();
+      expect(drift.getDrift).toHaveBeenCalledOnce();
+    });
+
+    it('should return an empty entries list when there is no drift', async () => {
+      const drift = makeDrift({ entries: [] });
+      const result = await new DriftHttpController(drift).get();
+      expect(result).toEqual({ entries: [] });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/drift-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/drift-http.controller.test.ts
@@ -17,7 +17,7 @@ const DEFAULT_REPORT: DriftReport = {
 function makeDrift(report: DriftReport = DEFAULT_REPORT): DriftService {
   return {
     getDrift: vi.fn().mockResolvedValue(report),
-  } as unknown as DriftService;
+  } as Partial<DriftService> as DriftService;
 }
 
 describe('DriftHttpController', () => {

--- a/app/packages/desktop-main/src/controllers/drift-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/drift-http.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get } from '@nestjs/common';
+import type { DriftReport } from '@hyveon/shared';
+import { DriftService } from '../services/DriftService.js';
+
+/**
+ * HTTP shim that exposes drift detection as a plain REST endpoint
+ * (`GET /api/drift`). The browser client (`api.service.ts`) and the
+ * integration-test server consume this route over HTTP; the Electron
+ * main-process host uses the IPC {@link DriftController} (`@MessagePattern`)
+ * handler instead.
+ *
+ * Both controllers delegate to the same {@link DriftService} provider — the
+ * heavy lifting lives in that service, not in the thin orchestration
+ * duplicated here.
+ */
+@Controller('drift')
+export class DriftHttpController {
+  constructor(private readonly drift: DriftService) {}
+
+  /** Returns the current {@link DriftReport} — see `DriftService.getDrift()`. */
+  @Get()
+  get(): Promise<DriftReport> {
+    return this.drift.getDrift();
+  }
+}

--- a/app/packages/desktop-main/src/controllers/drift.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/drift.controller.test.ts
@@ -1,0 +1,58 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import type { DriftReport } from '@hyveon/shared';
+import { DriftController } from './drift.controller.js';
+import type { DriftService } from '../services/DriftService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Default drift report used by most tests. */
+const DEFAULT_REPORT: DriftReport = {
+  entries: [{ game: 'minecraft', kind: 'config_drift', changedFields: ['cpu'] }],
+};
+
+/** Build a DriftService stub with `getDrift` pre-wired to resolve `report`. */
+function makeDrift(report: DriftReport = DEFAULT_REPORT): DriftService {
+  return {
+    getDrift: vi.fn().mockResolvedValue(report),
+  } as unknown as DriftService;
+}
+
+/**
+ * The metadata key NestJS stores on each method decorated with
+ * `@MessagePattern`. Asserting this value is the only automated guard
+ * that prevents a typo in the controller from silently breaking IPC —
+ * calling the method directly (as every other test does) would succeed
+ * regardless of what string is registered with the transport.
+ */
+const PATTERN_METADATA_KEY = 'microservices:pattern';
+
+describe('DriftController', () => {
+  describe('@MessagePattern channel names', () => {
+    it('should register get on the "drift.get" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, DriftController.prototype.get);
+      expect(pattern).toEqual(['drift.get']);
+    });
+  });
+
+  describe('get', () => {
+    it('should return the DriftReport from DriftService', async () => {
+      const result = await new DriftController(makeDrift()).get();
+      expect(result).toEqual(DEFAULT_REPORT);
+    });
+
+    it('should delegate to DriftService.getDrift', async () => {
+      const drift = makeDrift();
+      await new DriftController(drift).get();
+      expect(drift.getDrift).toHaveBeenCalledOnce();
+    });
+
+    it('should return an empty entries list when there is no drift', async () => {
+      const drift = makeDrift({ entries: [] });
+      const result = await new DriftController(drift).get();
+      expect(result).toEqual({ entries: [] });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/drift.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/drift.controller.test.ts
@@ -17,7 +17,7 @@ const DEFAULT_REPORT: DriftReport = {
 function makeDrift(report: DriftReport = DEFAULT_REPORT): DriftService {
   return {
     getDrift: vi.fn().mockResolvedValue(report),
-  } as unknown as DriftService;
+  } as Partial<DriftService> as DriftService;
 }
 
 /**

--- a/app/packages/desktop-main/src/controllers/drift.controller.ts
+++ b/app/packages/desktop-main/src/controllers/drift.controller.ts
@@ -1,0 +1,24 @@
+import { Controller } from '@nestjs/common';
+import { MessagePattern } from '@nestjs/microservices';
+import type { DriftReport } from '@hyveon/shared';
+import { DriftService } from '../services/DriftService.js';
+
+/**
+ * IPC-only controller exposing drift detection (declared `terraform.tfvars`
+ * vs. applied `terraform.tfstate`) for the Electron main-process host. The
+ * single handler is bound to an IPC channel via `@MessagePattern` — no HTTP
+ * routes are registered here. The browser client and the integration-test
+ * server reach the same operation over REST through the
+ * {@link DriftHttpController} shim, which delegates to the identical
+ * {@link DriftService} provider.
+ */
+@Controller()
+export class DriftController {
+  constructor(private readonly drift: DriftService) {}
+
+  /** Returns the current {@link DriftReport} — see `DriftService.getDrift()`. */
+  @MessagePattern('drift.get')
+  get(): Promise<DriftReport> {
+    return this.drift.getDrift();
+  }
+}

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -77,6 +77,35 @@ describe('ConfigService', () => {
       expect(outputs!.subnet_ids).toBe('');
       expect(outputs!.alb_dns_name).toBeNull();
       expect(outputs!.efs_access_points).toEqual({});
+      expect(outputs!.applied_game_servers).toBeNull();
+    });
+
+    it('should parse applied_game_servers when the output is present', () => {
+      mockExists.mockReturnValue(true);
+      const appliedGameServers = {
+        minecraft: {
+          image: 'itzg/minecraft-server',
+          cpu: 1024,
+          memory: 2048,
+          ports: [{ container: 25565, protocol: 'tcp' }],
+          volumes: [{ name: 'data', container_path: '/data' }],
+        },
+      };
+      mockRead.mockReturnValue(
+        makeState({
+          applied_game_servers: { value: appliedGameServers },
+        }),
+      );
+
+      const outputs = service.getTfOutputs();
+      expect(outputs!.applied_game_servers).toEqual(appliedGameServers);
+    });
+
+    it('should default applied_game_servers to null when the output is missing', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(makeState({ aws_region: { value: 'us-west-2' } }));
+
+      expect(service.getTfOutputs()!.applied_game_servers).toBeNull();
     });
 
     it('should apply the fallback aws_region when outputs omit it', () => {

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import type { GameServer } from '@hyveon/shared';
 import { logger } from '../logger.js';
 
 /** Absolute path to the `dist/services/` directory at runtime. */
@@ -39,6 +40,15 @@ export interface TfOutputs {
   discord_public_key_secret_arn: string;
   interactions_invoke_url: string | null;
   discord_interactions_url: string | null;
+  /**
+   * Full per-game `game_servers` configuration as last applied by Terraform
+   * (the `applied_game_servers` sensitive output — see `terraform/aws/outputs.tf`),
+   * keyed by game name. Used for drift detection: field-level comparison
+   * against the currently declared tfvars config (see `@hyveon/shared/drift.ts`).
+   * `null` when the output is absent (e.g. state predates this output, or
+   * `terraform apply` hasn't run since it was added).
+   */
+  applied_game_servers: Record<string, Omit<GameServer, 'name'>> | null;
 }
 
 /**
@@ -165,6 +175,7 @@ export class ConfigService {
         discord_public_key_secret_arn: get('discord_public_key_secret_arn', ''),
         interactions_invoke_url: get('interactions_invoke_url', null),
         discord_interactions_url: get('discord_interactions_url', null),
+        applied_game_servers: get('applied_game_servers', null),
       };
 
       logger.debug('Loaded Terraform outputs', { games: this.tfCache.game_names });

--- a/app/packages/desktop-main/src/services/DriftService.test.ts
+++ b/app/packages/desktop-main/src/services/DriftService.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { GameServer } from '@hyveon/shared';
+import { DriftService, computeDrift } from './DriftService.js';
+import type { ConfigService, TfOutputs } from './ConfigService.js';
+import type { TfvarsService } from './TfvarsService.js';
+
+/** Minimal, valid `GameServer` fixture for a single declared game. */
+function buildGameServer(name: string, overrides: Partial<GameServer> = {}): GameServer {
+  return {
+    name,
+    image: 'example/image:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'saves', container_path: '/data' }],
+    ...overrides,
+  };
+}
+
+/** Minimal TfOutputs for DriftService tests. */
+const DEFAULT_OUTPUTS: Partial<TfOutputs> = {
+  game_names: ['minecraft'],
+  applied_game_servers: {
+    minecraft: {
+      image: 'example/image:latest',
+      cpu: 1024,
+      memory: 2048,
+      ports: [{ container: 25565, protocol: 'tcp' }],
+      volumes: [{ name: 'saves', container_path: '/data' }],
+    },
+  },
+};
+
+/**
+ * Build a ConfigService stub. Pass `null` to simulate a pre-apply state
+ * where `getTfOutputs()` returns null.
+ */
+function makeConfig(outputs: Partial<TfOutputs> | null = DEFAULT_OUTPUTS): ConfigService {
+  return {
+    invalidateCache: vi.fn(),
+    getTfOutputs: vi.fn().mockReturnValue(outputs),
+  } as unknown as ConfigService;
+}
+
+/** Build a TfvarsService stub with `invalidateCache` and `getGameServers` pre-wired. */
+function makeTfvars(declared: GameServer[] = []): TfvarsService {
+  return {
+    invalidateCache: vi.fn(),
+    getGameServers: vi.fn().mockResolvedValue(declared),
+  } as Partial<TfvarsService> as TfvarsService;
+}
+
+describe('computeDrift', () => {
+  it('should report pending_create when a declared game is absent from deployedNames', () => {
+    const ark = buildGameServer('ark');
+
+    const result = computeDrift([ark], null, []);
+
+    expect(result).toEqual({ entries: [{ game: 'ark', kind: 'pending_create' }] });
+  });
+
+  it('should report pending_delete when a deployed game is absent from declared', () => {
+    const result = computeDrift([], null, ['minecraft']);
+
+    expect(result).toEqual({ entries: [{ game: 'minecraft', kind: 'pending_delete' }] });
+  });
+
+  it('should report config_drift with the exact set of changed fields when declared and applied configs differ', () => {
+    const declared = buildGameServer('minecraft', { cpu: 2048, ports: [{ container: 25566, protocol: 'tcp' }] });
+    const applied = { image: 'example/image:latest', cpu: 1024, memory: 2048, ports: [{ container: 25565, protocol: 'tcp' }], volumes: [{ name: 'saves', container_path: '/data' }] };
+
+    const result = computeDrift([declared], { minecraft: applied }, ['minecraft']);
+
+    expect(result).toEqual({
+      entries: [{ game: 'minecraft', kind: 'config_drift', changedFields: ['cpu', 'ports'] }],
+    });
+  });
+
+  it('should omit a game entirely when declared and applied configs match on every compared field', () => {
+    const minecraft = buildGameServer('minecraft');
+    const applied = { image: minecraft.image, cpu: minecraft.cpu, memory: minecraft.memory, ports: minecraft.ports, volumes: minecraft.volumes };
+
+    const result = computeDrift([minecraft], { minecraft: applied }, ['minecraft']);
+
+    expect(result).toEqual({ entries: [] });
+  });
+
+  it('should report every declared game as pending_create when nothing is deployed', () => {
+    const ark = buildGameServer('ark');
+    const rust = buildGameServer('rust');
+
+    const result = computeDrift([ark, rust], null, []);
+
+    expect(result).toEqual({
+      entries: [
+        { game: 'ark', kind: 'pending_create' },
+        { game: 'rust', kind: 'pending_create' },
+      ],
+    });
+  });
+
+  it('should use game_names as the deployed set (not treat it as empty) when applied_game_servers is null but the game is already listed in game_names', () => {
+    const minecraft = buildGameServer('minecraft');
+
+    // Simulates DriftService.getDrift() falling back to `game_names` when
+    // `applied_game_servers` is null (state predates the output).
+    const result = computeDrift([minecraft], null, ['minecraft']);
+
+    expect(result).toEqual({ entries: [] });
+  });
+
+  it('should report pending_delete for a game_names-only game even when applied_game_servers is null', () => {
+    const result = computeDrift([], null, ['minecraft']);
+
+    expect(result).toEqual({ entries: [{ game: 'minecraft', kind: 'pending_delete' }] });
+  });
+
+  it('should not report config_drift for ports/volumes that differ only in element order', () => {
+    const declared = buildGameServer('minecraft', {
+      ports: [
+        { container: 25566, protocol: 'udp' },
+        { container: 25565, protocol: 'tcp' },
+      ],
+      volumes: [
+        { name: 'config', container_path: '/config' },
+        { name: 'saves', container_path: '/data' },
+      ],
+    });
+    const applied = {
+      image: declared.image,
+      cpu: declared.cpu,
+      memory: declared.memory,
+      ports: [
+        { container: 25565, protocol: 'tcp' },
+        { container: 25566, protocol: 'udp' },
+      ],
+      volumes: [
+        { name: 'saves', container_path: '/data' },
+        { name: 'config', container_path: '/config' },
+      ],
+    };
+
+    const result = computeDrift([declared], { minecraft: applied }, ['minecraft']);
+
+    expect(result).toEqual({ entries: [] });
+  });
+
+  it('should order entries as declared (tfvars) order first, then deployed-only entries in deployedNames order', () => {
+    const ark = buildGameServer('ark');
+
+    const result = computeDrift([ark], null, ['zomboid', 'terraria']);
+
+    expect(result).toEqual({
+      entries: [
+        { game: 'ark', kind: 'pending_create' },
+        { game: 'zomboid', kind: 'pending_delete' },
+        { game: 'terraria', kind: 'pending_delete' },
+      ],
+    });
+  });
+
+  it.each<[keyof Omit<GameServer, 'name'>, Partial<GameServer>]>([
+    ['image', { image: 'other/image:latest' }],
+    ['cpu', { cpu: 4096 }],
+    ['memory', { memory: 4096 }],
+    ['ports', { ports: [{ container: 12345, protocol: 'tcp' }] }],
+    ['volumes', { volumes: [{ name: 'other', container_path: '/other' }] }],
+  ])('should report config_drift with changedFields: [%s] when only the %s field differs', (field, override) => {
+    const declared = buildGameServer('minecraft', override);
+    const applied = {
+      image: 'example/image:latest',
+      cpu: 1024,
+      memory: 2048,
+      ports: [{ container: 25565, protocol: 'tcp' }],
+      volumes: [{ name: 'saves', container_path: '/data' }],
+    };
+
+    const result = computeDrift([declared], { minecraft: applied }, ['minecraft']);
+
+    expect(result).toEqual({
+      entries: [{ game: 'minecraft', kind: 'config_drift', changedFields: [field] }],
+    });
+  });
+
+  it('should report a mix of pending_create, config_drift, pending_delete, and in-sync games in a single report', () => {
+    const ark = buildGameServer('ark');
+    const minecraft = buildGameServer('minecraft', { cpu: 4096 });
+    const rust = buildGameServer('rust');
+    const appliedMinecraft = { image: minecraft.image, cpu: 1024, memory: minecraft.memory, ports: minecraft.ports, volumes: minecraft.volumes };
+    const appliedRust = { image: rust.image, cpu: rust.cpu, memory: rust.memory, ports: rust.ports, volumes: rust.volumes };
+
+    const result = computeDrift(
+      [ark, minecraft, rust],
+      { minecraft: appliedMinecraft, rust: appliedRust },
+      ['minecraft', 'rust', 'zomboid'],
+    );
+
+    expect(result).toEqual({
+      entries: [
+        { game: 'ark', kind: 'pending_create' },
+        { game: 'minecraft', kind: 'config_drift', changedFields: ['cpu'] },
+        { game: 'zomboid', kind: 'pending_delete' },
+      ],
+    });
+  });
+});
+
+describe('DriftService', () => {
+  describe('getDrift', () => {
+    it('should invalidate the tfstate cache before reading state', async () => {
+      const config = makeConfig();
+      await new DriftService(makeTfvars(), config).getDrift();
+      expect(config.invalidateCache).toHaveBeenCalledOnce();
+    });
+
+    it('should invalidate the TfvarsService cache before reading state', async () => {
+      const tfvars = makeTfvars();
+      await new DriftService(tfvars, makeConfig()).getDrift();
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
+    });
+
+    it('should report every declared game as pending_create when terraform.tfstate has never been applied', async () => {
+      const ark = buildGameServer('ark');
+
+      const result = await new DriftService(makeTfvars([ark]), makeConfig(null)).getDrift();
+
+      expect(result).toEqual({ entries: [{ game: 'ark', kind: 'pending_create' }] });
+    });
+
+    it('should not report pending_create for a game already present in game_names when applied_game_servers is null', async () => {
+      const minecraft = buildGameServer('minecraft');
+      const outputs: Partial<TfOutputs> = { game_names: ['minecraft'], applied_game_servers: null };
+
+      const result = await new DriftService(makeTfvars([minecraft]), makeConfig(outputs)).getDrift();
+
+      expect(result).toEqual({ entries: [] });
+    });
+
+    it('should report pending_delete from game_names when applied_game_servers is null and the game is no longer declared', async () => {
+      const outputs: Partial<TfOutputs> = { game_names: ['minecraft'], applied_game_servers: null };
+
+      const result = await new DriftService(makeTfvars([]), makeConfig(outputs)).getDrift();
+
+      expect(result).toEqual({ entries: [{ game: 'minecraft', kind: 'pending_delete' }] });
+    });
+
+    it('should report config_drift when the declared config no longer matches the applied config', async () => {
+      const minecraft = buildGameServer('minecraft', { cpu: 4096 });
+
+      const result = await new DriftService(makeTfvars([minecraft]), makeConfig()).getDrift();
+
+      expect(result).toEqual({
+        entries: [{ game: 'minecraft', kind: 'config_drift', changedFields: ['cpu'] }],
+      });
+    });
+
+    it('should report a mixed/degraded report combining pending_create, config_drift, and pending_delete entries', async () => {
+      const ark = buildGameServer('ark');
+      const minecraft = buildGameServer('minecraft', { cpu: 4096 });
+      const outputs: Partial<TfOutputs> = {
+        game_names: ['minecraft', 'zomboid'],
+        applied_game_servers: {
+          minecraft: {
+            image: minecraft.image,
+            cpu: 1024,
+            memory: minecraft.memory,
+            ports: minecraft.ports,
+            volumes: minecraft.volumes,
+          },
+          zomboid: {
+            image: 'zomboid/image:latest',
+            cpu: 512,
+            memory: 1024,
+            ports: [],
+            volumes: [],
+          },
+        },
+      };
+
+      const result = await new DriftService(makeTfvars([ark, minecraft]), makeConfig(outputs)).getDrift();
+
+      expect(result).toEqual({
+        entries: [
+          { game: 'ark', kind: 'pending_create' },
+          { game: 'minecraft', kind: 'config_drift', changedFields: ['cpu'] },
+          { game: 'zomboid', kind: 'pending_delete' },
+        ],
+      });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/DriftService.test.ts
+++ b/app/packages/desktop-main/src/services/DriftService.test.ts
@@ -39,7 +39,7 @@ function makeConfig(outputs: Partial<TfOutputs> | null = DEFAULT_OUTPUTS): Confi
   return {
     invalidateCache: vi.fn(),
     getTfOutputs: vi.fn().mockReturnValue(outputs),
-  } as unknown as ConfigService;
+  } as Partial<ConfigService> as ConfigService;
 }
 
 /** Build a TfvarsService stub with `invalidateCache` and `getGameServers` pre-wired. */

--- a/app/packages/desktop-main/src/services/DriftService.ts
+++ b/app/packages/desktop-main/src/services/DriftService.ts
@@ -1,0 +1,164 @@
+import { Injectable } from '@nestjs/common';
+import type { DriftChangedField, DriftEntry, DriftReport, GameServer } from '@hyveon/shared';
+import { ConfigService } from './ConfigService.js';
+import { TfvarsService } from './TfvarsService.js';
+
+/**
+ * Config fields compared for a `'config_drift'` finding, paired with the
+ * accessor used to pull that field off a declared/applied `GameServer`-shaped
+ * object. Order here determines the order `changedFields` is reported in.
+ */
+const COMPARED_FIELDS: { field: DriftChangedField; get: (g: Omit<GameServer, 'name'>) => unknown }[] = [
+  { field: 'image', get: (g) => g.image },
+  { field: 'cpu', get: (g) => g.cpu },
+  { field: 'memory', get: (g) => g.memory },
+  { field: 'ports', get: (g) => g.ports },
+  { field: 'volumes', get: (g) => g.volumes },
+];
+
+/**
+ * Deep-equality check via JSON serialization. Sufficient for the plain
+ * JSON-ish `GameServer` field values (`string`, `number`, and arrays of
+ * plain objects) compared here — no need for a general-purpose deep-equal.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * The `'ports'` and `'volumes'` fields are HCL lists whose element order can
+ * shift between a `terraform.tfvars` edit and the last-applied snapshot (or
+ * vice versa) without the *set* of ports/volumes actually changing — e.g. an
+ * operator reordering entries in the tfvars file. Comparison for these two
+ * fields is therefore order-insensitive: array values are sorted by their
+ * JSON representation before the equality check. All other compared fields
+ * use `value` as-is (order-sensitive, which is correct for scalars).
+ */
+function normalizeForComparison(field: DriftChangedField, value: unknown): unknown {
+  if ((field === 'ports' || field === 'volumes') && Array.isArray(value)) {
+    return [...value].map((entry) => JSON.stringify(entry)).sort();
+  }
+  return value;
+}
+
+/**
+ * Compares a declared game's tfvars config against its applied (last
+ * `terraform apply`d) config and returns the list of {@link COMPARED_FIELDS}
+ * that differ, in declaration order. Empty when the two configs match on
+ * every compared field. `ports`/`volumes` comparisons are order-insensitive
+ * — see {@link normalizeForComparison}.
+ */
+function changedFields(
+  declared: Omit<GameServer, 'name'>,
+  applied: Omit<GameServer, 'name'>,
+): DriftChangedField[] {
+  return COMPARED_FIELDS.filter(
+    ({ field, get }) =>
+      !deepEqual(normalizeForComparison(field, get(declared)), normalizeForComparison(field, get(applied))),
+  ).map(({ field }) => field);
+}
+
+/**
+ * Pure computation of a {@link DriftReport} from a declared game list
+ * (`TfvarsService.getGameServers()`), the applied game config snapshot
+ * (`ConfigService.getTfOutputs()?.applied_game_servers`), and the
+ * authoritative set of deployed game names (`deployedNames`, mirroring the
+ * `deployed` parameter of `mergeGameLists()` in `./mergeGameLists.ts`). No
+ * I/O — safe to unit test directly.
+ *
+ * Per-game classification (see `@hyveon/shared/drift.ts` for the full
+ * contract):
+ *  - Declared but absent from `deployedNames` → `'pending_create'`.
+ *  - Present in `deployedNames` but absent from `declared` → `'pending_delete'`.
+ *  - Present in both `declared` and `applied`, with any of
+ *    `image`/`cpu`/`memory`/`ports`/`volumes` differing → `'config_drift'`,
+ *    with `changedFields` listing exactly which fields differ.
+ *  - Present in both with every compared field matching → no entry (in
+ *    sync games are omitted from the report entirely).
+ *
+ * `applied` is `null` when `terraform.tfstate` has no `applied_game_servers`
+ * output yet (state predates the output, or `terraform apply` hasn't run
+ * since it was added). In that case `deployedNames` is expected to fall back
+ * to `tfOutputs.game_names` (the caller's responsibility — see
+ * {@link DriftService.getDrift}), so games already known to be deployed via
+ * `game_names` are still correctly excluded from `'pending_create'` and
+ * still produce `'pending_delete'` entries when no longer declared, even
+ * though there's no applied config to diff for `'config_drift'`.
+ *
+ * Ordering is deterministic: entries appear in `declared` (tfvars) order
+ * first, followed by any deployed-only entries (`'pending_delete'`) in the
+ * order they appear in `deployedNames`.
+ */
+export function computeDrift(
+  declared: GameServer[],
+  applied: Record<string, Omit<GameServer, 'name'>> | null,
+  deployedNames: string[],
+): DriftReport {
+  const appliedMap = applied ?? {};
+  const deployedSet = new Set(deployedNames);
+  const declaredNames = new Set(declared.map((g) => g.name));
+  const entries: DriftEntry[] = [];
+
+  for (const game of declared) {
+    if (!deployedSet.has(game.name)) {
+      entries.push({ game: game.name, kind: 'pending_create' });
+      continue;
+    }
+
+    const appliedEntry = appliedMap[game.name];
+    if (!appliedEntry) {
+      continue;
+    }
+
+    const diffs = changedFields(game, appliedEntry);
+    if (diffs.length > 0) {
+      entries.push({ game: game.name, kind: 'config_drift', changedFields: diffs });
+    }
+  }
+
+  for (const name of deployedNames) {
+    if (!declaredNames.has(name)) {
+      entries.push({ game: name, kind: 'pending_delete' });
+    }
+  }
+
+  return { entries };
+}
+
+/**
+ * Computes drift between the declared game server configuration
+ * (`terraform.tfvars`, via {@link TfvarsService.getGameServers}) and the
+ * applied configuration Terraform last wrote to `terraform.tfstate` (via
+ * {@link ConfigService.getTfOutputs}'s `applied_game_servers` and
+ * `game_names` outputs). See issue #94.
+ *
+ * All comparison logic lives in the pure, exported {@link computeDrift}
+ * function — this service is a thin I/O wrapper that fetches the inputs and
+ * delegates.
+ */
+@Injectable()
+export class DriftService {
+  constructor(
+    private readonly tfvars: TfvarsService,
+    private readonly config: ConfigService,
+  ) {}
+
+  /**
+   * Returns the current {@link DriftReport} — see {@link computeDrift} for
+   * the classification rules. Invalidates the tfstate cache and the
+   * `TfvarsService` cache first (mirroring `GamesController.listGames()`) so
+   * a fresh `terraform apply` / tfvars edit is reflected without having to
+   * restart the server. Backs the `GET /api/drift` route.
+   */
+  async getDrift(): Promise<DriftReport> {
+    this.config.invalidateCache();
+    this.tfvars.invalidateCache();
+    const declared = await this.tfvars.getGameServers();
+    const tfOutputs = this.config.getTfOutputs();
+    const applied = tfOutputs?.applied_game_servers ?? null;
+    const deployedNames = tfOutputs?.applied_game_servers
+      ? Object.keys(tfOutputs.applied_game_servers)
+      : (tfOutputs?.game_names ?? []);
+    return computeDrift(declared, applied, deployedNames);
+  }
+}

--- a/app/packages/desktop-main/src/services/DriftService.ts
+++ b/app/packages/desktop-main/src/services/DriftService.ts
@@ -26,17 +26,39 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
+ * Deterministically stringifies a value for order-insensitive comparison,
+ * recursively sorting object keys so that two objects differing only in key
+ * order (e.g. `{container, protocol}` vs `{protocol, container}`, as HCL/JSON
+ * key order isn't guaranteed to be stable) produce identical strings. Arrays
+ * preserve their element order — only object *key* order is canonicalized.
+ */
+function canonicalStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalStringify(entry)).join(',')}]`;
+  }
+  if (value !== null && typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalStringify((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
  * The `'ports'` and `'volumes'` fields are HCL lists whose element order can
  * shift between a `terraform.tfvars` edit and the last-applied snapshot (or
  * vice versa) without the *set* of ports/volumes actually changing — e.g. an
  * operator reordering entries in the tfvars file. Comparison for these two
  * fields is therefore order-insensitive: array values are sorted by their
- * JSON representation before the equality check. All other compared fields
- * use `value` as-is (order-sensitive, which is correct for scalars).
+ * canonical (key-order-independent) string representation before the
+ * equality check, so key-order-only differences within each entry (e.g. from
+ * how Terraform serializes JSON) don't falsely trigger drift. All other
+ * compared fields use `value` as-is (order-sensitive, which is correct for
+ * scalars).
  */
 function normalizeForComparison(field: DriftChangedField, value: unknown): unknown {
   if ((field === 'ports' || field === 'volumes') && Array.isArray(value)) {
-    return [...value].map((entry) => JSON.stringify(entry)).sort();
+    return [...value].map((entry) => canonicalStringify(entry)).sort();
   }
   return value;
 }

--- a/app/packages/shared/src/drift.ts
+++ b/app/packages/shared/src/drift.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared types for drift detection — comparing the declared game server
+ * configuration (`terraform.tfvars`, via `TfvarsService.getGameServers()`)
+ * against the live deployed state (`terraform.tfstate`, via
+ * `ConfigService.getTfOutputs()`). See issue #94.
+ */
+
+/**
+ * Category of mismatch between a game's declared (tfvars) and deployed
+ * (tfstate) state.
+ *
+ * - `pending_create` — declared in tfvars but not yet applied/deployed.
+ * - `pending_delete` — deployed but no longer present in tfvars.
+ * - `config_drift`   — present in both, but one or more fields (ports,
+ *   image, CPU, memory, volume mounts, etc.) differ between the declared
+ *   and deployed configuration.
+ */
+export type DriftKind = 'pending_create' | 'pending_delete' | 'config_drift';
+
+/**
+ * Name of a top-level game server config field that can differ between the
+ * declared (tfvars) and deployed (tfstate) configuration for a
+ * `'config_drift'` finding. Deliberately a closed set of field names — no
+ * declared/deployed config payloads are echoed back, only which fields
+ * changed.
+ */
+export type DriftChangedField = 'ports' | 'image' | 'cpu' | 'memory' | 'volumes';
+
+/**
+ * A single per-game drift finding, produced by comparing a game's declared
+ * tfvars configuration against its live tfstate configuration.
+ */
+export interface DriftEntry {
+  /** Game key (matches the `game_servers` map key / tfstate game name). */
+  game: string;
+  /** Category of drift detected for this game. */
+  kind: DriftKind;
+  /**
+   * Names of the fields that differ between declared and deployed
+   * configuration. Only present when `kind` is `'config_drift'`. No
+   * declared/deployed values are included — only the field names.
+   */
+  changedFields?: DriftChangedField[];
+}
+
+/**
+ * Aggregate drift report returned by `GET /api/drift`. Lists every game
+ * that is out of sync between its declared and deployed configuration;
+ * games that are in sync (declared and deployed, with matching config) are
+ * omitted entirely.
+ */
+export interface DriftReport {
+  /** Per-game drift findings. Empty when declared and deployed state match. */
+  entries: DriftEntry[];
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './tfvars.js';
+export * from './drift.js';
 export * from './cloud.js';
 export * from './sanitize.js';
 export * from './canRun.js';

--- a/app/test/fake-terraform.test.ts
+++ b/app/test/fake-terraform.test.ts
@@ -169,9 +169,12 @@ describe('fake-terraform.mjs', () => {
       },
     });
 
-    const startedAt = Date.now();
+    // performance.now() is monotonic (unlike Date.now(), which tracks wall-clock
+    // time and can jump backwards under NTP/VM clock adjustments — observed as a
+    // negative elapsedMs under coverage-run parallel worker load).
+    const startedAt = performance.now();
     const { exitCode, stdout } = runFakeTerraform(['apply'], fixturePath);
-    const elapsedMs = Date.now() - startedAt;
+    const elapsedMs = performance.now() - startedAt;
 
     expect(exitCode).toBe(0);
     expect(stdout).toBe('first\nsecond\n');

--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -173,6 +173,7 @@ When `file_seeds` is non-empty, `efs-seeder.tf` creates a seeder Lambda for the 
 | `ecs_cluster_name`, `ecs_cluster_arn` | watchdog + followup Lambda env + the management app. |
 | `efs_file_system_id`, `efs_access_points` | Reference; each task mounts its own AP. |
 | `game_names` | interactions / followup / update-dns / watchdog Lambdas (env var `GAME_NAMES`). |
+| `applied_game_servers` (sensitive) | Management app drift detection — the full per-game `game_servers` configuration object (image, cpu, memory, ports, env, volumes, `file_seeds`, etc.) as last applied by Terraform, for field-level comparison against the currently declared tfvars config. Only present in `terraform.tfstate` after the next `terraform apply`. |
 | `task_definitions` | Ops (`aws ecs run-task --task-definition palworld-server`). |
 | `hosted_zone_id`, `domain_name`, `dns_records` | update-dns / watchdog Lambda env + DNS checks. |
 | `alb_dns_name`, `acm_certificate_arn` | Null if no HTTPS games; public reference otherwise. |

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -33,6 +33,12 @@ output "game_names" {
   value       = keys(var.game_servers)
 }
 
+output "applied_game_servers" {
+  description = "Full per-game game_servers configuration as last applied by Terraform (drift detection: compare field-by-field against the currently declared game_servers config)"
+  value       = var.game_servers
+  sensitive   = true
+}
+
 output "task_definitions" {
   description = "Map of game name → ECS task definition family name"
   value       = { for game, _ in var.game_servers : game => "${game}-server" }

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -34,7 +34,7 @@ output "game_names" {
 }
 
 output "applied_game_servers" {
-  description = "Full per-game game_servers configuration as last applied by Terraform (drift detection: compare field-by-field against the currently declared game_servers config)"
+  description = "Full per-game game_servers configuration as last applied by Terraform (drift detection: compare field-by-field against the currently declared game_servers config; only present in state after the next terraform apply)"
   value       = var.game_servers
   sensitive   = true
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -33,6 +33,12 @@ output "game_names" {
   value       = module.cloud[0].game_names
 }
 
+output "applied_game_servers" {
+  description = "Full per-game game_servers configuration as last applied by Terraform (drift detection: compare field-by-field against the currently declared game_servers config)"
+  value       = module.cloud[0].applied_game_servers
+  sensitive   = true
+}
+
 output "task_definitions" {
   description = "Map of game name → ECS task definition family name"
   value       = module.cloud[0].task_definitions

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -34,7 +34,7 @@ output "game_names" {
 }
 
 output "applied_game_servers" {
-  description = "Full per-game game_servers configuration as last applied by Terraform (drift detection: compare field-by-field against the currently declared game_servers config)"
+  description = "Full per-game game_servers configuration as last applied by Terraform (drift detection: compare field-by-field against the currently declared game_servers config; only present in state after the next terraform apply)"
   value       = module.cloud[0].applied_game_servers
   sensitive   = true
 }


### PR DESCRIPTION
Closes #94

## Summary

- Adds a shared `DriftEntry`/`DriftReport`/`DriftKind` type (`@hyveon/shared/drift.ts`) so both the server and future consumers share one drift shape.
- Adds `DriftService` (`app/packages/desktop-main/src/services/DriftService.ts`), comparing `TfvarsService.getGameServers()` against `ConfigService.getTfOutputs()` to classify each game as `pending_create` (declared, not deployed), `pending_delete` (deployed, not declared), or `config_drift` (both, but ports/image/CPU/memory/volumes differ).
- Exposes drift via paired IPC (`DriftController`) and HTTP (`DriftHttpController`) controllers, wired into `AppModule` and gated by the existing `ApiTokenGuard`.
- Extends `ConfigService`/Terraform outputs with `applied_game_servers` (root + `aws` module `outputs.tf`, docs) so the live task-definition config (ports/image/CPU/memory/volumes) is available for comparison, not just which games are running.

## Changes

```
 app/packages/desktop-main/src/app.module.ts        |   6 +
 .../src/controllers/drift-http.controller.test.ts  |  42 +++
 .../src/controllers/drift-http.controller.ts       |  25 ++
 .../src/controllers/drift.controller.test.ts       |  58 ++++
 .../src/controllers/drift.controller.ts            |  24 ++
 .../src/services/ConfigService.test.ts             |  29 ++
 .../desktop-main/src/services/ConfigService.ts     |  11 +
 .../desktop-main/src/services/DriftService.test.ts | 291 +++++++++++++++++++++
 .../desktop-main/src/services/DriftService.ts      | 164 ++++++++++++
 app/packages/shared/src/drift.ts                   |  55 ++++
 app/packages/shared/src/index.ts                   |   1 +
 docs/docs/components/terraform.md                  |   1 +
 terraform/aws/outputs.tf                           |   6 +
 terraform/outputs.tf                               |   6 +
 14 files changed, 719 insertions(+)
```

## Test plan

- [x] `/api/drift` (and IPC `drift.get`) return the three drift categories: `pending_create`, `pending_delete`, `config_drift`.
- [x] `config_drift` correctly compares ports, image, CPU, memory, and volume mounts — covered by `DriftService.test.ts`.
- [x] Unit tests cover each drift category individually and mixed states (`DriftService.test.ts`).
- [x] Controller tests cover both `DriftController` (IPC) and `DriftHttpController` (HTTP) behind the auth guard.
- [x] `ConfigService` parses the new `applied_game_servers` terraform output (`ConfigService.test.ts`).
- [x] `npm run app:test` passes.
