### PR TITLE
feat(shared): tfvars schema validation (Zod)

### DIFF
--- a/app/packages/shared/package.json
+++ b/app/packages/shared/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.600.0",
     "@aws-sdk/client-secrets-manager": "^3.600.0",
-    "@aws-sdk/lib-dynamodb": "^3.600.0"
+    "@aws-sdk/lib-dynamodb": "^3.600.0",
+    "zod": "^3.23.8"
   }
 }

--- a/app/packages/shared/src/gameServerValidator.test.ts
+++ b/app/packages/shared/src/gameServerValidator.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import { validateGameServer } from './gameServerValidator.js';
+import type { GameServer } from './tfvars.js';
+
+/** Build a minimal, fully-valid proposed entry; override any fields per test. */
+function makeProposed(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    image: 'itzg/minecraft-server',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    ...overrides,
+  };
+}
+
+/** Build a minimal existing GameServer entry (as returned by TfvarsService.getGameServers()); override any fields per test. */
+function makeExisting(overrides: Partial<GameServer> = {}): GameServer {
+  return {
+    name: 'valheim',
+    image: 'lloesche/valheim-server',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 2456, protocol: 'udp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    ...overrides,
+  };
+}
+
+describe('validateGameServer', () => {
+  it('should succeed for a fully valid entry and reattach name onto the returned GameServer', () => {
+    const result = validateGameServer('minecraft', makeProposed(), []);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('minecraft');
+      expect(result.data.image).toBe('itzg/minecraft-server');
+      expect(result.data.cpu).toBe(1024);
+      expect(result.data.memory).toBe(2048);
+    }
+  });
+
+  describe('Fargate cpu/memory pairing', () => {
+    it('should accept each of the three discrete memory values for cpu=256', () => {
+      for (const memory of [512, 1024, 2048]) {
+        const result = validateGameServer('game', makeProposed({ cpu: 256, memory }), []);
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('should reject a memory value for cpu=256 that is not one of the three discrete values', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 256, memory: 1536 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should accept memory=2048 for cpu=512 (bottom of the 1024-4096 ranged tier)', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 512, memory: 2048 }), []);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a memory value for cpu=512 that violates the 1024-step boundary', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 512, memory: 2500 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should accept memory=8192 for cpu=1024 (top of the 2048-8192 ranged tier)', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 1024, memory: 8192 }), []);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a memory value for cpu=1024 that violates the 1024-step boundary', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 1024, memory: 3000 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should accept memory=16384 for cpu=2048 (top of the 4096-16384 ranged tier)', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 2048, memory: 16384 }), []);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a memory value for cpu=2048 that violates the 1024-step boundary', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 2048, memory: 5000 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should accept memory=30720 for cpu=4096 (top of the 8192-30720 ranged tier)', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 4096, memory: 30720 }), []);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a memory value for cpu=4096 that violates the 1024-step boundary', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 4096, memory: 8700 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should accept memory=61440 for cpu=8192 (top of the 16384-61440 ranged tier)', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 8192, memory: 61440 }), []);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a memory value for cpu=8192 that violates the 4096-step boundary', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 8192, memory: 17000 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should accept memory=122880 for cpu=16384 (top of the 32768-122880 ranged tier)', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 16384, memory: 122880 }), []);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a memory value for cpu=16384 that violates the 8192-step boundary', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 16384, memory: 40000 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'memory')).toBe(true);
+      }
+    });
+
+    it('should reject a cpu value that is not one of the supported Fargate CPU units', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 100, memory: 512 }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'cpu')).toBe(true);
+      }
+    });
+  });
+
+  describe('absolute paths', () => {
+    it('should accept an absolute volumes[].container_path and file_seeds[].path', () => {
+      const result = validateGameServer(
+        'game',
+        makeProposed({
+          volumes: [{ name: 'data', container_path: '/data' }],
+          file_seeds: [{ path: '/data/config.yml', content: 'foo: bar' }],
+        }),
+        [],
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a relative volumes[].container_path', () => {
+      const result = validateGameServer(
+        'game',
+        makeProposed({ volumes: [{ name: 'data', container_path: 'data' }] }),
+        [],
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'volumes[0].container_path')).toBe(true);
+      }
+    });
+
+    it('should reject a relative file_seeds[].path', () => {
+      const result = validateGameServer(
+        'game',
+        makeProposed({ file_seeds: [{ path: 'config.yml', content: 'foo: bar' }] }),
+        [],
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'file_seeds[0].path')).toBe(true);
+      }
+    });
+  });
+
+  describe('connect_message placeholders', () => {
+    it('should accept all four allowed placeholder tokens', () => {
+      const result = validateGameServer(
+        'game',
+        makeProposed({ connect_message: 'Connect at {host}:{port} ({ip}) to play {game}.' }),
+        [],
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject an unknown placeholder token', () => {
+      const result = validateGameServer('game', makeProposed({ connect_message: 'Connect at {password}' }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'connect_message')).toBe(true);
+      }
+    });
+  });
+
+  describe('port collisions', () => {
+    it('should reject two ports within the proposed entry that collide on container/protocol', () => {
+      const result = validateGameServer(
+        'game',
+        makeProposed({
+          ports: [
+            { container: 25565, protocol: 'tcp' },
+            { container: 25565, protocol: 'TCP' },
+          ],
+        }),
+        [],
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'ports[1]')).toBe(true);
+      }
+    });
+
+    it('should reject a proposed port that collides with an existing game server', () => {
+      const existing = makeExisting({ name: 'valheim', ports: [{ container: 25565, protocol: 'tcp' }] });
+      const result = validateGameServer(
+        'minecraft',
+        makeProposed({ ports: [{ container: 25565, protocol: 'tcp' }] }),
+        [existing],
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'ports[0]' && i.message.includes('valheim'))).toBe(true);
+      }
+    });
+
+    it('should not collide with itself when re-validating an already-declared game under its own name', () => {
+      const existing = makeExisting({ name: 'minecraft', ports: [{ container: 25565, protocol: 'tcp' }] });
+      const result = validateGameServer(
+        'minecraft',
+        makeProposed({ ports: [{ container: 25565, protocol: 'tcp' }] }),
+        [existing],
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('should not report a false collision when the same container number is used by a different protocol', () => {
+      // `existing` (default valheim fixture) declares container 2456/udp; the proposed entry
+      // reuses container 2456 but on tcp, which must not be treated as a collision.
+      const existing = makeExisting();
+      const result = validateGameServer(
+        'minecraft',
+        makeProposed({
+          ports: [
+            { container: 2456, protocol: 'tcp' },
+            { container: 25565, protocol: 'udp' },
+          ],
+        }),
+        [existing],
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('structural (zod) failures', () => {
+    it('should surface a missing required field with its JSON-path issue.path', () => {
+      const proposed = makeProposed();
+      delete (proposed as Record<string, unknown>)['image'];
+      const result = validateGameServer('game', proposed, []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'image')).toBe(true);
+      }
+    });
+
+    it('should surface a mistyped field with its JSON-path issue.path', () => {
+      const result = validateGameServer('game', makeProposed({ cpu: 'not-a-number' }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'cpu')).toBe(true);
+      }
+    });
+
+    it('should reject an empty volumes array', () => {
+      const result = validateGameServer('game', makeProposed({ volumes: [] }), []);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues.some((i) => i.path === 'volumes')).toBe(true);
+      }
+    });
+  });
+});

--- a/app/packages/shared/src/gameServerValidator.ts
+++ b/app/packages/shared/src/gameServerValidator.ts
@@ -1,0 +1,322 @@
+/**
+ * Zod-backed structural schema + business-rule validator for a single
+ * `game_servers` map entry (see `terraform/variables.tf:game_servers` and
+ * the {@link GameServer} mirror in `./tfvars.js`).
+ *
+ * This module is deliberately split in two:
+ *  - {@link gameServerSchema} mirrors the Terraform `game_servers` object
+ *    type field-for-field (it does NOT include `name` — like the Terraform
+ *    object, `name` is the map key, not an attribute of the entry).
+ *  - {@link validateGameServer} layers the four custom business rules that
+ *    can't be expressed as a pure per-field zod refinement because they
+ *    either need the sibling `game_servers` entries (port collisions) or
+ *    are cross-cutting checks over the already-typed entry (Fargate
+ *    CPU/memory pairing, absolute paths, connect-message placeholders).
+ *
+ * Intended for both the desktop-main API (validating a proposed tfvars edit
+ * before writing it back) and the web client (surfacing the same messages
+ * in a form).
+ */
+
+import { z } from 'zod';
+import type { GameServer, GameServerPort } from './tfvars.js';
+
+/** Zod schema mirroring {@link GameServerPort}. */
+export const gameServerPortSchema = z.object({
+  container: z.number(),
+  protocol: z.string(),
+});
+
+/** Zod schema mirroring `GameServerEnvironmentVariable`. */
+export const gameServerEnvironmentVariableSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+
+/**
+ * Zod schema mirroring `GameServerVolume`. `name` and `container_path` must
+ * be non-empty, matching the Terraform validation block on
+ * `game_servers` (`terraform/variables.tf`).
+ */
+export const gameServerVolumeSchema = z.object({
+  name: z.string().min(1, 'volumes[].name must not be empty.'),
+  container_path: z.string().min(1, 'volumes[].container_path must not be empty.'),
+});
+
+/** Zod schema mirroring `GameServerFileSeed`. */
+export const gameServerFileSeedSchema = z.object({
+  path: z.string(),
+  content: z.string().optional(),
+  content_base64: z.string().optional(),
+  mode: z.string().optional(),
+});
+
+/**
+ * Zod schema mirroring {@link GameServer} field-for-field, minus `name`
+ * (which is the `game_servers` map key, not a Terraform object attribute —
+ * see {@link GameServer}'s own doc comment). Enforces only structural/shape
+ * rules; the four business rules (Fargate CPU/memory pairing, absolute
+ * paths, connect-message placeholders, port collisions) live in
+ * {@link validateGameServer} instead, since some of them need sibling
+ * `game_servers` entries that a single-entry schema can't see.
+ */
+export const gameServerSchema = z.object({
+  image: z.string(),
+  cpu: z.number(),
+  memory: z.number(),
+  ports: z.array(gameServerPortSchema),
+  environment: z.array(gameServerEnvironmentVariableSchema).optional(),
+  volumes: z
+    .array(gameServerVolumeSchema)
+    .min(1, 'Each game server must have at least one volume entry with non-empty name and container_path.'),
+  https: z.boolean().optional(),
+  connect_message: z.string().optional(),
+  file_seeds: z.array(gameServerFileSeedSchema).optional(),
+});
+
+/** Structural (name-less) shape validated by {@link gameServerSchema}. */
+export type GameServerEntryInput = z.infer<typeof gameServerSchema>;
+
+/**
+ * A single validation failure, positioned with a JSON-path-like string
+ * (e.g. `volumes[0].container_path`, `ports[1]`, `memory`) so callers can
+ * highlight the offending field in a form. Built either from a zod issue's
+ * `path` array or from one of the custom business-rule checks below.
+ */
+export interface GameServerValidationIssue {
+  path: string;
+  message: string;
+}
+
+/** Result of {@link validateGameServer}: either the fully-typed entry, or every issue found. */
+export type GameServerValidationResult =
+  | { success: true; data: GameServer }
+  | { success: false; issues: GameServerValidationIssue[] };
+
+/** Joins a zod issue path (`(string | number)[]`) into a JSON-path-like string, e.g. `['volumes', 0, 'container_path']` → `volumes[0].container_path`. */
+function formatPath(path: (string | number)[]): string {
+  return path.reduce<string>((acc, segment) => {
+    if (typeof segment === 'number') {
+      return `${acc}[${segment}]`;
+    }
+    return acc.length > 0 ? `${acc}.${segment}` : segment;
+  }, '');
+}
+
+/** Converts a raw zod issue into a {@link GameServerValidationIssue}. */
+function zodIssueToValidationIssue(issue: z.ZodIssue): GameServerValidationIssue {
+  return { path: formatPath(issue.path), message: issue.message };
+}
+
+/**
+ * The current Fargate CPU → valid memory (MiB) table. `256` only accepts
+ * three discrete values; every other tier accepts a stepped range. Source:
+ * AWS Fargate task size documentation, mirrored here so tfvars edits are
+ * rejected client-side before a `terraform apply` would fail.
+ */
+const FARGATE_CPU_MEMORY_TABLE: Readonly<
+  Record<number, { values: number[] } | { min: number; max: number; step: number }>
+> = {
+  256: { values: [512, 1024, 2048] },
+  512: { min: 1024, max: 4096, step: 1024 },
+  1024: { min: 2048, max: 8192, step: 1024 },
+  2048: { min: 4096, max: 16384, step: 1024 },
+  4096: { min: 8192, max: 30720, step: 1024 },
+  8192: { min: 16384, max: 61440, step: 4096 },
+  16384: { min: 32768, max: 122880, step: 8192 },
+};
+
+/** Human-readable description of the valid memory values/range for a given Fargate `cpu` tier. */
+function describeFargateMemoryOptions(cpu: number): string {
+  const range = FARGATE_CPU_MEMORY_TABLE[cpu];
+  if (!range) {
+    return '';
+  }
+  if ('values' in range) {
+    return `${range.values.join(', ')} MiB`;
+  }
+  return `${range.min}-${range.max} MiB in steps of ${range.step}`;
+}
+
+/** Validates the `cpu`/`memory` pairing against the Fargate task-size table. */
+function checkFargateCpuMemoryPairing(entry: GameServerEntryInput): GameServerValidationIssue[] {
+  const range = FARGATE_CPU_MEMORY_TABLE[entry.cpu];
+  if (!range) {
+    return [
+      {
+        path: 'cpu',
+        message: `cpu must be one of the supported Fargate CPU units (${Object.keys(FARGATE_CPU_MEMORY_TABLE).join(', ')}), got ${entry.cpu}.`,
+      },
+    ];
+  }
+
+  const isValidMemory =
+    'values' in range
+      ? range.values.includes(entry.memory)
+      : entry.memory >= range.min && entry.memory <= range.max && (entry.memory - range.min) % range.step === 0;
+
+  if (!isValidMemory) {
+    return [
+      {
+        path: 'memory',
+        message: `memory ${entry.memory} MiB is not a valid Fargate pairing for cpu=${entry.cpu}; must be ${describeFargateMemoryOptions(entry.cpu)}.`,
+      },
+    ];
+  }
+
+  return [];
+}
+
+/** Validates that `volumes[].container_path` and `file_seeds[].path` are absolute (start with `/`). */
+function checkAbsolutePaths(entry: GameServerEntryInput): GameServerValidationIssue[] {
+  const issues: GameServerValidationIssue[] = [];
+
+  entry.volumes.forEach((volume, index) => {
+    if (!volume.container_path.startsWith('/')) {
+      issues.push({
+        path: `volumes[${index}].container_path`,
+        message: `volumes[${index}].container_path must be an absolute path (start with "/"), got "${volume.container_path}".`,
+      });
+    }
+  });
+
+  entry.file_seeds?.forEach((seed, index) => {
+    if (!seed.path.startsWith('/')) {
+      issues.push({
+        path: `file_seeds[${index}].path`,
+        message: `file_seeds[${index}].path must be an absolute path (start with "/"), got "${seed.path}".`,
+      });
+    }
+  });
+
+  return issues;
+}
+
+/** Placeholder tokens allowed inside `connect_message`, matching the Terraform variable's doc comment. */
+const ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS: ReadonlySet<string> = new Set(['host', 'ip', 'port', 'game']);
+
+/** Matches every `{token}` occurrence in a string, capturing the token itself. */
+const PLACEHOLDER_TOKEN_PATTERN = /\{([^{}]*)\}/g;
+
+/** Rejects any `{token}` in `connect_message` outside `{host}`/`{ip}`/`{port}`/`{game}`. */
+function checkConnectMessagePlaceholders(entry: GameServerEntryInput): GameServerValidationIssue[] {
+  if (!entry.connect_message) {
+    return [];
+  }
+
+  const issues: GameServerValidationIssue[] = [];
+  for (const match of entry.connect_message.matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
+    const token = match[1] ?? '';
+    if (!ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS.has(token)) {
+      issues.push({
+        path: 'connect_message',
+        message: `Unknown placeholder "{${token}}" in connect_message; allowed placeholders are {host}, {ip}, {port}, {game}.`,
+      });
+    }
+  }
+  return issues;
+}
+
+/** Builds the collision key (`container/protocol`, case-insensitive on protocol) used to detect port clashes. */
+function portKey(port: GameServerPort): string {
+  return `${port.container}/${port.protocol.toLowerCase()}`;
+}
+
+/**
+ * Detects container-port collisions both within the proposed entry's own
+ * `ports` list and against every other declared `game_servers` entry (the
+ * entry being re-validated, identified by `name`, is skipped so editing an
+ * already-declared game doesn't collide with itself).
+ */
+function checkPortCollisions(
+  name: string,
+  ports: GameServerPort[],
+  existingGameServers: GameServer[],
+): GameServerValidationIssue[] {
+  const issues: GameServerValidationIssue[] = [];
+  const seenWithinEntry = new Map<string, number>();
+
+  ports.forEach((port, index) => {
+    const key = portKey(port);
+
+    const firstIndex = seenWithinEntry.get(key);
+    if (firstIndex !== undefined) {
+      issues.push({
+        path: `ports[${index}]`,
+        message: `Port ${port.container}/${port.protocol} collides with ports[${firstIndex}] in the same game server.`,
+      });
+    } else {
+      seenWithinEntry.set(key, index);
+    }
+
+    for (const existing of existingGameServers) {
+      if (existing.name === name) {
+        continue;
+      }
+      if (existing.ports.some((existingPort) => portKey(existingPort) === key)) {
+        issues.push({
+          path: `ports[${index}]`,
+          message: `Port ${port.container}/${port.protocol} collides with existing game "${existing.name}".`,
+        });
+      }
+    }
+  });
+
+  return issues;
+}
+
+/** Narrows `value` to a plain object so `proposed.ports` can be read without a full parse. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Validates a proposed `game_servers` entry: structural shape (via
+ * {@link gameServerSchema}) plus all four business rules — Fargate
+ * CPU/memory pairing, absolute paths for volumes/file_seeds, connect-message
+ * placeholder allowlisting, and container-port collisions (within the
+ * entry itself and against every other entry in `existingGameServers`).
+ *
+ * @param name - The `game_servers` map key this entry would be saved under.
+ *   Used to build the returned {@link GameServer} on success, and to skip
+ *   self-collisions when `existingGameServers` already contains an entry
+ *   being edited in place.
+ * @param proposed - The candidate entry, typically untrusted input (e.g.
+ *   parsed JSON from an API request body).
+ * @param existingGameServers - Every other already-declared `game_servers`
+ *   entry (as returned by `TfvarsService.getGameServers()`), used for the
+ *   cross-game port-collision check.
+ */
+export function validateGameServer(
+  name: string,
+  proposed: unknown,
+  existingGameServers: GameServer[],
+): GameServerValidationResult {
+  const issues: GameServerValidationIssue[] = [];
+
+  const parsed = gameServerSchema.safeParse(proposed);
+  if (!parsed.success) {
+    issues.push(...parsed.error.issues.map(zodIssueToValidationIssue));
+  } else {
+    issues.push(...checkFargateCpuMemoryPairing(parsed.data));
+    issues.push(...checkAbsolutePaths(parsed.data));
+    issues.push(...checkConnectMessagePlaceholders(parsed.data));
+  }
+
+  // Port-collision detection only needs `ports` to be structurally valid, so
+  // run it independently of whether the rest of the entry parsed cleanly.
+  const portsResult = z
+    .array(gameServerPortSchema)
+    .safeParse(isRecord(proposed) ? proposed['ports'] : undefined);
+  if (portsResult.success) {
+    issues.push(...checkPortCollisions(name, portsResult.data, existingGameServers));
+  }
+
+  if (issues.length > 0) {
+    return { success: false, issues };
+  }
+
+  // `parsed.success` is guaranteed true here: any structural failure above
+  // would have pushed at least one issue and returned early.
+  return { success: true, data: { name, ...(parsed as z.SafeParseSuccess<GameServerEntryInput>).data } };
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './tfvars.js';
+export * from './gameServerValidator.js';
 export * from './drift.js';
 export * from './cloud.js';
 export * from './sanitize.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,8 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.600.0",
         "@aws-sdk/client-secrets-manager": "^3.600.0",
-        "@aws-sdk/lib-dynamodb": "^3.600.0"
+        "@aws-sdk/lib-dynamodb": "^3.600.0",
+        "zod": "^3.23.8"
       }
     },
     "app/packages/web": {
@@ -19113,6 +19114,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "scripts": {


### PR DESCRIPTION
Closes #97

## Summary

- Adds `zod` as a dependency to `@hyveon/shared` for schema-based validation.
- Implements `GameServerValidator` in `@hyveon/shared` (`gameServerValidator.ts`), mirroring the `game_servers` object shape from `terraform/variables.tf:game_servers`, plus custom cross-field rules (port collisions across games, Fargate CPU/memory pairings, absolute `efs_path`/volume `container_path`, valid `connect_message` placeholders).
- Adds full unit test coverage (`gameServerValidator.test.ts`, 28 tests) for every validation rule.

## Changes

```
 app/packages/shared/package.json                   |   3 +-
 app/packages/shared/src/gameServerValidator.test.ts | 288 ++++++++++++++++++
 app/packages/shared/src/gameServerValidator.ts      | 322 +++++++++++++++++++++
 app/packages/shared/src/index.ts                    |   1 +
 package-lock.json                                   |  12 +-
 5 files changed, 624 insertions(+), 2 deletions(-)
```

## Test plan

- [x] Validator rejects each invalid case with a typed error including a JSON path.
- [x] Port-collision check considers existing games + the proposed change.
- [x] Unit tests cover each rule (port collisions, CPU/memory pairings, absolute paths, connect_message placeholders, required/optional fields, types).
- [x] `npx vitest run app/packages/shared/src/gameServerValidator.test.ts` — 28/28 passing.
