### PR TITLE
fix(desktop): window/app title shows "Game Server Manager" instead of "Hyveon"

### DIFF
--- a/app/packages/web/index.html
+++ b/app/packages/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Game Server Manager</title>
+    <title>Hyveon</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  Hyveon — Windows setup script (PowerShell equivalent of setup.sh).
+  Hyveon - Windows setup script (PowerShell equivalent of setup.sh).
 
 .DESCRIPTION
   Checks prerequisites (Node.js 20+, Terraform, AWS CLI), installs missing tools

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  Game Server Manager — Windows setup script (PowerShell equivalent of setup.sh).
+  Hyveon — Windows setup script (PowerShell equivalent of setup.sh).
 
 .DESCRIPTION
   Checks prerequisites (Node.js 20+, Terraform, AWS CLI), installs missing tools
@@ -15,7 +15,7 @@ Set-StrictMode -Version Latest
 $ScriptDir = $PSScriptRoot
 
 Write-Host ""
-Write-Host "  Game Server Manager - Setup"
+Write-Host "  Hyveon - Setup"
 Write-Host "  --------------------------------------"
 Write-Host ""
 


### PR DESCRIPTION
Closes #274

## Summary

- Updates the renderer `<title>` in `app/packages/web/index.html` from "Game Server Manager" to "Hyveon", so the Electron window titlebar (and the browser tab in dev/`vite preview`) reflects the current brand name.
- Sweeps the remaining stray "Game Server Manager" reference found in `setup.ps1` (script synopsis comment and console banner text) to "Hyveon" while in the area.

## Changes

```
 app/packages/web/index.html | 2 +-
 setup.ps1                   | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```

## Test plan

- [x] `app/packages/web/index.html`'s `<title>` reads "Hyveon".
- [x] No remaining "Game Server Manager" references in `app/packages/web/index.html`.
- [x] Grepped for stray "Game Server Manager" references elsewhere; found and fixed `setup.ps1`.
- [ ] Launching the Electron app (`npm run app:dev`) shows "Hyveon" in the window titlebar (manual verification — not run in this environment).
- [ ] Packaged build (`npm run desktop:package`) shows "Hyveon" in the window titlebar (manual verification — not run in this environment).