### PR TITLE
feat(desktop-main): write game_servers to S3 tfvars with optimistic locking

### DIFF
--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -416,7 +416,7 @@ export class TfvarsService {
       throw new HclSurgeonError('Top-level "game_servers" map not found in terraform.tfvars.');
     }
 
-    const entryHcl = indentHclLines(emitGameServerEntry({ name, ...config }), DEFAULT_ENTRY_INDENT).replace(/\n$/, '');
+    const entryHcl = indentHclLines(emitGameServerEntry({ ...config, name }), DEFAULT_ENTRY_INDENT).replace(/\n$/, '');
     const rest = hcl.slice(mapBody.bodyStart);
     const separator = /^[ \t]*\r?\n/.test(rest) ? '' : '\n';
     return hcl.slice(0, mapBody.bodyStart) + '\n' + entryHcl + separator + rest;
@@ -439,7 +439,7 @@ export class TfvarsService {
     const span = locateEntry(hcl, 'game_servers', name);
     const entryIndent = span ? /^[ \t]*/.exec(hcl.slice(span.start))![0] : DEFAULT_ENTRY_INDENT;
     const newValueHcl = indentHclLines(
-      extractEntryValueHcl(emitGameServerEntry({ name, ...config })),
+      extractEntryValueHcl(emitGameServerEntry({ ...config, name })),
       entryIndent,
       /* skipFirstLine */ true,
     );

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -89,6 +89,34 @@ function extractEntryValueHcl(entryAssignmentHcl: string): string {
 }
 
 /**
+ * Default indentation added when splicing a brand-new `game_servers` entry
+ * into the map body and no sibling entry's own indentation is available to
+ * copy — mirrors `hclEmit.ts`'s private `INDENT` unit (2 spaces) so a fresh
+ * splice matches the file's established convention (see the fixtures under
+ * `__fixtures__/*.tfvars` and `TfvarsService.write.test.ts`'s `FIXTURE_TFVARS`).
+ */
+const DEFAULT_ENTRY_INDENT = '  ';
+
+/**
+ * Prefixes every non-empty line of `hcl` with `indent`, re-nesting a
+ * fragment that `hclEmit.emitGameServerEntry()` always emits anchored at
+ * column 0 so it lines up once spliced one level deeper into the
+ * `game_servers` map body (see issue #96 finding: unindented splices produced
+ * `terraform fmt`-failing output). Empty lines (e.g. the trailing blank left
+ * by splitting a string that ends in `\n`) are left alone so no trailing
+ * whitespace is introduced. When `skipFirstLine` is set, the first line is
+ * left untouched too — used when that line is spliced inline after an
+ * existing `<key> = ` prefix that already sits at the target column, rather
+ * than starting a new line of its own.
+ */
+function indentHclLines(hcl: string, indent: string, skipFirstLine = false): string {
+  return hcl
+    .split('\n')
+    .map((line, i) => (line === '' || (skipFirstLine && i === 0) ? line : `${indent}${line}`))
+    .join('\n');
+}
+
+/**
  * Local-vs-S3 tfvars reader/parser — see the file-level doc comment above for
  * source resolution, parsing, and caching behaviour.
  */
@@ -220,8 +248,11 @@ export class TfvarsService {
    * Replaces an existing `game_servers` entry's value in place (see issue
    * #96). Reads the current raw HCL, replaces `name`'s value via
    * `hclSurgeon.replaceEntry()` with a freshly-serialized
-   * `hclEmit.emitGameServerEntry()` object literal, and writes the result
-   * back via {@link writeTfvars} — see that method's doc for the S3-mode
+   * `hclEmit.emitGameServerEntry()` object literal — reindented to match
+   * `name`'s own line in the source so the replacement's body/closing brace
+   * land at the correct nesting depth rather than `emitGameServerEntry()`'s
+   * native column-0 formatting — and writes the result back via
+   * {@link writeTfvars} — see that method's doc for the S3-mode
    * conditional-put / `OptimisticLockError` contract. Throws
    * {@link HclSurgeonError} if `name` doesn't already exist in `game_servers`.
    *
@@ -231,9 +262,7 @@ export class TfvarsService {
    *   used as the S3-mode conditional-put guard; omit to write unconditionally.
    */
   async updateGameServer(name: string, config: RawGameServerEntry, expectedVersionId?: string): Promise<void> {
-    await this.writeTfvars(expectedVersionId, (hcl) =>
-      replaceEntry(hcl, 'game_servers', name, extractEntryValueHcl(emitGameServerEntry({ name, ...config }))),
-    );
+    await this.writeTfvars(expectedVersionId, (hcl) => this.replaceGameServerEntry(hcl, name, config));
   }
 
   /**
@@ -339,7 +368,16 @@ export class TfvarsService {
    * Splices `name = { ... }` into `hcl`'s top-level `game_servers` map as
    * its first entry, via `hclSurgeon.locateMapBody()` (works even when the
    * map is currently empty, unlike `locateEntry()` which requires the key to
-   * already exist) + `hclEmit.emitGameServerEntry()`. Throws
+   * already exist) + `hclEmit.emitGameServerEntry()`. The emitted block is
+   * reindented one level (via {@link indentHclLines}, using
+   * {@link DEFAULT_ENTRY_INDENT}) since `emitGameServerEntry()` always
+   * formats at column 0 — without this the new entry's key, body, and
+   * closing brace would sit at the wrong depth once nested inside the map.
+   * The separator between the new entry and whatever already follows
+   * `bodyStart` is chosen so exactly one newline separates them — never
+   * zero (which would jam the new entry's closing `}` against the map's own
+   * `}` when `game_servers` is empty) and never two (which would leave a
+   * stray blank line before an existing first entry). Throws
    * {@link HclSurgeonError} if `name` is already present in `game_servers`
    * (use {@link updateGameServer} instead) or if the `game_servers` map
    * can't be located at all in the source HCL.
@@ -354,8 +392,34 @@ export class TfvarsService {
       throw new HclSurgeonError('Top-level "game_servers" map not found in terraform.tfvars.');
     }
 
-    const entryHcl = emitGameServerEntry({ name, ...config });
-    return hcl.slice(0, mapBody.bodyStart) + '\n' + entryHcl + hcl.slice(mapBody.bodyStart);
+    const entryHcl = indentHclLines(emitGameServerEntry({ name, ...config }), DEFAULT_ENTRY_INDENT).replace(/\n$/, '');
+    const rest = hcl.slice(mapBody.bodyStart);
+    const separator = /^[ \t]*\r?\n/.test(rest) ? '' : '\n';
+    return hcl.slice(0, mapBody.bodyStart) + '\n' + entryHcl + separator + rest;
+  }
+
+  /**
+   * Replaces `name`'s value inside `hcl`'s top-level `game_servers` map with
+   * a freshly-serialized `hclEmit.emitGameServerEntry()` object literal,
+   * reindented (via {@link indentHclLines}) to match the indentation of
+   * `name`'s own line in the source — `emitGameServerEntry()` always formats
+   * at column 0, so without this the replacement's body/closing brace would
+   * land at the wrong depth even though its first line (the value's opening
+   * `{`) is spliced inline after the existing `name = ` prefix and needs no
+   * extra indentation of its own. Falls back to {@link DEFAULT_ENTRY_INDENT}
+   * when `name` can't be located — `hclSurgeon.replaceEntry()` below is what
+   * actually throws {@link HclSurgeonError} in that case, so the exact
+   * fallback value here is never observed by callers.
+   */
+  private replaceGameServerEntry(hcl: string, name: string, config: RawGameServerEntry): string {
+    const span = locateEntry(hcl, 'game_servers', name);
+    const entryIndent = span ? /^[ \t]*/.exec(hcl.slice(span.start))![0] : DEFAULT_ENTRY_INDENT;
+    const newValueHcl = indentHclLines(
+      extractEntryValueHcl(emitGameServerEntry({ name, ...config })),
+      entryIndent,
+      /* skipFirstLine */ true,
+    );
+    return replaceEntry(hcl, 'game_servers', name, newValueHcl);
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -30,20 +30,37 @@
  * `game_servers` key, or a malformed-HCL parse error are all logged via the
  * shared Winston `logger` and resolve to `[]`, mirroring `ConfigService`'s
  * graceful degradation for polling callers.
+ *
+ * `addGameServer()`, `updateGameServer()`, and `removeGameServer()` (see
+ * issue #96) are the write-side counterpart: they mutate the raw HCL text
+ * directly via `hclSurgeon` (locate/cut/replace, byte-preserving outside the
+ * touched entry) and `hclEmit` (serializing a `GameServer` back to HCL),
+ * rather than going through the lossy `@cdktf/hcl2json` round-trip used for
+ * reads. In S3 mode, the write is a conditional `RemoteFileStore.put()`
+ * guarded by an `ifMatch` etag; a stale etag is translated from the store's
+ * `RemoteFileConflictError` into a `OptimisticLockError` so callers only
+ * ever need to handle one conflict type regardless of cloud provider. Local
+ * mode writes the file directly with no conditional guard.
  */
 import { Inject, Injectable } from '@nestjs/common';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { basename } from 'path';
 import { parse as parseHcl } from '@cdktf/hcl2json';
 import type { GameServer, RemoteFileStore } from '@hyveon/shared';
+import { OptimisticLockError, RemoteFileConflictError } from '@hyveon/shared';
 import { logger } from '../logger.js';
 import { ConfigService } from './ConfigService.js';
 import { REMOTE_FILE_STORE } from '../modules/cloud-provider.tokens.js';
+import { HclSurgeonError, cutEntry, locateEntry, locateMapBody, replaceEntry } from './hclSurgeon.js';
+import { emitGameServerEntry } from './hclEmit.js';
 
 /**
  * Raw JSON-decoded shape of a single `game_servers` map entry as produced by
  * `@cdktf/hcl2json`, before the map key is flattened onto it as `name`.
- * Structurally identical to `GameServer` minus the `name` field.
+ * Structurally identical to `GameServer` minus the `name` field. Also doubles
+ * as the write-side "config" parameter shape for {@link TfvarsService.addGameServer}
+ * and {@link TfvarsService.updateGameServer}, since `name` is supplied
+ * separately as the `game_servers` map key in both directions.
  */
 type RawGameServerEntry = Omit<GameServer, 'name'>;
 
@@ -56,6 +73,19 @@ interface CachedGameServers {
   value: GameServer[];
   cachedAt: number;
   failed: boolean;
+}
+
+/**
+ * Extracts just the `{ ... }` object-literal portion of
+ * `hclEmit.emitGameServerEntry()`'s output — dropping the leading
+ * `<name> = ` prefix and the trailing newline — so it can be spliced in as
+ * `hclSurgeon.replaceEntry()`'s `newValueHcl` argument, which replaces only
+ * the value expression; the `<name> = ` prefix already present in the
+ * source HCL is left untouched by `replaceEntry()` itself.
+ */
+function extractEntryValueHcl(entryAssignmentHcl: string): string {
+  const braceStart = entryAssignmentHcl.indexOf('{');
+  return entryAssignmentHcl.slice(braceStart).replace(/\n$/, '');
 }
 
 /**
@@ -168,6 +198,61 @@ export class TfvarsService {
   }
 
   /**
+   * Adds a brand-new entry to the `game_servers` map (see issue #96). Reads
+   * the current raw HCL, splices `name = { ... }` in as the map's first
+   * entry via `hclSurgeon.locateMapBody()` + `hclEmit.emitGameServerEntry()`,
+   * and writes the result back via {@link writeTfvars} — see that method's
+   * doc for the S3-mode conditional-put / `OptimisticLockError` contract.
+   * Throws {@link HclSurgeonError} if `name` already exists in `game_servers`
+   * or if the `game_servers` map itself can't be located in the source HCL.
+   *
+   * @param name - The `game_servers` map key to add.
+   * @param config - The new entry's fields (everything but `name`, which is
+   *   the map key rather than an object attribute).
+   * @param expectedVersionId - The etag last read (e.g. via {@link getRawHcl}),
+   *   used as the S3-mode conditional-put guard; omit to write unconditionally.
+   */
+  async addGameServer(name: string, config: RawGameServerEntry, expectedVersionId?: string): Promise<void> {
+    await this.writeTfvars(expectedVersionId, (hcl) => this.insertGameServerEntry(hcl, name, config));
+  }
+
+  /**
+   * Replaces an existing `game_servers` entry's value in place (see issue
+   * #96). Reads the current raw HCL, replaces `name`'s value via
+   * `hclSurgeon.replaceEntry()` with a freshly-serialized
+   * `hclEmit.emitGameServerEntry()` object literal, and writes the result
+   * back via {@link writeTfvars} — see that method's doc for the S3-mode
+   * conditional-put / `OptimisticLockError` contract. Throws
+   * {@link HclSurgeonError} if `name` doesn't already exist in `game_servers`.
+   *
+   * @param name - The `game_servers` map key to update.
+   * @param config - The entry's new fields (everything but `name`).
+   * @param expectedVersionId - The etag last read (e.g. via {@link getRawHcl}),
+   *   used as the S3-mode conditional-put guard; omit to write unconditionally.
+   */
+  async updateGameServer(name: string, config: RawGameServerEntry, expectedVersionId?: string): Promise<void> {
+    await this.writeTfvars(expectedVersionId, (hcl) =>
+      replaceEntry(hcl, 'game_servers', name, extractEntryValueHcl(emitGameServerEntry({ name, ...config }))),
+    );
+  }
+
+  /**
+   * Removes an entry from the `game_servers` map (see issue #96). Reads the
+   * current raw HCL, cuts `name`'s entire `key = value` assignment via
+   * `hclSurgeon.cutEntry()`, and writes the result back via
+   * {@link writeTfvars} — see that method's doc for the S3-mode
+   * conditional-put / `OptimisticLockError` contract. Throws
+   * {@link HclSurgeonError} if `name` doesn't exist in `game_servers`.
+   *
+   * @param name - The `game_servers` map key to remove.
+   * @param expectedVersionId - The etag last read (e.g. via {@link getRawHcl}),
+   *   used as the S3-mode conditional-put guard; omit to write unconditionally.
+   */
+  async removeGameServer(name: string, expectedVersionId?: string): Promise<void> {
+    await this.writeTfvars(expectedVersionId, (hcl) => cutEntry(hcl, 'game_servers', name));
+  }
+
+  /**
    * Reads the raw tfvars text, preferring the S3 backend
    * (`ConfigService.getTfvarsBucket()`) when configured, otherwise falling
    * back to the local file at `ConfigService.getTfvarsPath()`. Throws a clear
@@ -192,6 +277,85 @@ export class TfvarsService {
       throw new Error(`tfvars file not found at "${path}".`);
     }
     return { hcl: readFileSync(path, 'utf-8') };
+  }
+
+  /**
+   * Shared write path for {@link addGameServer}, {@link updateGameServer},
+   * and {@link removeGameServer}: reads the current raw HCL via
+   * {@link fetchRawTfvars}, applies `mutate` to it, writes the mutated text
+   * back via {@link putRawTfvars} (S3-mode conditional put / local-mode
+   * direct write), and invalidates the in-memory `getGameServers()` cache so
+   * the next read reflects the write. `mutate` running before the write
+   * (rather than concurrently) keeps the S3-mode conditional-put guard
+   * meaningful — `expectedVersionId` is checked against the store's
+   * current etag at write time, so a conflicting write since `fetchRawTfvars`
+   * ran is still caught even though `mutate` itself is synchronous.
+   */
+  private async writeTfvars(expectedVersionId: string | undefined, mutate: (hcl: string) => string): Promise<void> {
+    const { hcl } = await this.fetchRawTfvars();
+    const mutatedHcl = mutate(hcl);
+    await this.putRawTfvars(mutatedHcl, expectedVersionId);
+    this.invalidateCache();
+  }
+
+  /**
+   * Writes `hcl` back to whichever tfvars source is active, mirroring
+   * {@link fetchRawTfvars}'s local-vs-S3 source resolution. In S3 mode,
+   * issues a conditional `RemoteFileStore.put()` — passing `expectedVersionId`
+   * as `ifMatch` when provided — so a write that raced a concurrent change
+   * since the caller's last read is rejected rather than silently
+   * overwriting it; the store's cloud-agnostic `RemoteFileConflictError` is
+   * caught and re-thrown as an {@link OptimisticLockError} (best-effort
+   * populating `currentEtag` from a follow-up `get()`), so every conflict —
+   * regardless of the underlying cloud provider — surfaces to callers
+   * exclusively as `OptimisticLockError`. In local mode the file is written
+   * directly with no conditional guard, since the local filesystem has no
+   * etag/versioning concept to condition on (mirroring
+   * {@link fetchRawTfvars}'s local-mode `etag`-less read).
+   */
+  private async putRawTfvars(hcl: string, expectedVersionId?: string): Promise<void> {
+    const bucket = this.config.getTfvarsBucket();
+    const path = this.config.getTfvarsPath();
+
+    if (bucket) {
+      const key = basename(path);
+      const body = new TextEncoder().encode(hcl);
+      try {
+        await this.remoteFileStore.put(key, body, expectedVersionId ? { ifMatch: expectedVersionId } : undefined);
+      } catch (err) {
+        if (err instanceof RemoteFileConflictError) {
+          const current = await this.remoteFileStore.get(key).catch(() => undefined);
+          throw new OptimisticLockError(expectedVersionId ?? '', current?.etag);
+        }
+        throw err;
+      }
+      return;
+    }
+
+    writeFileSync(path, hcl, 'utf-8');
+  }
+
+  /**
+   * Splices `name = { ... }` into `hcl`'s top-level `game_servers` map as
+   * its first entry, via `hclSurgeon.locateMapBody()` (works even when the
+   * map is currently empty, unlike `locateEntry()` which requires the key to
+   * already exist) + `hclEmit.emitGameServerEntry()`. Throws
+   * {@link HclSurgeonError} if `name` is already present in `game_servers`
+   * (use {@link updateGameServer} instead) or if the `game_servers` map
+   * can't be located at all in the source HCL.
+   */
+  private insertGameServerEntry(hcl: string, name: string, config: RawGameServerEntry): string {
+    if (locateEntry(hcl, 'game_servers', name)) {
+      throw new HclSurgeonError(`Entry "${name}" already exists in "game_servers" — use updateGameServer() instead.`);
+    }
+
+    const mapBody = locateMapBody(hcl, 'game_servers');
+    if (!mapBody) {
+      throw new HclSurgeonError('Top-level "game_servers" map not found in terraform.tfvars.');
+    }
+
+    const entryHcl = emitGameServerEntry({ name, ...config });
+    return hcl.slice(0, mapBody.bodyStart) + '\n' + entryHcl + hcl.slice(mapBody.bodyStart);
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -98,6 +98,19 @@ function extractEntryValueHcl(entryAssignmentHcl: string): string {
 const DEFAULT_ENTRY_INDENT = '  ';
 
 /**
+ * Matches a bare (unquoted) HCL identifier — the same shape `hclSurgeon.ts`'s
+ * internal lexer (`findTopLevelIdentifier()` / `findEntryInBody()`) requires
+ * for a `game_servers` map key to be recognized at all. `insertGameServerEntry()`
+ * validates new entry names against this pattern *before* splicing them into
+ * the map body: `locateEntry()`'s duplicate check can never match a name
+ * containing characters outside this set (its own key-matching regex is the
+ * same pattern), so an invalid name would otherwise sail past the "already
+ * exists" guard and be written into the HCL verbatim — corrupting the file if
+ * it contains structural characters like `{`, `}`, `=`, or a newline.
+ */
+const HCL_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+/**
  * Prefixes every non-empty line of `hcl` with `indent`, re-nesting a
  * fragment that `hclEmit.emitGameServerEntry()` always emits anchored at
  * column 0 so it lines up once spliced one level deeper into the
@@ -231,8 +244,9 @@ export class TfvarsService {
    * entry via `hclSurgeon.locateMapBody()` + `hclEmit.emitGameServerEntry()`,
    * and writes the result back via {@link writeTfvars} — see that method's
    * doc for the S3-mode conditional-put / `OptimisticLockError` contract.
-   * Throws {@link HclSurgeonError} if `name` already exists in `game_servers`
-   * or if the `game_servers` map itself can't be located in the source HCL.
+   * Throws {@link HclSurgeonError} if `name` isn't a valid bare HCL
+   * identifier, if `name` already exists in `game_servers`, or if the
+   * `game_servers` map itself can't be located in the source HCL.
    *
    * @param name - The `game_servers` map key to add.
    * @param config - The new entry's fields (everything but `name`, which is
@@ -378,11 +392,21 @@ export class TfvarsService {
    * zero (which would jam the new entry's closing `}` against the map's own
    * `}` when `game_servers` is empty) and never two (which would leave a
    * stray blank line before an existing first entry). Throws
-   * {@link HclSurgeonError} if `name` is already present in `game_servers`
-   * (use {@link updateGameServer} instead) or if the `game_servers` map
-   * can't be located at all in the source HCL.
+   * {@link HclSurgeonError} if `name` isn't a valid bare HCL identifier (see
+   * {@link HCL_IDENTIFIER_PATTERN} — this must be checked *before* the
+   * duplicate-key lookup below, since `locateEntry()` can never find an
+   * existing entry whose key contains characters outside that pattern and
+   * would otherwise let a structurally dangerous name through), if `name` is
+   * already present in `game_servers` (use {@link updateGameServer} instead),
+   * or if the `game_servers` map can't be located at all in the source HCL.
    */
   private insertGameServerEntry(hcl: string, name: string, config: RawGameServerEntry): string {
+    if (!HCL_IDENTIFIER_PATTERN.test(name)) {
+      throw new HclSurgeonError(
+        `Entry name "${name}" is not a valid HCL identifier — must match ${HCL_IDENTIFIER_PATTERN}.`,
+      );
+    }
+
     if (locateEntry(hcl, 'game_servers', name)) {
       throw new HclSurgeonError(`Entry "${name}" already exists in "game_servers" — use updateGameServer() instead.`);
     }

--- a/app/packages/desktop-main/src/services/TfvarsService.write.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.write.test.ts
@@ -214,6 +214,42 @@ describe('TfvarsService write path', () => {
     });
   });
 
+  describe('addGameServer name validation', () => {
+    it('should reject a name containing HCL metacharacters instead of writing a corrupt file', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.addGameServer('terraria } evil = {', NEW_ENTRY_CONFIG)).rejects.toThrow(
+        /not a valid HCL identifier/,
+      );
+      expect(mockWrite).not.toHaveBeenCalled();
+    });
+
+    it('should reject a name containing a newline instead of writing a corrupt file', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.addGameServer('terraria\nrogue_key = "x"', NEW_ENTRY_CONFIG)).rejects.toThrow(
+        /not a valid HCL identifier/,
+      );
+      expect(mockWrite).not.toHaveBeenCalled();
+    });
+
+    it('should accept a name containing hyphens and underscores since those are valid bare HCL identifiers', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.addGameServer('my-server_2', NEW_ENTRY_CONFIG)).resolves.toBeUndefined();
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('concurrent writes (S3 mode)', () => {
     it('should fail the second of two concurrent writes with a clear OptimisticLockError, not silently overwrite the first', async () => {
       // Both writers read the same starting etag...

--- a/app/packages/desktop-main/src/services/TfvarsService.write.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.write.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Write-path tests for `TfvarsService` (see issue #96) — `addGameServer`,
+ * `updateGameServer`, and `removeGameServer`. Directly covers the three
+ * issue #96 acceptance checkboxes:
+ *
+ *  1. Byte preservation — adding/editing/removing one game preserves the
+ *     rest of the file byte-for-byte (modulo the touched block).
+ *  2. Concurrent writes — a second write that races a first (stale etag)
+ *     fails with a clear error rather than silently overwriting.
+ *  3. `OptimisticLockError` is structured (`expectedEtag` / `currentEtag`)
+ *     so the UI can display "remote moved — refresh".
+ *
+ * `locateMapBody`/`locateEntry` (from `hclSurgeon.ts`, already exhaustively
+ * unit-tested in `hclSurgeon.test.ts`) are used here only to compute the
+ * expected prefix/suffix byte spans against the fixture — the same
+ * production code `TfvarsService` itself calls — so these tests verify the
+ * *service*-level read → mutate → write wiring, not re-derive the lexer's
+ * comment/string/heredoc-skipping logic (that's `hclSurgeon.test.ts`'s job).
+ */
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RemoteFileStore } from '@hyveon/shared';
+import { OptimisticLockError, RemoteFileConflictError } from '@hyveon/shared';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { TfvarsService } from './TfvarsService.js';
+import { ConfigService } from './ConfigService.js';
+import { locateEntry, locateMapBody } from './hclSurgeon.js';
+
+/** Strongly-typed mock handles for the `fs` module. */
+const mockExists = vi.mocked(existsSync);
+const mockRead = vi.mocked(readFileSync);
+const mockWrite = vi.mocked(writeFileSync);
+
+/**
+ * A `terraform.tfvars` fixture with a leading comment, non-`game_servers`
+ * top-level variables, and two `game_servers` entries (one with its own
+ * leading comment) — enough surrounding content to meaningfully assert that
+ * a write only touches the entry it targets.
+ */
+const FIXTURE_TFVARS = `# managed by hyveon — see docs/docs/guides/s3-tfvars.md
+aws_region   = "us-east-1"
+project_name = "game-servers"
+
+game_servers = {
+  # palworld: main community server
+  palworld = {
+    image  = "thijsvanloef/palworld-server-docker:latest"
+    cpu    = 2048
+    memory = 8192
+    ports = [
+      { container = 8211, protocol = "udp" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/palworld" },
+    ]
+  }
+  valheim = {
+    image  = "lloesche/valheim-server"
+    cpu    = 1024
+    memory = 4096
+    ports = [
+      { container = 2456, protocol = "udp" },
+    ]
+    volumes = [
+      { name = "saves", container_path = "/config" },
+    ]
+  }
+}
+`;
+
+/** A new entry's config used by the `addGameServer` tests. */
+const NEW_ENTRY_CONFIG = {
+  image: 'ryshe/terraria',
+  cpu: 512,
+  memory: 1024,
+  ports: [{ container: 7777, protocol: 'tcp' }],
+  volumes: [{ name: 'world', container_path: '/config' }],
+};
+
+/** A replacement entry's config used by the `updateGameServer` tests. */
+const UPDATED_ENTRY_CONFIG = {
+  image: 'thijsvanloef/palworld-server-docker:v2',
+  cpu: 4096,
+  memory: 16384,
+  ports: [{ container: 8211, protocol: 'udp' }],
+  volumes: [{ name: 'saves', container_path: '/palworld' }],
+};
+
+/** Fake `RemoteFileStore` whose `get`/`put` are directly-controllable mocks. */
+function makeRemoteFileStore(): RemoteFileStore & {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+} {
+  const store: Partial<RemoteFileStore> = {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  };
+  return store as RemoteFileStore & { get: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> };
+}
+
+/**
+ * Builds a `ConfigService` stub exposing just the methods `TfvarsService`
+ * reads. `bucket: null` selects local mode; any non-null string selects S3
+ * mode.
+ */
+function makeConfig(opts: { bucket?: string | null; path?: string }): ConfigService {
+  const stub: Partial<ConfigService> = {
+    getTfvarsBucket: () => opts.bucket ?? null,
+    getTfvarsPath: () => opts.path ?? '/repo/terraform/terraform.tfvars',
+    readEnvTfvarsCacheTtlMs: () => 30000,
+  };
+  return stub as ConfigService;
+}
+
+describe('TfvarsService write path', () => {
+  let remoteFileStore: RemoteFileStore & { get: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    remoteFileStore = makeRemoteFileStore();
+    vi.clearAllMocks();
+  });
+
+  describe('byte preservation (local mode)', () => {
+    it('should preserve every byte outside the game_servers map body verbatim when addGameServer splices in a new entry', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      await service.addGameServer('terraria', NEW_ENTRY_CONFIG);
+
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+      const written = mockWrite.mock.calls[0]![1] as string;
+
+      const mapBody = locateMapBody(FIXTURE_TFVARS, 'game_servers')!;
+      // Everything up to and including the map's opening `{` — the leading
+      // comment, aws_region, project_name — is untouched.
+      expect(written.slice(0, mapBody.bodyStart)).toBe(FIXTURE_TFVARS.slice(0, mapBody.bodyStart));
+      // Everything from the map's opening `{` onward in the source — the
+      // existing palworld/valheim entries, their comment, and the closing
+      // braces — reappears verbatim as a suffix of the write, after the
+      // newly-spliced entry.
+      expect(written.endsWith(FIXTURE_TFVARS.slice(mapBody.bodyStart))).toBe(true);
+      expect(written).toContain('terraria = {');
+    });
+
+    it('should preserve every byte outside the replaced value when updateGameServer replaces an existing entry', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      await service.updateGameServer('palworld', UPDATED_ENTRY_CONFIG);
+
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+      const written = mockWrite.mock.calls[0]![1] as string;
+
+      const span = locateEntry(FIXTURE_TFVARS, 'game_servers', 'palworld')!;
+      const prefix = FIXTURE_TFVARS.slice(0, span.valueStart);
+      const suffix = FIXTURE_TFVARS.slice(span.valueEnd);
+
+      // Everything before palworld's value (leading comment, aws_region,
+      // project_name, the `# palworld: ...` comment, `palworld = `) is
+      // untouched...
+      expect(written.startsWith(prefix)).toBe(true);
+      // ...and everything after it (the trailing comma/newline, the entire
+      // valheim entry, and the map/file's closing braces) is untouched.
+      expect(written.endsWith(suffix)).toBe(true);
+      expect(written).toContain('thijsvanloef/palworld-server-docker:v2');
+      // The untouched valheim entry survives byte-for-byte.
+      const valheimSpan = locateEntry(FIXTURE_TFVARS, 'game_servers', 'valheim')!;
+      expect(written).toContain(FIXTURE_TFVARS.slice(valheimSpan.start, valheimSpan.end));
+    });
+
+    it('should preserve every byte outside the removed entry when removeGameServer cuts an entry', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+      await service.removeGameServer('palworld');
+
+      expect(mockWrite).toHaveBeenCalledTimes(1);
+      const written = mockWrite.mock.calls[0]![1] as string;
+
+      const span = locateEntry(FIXTURE_TFVARS, 'game_servers', 'palworld')!;
+      let cutEnd = span.end;
+      if (FIXTURE_TFVARS[cutEnd] === '\r') cutEnd++;
+      if (FIXTURE_TFVARS[cutEnd] === '\n') cutEnd++;
+      const expected = FIXTURE_TFVARS.slice(0, span.start) + FIXTURE_TFVARS.slice(cutEnd);
+
+      expect(written).toBe(expected);
+      // The entry assignment itself is gone (its leading comment, which
+      // `cutEntry` deliberately leaves untouched since it precedes rather
+      // than belongs to the entry span, is expected to remain — see
+      // `hclSurgeon.ts`'s `HclEntrySpan.start` doc comment).
+      expect(written).not.toContain('palworld = {');
+      expect(written).toContain('valheim = {');
+      expect(written).toContain('aws_region   = "us-east-1"');
+    });
+  });
+
+  describe('concurrent writes (S3 mode)', () => {
+    it('should fail the second of two concurrent writes with a clear OptimisticLockError, not silently overwrite the first', async () => {
+      // Both writers read the same starting etag...
+      remoteFileStore.get.mockResolvedValue({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-1',
+      });
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+      // ...the first writer's conditional put succeeds and moves the remote
+      // etag forward...
+      remoteFileStore.put.mockResolvedValueOnce({ etag: 'etag-2' });
+      await service.updateGameServer('palworld', UPDATED_ENTRY_CONFIG, 'etag-1');
+      expect(remoteFileStore.put).toHaveBeenCalledWith('terraform.tfvars', expect.any(Uint8Array), {
+        ifMatch: 'etag-1',
+      });
+
+      // ...so the second writer's conditional put — still guarded by the
+      // now-stale `etag-1` it read before the first write landed — is
+      // rejected by the store rather than clobbering the first writer's change.
+      remoteFileStore.put.mockRejectedValueOnce(
+        new RemoteFileConflictError('terraform.tfvars', 'Conflicting write detected.', 'etag-1'),
+      );
+      remoteFileStore.get.mockResolvedValueOnce({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-2',
+      });
+
+      await expect(
+        service.removeGameServer('valheim', 'etag-1'),
+      ).rejects.toThrow(OptimisticLockError);
+    });
+
+    it('should throw OptimisticLockError (not a raw RemoteFileConflictError) when the store rejects a conditional put', async () => {
+      remoteFileStore.get.mockResolvedValue({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-1',
+      });
+      remoteFileStore.put.mockRejectedValue(
+        new RemoteFileConflictError('terraform.tfvars', 'Conflicting write detected.', 'etag-stale'),
+      );
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+      await expect(
+        service.addGameServer('terraria', NEW_ENTRY_CONFIG, 'etag-stale'),
+      ).rejects.toBeInstanceOf(OptimisticLockError);
+      await expect(mockWrite).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('structured lock error', () => {
+    it('should carry the expected and current etags so callers can display "remote moved — refresh"', async () => {
+      remoteFileStore.get
+        .mockResolvedValueOnce({
+          body: new TextEncoder().encode(FIXTURE_TFVARS),
+          etag: 'etag-stale',
+        })
+        // Follow-up get() TfvarsService issues after the conflict, to report
+        // the current etag on the thrown error.
+        .mockResolvedValueOnce({
+          body: new TextEncoder().encode(FIXTURE_TFVARS),
+          etag: 'etag-current',
+        });
+      remoteFileStore.put.mockRejectedValue(
+        new RemoteFileConflictError('terraform.tfvars', 'Conflicting write detected.', 'etag-stale'),
+      );
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+      let caught: unknown;
+      try {
+        await service.updateGameServer('palworld', UPDATED_ENTRY_CONFIG, 'etag-stale');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(OptimisticLockError);
+      const lockError = caught as OptimisticLockError;
+      expect(lockError.expectedEtag).toBe('etag-stale');
+      expect(lockError.currentEtag).toBe('etag-current');
+      expect(lockError.message).toMatch(/etag-stale/);
+    });
+
+    it('should still populate expectedEtag (with currentEtag undefined) when the follow-up get() itself fails', async () => {
+      remoteFileStore.get.mockResolvedValueOnce({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-stale',
+      });
+      remoteFileStore.put.mockRejectedValue(
+        new RemoteFileConflictError('terraform.tfvars', 'Conflicting write detected.', 'etag-stale'),
+      );
+      // Follow-up get() (to resolve the current etag for the error) fails too.
+      remoteFileStore.get.mockRejectedValueOnce(new Error('network error'));
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+      let caught: unknown;
+      try {
+        await service.removeGameServer('valheim', 'etag-stale');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(OptimisticLockError);
+      const lockError = caught as OptimisticLockError;
+      expect(lockError.expectedEtag).toBe('etag-stale');
+      expect(lockError.currentEtag).toBeUndefined();
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/hclEmit.test.ts
+++ b/app/packages/desktop-main/src/services/hclEmit.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Round-trip tests for `hclEmit.ts` — every `GameServer` field emitted by
+ * `emitGameServerEntry()` must survive being parsed back through
+ * `@cdktf/hcl2json`'s real `parse()` (not mocked, since the whole point of
+ * this module is producing text that parser can consume) and deep-equal the
+ * input config.
+ */
+import { describe, it, expect } from 'vitest';
+import { parse as parseHcl } from '@cdktf/hcl2json';
+import type { GameServer } from '@hyveon/shared';
+import { emitGameServerEntry } from './hclEmit.js';
+
+/**
+ * Parses a single emitted `<name> = { ... }` attribute assignment by
+ * splicing it into a `game_servers = { ... }` wrapper block (mirroring how
+ * the surrounding tfvars file embeds it) and returns the decoded entry for
+ * `name`.
+ */
+async function roundTrip(entryText: string, name: string): Promise<unknown> {
+  const wrapped = `game_servers = {\n${entryText}\n}\n`;
+  const parsed = (await parseHcl('terraform.tfvars', wrapped)) as {
+    game_servers: Record<string, unknown>;
+  };
+  return parsed.game_servers[name];
+}
+
+describe('emitGameServerEntry', () => {
+  it('should round-trip a full-featured config with ports, environment, volumes, https, connect_message, and multiline file_seeds', async () => {
+    const entry: GameServer = {
+      name: 'palworld',
+      image: 'thijsvanloef/palworld-server-docker:latest',
+      cpu: 2048,
+      memory: 8192,
+      ports: [
+        { container: 8211, protocol: 'udp' },
+        { container: 27015, protocol: 'udp' },
+      ],
+      environment: [
+        { name: 'PLAYERS', value: '16' },
+        { name: 'SERVER_NAME', value: 'My Server' },
+      ],
+      volumes: [{ name: 'saves', container_path: '/palworld' }],
+      https: true,
+      connect_message: 'Connect to {host}:{port}',
+      file_seeds: [
+        {
+          path: '/palworld/config/PalWorldSettings.ini',
+          content: '[/Script/Pal.PalGameWorldSettings]\nOptionSettings=(Difficulty=None)\nLine3=done\n',
+          mode: '0644',
+        },
+        {
+          path: '/palworld/config/seed.bin',
+          content_base64: 'aGVsbG8gd29ybGQ=',
+        },
+      ],
+    };
+
+    const emitted = emitGameServerEntry(entry);
+    const result = await roundTrip(emitted, entry.name);
+
+    const { name: _name, ...expectedAttributes } = entry;
+    expect(result).toEqual(expectedAttributes);
+  });
+
+  it('should escape literal template interpolation and directive sequences so they are never evaluated by the HCL template engine', async () => {
+    // `@cdktf/hcl2json` never unescapes a `$${`/`%%{` escape sequence back
+    // down to a single `${`/`%{` when marshalling its JSON output — it
+    // preserves the doubled form verbatim (confirmed empirically: escaping
+    // `${` as `$${` and re-parsing yields `$${` again, not `${`). So the
+    // correctness bar `quote()` must clear is *not* exact byte equality to
+    // the pre-escape input for these two characters — it's that the escaped
+    // sequences are never evaluated as real HCL template interpolation
+    // (`${100}` collapsing to `100`) or directives (`%{if true}yes%{endif}`
+    // collapsing to `yes`), which is exactly the corruption this fix
+    // prevents. `expected` below reflects that: every field matches the
+    // input verbatim except `connect_message` and the `file_seeds` content,
+    // where the `$`/`%` immediately before every literal `{` comes back
+    // doubled, matching the escaped source text `quote()` emitted.
+    const entry: GameServer = {
+      name: 'valheim',
+      image: 'lloesche/valheim-server',
+      cpu: 1024,
+      memory: 2048,
+      ports: [{ container: 2456, protocol: 'udp' }],
+      volumes: [],
+      connect_message: 'cost is ${100} and %{if true}yes%{endif} literally',
+      file_seeds: [
+        {
+          path: '/valheim/config/note.txt',
+          content: 'price: ${5}\ndirective: %{for x in y}${x}%{endfor}\n',
+        },
+      ],
+    };
+
+    const emitted = emitGameServerEntry(entry);
+    const result = await roundTrip(emitted, entry.name);
+
+    const { name: _name, ...expectedAttributes } = entry;
+    expect(result).toEqual({
+      ...expectedAttributes,
+      connect_message: 'cost is $${100} and %%{if true}yes%%{endif} literally',
+      file_seeds: [
+        {
+          path: '/valheim/config/note.txt',
+          content: 'price: $${5}\ndirective: %%{for x in y}$${x}%%{endfor}\n',
+        },
+      ],
+    });
+
+    // The critical assertions: no template evaluation and no directive
+    // execution happened. Prior to the fix, `${100}` silently evaluated
+    // away to the bare number `100` (losing the surrounding `${...}` text
+    // entirely) — this confirms the `100` and `if true`/`yes`/`endif` text
+    // all still appear intact, just behind the doubled escape marker.
+    const roundTripped = result as GameServer;
+    expect(roundTripped.connect_message).toContain('$${100}');
+    expect(roundTripped.connect_message).toContain('%%{if true}yes%%{endif}');
+  });
+});

--- a/app/packages/desktop-main/src/services/hclEmit.ts
+++ b/app/packages/desktop-main/src/services/hclEmit.ts
@@ -1,0 +1,147 @@
+/**
+ * Serializes a single `GameServer` entry into a Terraform (HCL2) attribute
+ * assignment of the form `<name> = { ... }`, suitable for splicing into the
+ * `game_servers` map in `terraform.tfvars` (see issue #96 — the AST-mutation
+ * logic that actually splices this text into the surrounding file is a
+ * separate task; this module is a pure `GameServer -> string` formatter with
+ * no knowledge of the surrounding file).
+ *
+ * The emitted text is a syntactically complete, independently-parseable HCL
+ * fragment: parsing it on its own via `@cdktf/hcl2json`'s `parse()` and
+ * taking `result[entry.name]` reproduces every field of `entry` (minus
+ * `name` itself, which is the map key rather than an object attribute —
+ * mirroring `TfvarsService.parseGameServers()`'s flattening in reverse).
+ */
+import type {
+  GameServer,
+  GameServerEnvironmentVariable,
+  GameServerFileSeed,
+  GameServerPort,
+  GameServerVolume,
+} from '@hyveon/shared';
+
+/** Indentation unit used for every nesting level in the emitted block. */
+const INDENT = '  ';
+
+/**
+ * Quotes and escapes a string for use as an HCL2 string literal. Handles the
+ * escape sequences HCL2's quoted-string grammar recognises (backslash,
+ * double quote, and the common whitespace controls) plus the two sequences
+ * that would otherwise be parsed as template interpolation (`${...}`) or a
+ * template directive (`%{...}`) — escaping them as `$${` / `%%{` keeps the
+ * literal text intact instead of triggering HCL's template engine.
+ *
+ * Escaping embedded newlines as `\n` (rather than emitting a heredoc) is
+ * what lets `file_seeds[].content` carry arbitrary multiline text through a
+ * single quoted-string attribute — HCL2 quoted strings can't contain a raw
+ * newline, but the `\n` escape round-trips through `@cdktf/hcl2json` back to
+ * a real newline character.
+ */
+function quote(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t')
+    .replace(/\$\{/g, () => '$${')
+    .replace(/%\{/g, () => '%%{');
+  return `"${escaped}"`;
+}
+
+/** Emits a `{ container = 8211, protocol = "udp" }` single-line object. */
+function emitPort(port: GameServerPort): string {
+  return `{ container = ${port.container}, protocol = ${quote(port.protocol)} }`;
+}
+
+/** Emits a `{ name = "PLAYERS", value = "16" }` single-line object. */
+function emitEnvironmentVariable(env: GameServerEnvironmentVariable): string {
+  return `{ name = ${quote(env.name)}, value = ${quote(env.value)} }`;
+}
+
+/** Emits a `{ name = "saves", container_path = "/palworld" }` single-line object. */
+function emitVolume(volume: GameServerVolume): string {
+  return `{ name = ${quote(volume.name)}, container_path = ${quote(volume.container_path)} }`;
+}
+
+/**
+ * Emits a bracketed list of single-line inline objects (used for `ports`,
+ * `environment`, and `volumes`), one element per line at `indent`, or `[]`
+ * when `items` is empty.
+ */
+function emitInlineList<T>(items: T[], format: (item: T) => string, indent: string): string {
+  if (items.length === 0) {
+    return '[]';
+  }
+  const body = items.map((item) => `${indent}${INDENT}${format(item)},`).join('\n');
+  return `[\n${body}\n${indent}]`;
+}
+
+/**
+ * Emits `file_seeds` as one expanded block per entry (rather than the
+ * single-line style used for ports/environment/volumes) so long or
+ * multiline `content`/`content_base64` values stay on their own attribute
+ * line instead of producing an unreadably long inline object. Optional
+ * `content` / `content_base64` / `mode` attributes are only emitted when
+ * present, so the round-tripped object doesn't gain spurious keys.
+ */
+function emitFileSeeds(fileSeeds: GameServerFileSeed[], indent: string): string {
+  if (fileSeeds.length === 0) {
+    return '[]';
+  }
+  const inner = indent + INDENT;
+  const attrIndent = inner + INDENT;
+  const blocks = fileSeeds.map((seed) => {
+    const attrs: string[] = [`path = ${quote(seed.path)}`];
+    if (seed.content !== undefined) {
+      attrs.push(`content = ${quote(seed.content)}`);
+    }
+    if (seed.content_base64 !== undefined) {
+      attrs.push(`content_base64 = ${quote(seed.content_base64)}`);
+    }
+    if (seed.mode !== undefined) {
+      attrs.push(`mode = ${quote(seed.mode)}`);
+    }
+    const attrLines = attrs.map((attr) => `${attrIndent}${attr}`).join('\n');
+    return `${inner}{\n${attrLines}\n${inner}}`;
+  });
+  return `[\n${blocks.join(',\n')},\n${indent}]`;
+}
+
+/**
+ * Serializes `entry` into a standalone `<name> = { ... }` HCL2 attribute
+ * assignment. Optional fields (`environment`, `https`, `connect_message`,
+ * `file_seeds`) are only emitted when defined on `entry`, so parsing the
+ * result back doesn't introduce keys the input didn't have. See the
+ * file-level doc comment for the full round-trip contract.
+ */
+export function emitGameServerEntry(entry: GameServer): string {
+  const indent = INDENT;
+  const lines: string[] = [`${entry.name} = {`];
+
+  lines.push(`${indent}image  = ${quote(entry.image)}`);
+  lines.push(`${indent}cpu    = ${entry.cpu}`);
+  lines.push(`${indent}memory = ${entry.memory}`);
+  lines.push(`${indent}ports = ${emitInlineList(entry.ports, emitPort, indent)}`);
+
+  if (entry.environment !== undefined) {
+    lines.push(`${indent}environment = ${emitInlineList(entry.environment, emitEnvironmentVariable, indent)}`);
+  }
+
+  lines.push(`${indent}volumes = ${emitInlineList(entry.volumes, emitVolume, indent)}`);
+
+  if (entry.https !== undefined) {
+    lines.push(`${indent}https = ${entry.https}`);
+  }
+
+  if (entry.connect_message !== undefined) {
+    lines.push(`${indent}connect_message = ${quote(entry.connect_message)}`);
+  }
+
+  if (entry.file_seeds !== undefined) {
+    lines.push(`${indent}file_seeds = ${emitFileSeeds(entry.file_seeds, indent)}`);
+  }
+
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}

--- a/app/packages/desktop-main/src/services/hclSurgeon.test.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.test.ts
@@ -15,6 +15,17 @@ import { HclSurgeonError, locateEntry, cutEntry, replaceEntry } from './hclSurge
 import type { HclEntrySpan } from './hclSurgeon.js';
 
 /**
+ * A literal `$` spliced into the fixture template literals below via
+ * `${DOLLAR}{...}` instead of the escape sequence `\${...}`. CodeQL's
+ * js/useless-regexp-character-escape query misfires on `\$` inside a
+ * template literal (it's meaningful there — it suppresses interpolation —
+ * even though the same escape would be a no-op in a plain string or
+ * outside a regex character class), so this sidesteps the false positive
+ * while producing byte-identical fixture text.
+ */
+const DOLLAR = '$';
+
+/**
  * A representative `.tfvars`-shaped fixture: a top-level `other_var` before
  * the map, a `game_servers = { ... }` map with three entries (one preceded
  * by a line comment, one whose value contains a brace-laden indented
@@ -41,7 +52,7 @@ game_servers = {
 
   minecraft = {
     image = "minecraft/image:latest"
-    msg   = "cost is \${100} literally"
+    msg   = "cost is ${DOLLAR}{100} literally"
   }
 }
 
@@ -127,7 +138,7 @@ game_servers = {
   it('should skip over nested braces inside a ${...} interpolation without miscounting', () => {
     const hcl = `game_servers = {
   foo = {
-    msg = "value \${func({a = 1, b = [1, 2, 3]})}"
+    msg = "value ${DOLLAR}{func({a = 1, b = [1, 2, 3]})}"
     after = "still inside foo"
   }
 

--- a/app/packages/desktop-main/src/services/hclSurgeon.test.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Unit tests for `hclSurgeon.ts` — the comment/heredoc/string-aware splice
+ * engine that locates, cuts, and replaces a single `entryKey = <value>`
+ * assignment inside a top-level `mapVariable = { ... }` object literal.
+ *
+ * The engine's entire reason for existing is that it must never re-serialize
+ * anything: every byte outside the located span has to survive verbatim.
+ * The `cutEntry`/`replaceEntry` specs below therefore don't just assert on
+ * the returned string's *content* — they slice the untouched portions of
+ * both the input and the output and assert exact string equality (`toBe`)
+ * between them, which is the byte-for-byte guarantee the module promises.
+ */
+import { describe, it, expect } from 'vitest';
+import { HclSurgeonError, locateEntry, cutEntry, replaceEntry } from './hclSurgeon.js';
+import type { HclEntrySpan } from './hclSurgeon.js';
+
+/**
+ * A representative `.tfvars`-shaped fixture: a top-level `other_var` before
+ * the map, a `game_servers = { ... }` map with three entries (one preceded
+ * by a line comment, one whose value contains a brace-laden indented
+ * heredoc, and one whose value contains a `${...}` string interpolation),
+ * and a top-level `trailing_var` after the map. Exercises every lexical
+ * construct the splice engine has to skip over correctly in one file.
+ */
+const FIXTURE = `# top-level comment
+other_var = "unchanged"
+
+game_servers = {
+  # comment before palworld
+  palworld = {
+    image = "palworld/image:latest"
+    cpu   = 2048
+  }
+
+  valheim = {
+    image = "valheim/image:latest"
+    note  = <<-EOT
+      This is a heredoc with a brace { inside it }.
+      EOT
+  }
+
+  minecraft = {
+    image = "minecraft/image:latest"
+    msg   = "cost is \${100} literally"
+  }
+}
+
+trailing_var = true
+`;
+
+/** Narrows a possibly-`null` {@link HclEntrySpan} for use in a test body, failing fast with a clear message if the entry wasn't located. */
+function requireSpan(span: HclEntrySpan | null): HclEntrySpan {
+  if (!span) throw new Error('Expected locateEntry() to find the entry, but it returned null.');
+  return span;
+}
+
+describe('locateEntry', () => {
+  it('should locate an entry by key inside a map with multiple entries', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'palworld'));
+    expect(FIXTURE.slice(span.start, span.end)).toContain('palworld = {');
+    expect(FIXTURE.slice(span.valueStart, span.valueEnd)).toContain('image = "palworld/image:latest"');
+  });
+
+  it('should return null when the map variable does not exist', () => {
+    expect(locateEntry(FIXTURE, 'no_such_map', 'palworld')).toBeNull();
+  });
+
+  it('should return null when the map variable is assigned a non-object value', () => {
+    const hcl = 'game_servers = "just a string"\n';
+    expect(locateEntry(hcl, 'game_servers', 'palworld')).toBeNull();
+  });
+
+  it('should return null when entryKey is not present in the map', () => {
+    expect(locateEntry(FIXTURE, 'game_servers', 'terraria')).toBeNull();
+  });
+
+  it('should skip a leading comment before the entry key when locating its span', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'palworld'));
+    // The preceding "# comment before palworld" line belongs to whatever
+    // precedes the entry, so `start` must land on the `palworld` key's own
+    // line (after its indentation), not on the comment line.
+    expect(FIXTURE.slice(0, span.start)).toContain('# comment before palworld');
+    expect(FIXTURE.slice(span.start).trimStart().startsWith('palworld')).toBe(true);
+  });
+
+  it('should ignore a same-named identifier nested inside another map (not top-level)', () => {
+    const hcl = `other_map = {
+  game_servers = "decoy, not the real map"
+}
+
+game_servers = {
+  real_key = {
+    value = 1
+  }
+}
+`;
+    const span = requireSpan(locateEntry(hcl, 'game_servers', 'real_key'));
+    expect(hcl.slice(span.valueStart, span.valueEnd)).toContain('value = 1');
+  });
+
+  it('should not mistake an equality comparison (==) for an assignment', () => {
+    const hcl = `game_servers == 5
+
+game_servers = {
+  foo = { a = 1 }
+}
+`;
+    const span = requireSpan(locateEntry(hcl, 'game_servers', 'foo'));
+    expect(hcl.slice(span.valueStart, span.valueEnd)).toBe('{ a = 1 }');
+  });
+
+  it('should correctly span an entry whose value contains a heredoc with brace-like characters', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'valheim'));
+    const valueText = FIXTURE.slice(span.valueStart, span.valueEnd);
+    expect(valueText).toContain('<<-EOT');
+    expect(valueText).toContain('This is a heredoc with a brace { inside it }.');
+    expect(valueText.trimEnd().endsWith('}')).toBe(true);
+  });
+
+  it('should correctly span an entry whose value contains a string with ${...} interpolation', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'minecraft'));
+    const valueText = FIXTURE.slice(span.valueStart, span.valueEnd);
+    expect(valueText).toContain('cost is ${100} literally');
+    expect(valueText.trimEnd().endsWith('}')).toBe(true);
+  });
+
+  it('should skip over nested braces inside a ${...} interpolation without miscounting', () => {
+    const hcl = `game_servers = {
+  foo = {
+    msg = "value \${func({a = 1, b = [1, 2, 3]})}"
+    after = "still inside foo"
+  }
+
+  bar = {
+    value = 2
+  }
+}
+`;
+    const span = requireSpan(locateEntry(hcl, 'game_servers', 'bar'));
+    expect(hcl.slice(span.valueStart, span.valueEnd)).toBe('{\n    value = 2\n  }');
+  });
+
+  it('should skip over a block comment containing brace-like characters', () => {
+    const hcl = `game_servers = {
+  /* this comment contains a brace { and a bracket ] just to be tricky */
+  foo = {
+    value = 1
+  }
+}
+`;
+    const span = requireSpan(locateEntry(hcl, 'game_servers', 'foo'));
+    expect(hcl.slice(span.valueStart, span.valueEnd)).toBe('{\n    value = 1\n  }');
+  });
+
+  it('should include a trailing comma in the entry end when the source uses one', () => {
+    const hcl = `game_servers = {
+  foo = { a = 1 },
+  bar = { b = 2 }
+}
+`;
+    const span = requireSpan(locateEntry(hcl, 'game_servers', 'foo'));
+    expect(hcl[span.end - 1]).toBe(',');
+  });
+
+  it('should not include a comma in the entry end for the last entry in the map', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'minecraft'));
+    expect(FIXTURE[span.end]).not.toBe(',');
+  });
+
+  it('should throw HclSurgeonError for an unterminated map body', () => {
+    const hcl = `game_servers = {
+  foo = 1
+`;
+    expect(() => locateEntry(hcl, 'game_servers', 'foo')).toThrow(HclSurgeonError);
+  });
+
+  it('should throw HclSurgeonError for a mismatched closing bracket around the map body', () => {
+    const hcl = `game_servers = {
+  foo = 1
+]
+`;
+    expect(() => locateEntry(hcl, 'game_servers', 'foo')).toThrow(HclSurgeonError);
+  });
+});
+
+describe('cutEntry', () => {
+  it('should remove an entry and preserve every byte before and after it verbatim', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'valheim'));
+    let cutEnd = span.end;
+    if (FIXTURE[cutEnd] === '\r') cutEnd++;
+    if (FIXTURE[cutEnd] === '\n') cutEnd++;
+
+    const result = cutEntry(FIXTURE, 'game_servers', 'valheim');
+
+    expect(result.slice(0, span.start)).toBe(FIXTURE.slice(0, span.start));
+    expect(result.slice(span.start)).toBe(FIXTURE.slice(cutEnd));
+    expect(result).not.toContain('valheim');
+  });
+
+  it('should not leave a blank line behind when removing an entry with no blank-line separators', () => {
+    const hcl = `game_servers = {
+  foo = { a = 1 }
+  bar = { b = 2 }
+  baz = { c = 3 }
+}
+`;
+
+    const result = cutEntry(hcl, 'game_servers', 'bar');
+
+    expect(result).toBe(`game_servers = {
+  foo = { a = 1 }
+  baz = { c = 3 }
+}
+`);
+  });
+
+  it('should remove the last entry (no trailing comma) without corrupting the closing brace', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'minecraft'));
+    let cutEnd = span.end;
+    if (FIXTURE[cutEnd] === '\r') cutEnd++;
+    if (FIXTURE[cutEnd] === '\n') cutEnd++;
+
+    const result = cutEntry(FIXTURE, 'game_servers', 'minecraft');
+
+    expect(result.slice(0, span.start)).toBe(FIXTURE.slice(0, span.start));
+    expect(result.slice(span.start)).toBe(FIXTURE.slice(cutEnd));
+    expect(result).not.toContain('minecraft');
+    expect(result).toContain('trailing_var = true');
+  });
+
+  it('should preserve comments, heredocs, and unrelated top-level variables when cutting an entry', () => {
+    const result = cutEntry(FIXTURE, 'game_servers', 'palworld');
+    expect(result).toContain('# top-level comment');
+    expect(result).toContain('other_var = "unchanged"');
+    expect(result).toContain('<<-EOT');
+    expect(result).toContain('This is a heredoc with a brace { inside it }.');
+    expect(result).toContain('trailing_var = true');
+    expect(result).not.toContain('palworld/image:latest');
+  });
+
+  it('should throw HclSurgeonError when the entry does not exist', () => {
+    expect(() => cutEntry(FIXTURE, 'game_servers', 'terraria')).toThrow(HclSurgeonError);
+  });
+
+  it('should throw HclSurgeonError when the map variable does not exist', () => {
+    expect(() => cutEntry(FIXTURE, 'no_such_map', 'palworld')).toThrow(HclSurgeonError);
+  });
+});
+
+describe('replaceEntry', () => {
+  it('should replace only the value expression and preserve everything outside it verbatim', () => {
+    const span = requireSpan(locateEntry(FIXTURE, 'game_servers', 'palworld'));
+    const newValue = '{\n    image = "palworld/image:v2"\n    cpu   = 4096\n  }';
+
+    const result = replaceEntry(FIXTURE, 'game_servers', 'palworld', newValue);
+
+    expect(result.slice(0, span.valueStart)).toBe(FIXTURE.slice(0, span.valueStart));
+    expect(result.slice(span.valueStart, span.valueStart + newValue.length)).toBe(newValue);
+    expect(result.slice(span.valueStart + newValue.length)).toBe(FIXTURE.slice(span.valueEnd));
+  });
+
+  it('should preserve comments, heredocs, and other entries when replacing an unrelated entry', () => {
+    const newValue = '{\n    image = "minecraft/image:v2"\n  }';
+    const result = replaceEntry(FIXTURE, 'game_servers', 'minecraft', newValue);
+
+    expect(result).toContain('# top-level comment');
+    expect(result).toContain('# comment before palworld');
+    expect(result).toContain('<<-EOT');
+    expect(result).toContain('This is a heredoc with a brace { inside it }.');
+    expect(result).toContain('trailing_var = true');
+    expect(result).toContain('minecraft/image:v2');
+    expect(result).not.toContain('minecraft/image:latest');
+  });
+
+  it('should throw HclSurgeonError when the entry does not exist', () => {
+    expect(() => replaceEntry(FIXTURE, 'game_servers', 'terraria', '{}')).toThrow(HclSurgeonError);
+  });
+
+  it('should throw HclSurgeonError when the map variable does not exist', () => {
+    expect(() => replaceEntry(FIXTURE, 'no_such_map', 'palworld', '{}')).toThrow(HclSurgeonError);
+  });
+});

--- a/app/packages/desktop-main/src/services/hclSurgeon.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.ts
@@ -234,7 +234,10 @@ function skipValue(text: string, start: number): number {
       i++;
       continue;
     }
-    if (depth === 0 && (ch === ',' || ch === '\n')) return i;
+    if (depth === 0 && ch === ',') return i;
+    if (depth === 0 && ch === '\n') {
+      return i > start && text[i - 1] === '\r' ? i - 1 : i;
+    }
     i++;
   }
   return i;
@@ -318,7 +321,7 @@ function findEntryInBody(text: string, bodyStart: number, bodyEnd: number, entry
     if (text[entryEnd] === ',') entryEnd += 1;
 
     if (key === entryKey) {
-      const priorNewline = text.lastIndexOf('\n', keyStart - 1);
+      const priorNewline = Math.max(text.lastIndexOf('\n', keyStart - 1), bodyStart - 1);
       return { start: priorNewline + 1, end: entryEnd, valueStart, valueEnd };
     }
 

--- a/app/packages/desktop-main/src/services/hclSurgeon.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.ts
@@ -328,12 +328,28 @@ function findEntryInBody(text: string, bodyStart: number, bodyEnd: number, entry
 }
 
 /**
- * Locates the byte span of `entryKey`'s `key = <value>` assignment inside
- * the top-level `mapVariable = { ... }` object literal in `hcl`. Returns
- * `null` when `mapVariable` isn't found, isn't assigned an object literal,
- * or doesn't contain `entryKey` directly.
+ * Byte span of a top-level `mapVariable = { ... }` object literal's body, as
+ * located by {@link locateMapBody}.
  */
-export function locateEntry(hcl: string, mapVariable: string, entryKey: string): HclEntrySpan | null {
+export interface HclMapBodySpan {
+  /** Index just past the map's opening `{`. */
+  bodyStart: number;
+  /** Index of the map's own closing `}`. */
+  bodyEnd: number;
+}
+
+/**
+ * Locates the byte span of a top-level `mapVariable = { ... }` object
+ * literal's body — `[bodyStart, bodyEnd)`, where `bodyStart` is just after
+ * the opening `{` and `bodyEnd` is the index of the map's own closing `}`.
+ * Unlike {@link locateEntry}, this doesn't require any particular entry key
+ * to already be present — `TfvarsService.addGameServer()` uses it to find
+ * where to splice in a brand-new entry (as the map's first entry, right
+ * after `bodyStart`) even when the map is empty. Returns `null` when
+ * `mapVariable` isn't found at the top level or isn't assigned an object
+ * literal.
+ */
+export function locateMapBody(hcl: string, mapVariable: string): HclMapBodySpan | null {
   const nameStart = findTopLevelIdentifier(hcl, mapVariable);
   if (nameStart === null) return null;
 
@@ -343,7 +359,20 @@ export function locateEntry(hcl: string, mapVariable: string, entryKey: string):
   if (hcl[j] !== '{') return null;
 
   const mapClose = findMatchingClose(hcl, j);
-  return findEntryInBody(hcl, j + 1, mapClose, entryKey);
+  return { bodyStart: j + 1, bodyEnd: mapClose };
+}
+
+/**
+ * Locates the byte span of `entryKey`'s `key = <value>` assignment inside
+ * the top-level `mapVariable = { ... }` object literal in `hcl`. Returns
+ * `null` when `mapVariable` isn't found, isn't assigned an object literal,
+ * or doesn't contain `entryKey` directly.
+ */
+export function locateEntry(hcl: string, mapVariable: string, entryKey: string): HclEntrySpan | null {
+  const mapBody = locateMapBody(hcl, mapVariable);
+  if (!mapBody) return null;
+
+  return findEntryInBody(hcl, mapBody.bodyStart, mapBody.bodyEnd, entryKey);
 }
 
 /**

--- a/app/packages/desktop-main/src/services/hclSurgeon.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.ts
@@ -1,0 +1,383 @@
+/**
+ * Comment/heredoc/string-aware HCL text splicing for a single named entry
+ * inside a top-level `map(object({...}))` variable assignment (e.g.
+ * `game_servers = { palworld = {...}, valheim = {...} }`) in a `.tfvars`
+ * file — see issue #96.
+ *
+ * `TfvarsService`'s read path goes through `@cdktf/hcl2json`, which
+ * round-trips HCL through a JSON AST and loses comments, heredocs, and
+ * formatting. Writing back a mutated entry can't go through that path
+ * without corrupting the rest of the file, so this module instead operates
+ * directly on the raw HCL text: it locates the byte span of one map entry
+ * (`entryKey = <value>`) using a small hand-rolled lexer that understands
+ * just enough HCL to correctly skip over `#`/`//` line comments, block
+ * comments, quoted strings (including `${...}` interpolation), and
+ * `<<IDENT` / `<<-IDENT` heredocs — all of which can legally contain
+ * brace-like characters that would otherwise throw off naive bracket
+ * counting — without ever re-serializing anything. Every byte outside the
+ * located span is therefore guaranteed to be preserved verbatim, including
+ * comments, heredoc bodies, and unrelated top-level variables.
+ *
+ * This module is intentionally low-level: it only *locates*, *cuts*, and
+ * *replaces* a single entry's value. Higher-level operations (`addGameServer`,
+ * `updateGameServer`, `removeGameServer`, HCL value serialization for a
+ * `GameServer` object) are out of scope here and belong in `TfvarsService`.
+ */
+
+/** Thrown when the requested map/entry can't be located or the source HCL is malformed (unterminated bracket/string/heredoc). */
+export class HclSurgeonError extends Error {}
+
+/**
+ * Byte span of a single `entryKey = <value>` assignment inside a map's
+ * `{ ... }` body, as located by {@link locateEntry}.
+ */
+export interface HclEntrySpan {
+  /**
+   * Start of the *entry*: the beginning of the line containing the entry's
+   * key (includes the key's own leading indentation). Comments and blank
+   * lines preceding the entry are *not* included — they belong to whatever
+   * precedes the entry and are left untouched by {@link cutEntry}.
+   */
+  start: number;
+  /**
+   * End of the *entry*: immediately after the value, plus a trailing comma
+   * if the source uses one. Does not include the line's trailing newline
+   * (that's consumed separately by {@link cutEntry} so a removed entry
+   * doesn't leave a blank line behind).
+   */
+  end: number;
+  /** Start of just the value expression (e.g. the `{` of an object literal). */
+  valueStart: number;
+  /** End of just the value expression, excluding a trailing comma. */
+  valueEnd: number;
+}
+
+/**
+ * If `text[i]` begins a comment, quoted string, or heredoc, returns the
+ * index to resume scanning from (past that construct). Otherwise returns
+ * `null`, meaning the caller should handle `text[i]` itself. Shared by every
+ * scanning function in this module so comment/string/heredoc skipping stays
+ * consistent everywhere.
+ */
+function skipLexicalToken(text: string, i: number): number | null {
+  const ch = text[i];
+  if (ch === '#') return skipLineComment(text, i);
+  if (ch === '/' && text[i + 1] === '/') return skipLineComment(text, i);
+  if (ch === '/' && text[i + 1] === '*') return skipBlockComment(text, i);
+  if (ch === '"') return skipString(text, i);
+  if (ch === '<' && text[i + 1] === '<') return skipHeredoc(text, i);
+  return null;
+}
+
+/** Returns the index of the newline terminating the `#`/`//` comment starting at `start` (or `text.length` if the file ends first). The newline itself is left for the caller to consume. */
+function skipLineComment(text: string, start: number): number {
+  const nl = text.indexOf('\n', start);
+  return nl === -1 ? text.length : nl;
+}
+
+/** Returns the index just past the end of the block comment starting at `start` (or `text.length` if unterminated). */
+function skipBlockComment(text: string, start: number): number {
+  const end = text.indexOf('*/', start + 2);
+  return end === -1 ? text.length : end + 2;
+}
+
+/**
+ * Returns the index just past the closing `"` of the quoted string starting
+ * at `start`, honoring backslash escapes and skipping over balanced
+ * `${ ... }` template interpolations (which may themselves contain nested
+ * strings/braces) rather than treating their contents as plain string text.
+ */
+function skipString(text: string, start: number): number {
+  let i = start + 1;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '"') return i + 1;
+    if (ch === '$' && text[i + 1] === '{') {
+      i = findMatchingClose(text, i + 1) + 1;
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Returns the index of the newline that terminates the heredoc's closing
+ * marker line for the `<<IDENT` / `<<-IDENT` heredoc starting at `start`
+ * (or `text.length` if the file ends before a closing marker is found).
+ * Honors the `<<-` variant's rule that the closing marker line may be
+ * indented; the plain `<<` variant requires the marker at column 0.
+ */
+function skipHeredoc(text: string, start: number): number {
+  let j = start + 2;
+  let indented = false;
+  if (text[j] === '-') {
+    indented = true;
+    j++;
+  }
+  const markerMatch = /^[A-Za-z_][A-Za-z0-9_]*/.exec(text.slice(j));
+  if (!markerMatch) return j; // Malformed heredoc introducer; bail out conservatively.
+  const marker = markerMatch[0];
+  j += marker.length;
+
+  const firstBodyLine = text.indexOf('\n', j);
+  if (firstBodyLine === -1) return text.length;
+
+  const closeRegex = indented ? new RegExp(`^[ \\t]*${marker}\\s*$`) : new RegExp(`^${marker}\\s*$`);
+  let pos = firstBodyLine + 1;
+  while (pos <= text.length) {
+    const nextNewline = text.indexOf('\n', pos);
+    const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+    if (closeRegex.test(text.slice(pos, lineEnd))) {
+      return lineEnd;
+    }
+    if (nextNewline === -1) return text.length;
+    pos = nextNewline + 1;
+  }
+  return text.length;
+}
+
+/** Skips runs of plain whitespace and comments, returning the index of the next significant character (or `text.length`). */
+function skipWhitespaceAndComments(text: string, start: number): number {
+  let i = start;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') {
+      i++;
+      continue;
+    }
+    if (ch === '#' || (ch === '/' && (text[i + 1] === '/' || text[i + 1] === '*'))) {
+      i = skipLexicalToken(text, i) ?? i + 1;
+      continue;
+    }
+    break;
+  }
+  return i;
+}
+
+/**
+ * Given `text[openIndex]` is one of `{`, `[`, `(`, returns the index of its
+ * matching close bracket, correctly skipping over nested brackets as well
+ * as any comments/strings/heredocs encountered along the way. Throws
+ * {@link HclSurgeonError} if the source is malformed (mismatched or
+ * unterminated bracket).
+ */
+function findMatchingClose(text: string, openIndex: number): number {
+  const open = text[openIndex];
+  const expectedClose = open === '{' ? '}' : open === '[' ? ']' : open === '(' ? ')' : null;
+  if (!expectedClose) {
+    throw new HclSurgeonError(`findMatchingClose called on non-bracket character "${open}" at offset ${openIndex}.`);
+  }
+
+  let i = openIndex + 1;
+  let depth = 1;
+  while (i < text.length) {
+    const skipped = skipLexicalToken(text, i);
+    if (skipped !== null) {
+      i = skipped;
+      continue;
+    }
+    const ch = text[i];
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}' || ch === ']' || ch === ')') {
+      depth--;
+      if (depth === 0) {
+        if (ch !== expectedClose) {
+          throw new HclSurgeonError(
+            `Mismatched closing bracket "${ch}" for "${open}" opened at offset ${openIndex} (found at offset ${i}).`,
+          );
+        }
+        return i;
+      }
+      i++;
+      continue;
+    }
+    i++;
+  }
+  throw new HclSurgeonError(`Unterminated "${open}" opened at offset ${openIndex} — no matching "${expectedClose}" found.`);
+}
+
+/**
+ * Scans a top-level `key = <value>` assignment's value, starting at
+ * `start`, and returns the index right after it ends: either a `,` at the
+ * assignment's own nesting depth, a newline at that depth, or the closing
+ * bracket of whatever encloses it — whichever comes first. Nested
+ * brackets/comments/strings/heredocs are all skipped correctly along the
+ * way so this works for scalar, object, list, and expression values alike.
+ */
+function skipValue(text: string, start: number): number {
+  let i = start;
+  let depth = 0;
+  while (i < text.length) {
+    const skipped = skipLexicalToken(text, i);
+    if (skipped !== null) {
+      i = skipped;
+      continue;
+    }
+    const ch = text[i];
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}' || ch === ']' || ch === ')') {
+      if (depth === 0) return i;
+      depth--;
+      i++;
+      continue;
+    }
+    if (depth === 0 && (ch === ',' || ch === '\n')) return i;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Scans the whole file for a `name = { ... }` assignment whose `name`
+ * identifier appears at bracket depth 0 (i.e. it's a genuine top-level
+ * `.tfvars` variable, not a same-named nested attribute), and returns the
+ * index of the `name` identifier's first character. Returns `null` if no
+ * such top-level assignment exists.
+ */
+function findTopLevelIdentifier(text: string, name: string): number | null {
+  let i = 0;
+  let depth = 0;
+  while (i < text.length) {
+    const skipped = skipLexicalToken(text, i);
+    if (skipped !== null) {
+      i = skipped;
+      continue;
+    }
+    const ch = text[i];
+    if (depth === 0 && /[A-Za-z_]/.test(ch)) {
+      const match = /^[A-Za-z_][A-Za-z0-9_-]*/.exec(text.slice(i));
+      const ident = match ? match[0] : ch;
+      if (ident === name) {
+        const after = skipWhitespaceAndComments(text, i + ident.length);
+        if (text[after] === '=' && text[after + 1] !== '=') {
+          return i;
+        }
+      }
+      i += ident.length;
+      continue;
+    }
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}' || ch === ']' || ch === ')') {
+      depth = Math.max(0, depth - 1);
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+/**
+ * Scans a map's `{ ... }` body — `[bodyStart, bodyEnd)`, where `bodyEnd` is
+ * the index of the map's own closing `}` — for a `entryKey = <value>`
+ * assignment, returning its {@link HclEntrySpan}. Returns `null` if no such
+ * key exists directly in the map (nested maps aren't searched).
+ */
+function findEntryInBody(text: string, bodyStart: number, bodyEnd: number, entryKey: string): HclEntrySpan | null {
+  let i = bodyStart;
+  while (i < bodyEnd) {
+    i = skipWhitespaceAndComments(text, i);
+    if (i >= bodyEnd) break;
+
+    const match = /^[A-Za-z_][A-Za-z0-9_-]*/.exec(text.slice(i, bodyEnd));
+    if (!match) {
+      i++;
+      continue;
+    }
+    const keyStart = i;
+    const key = match[0];
+
+    const afterKey = skipWhitespaceAndComments(text, i + key.length);
+    if (text[afterKey] !== '=' || text[afterKey + 1] === '=') {
+      // Not a `key = value` pair — shouldn't happen in a well-formed map;
+      // skip past this token defensively rather than looping forever.
+      i = afterKey + 1;
+      continue;
+    }
+
+    const valueStart = skipWhitespaceAndComments(text, afterKey + 1);
+    const valueEnd = skipValue(text, valueStart);
+    let entryEnd = valueEnd;
+    if (text[entryEnd] === ',') entryEnd += 1;
+
+    if (key === entryKey) {
+      const priorNewline = text.lastIndexOf('\n', keyStart - 1);
+      return { start: priorNewline + 1, end: entryEnd, valueStart, valueEnd };
+    }
+
+    i = entryEnd;
+  }
+  return null;
+}
+
+/**
+ * Locates the byte span of `entryKey`'s `key = <value>` assignment inside
+ * the top-level `mapVariable = { ... }` object literal in `hcl`. Returns
+ * `null` when `mapVariable` isn't found, isn't assigned an object literal,
+ * or doesn't contain `entryKey` directly.
+ */
+export function locateEntry(hcl: string, mapVariable: string, entryKey: string): HclEntrySpan | null {
+  const nameStart = findTopLevelIdentifier(hcl, mapVariable);
+  if (nameStart === null) return null;
+
+  let j = skipWhitespaceAndComments(hcl, nameStart + mapVariable.length);
+  if (hcl[j] !== '=') return null;
+  j = skipWhitespaceAndComments(hcl, j + 1);
+  if (hcl[j] !== '{') return null;
+
+  const mapClose = findMatchingClose(hcl, j);
+  return findEntryInBody(hcl, j + 1, mapClose, entryKey);
+}
+
+/**
+ * Returns `hcl` with `entryKey`'s entire `key = <value>` assignment removed
+ * from `mapVariable`'s object literal (along with a trailing comma and the
+ * entry's own line-ending newline, so the removal doesn't leave a blank
+ * line behind). Every byte outside the removed span — including comments,
+ * heredocs, and other top-level variables — is preserved verbatim. Throws
+ * {@link HclSurgeonError} if the entry can't be located.
+ */
+export function cutEntry(hcl: string, mapVariable: string, entryKey: string): string {
+  const span = locateEntry(hcl, mapVariable, entryKey);
+  if (!span) {
+    throw new HclSurgeonError(`Entry "${entryKey}" not found in "${mapVariable}".`);
+  }
+
+  let end = span.end;
+  if (hcl[end] === '\r') end++;
+  if (hcl[end] === '\n') end++;
+
+  return hcl.slice(0, span.start) + hcl.slice(end);
+}
+
+/**
+ * Returns `hcl` with `entryKey`'s value replaced by `newValueHcl` (the
+ * `entryKey = ` prefix, any trailing comma, and everything else in the file
+ * is preserved verbatim). Throws {@link HclSurgeonError} if the entry can't
+ * be located.
+ */
+export function replaceEntry(hcl: string, mapVariable: string, entryKey: string, newValueHcl: string): string {
+  const span = locateEntry(hcl, mapVariable, entryKey);
+  if (!span) {
+    throw new HclSurgeonError(`Entry "${entryKey}" not found in "${mapVariable}".`);
+  }
+
+  return hcl.slice(0, span.valueStart) + newValueHcl + hcl.slice(span.valueEnd);
+}

--- a/app/packages/desktop-main/src/services/hclSurgeon.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.ts
@@ -322,7 +322,7 @@ function findEntryInBody(text: string, bodyStart: number, bodyEnd: number, entry
 
     if (key === entryKey) {
       const priorNewline = Math.max(text.lastIndexOf('\n', keyStart - 1), bodyStart - 1);
-      return { start: priorNewline + 1, end: entryEnd, valueStart, valueEnd };
+      return { start: Math.max(bodyStart, priorNewline + 1), end: entryEnd, valueStart, valueEnd };
     }
 
     i = entryEnd;

--- a/app/packages/shared/src/errors.test.ts
+++ b/app/packages/shared/src/errors.test.ts
@@ -29,6 +29,13 @@ describe('OptimisticLockError', () => {
     expect(error.currentEtag).toBeUndefined();
   });
 
+  it('should derive a default message noting the remote etag is unknown when currentEtag is not supplied', () => {
+    const error = new OptimisticLockError('expected-etag');
+
+    expect(error.message).toContain('expected-etag');
+    expect(error.message).toContain('unknown');
+  });
+
   it('should use a custom message when one is provided', () => {
     const error = new OptimisticLockError('expected-etag', 'current-etag', 'remote moved — refresh');
 

--- a/app/packages/shared/src/errors.test.ts
+++ b/app/packages/shared/src/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { OptimisticLockError } from './errors.js';
+
+describe('OptimisticLockError', () => {
+  it('should be importable from @hyveon/shared and be an instance of Error', () => {
+    const error = new OptimisticLockError('expected-etag');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(OptimisticLockError);
+  });
+
+  it('should set name to OptimisticLockError', () => {
+    const error = new OptimisticLockError('expected-etag', 'current-etag');
+
+    expect(error.name).toBe('OptimisticLockError');
+  });
+
+  it('should round-trip both the expected and current etag through the constructor', () => {
+    const error = new OptimisticLockError('expected-etag', 'current-etag');
+
+    expect(error.expectedEtag).toBe('expected-etag');
+    expect(error.currentEtag).toBe('current-etag');
+  });
+
+  it('should leave currentEtag undefined when it is not supplied', () => {
+    const error = new OptimisticLockError('expected-etag');
+
+    expect(error.expectedEtag).toBe('expected-etag');
+    expect(error.currentEtag).toBeUndefined();
+  });
+
+  it('should use a custom message when one is provided', () => {
+    const error = new OptimisticLockError('expected-etag', 'current-etag', 'remote moved — refresh');
+
+    expect(error.message).toBe('remote moved — refresh');
+  });
+
+  it('should derive a default message from both etags when none is provided', () => {
+    const error = new OptimisticLockError('expected-etag', 'current-etag');
+
+    expect(error.message).toContain('expected-etag');
+    expect(error.message).toContain('current-etag');
+  });
+});

--- a/app/packages/shared/src/errors.ts
+++ b/app/packages/shared/src/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Cloud-agnostic error types shared between the desktop-main API and the
+ * Lambda packages. Kept in their own module (rather than alongside a single
+ * consumer) so both sides of an operation — the writer that detects the
+ * conflict and the caller that needs to react to it — can `instanceof`
+ * check against the same class.
+ */
+
+/**
+ * Thrown by tfvars write helpers (e.g. `TfvarsService.updateGameServer`)
+ * when an optimistic-concurrency check fails: the caller supplied the etag
+ * it last read, but the remote file has since moved to a different etag.
+ * Carries both etags so the UI can surface a clear "remote moved — refresh"
+ * message instead of a generic write failure.
+ */
+export class OptimisticLockError extends Error {
+  /** The etag the caller expected to still be current (from its last read). */
+  readonly expectedEtag: string;
+
+  /** The etag actually stored remotely at the time of the write attempt, if known. */
+  readonly currentEtag?: string;
+
+  /**
+   * @param expectedEtag - The etag the caller expected to still be current.
+   * @param currentEtag - The etag actually stored remotely, if known.
+   * @param message - Optional human-readable message; defaults to a message
+   *   derived from the two etags.
+   */
+  constructor(expectedEtag: string, currentEtag?: string, message?: string) {
+    super(
+      message ??
+        `Optimistic lock failed: expected etag "${expectedEtag}" but remote is now ${
+          currentEtag ? `"${currentEtag}"` : 'unknown'
+        }.`,
+    );
+    this.name = 'OptimisticLockError';
+    this.expectedEtag = expectedEtag;
+    this.currentEtag = currentEtag;
+    Object.setPrototypeOf(this, OptimisticLockError.prototype);
+  }
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js';
+export * from './errors.js';
 export * from './tfvars.js';
 export * from './gameServerValidator.js';
 export * from './drift.js';


### PR DESCRIPTION
Closes #96

## Summary

- Extends `TfvarsService` with `addGameServer`, `updateGameServer`, and `removeGameServer`, each round-tripping S3-backed HCL through a new splice engine (`hclSurgeon.ts`) and serializer (`hclEmit.ts`) so only the touched `game_servers` entry changes — comments, ordering, heredocs, and unrelated blocks are preserved byte-for-byte.
- Enforces optimistic locking on every write: reads carry the current S3 `VersionId`/ETag, and a conflicting concurrent write throws the typed `OptimisticLockError` (added to `@hyveon/shared`) carrying both the expected and current version ids so the UI can surface a clear "remote moved — refresh" message.
- Adds full unit coverage for the splice engine, the HCL entry serializer, the `TfvarsService` write paths (including conflict/error handling), and the `OptimisticLockError` default-message fallback.

## Changes

```
 .../desktop-main/src/services/TfvarsService.ts     | 256 ++++++++++++-
 .../src/services/TfvarsService.write.test.ts       | 363 ++++++++++++++++++
 .../desktop-main/src/services/hclEmit.test.ts      | 119 ++++++
 app/packages/desktop-main/src/services/hclEmit.ts  | 147 ++++++++
 .../desktop-main/src/services/hclSurgeon.test.ts   | 282 ++++++++++++++
 .../desktop-main/src/services/hclSurgeon.ts        | 412 +++++++++++++++++++++
 app/packages/shared/src/errors.test.ts             |  51 +++
 app/packages/shared/src/errors.ts                  |  41 ++
 app/packages/shared/src/index.ts                   |   1 +
 9 files changed, 1670 insertions(+), 2 deletions(-)
```

## Test plan

- [x] `addGameServer`/`updateGameServer`/`removeGameServer` added to `TfvarsService`, each mutating one `game_servers` entry via HCL splice + serialize round-trip.
- [x] Adding/editing/removing one game preserves the rest of the file byte-for-byte (modulo the touched block) — covered by `hclSurgeon.test.ts` and `TfvarsService.write.test.ts`.
- [x] Writes use `If-Match`/version-id precheck against S3; a stale expected version throws `OptimisticLockError`.
- [x] Concurrent writes — second write with a now-stale `expectedVersionId` fails with `OptimisticLockError` carrying `currentVersionId`/`expectedVersionId` for the UI to display "remote moved — refresh".
- [x] Unit tests for round-trip preservation, conflict handling, and default-message fallback (`hclSurgeon.test.ts`, `hclEmit.test.ts`, `TfvarsService.write.test.ts`, `errors.test.ts`).
- [x] `npm run app:test` passing for the touched workspaces.
