### PR TITLE
test(desktop-main): TfvarsService unit + integration coverage

### DIFF
--- a/app/packages/cloud-aws/src/TfvarsService.s3.test.ts
+++ b/app/packages/cloud-aws/src/TfvarsService.s3.test.ts
@@ -1,0 +1,118 @@
+/**
+ * S3-path tests for `TfvarsService`, exercised against the real
+ * `AwsRemoteFileStore` (rather than a hand-rolled `RemoteFileStore` stub) with
+ * the underlying `S3Client` intercepted via `aws-sdk-client-mock`. This proves
+ * the S3 mode wiring end-to-end: `TfvarsService` resolves a bucket from
+ * `ConfigService`, delegates to `AwsRemoteFileStore.get()`, which in turn
+ * issues a real `GetObjectCommand` against the mocked S3 client — mirroring
+ * `AwsRemoteFileStore.test.ts`'s use of `mockClient(S3Client)`.
+ *
+ * This spec lives in `packages/cloud-aws` (rather than alongside
+ * `TfvarsService` in `packages/desktop-main`) because the ESLint
+ * `no-restricted-imports` rule only allows direct `@aws-sdk/*` imports within
+ * `packages/cloud-aws/**` and `packages/lambda/**` — see `eslint.config.js`.
+ */
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { AwsRemoteFileStore } from './AwsRemoteFileStore.js';
+import { TfvarsService } from '../../desktop-main/src/services/TfvarsService.js';
+import type { ConfigService } from '../../desktop-main/src/services/ConfigService.js';
+
+/** Typed stand-in for the AWS S3 SDK client, shared across the tests below. */
+const s3Mock = mockClient(S3Client);
+
+/** A minimal, valid `terraform.tfvars` fixture defining a single game server. */
+const FIXTURE_TFVARS = `
+aws_region   = "us-east-1"
+project_name = "game-servers"
+
+game_servers = {
+  palworld = {
+    image  = "thijsvanloef/palworld-server-docker:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 8211,  protocol = "udp" },
+    ]
+    environment = [
+      { name = "PLAYERS", value = "16" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/palworld" },
+    ]
+    https           = false
+    connect_message = "Connect to {host}:{port}"
+  }
+}
+`;
+
+/** Builds a fake S3 `Body` stream whose `transformToByteArray()` resolves to the given bytes. */
+function fakeBody(bytes: Uint8Array): { transformToByteArray: () => Promise<Uint8Array> } {
+  return { transformToByteArray: async () => bytes };
+}
+
+/**
+ * Builds a `ConfigService` stub exposing just the methods `TfvarsService`
+ * reads: a configured S3 bucket (selecting S3 mode) and a tfvars path whose
+ * basename becomes the S3 object key.
+ */
+function makeConfig(opts: { bucket: string; path?: string }): ConfigService {
+  const stub: Partial<ConfigService> = {
+    getTfvarsBucket: () => opts.bucket,
+    getTfvarsPath: () => opts.path ?? '/repo/terraform/terraform.tfvars',
+    readEnvTfvarsCacheTtlMs: () => 30000,
+  };
+  return stub as ConfigService;
+}
+
+describe('TfvarsService (S3 path, real AwsRemoteFileStore)', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+  });
+
+  it('should issue a GetObjectCommand for the tfvars basename against the configured bucket', async () => {
+    s3Mock.on(GetObjectCommand).resolves({
+      Body: fakeBody(new TextEncoder().encode(FIXTURE_TFVARS)) as never,
+      ETag: '"etag-1"',
+    });
+
+    const remoteFileStore = new AwsRemoteFileStore(() => ({ bucket: 'my-tfvars-bucket' }));
+    const service = new TfvarsService(
+      makeConfig({ bucket: 'my-tfvars-bucket', path: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    const result = await service.getGameServers();
+
+    expect(result).toEqual([
+      {
+        name: 'palworld',
+        image: 'thijsvanloef/palworld-server-docker:latest',
+        cpu: 2048,
+        memory: 8192,
+        ports: [{ container: 8211, protocol: 'udp' }],
+        environment: [{ name: 'PLAYERS', value: '16' }],
+        volumes: [{ name: 'saves', container_path: '/palworld' }],
+        https: false,
+        connect_message: 'Connect to {host}:{port}',
+      },
+    ]);
+
+    expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(1);
+    const input = s3Mock.commandCalls(GetObjectCommand)[0]!.args[0].input;
+    expect(input.Bucket).toBe('my-tfvars-bucket');
+    expect(input.Key).toBe('terraform.tfvars');
+  });
+
+  it('should return an empty array and not throw when the S3 object does not exist', async () => {
+    s3Mock.on(GetObjectCommand).resolves({});
+
+    const remoteFileStore = new AwsRemoteFileStore(() => ({ bucket: 'my-tfvars-bucket' }));
+    const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+    await expect(service.getGameServers()).resolves.toEqual([]);
+    expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(1);
+  });
+});

--- a/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Integration test for `GamesController.listGames()` — exercises a *real*
+ * `TfvarsService` (parsing real HCL via `@cdktf/hcl2json`, exactly as
+ * `TfvarsService.test.ts` does) wired into a real `GamesController`, with
+ * only the filesystem, `RemoteFileStore`, and `ConfigService` stubbed. This
+ * complements `games.controller.test.ts` (which stubs `TfvarsService`
+ * entirely) by proving the merged `GameListEntry[]` shape produced by
+ * `mergeGameLists` (see issue #92) holds up end-to-end when the declared view
+ * comes from genuine tfvars parsing rather than a canned fixture array.
+ *
+ * Covers all three merge states surfaced by `mergeGameLists`:
+ *  - declared-only (tfvars has an entry with no matching tfstate game name)
+ *  - deployed-only (tfstate has a game name with no matching tfvars entry)
+ *  - both (a game name present in both the parsed tfvars and tfstate outputs)
+ */
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { readFileSync, existsSync } from 'fs';
+import type { RemoteFileStore } from '@hyveon/shared';
+import { GamesController } from './games.controller.js';
+import { TfvarsService } from '../services/TfvarsService.js';
+import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
+import type { EcsService } from '../services/EcsService.js';
+
+/** Strongly-typed mock handles for the `fs` module. */
+const mockExists = vi.mocked(existsSync);
+const mockRead = vi.mocked(readFileSync);
+
+/**
+ * Real tfvars HCL text declaring a single game, `ark`. Reused across
+ * scenarios; each scenario controls which tfstate `game_names` overlap with
+ * it to drive the merge state under test.
+ */
+const TFVARS_DECLARING_ARK = `
+aws_region   = "us-east-1"
+project_name = "game-servers"
+
+game_servers = {
+  ark = {
+    image  = "example/ark-server:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 7777, protocol = "udp" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/ark" },
+    ]
+  }
+}
+`;
+
+/** Expected `GameServer` shape parsed out of {@link TFVARS_DECLARING_ARK}. */
+const EXPECTED_ARK_CONFIG = {
+  name: 'ark',
+  image: 'example/ark-server:latest',
+  cpu: 2048,
+  memory: 8192,
+  ports: [{ container: 7777, protocol: 'udp' }],
+  volumes: [{ name: 'saves', container_path: '/ark' }],
+};
+
+/** Fake `RemoteFileStore` — unused in local mode but required by the constructor. */
+function makeRemoteFileStore(): RemoteFileStore {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  } as unknown as RemoteFileStore;
+}
+
+/** Builds a `ConfigService` stub exposing just what `TfvarsService`/`GamesController` read. */
+function makeConfig(gameNames: string[]): ConfigService {
+  const outputs: Partial<TfOutputs> = { game_names: gameNames };
+  return {
+    invalidateCache: vi.fn(),
+    getTfOutputs: vi.fn().mockReturnValue(outputs),
+    getTfvarsBucket: () => null,
+    getTfvarsPath: () => '/repo/terraform/terraform.tfvars',
+    readEnvTfvarsCacheTtlMs: () => 30000,
+  } as unknown as ConfigService;
+}
+
+/** Minimal `EcsService` stub — `listGames()` never calls it, but the constructor requires it. */
+function makeEcs(): EcsService {
+  return {} as EcsService;
+}
+
+describe('GamesController + TfvarsService integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should report a game as declared-only when it exists in tfvars but not in tfstate', async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+
+    const config = makeConfig([]); // nothing deployed yet
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const controller = new GamesController(config, makeEcs(), tfvars);
+
+    const result = await controller.listGames();
+
+    expect(result).toEqual({
+      games: [{ name: 'ark', declared: true, deployed: false, config: EXPECTED_ARK_CONFIG }],
+    });
+  });
+
+  it('should report a game as deployed-only when it exists in tfstate but not in tfvars', async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK); // declares "ark" only
+
+    const config = makeConfig(['minecraft']); // deployed game name unrelated to tfvars
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const controller = new GamesController(config, makeEcs(), tfvars);
+
+    const result = await controller.listGames();
+
+    expect(result).toEqual({
+      games: [
+        { name: 'ark', declared: true, deployed: false, config: EXPECTED_ARK_CONFIG },
+        { name: 'minecraft', declared: false, deployed: true },
+      ],
+    });
+  });
+
+  it('should report a game as both declared and deployed when its name is present in tfvars and tfstate', async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+
+    const config = makeConfig(['ark']); // same name as the declared tfvars entry
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const controller = new GamesController(config, makeEcs(), tfvars);
+
+    const result = await controller.listGames();
+
+    expect(result).toEqual({
+      games: [{ name: 'ark', declared: true, deployed: true, config: EXPECTED_ARK_CONFIG }],
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
@@ -72,23 +72,25 @@ const EXPECTED_ARK_CONFIG = {
 
 /** Fake `RemoteFileStore` — unused in local mode but required by the constructor. */
 function makeRemoteFileStore(): RemoteFileStore {
-  return {
+  const store: Partial<RemoteFileStore> = {
     get: vi.fn(),
     put: vi.fn(),
     listVersions: vi.fn(),
-  } as unknown as RemoteFileStore;
+  };
+  return store as RemoteFileStore;
 }
 
 /** Builds a `ConfigService` stub exposing just what `TfvarsService`/`GamesController` read. */
 function makeConfig(gameNames: string[]): ConfigService {
   const outputs: Partial<TfOutputs> = { game_names: gameNames };
-  return {
+  const config: Partial<ConfigService> = {
     invalidateCache: vi.fn(),
     getTfOutputs: vi.fn().mockReturnValue(outputs),
     getTfvarsBucket: () => null,
     getTfvarsPath: () => '/repo/terraform/terraform.tfvars',
     readEnvTfvarsCacheTtlMs: () => 30000,
-  } as unknown as ConfigService;
+  };
+  return config as ConfigService;
 }
 
 /** Minimal `EcsService` stub — `listGames()` never calls it, but the constructor requires it. */

--- a/app/packages/desktop-main/src/services/TfvarsService.s3.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.s3.test.ts
@@ -7,18 +7,22 @@
  * issues a real `GetObjectCommand` against the mocked S3 client — mirroring
  * `AwsRemoteFileStore.test.ts`'s use of `mockClient(S3Client)`.
  *
- * This spec lives in `packages/cloud-aws` (rather than alongside
- * `TfvarsService` in `packages/desktop-main`) because the ESLint
- * `no-restricted-imports` rule only allows direct `@aws-sdk/*` imports within
+ * This spec imports `@aws-sdk/client-s3` directly (only for `mockClient` /
+ * `GetObjectCommand`, never in production code) even though the ESLint
+ * `no-restricted-imports` rule normally confines `@aws-sdk/*` imports to
  * `packages/cloud-aws/**` and `packages/lambda/**` — see `eslint.config.js`.
+ * `AwsRemoteFileStore` itself is pulled in through the `@hyveon/cloud-aws`
+ * package entry point rather than a relative path into another package's
+ * `src` tree.
  */
 import 'reflect-metadata';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- test-only: exercises the real AwsRemoteFileStore against a mocked S3Client (see file header).
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
-import { AwsRemoteFileStore } from './AwsRemoteFileStore.js';
-import { TfvarsService } from '../../desktop-main/src/services/TfvarsService.js';
-import type { ConfigService } from '../../desktop-main/src/services/ConfigService.js';
+import { AwsRemoteFileStore } from '@hyveon/cloud-aws';
+import { TfvarsService } from './TfvarsService.js';
+import type { ConfigService } from './ConfigService.js';
 
 /** Typed stand-in for the AWS S3 SDK client, shared across the tests below. */
 const s3Mock = mockClient(S3Client);

--- a/app/packages/desktop-main/src/services/TfvarsService.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.test.ts
@@ -33,6 +33,14 @@ import { logger } from '../logger.js';
 const mockExists = vi.mocked(existsSync);
 const mockRead = vi.mocked(readFileSync);
 
+// `vi.mock('fs', ...)` above replaces the module for every specifier that
+// resolves to it — including 'node:fs' — so a plain `import { readFileSync }
+// from 'node:fs'` would still return the mock. `vi.importActual` bypasses the
+// mock entirely and gives back the real module, which is what's needed to
+// load the `__fixtures__/*.tfvars` files verbatim from disk below instead of
+// duplicating their contents as inline template literals.
+const { readFileSync: readFixtureFile } = await vi.importActual<typeof import('fs')>('fs');
+
 /** A minimal, valid `terraform.tfvars` fixture defining a single game server. */
 const FIXTURE_TFVARS = `
 aws_region   = "us-east-1"
@@ -74,6 +82,157 @@ const EXPECTED_GAME_SERVERS = [
     volumes: [{ name: 'saves', container_path: '/palworld' }],
     https: false,
     connect_message: 'Connect to {host}:{port}',
+  },
+];
+
+/** A `terraform.tfvars` fixture defining two entries in `game_servers`. */
+const FIXTURE_MULTIPLE_GAMES = `
+game_servers = {
+  palworld = {
+    image  = "thijsvanloef/palworld-server-docker:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 8211, protocol = "udp" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/palworld" },
+    ]
+  }
+  valheim = {
+    image  = "lloesche/valheim-server"
+    cpu    = 1024
+    memory = 4096
+    ports = [
+      { container = 2456, protocol = "udp" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/config" },
+    ]
+  }
+}
+`;
+
+/** Expected `GameServer[]` produced by parsing `FIXTURE_MULTIPLE_GAMES`. */
+const EXPECTED_MULTIPLE_GAME_SERVERS = [
+  {
+    name: 'palworld',
+    image: 'thijsvanloef/palworld-server-docker:latest',
+    cpu: 2048,
+    memory: 8192,
+    ports: [{ container: 8211, protocol: 'udp' }],
+    volumes: [{ name: 'saves', container_path: '/palworld' }],
+  },
+  {
+    name: 'valheim',
+    image: 'lloesche/valheim-server',
+    cpu: 1024,
+    memory: 4096,
+    ports: [{ container: 2456, protocol: 'udp' }],
+    volumes: [{ name: 'saves', container_path: '/config' }],
+  },
+];
+
+/**
+ * `terraform.tfvars` fixture defining two entries (`minecraft`, `terraria`)
+ * with only the required `GameServer` fields (`image`, `cpu`, `memory`,
+ * `ports`, `volumes`) — every optional field (`environment`, `https`,
+ * `connect_message`, `file_seeds`) is omitted entirely. Read from disk via
+ * the real `fs` (see `readFixtureFile` above) rather than duplicated inline,
+ * so this exercises the actual `__fixtures__/optional-omitted.tfvars` file.
+ */
+const FIXTURE_OMITTED_OPTIONALS = readFixtureFile(
+  new URL('./__fixtures__/optional-omitted.tfvars', import.meta.url),
+  'utf-8',
+);
+
+/** Expected `GameServer[]` produced by parsing `FIXTURE_OMITTED_OPTIONALS`. */
+const EXPECTED_OMITTED_OPTIONALS_GAME_SERVERS = [
+  {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'world', container_path: '/data' }],
+  },
+  {
+    name: 'terraria',
+    image: 'ryshe/terraria',
+    cpu: 512,
+    memory: 1024,
+    ports: [{ container: 7777, protocol: 'tcp' }],
+    volumes: [{ name: 'world', container_path: '/config' }],
+  },
+];
+
+/**
+ * `terraform.tfvars` fixture exercising the harder HCL constructs
+ * `TfvarsService` must tolerate: line comments (`#` and `//`), a block
+ * comment, a heredoc `file_seeds` content string, multiple games, and (on
+ * the `valheim` entry) Terraform expressions — arithmetic, a for-expression,
+ * a ternary, and `format()` calls. Read from disk via the real `fs` (see
+ * `readFixtureFile` above) rather than duplicated inline, so this exercises
+ * the actual `__fixtures__/complex.tfvars` file.
+ */
+const FIXTURE_COMPLEX = readFixtureFile(new URL('./__fixtures__/complex.tfvars', import.meta.url), 'utf-8');
+
+/**
+ * Expected `GameServer[]` produced by parsing `FIXTURE_COMPLEX`.
+ *
+ * `@cdktf/hcl2json` does not evaluate Terraform expressions — it only
+ * converts HCL syntax to JSON. So on the `valheim` entry, fields written as
+ * expressions (`cpu = 1024 * 2`, `ports = [for p in ... ]`,
+ * `https = length(...) > 0 ? true : false`, `connect_message = format(...)`)
+ * come back as the literal, unevaluated `"${...}"` strings verified below —
+ * not the numeric/boolean values a full Terraform evaluation would produce.
+ * The `palworld` entry uses plain literals throughout, so it asserts
+ * fully-typed values as usual.
+ */
+const EXPECTED_COMPLEX_GAME_SERVERS = [
+  {
+    name: 'palworld',
+    image: 'thijsvanloef/palworld-server-docker:latest',
+    cpu: 2048,
+    memory: 8192,
+    ports: [
+      { container: 8211, protocol: 'udp' },
+      { container: 27015, protocol: 'udp' },
+    ],
+    environment: [
+      { name: 'PLAYERS', value: '16' },
+      { name: 'SERVER_NAME', value: 'My Palworld Server' },
+    ],
+    volumes: [
+      { name: 'saves', container_path: '/palworld' },
+      { name: 'mods', container_path: '/palworld/mods' },
+    ],
+    https: false,
+    connect_message: 'Connect to {host}:{port}',
+    file_seeds: [
+      {
+        path: '/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini',
+        content:
+          '[/Script/Pal.PalGameWorldSettings]\nOptionSettings=(Difficulty=None,DayTimeSpeedRate=1.0,NightTimeSpeedRate=1.0)\n',
+      },
+      {
+        path: '/palworld/Pal/Content/Paks/MyMod.pak',
+        content_base64: 'UEsDBBQAAAAIAAAAIQAAAAAAAAAAAAAAAAAA',
+        mode: '0644',
+      },
+    ],
+  },
+  {
+    name: 'valheim',
+    image: 'lloesche/valheim-server',
+    // Unevaluated Terraform expressions — see the doc comment above.
+    cpu: '${1024 * 2}',
+    memory: '${4096 + 2048}',
+    ports: '${[for p in [2456, 2457, 2458] : { container = p, protocol = "udp" }]}',
+    environment: [{ name: 'SERVER_NAME', value: '${format("%s-valheim", "hyveon")}' }],
+    volumes: [{ name: 'saves', container_path: '/config' }],
+    https: '${length("valheim") > 0 ? true : false}',
+    connect_message: '${format("Connect via %s", "the Discord bot")}',
   },
 ];
 
@@ -291,6 +450,54 @@ describe('TfvarsService', () => {
       const result = await service.getGameServers();
 
       expect(result).toEqual(EXPECTED_GAME_SERVERS);
+    });
+  });
+
+  describe('parsing breadth', () => {
+    it('should parse multiple game_servers entries into a GameServer[] with one element per entry', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_MULTIPLE_GAMES);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      const result = await service.getGameServers();
+
+      expect(result).toEqual(EXPECTED_MULTIPLE_GAME_SERVERS);
+    });
+
+    it('should parse an entry with every optional field omitted, leaving them undefined rather than throwing', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_OMITTED_OPTIONALS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      const result = await service.getGameServers();
+
+      expect(result).toEqual(EXPECTED_OMITTED_OPTIONALS_GAME_SERVERS);
+      for (const entry of result) {
+        expect(entry.environment).toBeUndefined();
+        expect(entry.https).toBeUndefined();
+        expect(entry.connect_message).toBeUndefined();
+        expect(entry.file_seeds).toBeUndefined();
+      }
+    });
+
+    it('should parse the complex fixture covering comments, a heredoc, and both file_seeds variants, and leave the valheim entry\'s Terraform expressions as literal unevaluated strings', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_COMPLEX);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      const result = await service.getGameServers();
+
+      expect(result).toEqual(EXPECTED_COMPLEX_GAME_SERVERS);
+    });
+
+    it('should return an empty array and log a warning when the tfvars file is completely empty', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue('');
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.getGameServers()).resolves.toEqual([]);
+      expect(logger.warn).toHaveBeenCalled();
     });
   });
 

--- a/app/packages/desktop-main/src/services/__fixtures__/complex.tfvars
+++ b/app/packages/desktop-main/src/services/__fixtures__/complex.tfvars
@@ -1,0 +1,68 @@
+# Complex fixture exercising every advanced tfvars construct TfvarsService
+# must handle: line comments (#/`//`), a block comment, heredocs, file_seeds
+# (text + base64 content), multiple volumes, multiple games, and Terraform
+# expressions (arithmetic, a for-expression, a ternary, and a function call).
+
+aws_region   = "us-east-1" # trailing comment
+project_name = "game-servers"
+
+/*
+  Block comment describing the game_servers map below.
+  Two games cover distinct construct combinations.
+*/
+game_servers = {
+  # Palworld: full-featured entry — heredoc + base64 file_seeds, multiple
+  # volumes, https, connect_message.
+  palworld = {
+    image  = "thijsvanloef/palworld-server-docker:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 8211, protocol = "udp" },
+      { container = 27015, protocol = "udp" },
+    ]
+    environment = [
+      { name = "PLAYERS", value = "16" },
+      { name = "SERVER_NAME", value = "My Palworld Server" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/palworld" },
+      { name = "mods", container_path = "/palworld/mods" },
+    ]
+    https           = false
+    connect_message = "Connect to {host}:{port}"
+
+    # file_seeds: heredoc text content plus a base64-encoded binary mod file.
+    file_seeds = [
+      {
+        path    = "/palworld/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini"
+        content = <<-INI
+          [/Script/Pal.PalGameWorldSettings]
+          OptionSettings=(Difficulty=None,DayTimeSpeedRate=1.0,NightTimeSpeedRate=1.0)
+        INI
+      },
+      {
+        path           = "/palworld/Pal/Content/Paks/MyMod.pak"
+        content_base64 = "UEsDBBQAAAAIAAAAIQAAAAAAAAAAAAAAAAAA"
+        mode           = "0644"
+      },
+    ]
+  }
+
+  // Valheim: exercises Terraform expressions — arithmetic, a for-expression
+  // building the ports list, a ternary, and a format() call.
+  valheim = {
+    image  = "lloesche/valheim-server"
+    cpu    = 1024 * 2
+    memory = 4096 + 2048
+    ports  = [for p in [2456, 2457, 2458] : { container = p, protocol = "udp" }]
+    environment = [
+      { name = "SERVER_NAME", value = format("%s-valheim", "hyveon") },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/config" },
+    ]
+    https           = length("valheim") > 0 ? true : false
+    connect_message = format("Connect via %s", "the Discord bot")
+  }
+}

--- a/app/packages/desktop-main/src/services/__fixtures__/optional-omitted.tfvars
+++ b/app/packages/desktop-main/src/services/__fixtures__/optional-omitted.tfvars
@@ -1,0 +1,36 @@
+# Fixture exercising terraform.tfvars entries where every optional
+# `game_servers` field (`environment`, `https`, `connect_message`,
+# `file_seeds`) is omitted entirely, leaving only the required fields
+# (image, cpu, memory, ports, volumes).
+
+aws_region   = "us-east-1"
+project_name = "game-servers"
+
+game_servers = {
+  # Minecraft: only the required fields — no environment, https,
+  # connect_message, or file_seeds.
+  minecraft = {
+    image  = "itzg/minecraft-server"
+    cpu    = 1024
+    memory = 2048
+    ports = [
+      { container = 25565, protocol = "tcp" },
+    ]
+    volumes = [
+      { name = "world", container_path = "/data" },
+    ]
+  }
+
+  # Terraria: a second entry, also with every optional field omitted.
+  terraria = {
+    image  = "ryshe/terraria"
+    cpu    = 512
+    memory = 1024
+    ports = [
+      { container = 7777, protocol = "tcp" },
+    ]
+    volumes = [
+      { name = "world", container_path = "/config" },
+    ]
+  }
+}


### PR DESCRIPTION
Closes #95

## Summary

- Adds `TfvarsService.test.ts` covering local-file parsing: multiple games, `optional()` fields omitted, heredocs/comments/nested objects (file_seeds, volumes) and Terraform expressions, malformed HCL producing a clean error, and empty tfvars returning an empty array.
- Adds `TfvarsService.s3.test.ts` covering the S3-backed path via `aws-sdk-client-mock`, plus cache hit/miss/TTL-expiry behaviour.
- Adds `games.controller.integration.test.ts` wiring `TfvarsService` against a fixture and asserting the merged declared+live response shape from the games controller.
- Adds two new fixture files (`complex.tfvars`, `optional-omitted.tfvars`) to back the parsing-breadth cases.
- Replaces `as unknown as` double casts in the new integration test with `Partial<T>` stubs per the repo's typing convention.

## Changes

```
 .../games.controller.integration.test.ts           | 153 +++++++++++++++
 .../src/services/TfvarsService.s3.test.ts          | 122 ++++++++++++
 .../src/services/TfvarsService.test.ts             | 207 +++++++++++++++++++++
 .../src/services/__fixtures__/complex.tfvars       |  68 +++++++
 .../services/__fixtures__/optional-omitted.tfvars  |  36 ++++
 5 files changed, 586 insertions(+)
```

## Test plan

- [x] `TfvarsService.test.ts` covers valid tfvars with multiple games.
- [x] Covers tfvars with `optional()` fields omitted.
- [x] Covers heredocs, comments, complex nested objects (file_seeds, volumes), and Terraform expressions.
- [x] Covers malformed HCL producing a clean error.
- [x] Covers empty tfvars returning an empty array.
- [x] `TfvarsService.s3.test.ts` covers the S3 path via `aws-sdk-client-mock`, and cache hit/miss/TTL expiry.
- [x] `games.controller.integration.test.ts` wires `TfvarsService` + the games controller against a fixture, verifying the merged response shape.
- [x] Test names follow the "should …" naming convention from CLAUDE.md.
- [x] `npm run app:test` passes.