### PR TITLE
feat(desktop-main): gsd.games.create/update/delete IPC handlers

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -24,6 +24,7 @@ import { DriftController } from './controllers/drift.controller.js';
 import { DriftHttpController } from './controllers/drift-http.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
 import { DriftService } from './services/DriftService.js';
+import { GamesWriteService } from './services/GamesWriteService.js';
 import { SafeStorageService } from './services/SafeStorageService.js';
 import { ElectronStoreService } from './services/ElectronStoreService.js';
 
@@ -66,6 +67,7 @@ import { ElectronStoreService } from './services/ElectronStoreService.js';
     },
     DiagnosticsService,
     DriftService,
+    GamesWriteService,
     SafeStorageService,
     ElectronStoreService,
   ],

--- a/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
@@ -1,10 +1,12 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi } from 'vitest';
-import type { GameServer } from '@hyveon/shared';
+import { ConflictException, HttpException, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import type { GameServer, GameWriteResult } from '@hyveon/shared';
 import { GamesHttpController } from './games-http.controller.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
 import type { TfvarsService } from '../services/TfvarsService.js';
+import type { GamesWriteService } from '../services/GamesWriteService.js';
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -59,17 +61,36 @@ function makeTfvars(declared: GameServer[] = []): TfvarsService {
   } as Partial<TfvarsService> as TfvarsService;
 }
 
+/** Build a GamesWriteService stub with all three write methods pre-wired to spies. */
+function makeGamesWrite(): GamesWriteService {
+  return {
+    createGame: vi.fn(),
+    updateGame: vi.fn(),
+    deleteGame: vi.fn(),
+  } as unknown as GamesWriteService;
+}
+
+/** Build a successful `GameWriteResult` for use in write-endpoint tests. */
+function buildWriteSuccess(game?: GameServer): GameWriteResult {
+  return { ok: true, game, games: [] };
+}
+
+/** Build a controller instance with default (unused) collaborators, wired to the given `GamesWriteService` stub. */
+function makeController(gamesWrite: GamesWriteService): GamesHttpController {
+  return new GamesHttpController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite);
+}
+
 describe('GamesHttpController', () => {
   describe('listGames', () => {
     it('should invalidate the tfstate cache before reading game names', async () => {
       const config = makeConfig();
-      await new GamesHttpController(config, makeEcs(), makeTfvars()).listGames();
+      await new GamesHttpController(config, makeEcs(), makeTfvars(), makeGamesWrite()).listGames();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should invalidate the TfvarsService cache before reading game names', async () => {
       const tfvars = makeTfvars();
-      await new GamesHttpController(makeConfig(), makeEcs(), tfvars).listGames();
+      await new GamesHttpController(makeConfig(), makeEcs(), tfvars, makeGamesWrite()).listGames();
       expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
@@ -79,6 +100,7 @@ describe('GamesHttpController', () => {
         makeConfig(),
         makeEcs(),
         makeTfvars([valheim]),
+        makeGamesWrite(),
       ).listGames();
       expect(result).toEqual({
         games: [
@@ -89,7 +111,12 @@ describe('GamesHttpController', () => {
     });
 
     it('should return an empty games array when Terraform has not been applied yet and nothing is declared', async () => {
-      const result = await new GamesHttpController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
+      const result = await new GamesHttpController(
+        makeConfig(null),
+        makeEcs(),
+        makeTfvars(),
+        makeGamesWrite(),
+      ).listGames();
       expect(result).toEqual({ games: [] });
     });
   });
@@ -97,32 +124,37 @@ describe('GamesHttpController', () => {
   describe('listStatus', () => {
     it('should invalidate cache before querying ECS', async () => {
       const config = makeConfig();
-      await new GamesHttpController(config, makeEcs(), makeTfvars()).listStatus();
+      await new GamesHttpController(config, makeEcs(), makeTfvars(), makeGamesWrite()).listStatus();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should invalidate the TfvarsService cache before querying ECS', async () => {
       const tfvars = makeTfvars();
-      await new GamesHttpController(makeConfig(), makeEcs(), tfvars).listStatus();
+      await new GamesHttpController(makeConfig(), makeEcs(), tfvars, makeGamesWrite()).listStatus();
       expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should query ECS status for every game in the Terraform outputs', async () => {
       const ecs = makeEcs();
-      await new GamesHttpController(makeConfig(), ecs, makeTfvars()).listStatus();
+      await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).listStatus();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
       expect(ecs.getStatus).toHaveBeenCalledWith('valheim');
     });
 
     it('should return an empty array when tfstate is absent', async () => {
-      const result = await new GamesHttpController(makeConfig(null), makeEcs(), makeTfvars()).listStatus();
+      const result = await new GamesHttpController(
+        makeConfig(null),
+        makeEcs(),
+        makeTfvars(),
+        makeGamesWrite(),
+      ).listStatus();
       expect(result).toEqual([]);
     });
 
     it('should return status entries in the same order as game_names', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockImplementation(async (g) => ({ game: g, state: 'stopped' as const }));
-      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).listStatus();
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).listStatus();
       expect(result.map((s) => s.game)).toEqual(['minecraft', 'valheim']);
     });
   });
@@ -131,7 +163,7 @@ describe('GamesHttpController', () => {
     it('should delegate to EcsService without invalidating the tfstate cache', async () => {
       const config = makeConfig();
       const ecs = makeEcs();
-      await new GamesHttpController(config, ecs, makeTfvars()).getStatus('minecraft');
+      await new GamesHttpController(config, ecs, makeTfvars(), makeGamesWrite()).getStatus('minecraft');
       expect(config.invalidateCache).not.toHaveBeenCalled();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
     });
@@ -139,7 +171,9 @@ describe('GamesHttpController', () => {
     it('should return the status provided by EcsService', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running' });
-      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).getStatus('minecraft');
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).getStatus(
+        'minecraft',
+      );
       expect(result).toEqual({ game: 'minecraft', state: 'running' });
     });
   });
@@ -147,14 +181,16 @@ describe('GamesHttpController', () => {
   describe('start', () => {
     it('should delegate to EcsService.start with the requested game name', async () => {
       const ecs = makeEcs();
-      await new GamesHttpController(makeConfig(), ecs, makeTfvars()).start('valheim');
+      await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).start('valheim');
       expect(ecs.start).toHaveBeenCalledWith('valheim');
     });
 
     it('should return the result from EcsService.start', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.start).mockResolvedValue({ success: true, message: 'running', taskArn: 'arn:task' });
-      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).start('minecraft');
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).start(
+        'minecraft',
+      );
       expect(result).toMatchObject({ success: true, taskArn: 'arn:task' });
     });
   });
@@ -162,15 +198,215 @@ describe('GamesHttpController', () => {
   describe('stop', () => {
     it('should delegate to EcsService.stop with the requested game name', async () => {
       const ecs = makeEcs();
-      await new GamesHttpController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
+      await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).stop('minecraft');
       expect(ecs.stop).toHaveBeenCalledWith('minecraft');
     });
 
     it('should return the result from EcsService.stop', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.stop).mockResolvedValue({ success: true, message: 'stopped' });
-      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
+      const result = await new GamesHttpController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).stop(
+        'minecraft',
+      );
       expect(result).toMatchObject({ success: true, message: 'stopped' });
+    });
+  });
+
+  describe('createGame', () => {
+    it('should forward the If-Match header as expectedVersionId', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.createGame).mockResolvedValue(buildWriteSuccess(buildGameServer('valheim')));
+      const config = buildGameServer('valheim');
+      await makeController(gamesWrite).createGame({ name: 'valheim', config }, 'etag-1');
+      expect(gamesWrite.createGame).toHaveBeenCalledWith({
+        name: 'valheim',
+        config,
+        expectedVersionId: 'etag-1',
+      });
+    });
+
+    it('should forward undefined expectedVersionId when no If-Match header is sent', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.createGame).mockResolvedValue(buildWriteSuccess());
+      const config = buildGameServer('valheim');
+      await makeController(gamesWrite).createGame({ name: 'valheim', config });
+      expect(gamesWrite.createGame).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedVersionId: undefined }),
+      );
+    });
+
+    it('should return the success body with status 200 semantics when the write succeeds', async () => {
+      const gamesWrite = makeGamesWrite();
+      const success = buildWriteSuccess(buildGameServer('valheim'));
+      vi.mocked(gamesWrite.createGame).mockResolvedValue(success);
+      const result = await makeController(gamesWrite).createGame({
+        name: 'valheim',
+        config: buildGameServer('valheim'),
+      });
+      expect(result).toEqual(success);
+    });
+
+    it('should throw ConflictException with both version ids when the result code is conflict', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.createGame).mockResolvedValue({
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'stale',
+        currentVersionId: 'fresh',
+        message: 'stale tfvars version',
+      });
+      const controller = makeController(gamesWrite);
+      await expect(
+        controller.createGame({ name: 'valheim', config: buildGameServer('valheim') }, 'stale'),
+      ).rejects.toThrow(ConflictException);
+      await expect(
+        controller.createGame({ name: 'valheim', config: buildGameServer('valheim') }, 'stale'),
+      ).rejects.toMatchObject({
+        response: { currentVersionId: 'fresh', expectedVersionId: 'stale' },
+      });
+    });
+
+    it('should throw an HttpException with status 422 and the issues array when the result code is validation', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.createGame).mockResolvedValue({
+        ok: false,
+        code: 'validation',
+        issues: [{ path: 'name', message: 'name is required' }],
+      });
+      const controller = makeController(gamesWrite);
+      await expect(controller.createGame({ name: '', config: buildGameServer('valheim') })).rejects.toThrow(
+        HttpException,
+      );
+      await expect(controller.createGame({ name: '', config: buildGameServer('valheim') })).rejects.toMatchObject({
+        status: 422,
+        response: { issues: [{ path: 'name', message: 'name is required' }] },
+      });
+    });
+
+    it('should throw InternalServerErrorException when the result code is error', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.createGame).mockResolvedValue({
+        ok: false,
+        code: 'error',
+        message: 'disk full',
+      });
+      await expect(
+        makeController(gamesWrite).createGame({ name: 'valheim', config: buildGameServer('valheim') }),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('updateGame', () => {
+    it('should forward the route param name, body config, and If-Match header to GamesWriteService.updateGame', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue(buildWriteSuccess(buildGameServer('valheim')));
+      const config = buildGameServer('valheim');
+      await makeController(gamesWrite).updateGame('valheim', { config }, 'etag-2');
+      expect(gamesWrite.updateGame).toHaveBeenCalledWith({
+        name: 'valheim',
+        config,
+        expectedVersionId: 'etag-2',
+      });
+    });
+
+    it('should return the success body when the write succeeds', async () => {
+      const gamesWrite = makeGamesWrite();
+      const success = buildWriteSuccess(buildGameServer('valheim'));
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue(success);
+      const result = await makeController(gamesWrite).updateGame('valheim', { config: buildGameServer('valheim') });
+      expect(result).toEqual(success);
+    });
+
+    it('should throw NotFoundException when the result code is not_found', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue({
+        ok: false,
+        code: 'not_found',
+        message: 'no such game',
+      });
+      await expect(
+        makeController(gamesWrite).updateGame('missing', { config: buildGameServer('missing') }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException when the result code is conflict', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue({
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'stale',
+        currentVersionId: 'fresh',
+        message: 'stale tfvars version',
+      });
+      await expect(
+        makeController(gamesWrite).updateGame('valheim', { config: buildGameServer('valheim') }, 'stale'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw an HttpException with status 422 when the result code is validation', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue({
+        ok: false,
+        code: 'validation',
+        issues: [{ path: 'ports', message: 'port collision' }],
+      });
+      await expect(
+        makeController(gamesWrite).updateGame('valheim', { config: buildGameServer('valheim') }),
+      ).rejects.toMatchObject({ status: 422 });
+    });
+
+    it('should throw InternalServerErrorException when the result code is error', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue({ ok: false, code: 'error', message: 'io error' });
+      await expect(
+        makeController(gamesWrite).updateGame('valheim', { config: buildGameServer('valheim') }),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('deleteGame', () => {
+    it('should forward the route param name and If-Match header to GamesWriteService.deleteGame', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.deleteGame).mockResolvedValue(buildWriteSuccess());
+      await makeController(gamesWrite).deleteGame('valheim', 'etag-3');
+      expect(gamesWrite.deleteGame).toHaveBeenCalledWith({ name: 'valheim', expectedVersionId: 'etag-3' });
+    });
+
+    it('should return the success body when the delete succeeds', async () => {
+      const gamesWrite = makeGamesWrite();
+      const success = buildWriteSuccess();
+      vi.mocked(gamesWrite.deleteGame).mockResolvedValue(success);
+      const result = await makeController(gamesWrite).deleteGame('valheim');
+      expect(result).toEqual(success);
+    });
+
+    it('should throw NotFoundException when the result code is not_found', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.deleteGame).mockResolvedValue({ ok: false, code: 'not_found', message: 'no such game' });
+      await expect(makeController(gamesWrite).deleteGame('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ConflictException with both version ids when the result code is conflict', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.deleteGame).mockResolvedValue({
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'stale',
+        currentVersionId: 'fresh',
+        message: 'stale tfvars version',
+      });
+      await expect(makeController(gamesWrite).deleteGame('valheim', 'stale')).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+      await expect(makeController(gamesWrite).deleteGame('valheim', 'stale')).rejects.toMatchObject({
+        response: { currentVersionId: 'fresh', expectedVersionId: 'stale' },
+      });
+    });
+
+    it('should throw InternalServerErrorException when the result code is error', async () => {
+      const gamesWrite = makeGamesWrite();
+      vi.mocked(gamesWrite.deleteGame).mockResolvedValue({ ok: false, code: 'error', message: 'io error' });
+      await expect(makeController(gamesWrite).deleteGame('valheim')).rejects.toThrow(InternalServerErrorException);
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.test.ts
@@ -67,7 +67,7 @@ function makeGamesWrite(): GamesWriteService {
     createGame: vi.fn(),
     updateGame: vi.fn(),
     deleteGame: vi.fn(),
-  } as unknown as GamesWriteService;
+  } as Partial<GamesWriteService> as GamesWriteService;
 }
 
 /** Build a successful `GameWriteResult` for use in write-endpoint tests. */

--- a/app/packages/desktop-main/src/controllers/games-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games-http.controller.ts
@@ -1,9 +1,29 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
-import type { GameListEntry } from '@hyveon/shared';
+import {
+  Body,
+  ConflictException,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  HttpException,
+  InternalServerErrorException,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import type { GameListEntry, GameServer, GameWriteResult } from '@hyveon/shared';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
 import { TfvarsService } from '../services/TfvarsService.js';
+import { GamesWriteService } from '../services/GamesWriteService.js';
 import { mergeGameLists } from '../services/mergeGameLists.js';
+
+/** Request body for `POST /api/games` and `PATCH /api/games/:name`. */
+interface GameWriteBody {
+  name?: string;
+  config: Omit<GameServer, 'name'>;
+}
 
 /**
  * HTTP shim that exposes the game-server operations as plain REST endpoints
@@ -23,6 +43,7 @@ export class GamesHttpController {
     private readonly config: ConfigService,
     private readonly ecs: EcsService,
     private readonly tfvars: TfvarsService,
+    private readonly gamesWrite: GamesWriteService,
   ) {}
 
   /**
@@ -77,5 +98,88 @@ export class GamesHttpController {
   @Post('stop/:game')
   stop(@Param('game') game: string) {
     return this.ecs.stop(game);
+  }
+
+  /**
+   * Creates a new `game_servers` entry. `If-Match` (optional) is forwarded to
+   * {@link GamesWriteService.createGame} as `expectedVersionId` so the
+   * S3-mode conditional-put guard is honoured. See {@link mapWriteResult} for
+   * the result → HTTP status mapping.
+   */
+  @Post('games')
+  async createGame(
+    @Body() body: GameWriteBody,
+    @Headers('if-match') ifMatch?: string,
+  ): Promise<GameWriteResult> {
+    const result = await this.gamesWrite.createGame({
+      name: body.name ?? '',
+      config: body.config,
+      expectedVersionId: ifMatch,
+    });
+    return this.mapWriteResult(result);
+  }
+
+  /**
+   * Replaces an existing `game_servers` entry, identified by the `:name`
+   * route param. `If-Match` (optional) is forwarded to
+   * {@link GamesWriteService.updateGame} as `expectedVersionId`. See
+   * {@link mapWriteResult} for the result → HTTP status mapping.
+   */
+  @Patch('games/:name')
+  async updateGame(
+    @Param('name') name: string,
+    @Body() body: GameWriteBody,
+    @Headers('if-match') ifMatch?: string,
+  ): Promise<GameWriteResult> {
+    const result = await this.gamesWrite.updateGame({
+      name,
+      config: body.config,
+      expectedVersionId: ifMatch,
+    });
+    return this.mapWriteResult(result);
+  }
+
+  /**
+   * Removes a `game_servers` entry, identified by the `:name` route param.
+   * `If-Match` (optional) is forwarded to
+   * {@link GamesWriteService.deleteGame} as `expectedVersionId`. See
+   * {@link mapWriteResult} for the result → HTTP status mapping.
+   */
+  @Delete('games/:name')
+  async deleteGame(
+    @Param('name') name: string,
+    @Headers('if-match') ifMatch?: string,
+  ): Promise<GameWriteResult> {
+    const result = await this.gamesWrite.deleteGame({ name, expectedVersionId: ifMatch });
+    return this.mapWriteResult(result);
+  }
+
+  /**
+   * Maps a {@link GameWriteResult} from `GamesWriteService` onto its HTTP
+   * representation: `ok: true` passes through as a 200 body; each failure
+   * `code` throws the matching Nest exception so the global exception filter
+   * produces the right status code, with the result's fields preserved on
+   * the exception body (`currentVersionId`/`expectedVersionId` for
+   * conflicts, `issues` for validation failures).
+   */
+  private mapWriteResult(result: GameWriteResult): GameWriteResult {
+    if (result.ok) return result;
+
+    switch (result.code) {
+      case 'conflict':
+        throw new ConflictException({
+          message: result.message,
+          code: result.code,
+          currentVersionId: result.currentVersionId,
+          expectedVersionId: result.expectedVersionId,
+        });
+      case 'validation':
+        throw new HttpException({ code: result.code, issues: result.issues }, 422);
+      case 'not_found':
+        throw new NotFoundException({ message: result.message, code: result.code });
+      case 'error':
+      default:
+        throw new InternalServerErrorException({ message: result.message, code: result.code });
+    }
   }
 }

--- a/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
@@ -204,6 +204,14 @@ describe('GamesController + TfvarsService integration', () => {
  * seeded with the HCL the write actually produced — proves the mutation is
  * visible in the merged games list end-to-end, not just asserted against the
  * `GameWriteResult` return value in isolation.
+ *
+ * `mockRead`/`mockWrite` are backed by a single mutable `currentHcl` string
+ * per test: `mockWrite` overwrites it on every call and `mockRead` always
+ * returns whatever it currently holds, so `GamesWriteService`'s own
+ * post-write `tfvars.getGameServers()` call (inside `successResult()`) sees
+ * the mutation immediately — matching how the real filesystem behaves —
+ * rather than requiring a manual `mockRead.mockReturnValue(...)` reset after
+ * the fact.
  */
 describe('GamesController + GamesWriteService write-then-list round trip', () => {
   beforeEach(() => {
@@ -211,8 +219,12 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
   });
 
   it('should rewrite the tfvars HCL and show the new game as declared on a subsequent games.list when games.create writes a valid entry', async () => {
+    let currentHcl = TFVARS_DECLARING_ARK;
     mockExists.mockReturnValue(true);
-    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+    mockRead.mockImplementation(() => currentHcl);
+    mockWrite.mockImplementation((_path, data) => {
+      currentHcl = data as string;
+    });
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
@@ -223,11 +235,22 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
 
     expect(createResult.ok).toBe(true);
     expect(mockWrite).toHaveBeenCalledTimes(1);
-    const writtenHcl = mockWrite.mock.calls[0]![1] as string;
-    expect(writtenHcl).toContain('minecraft = {');
-
-    // Simulate the write having landed on disk so the next read reflects it.
-    mockRead.mockReturnValue(writtenHcl);
+    expect(currentHcl).toContain('minecraft = {');
+    if (createResult.ok) {
+      expect(createResult.game).toEqual({ name: 'minecraft', ...VALID_MINECRAFT_CONFIG });
+      expect(createResult.games).toHaveLength(2);
+      expect(createResult.games).toEqual(
+        expect.arrayContaining([
+          { name: 'ark', declared: true, deployed: false, config: EXPECTED_ARK_CONFIG },
+          {
+            name: 'minecraft',
+            declared: true,
+            deployed: false,
+            config: { name: 'minecraft', ...VALID_MINECRAFT_CONFIG },
+          },
+        ]),
+      );
+    }
 
     const listResult = await controller.listGames();
 
@@ -246,8 +269,12 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
   });
 
   it("should replace the entry's fields in the emitted HCL and show them updated on a subsequent games.list when games.update writes a valid config", async () => {
+    let currentHcl = TFVARS_DECLARING_ARK;
     mockExists.mockReturnValue(true);
-    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+    mockRead.mockImplementation(() => currentHcl);
+    mockWrite.mockImplementation((_path, data) => {
+      currentHcl = data as string;
+    });
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
@@ -258,11 +285,14 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
 
     expect(updateResult.ok).toBe(true);
     expect(mockWrite).toHaveBeenCalledTimes(1);
-    const writtenHcl = mockWrite.mock.calls[0]![1] as string;
-    expect(writtenHcl).toContain('example/ark-server:v2');
-    expect(writtenHcl).not.toContain(EXPECTED_ARK_CONFIG.image);
-
-    mockRead.mockReturnValue(writtenHcl);
+    expect(currentHcl).toContain('example/ark-server:v2');
+    expect(currentHcl).not.toContain(EXPECTED_ARK_CONFIG.image);
+    if (updateResult.ok) {
+      expect(updateResult.game).toEqual({ name: 'ark', ...UPDATED_ARK_CONFIG });
+      expect(updateResult.games).toEqual([
+        { name: 'ark', declared: true, deployed: false, config: { name: 'ark', ...UPDATED_ARK_CONFIG } },
+      ]);
+    }
 
     const listResult = await controller.listGames();
 
@@ -272,8 +302,12 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
   });
 
   it('should remove the entry so it no longer appears on a subsequent games.list when games.delete succeeds', async () => {
+    let currentHcl = TFVARS_DECLARING_ARK;
     mockExists.mockReturnValue(true);
-    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+    mockRead.mockImplementation(() => currentHcl);
+    mockWrite.mockImplementation((_path, data) => {
+      currentHcl = data as string;
+    });
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
@@ -284,10 +318,11 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
 
     expect(deleteResult.ok).toBe(true);
     expect(mockWrite).toHaveBeenCalledTimes(1);
-    const writtenHcl = mockWrite.mock.calls[0]![1] as string;
-    expect(writtenHcl).not.toContain('ark = {');
-
-    mockRead.mockReturnValue(writtenHcl);
+    expect(currentHcl).not.toContain('ark = {');
+    if (deleteResult.ok) {
+      expect(deleteResult.game).toBeUndefined();
+      expect(deleteResult.games).toEqual([]);
+    }
 
     const listResult = await controller.listGames();
 

--- a/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
@@ -19,22 +19,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('fs', () => ({
   readFileSync: vi.fn(),
   existsSync: vi.fn(),
+  writeFileSync: vi.fn(),
 }));
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
 import type { RemoteFileStore } from '@hyveon/shared';
+import { RemoteFileConflictError } from '@hyveon/shared';
 import { GamesController } from './games.controller.js';
 import { TfvarsService } from '../services/TfvarsService.js';
+import { GamesWriteService } from '../services/GamesWriteService.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
 
 /** Strongly-typed mock handles for the `fs` module. */
 const mockExists = vi.mocked(existsSync);
 const mockRead = vi.mocked(readFileSync);
+const mockWrite = vi.mocked(writeFileSync);
 
 /**
  * Real tfvars HCL text declaring a single game, `ark`. Reused across
@@ -80,23 +84,63 @@ function makeRemoteFileStore(): RemoteFileStore {
   return store as RemoteFileStore;
 }
 
-/** Builds a `ConfigService` stub exposing just what `TfvarsService`/`GamesController` read. */
-function makeConfig(gameNames: string[]): ConfigService {
+/**
+ * Builds a `RemoteFileStore` stub whose `get`/`put` remain directly-controllable
+ * `vi.fn()` spies (unlike {@link makeRemoteFileStore}, which erases the mock
+ * type) — used by the S3-mode conflict spec below to queue per-call
+ * responses, mirroring `TfvarsService.write.test.ts`'s `makeRemoteFileStore()`.
+ */
+function makeSpyableRemoteFileStore(): RemoteFileStore & {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+} {
+  const store: Partial<RemoteFileStore> = {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  };
+  return store as RemoteFileStore & { get: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> };
+}
+
+/**
+ * Builds a `ConfigService` stub exposing just what `TfvarsService`/`GamesController`
+ * read. `bucket` defaults to `null` (local mode); pass a bucket name to
+ * select S3 mode for the conflict spec below.
+ */
+function makeConfig(gameNames: string[], bucket: string | null = null): ConfigService {
   const outputs: Partial<TfOutputs> = { game_names: gameNames };
   const config: Partial<ConfigService> = {
     invalidateCache: vi.fn(),
     getTfOutputs: vi.fn().mockReturnValue(outputs),
-    getTfvarsBucket: () => null,
+    getTfvarsBucket: () => bucket,
     getTfvarsPath: () => '/repo/terraform/terraform.tfvars',
     readEnvTfvarsCacheTtlMs: () => 30000,
   };
   return config as ConfigService;
 }
 
-/** Minimal `EcsService` stub — `listGames()` never calls it, but the constructor requires it. */
+/** Minimal `EcsService` stub — none of the specs in this file call it, but the constructor requires it. */
 function makeEcs(): EcsService {
   return {} as EcsService;
 }
+
+/** Valid, structurally-distinct config used by the `games.create` specs below (a different game from `ark`). */
+const VALID_MINECRAFT_CONFIG = {
+  image: 'example/minecraft-server:latest',
+  cpu: 1024,
+  memory: 2048,
+  ports: [{ container: 25565, protocol: 'tcp' }],
+  volumes: [{ name: 'saves', container_path: '/data' }],
+};
+
+/** Replacement fields for the `ark` entry used by the `games.update` spec below — deliberately different from {@link EXPECTED_ARK_CONFIG}. */
+const UPDATED_ARK_CONFIG = {
+  image: 'example/ark-server:v2',
+  cpu: 4096,
+  memory: 16384,
+  ports: [{ container: 7777, protocol: 'udp' }],
+  volumes: [{ name: 'saves', container_path: '/ark' }],
+};
 
 describe('GamesController + TfvarsService integration', () => {
   beforeEach(() => {
@@ -148,6 +192,174 @@ describe('GamesController + TfvarsService integration', () => {
 
     expect(result).toEqual({
       games: [{ name: 'ark', declared: true, deployed: true, config: EXPECTED_ARK_CONFIG }],
+    });
+  });
+});
+
+/**
+ * Write-then-read round trip specs (see issue #98): a real `GamesWriteService`
+ * (wired to the same real `TfvarsService` + mocked `fs` used above) performs
+ * the `games.create` / `games.update` / `games.delete` mutation, and a
+ * subsequent `listGames()` call — re-reading through the same mocked `fs`,
+ * seeded with the HCL the write actually produced — proves the mutation is
+ * visible in the merged games list end-to-end, not just asserted against the
+ * `GameWriteResult` return value in isolation.
+ */
+describe('GamesController + GamesWriteService write-then-list round trip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should rewrite the tfvars HCL and show the new game as declared on a subsequent games.list when games.create writes a valid entry', async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+
+    const config = makeConfig([]);
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const gamesWrite = new GamesWriteService(config, tfvars);
+    const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
+
+    const createResult = await controller.createGame({ name: 'minecraft', config: VALID_MINECRAFT_CONFIG });
+
+    expect(createResult.ok).toBe(true);
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    const writtenHcl = mockWrite.mock.calls[0]![1] as string;
+    expect(writtenHcl).toContain('minecraft = {');
+
+    // Simulate the write having landed on disk so the next read reflects it.
+    mockRead.mockReturnValue(writtenHcl);
+
+    const listResult = await controller.listGames();
+
+    expect(listResult.games).toHaveLength(2);
+    expect(listResult.games).toEqual(
+      expect.arrayContaining([
+        { name: 'ark', declared: true, deployed: false, config: EXPECTED_ARK_CONFIG },
+        {
+          name: 'minecraft',
+          declared: true,
+          deployed: false,
+          config: { name: 'minecraft', ...VALID_MINECRAFT_CONFIG },
+        },
+      ]),
+    );
+  });
+
+  it("should replace the entry's fields in the emitted HCL and show them updated on a subsequent games.list when games.update writes a valid config", async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+
+    const config = makeConfig([]);
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const gamesWrite = new GamesWriteService(config, tfvars);
+    const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
+
+    const updateResult = await controller.updateGame({ name: 'ark', config: UPDATED_ARK_CONFIG });
+
+    expect(updateResult.ok).toBe(true);
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    const writtenHcl = mockWrite.mock.calls[0]![1] as string;
+    expect(writtenHcl).toContain('example/ark-server:v2');
+    expect(writtenHcl).not.toContain(EXPECTED_ARK_CONFIG.image);
+
+    mockRead.mockReturnValue(writtenHcl);
+
+    const listResult = await controller.listGames();
+
+    expect(listResult).toEqual({
+      games: [{ name: 'ark', declared: true, deployed: false, config: { name: 'ark', ...UPDATED_ARK_CONFIG } }],
+    });
+  });
+
+  it('should remove the entry so it no longer appears on a subsequent games.list when games.delete succeeds', async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+
+    const config = makeConfig([]);
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const gamesWrite = new GamesWriteService(config, tfvars);
+    const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
+
+    const deleteResult = await controller.deleteGame({ name: 'ark' });
+
+    expect(deleteResult.ok).toBe(true);
+    expect(mockWrite).toHaveBeenCalledTimes(1);
+    const writtenHcl = mockWrite.mock.calls[0]![1] as string;
+    expect(writtenHcl).not.toContain('ark = {');
+
+    mockRead.mockReturnValue(writtenHcl);
+
+    const listResult = await controller.listGames();
+
+    expect(listResult).toEqual({ games: [] });
+  });
+});
+
+/**
+ * Failure-path specs for `games.create` (see issue #98): a business-rule
+ * validation failure (Fargate cpu/memory mismatch) must write nothing, and a
+ * stale S3-mode etag must surface as a `'conflict'` result carrying the
+ * store's current version id — exercised against a real `GamesWriteService`
+ * + `TfvarsService`, with only the `RemoteFileStore` stubbed to simulate the
+ * conflicting write (mirroring `TfvarsService.write.test.ts`'s S3-mode specs).
+ */
+describe('GamesController + GamesWriteService games.create failure paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should surface code 'validation' with a per-field issue and write nothing when the proposed config has a Fargate cpu/memory mismatch", async () => {
+    mockExists.mockReturnValue(true);
+    mockRead.mockReturnValue(TFVARS_DECLARING_ARK);
+
+    const config = makeConfig([]);
+    const tfvars = new TfvarsService(config, makeRemoteFileStore());
+    const gamesWrite = new GamesWriteService(config, tfvars);
+    const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
+
+    const result = await controller.createGame({
+      name: 'invalid-pairing',
+      // cpu=256 only pairs with memory 512/1024/2048 MiB — 4096 is not a valid pairing.
+      config: { ...VALID_MINECRAFT_CONFIG, cpu: 256, memory: 4096 },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'validation',
+      issues: expect.arrayContaining([expect.objectContaining({ path: 'memory' })]),
+    });
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("should surface code 'conflict' with the current version id when an S3-mode write hits a stale etag", async () => {
+    const remoteFileStore = makeSpyableRemoteFileStore();
+    remoteFileStore.get
+      // 1st get(): GamesWriteService.createGame()'s sibling lookup (getGameServers()).
+      .mockResolvedValueOnce({ body: new TextEncoder().encode(TFVARS_DECLARING_ARK), etag: 'etag-1' })
+      // 2nd get(): TfvarsService.writeTfvars()'s fetchRawTfvars() before mutating.
+      .mockResolvedValueOnce({ body: new TextEncoder().encode(TFVARS_DECLARING_ARK), etag: 'etag-1' })
+      // 3rd+ get(): the follow-up read TfvarsService issues after the conflict, to report the current etag.
+      .mockResolvedValue({ body: new TextEncoder().encode(TFVARS_DECLARING_ARK), etag: 'etag-2' });
+    remoteFileStore.put.mockRejectedValue(
+      new RemoteFileConflictError('terraform.tfvars', 'Conflicting write detected.', 'etag-1'),
+    );
+
+    const config = makeConfig([], 'my-tfvars-bucket');
+    const tfvars = new TfvarsService(config, remoteFileStore);
+    const gamesWrite = new GamesWriteService(config, tfvars);
+    const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
+
+    const result = await controller.createGame({
+      name: 'minecraft',
+      config: VALID_MINECRAFT_CONFIG,
+      expectedVersionId: 'etag-1',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'conflict',
+      expectedVersionId: 'etag-1',
+      currentVersionId: 'etag-2',
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/games.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.test.ts
@@ -3,8 +3,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { GamesController } from './games.controller.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
+import type { GamesWriteService } from '../services/GamesWriteService.js';
 import type { TfvarsService } from '../services/TfvarsService.js';
-import type { GameServer } from '@hyveon/shared';
+import type { GameServer, GameWriteResult } from '@hyveon/shared';
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -60,6 +61,23 @@ function makeTfvars(declared: GameServer[] = []): TfvarsService {
   } as Partial<TfvarsService> as TfvarsService;
 }
 
+/** A representative successful `GameWriteResult` used as the default stub return value. */
+const DEFAULT_WRITE_RESULT: GameWriteResult = { ok: true, games: [] };
+
+/**
+ * Build a `GamesWriteService` stub with all three write methods pre-wired
+ * to resolve with {@link DEFAULT_WRITE_RESULT}. Individual tests override
+ * the relevant method's resolved value to assert the controller forwards it
+ * verbatim.
+ */
+function makeGamesWrite(): GamesWriteService {
+  return {
+    createGame: vi.fn().mockResolvedValue(DEFAULT_WRITE_RESULT),
+    updateGame: vi.fn().mockResolvedValue(DEFAULT_WRITE_RESULT),
+    deleteGame: vi.fn().mockResolvedValue(DEFAULT_WRITE_RESULT),
+  } as Partial<GamesWriteService> as GamesWriteService;
+}
+
 /**
  * The metadata key NestJS stores on each method decorated with
  * `@MessagePattern`. Asserting this value is the only automated guard
@@ -95,23 +113,38 @@ describe('GamesController', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.stop);
       expect(pattern).toEqual(['games.stop']);
     });
+
+    it('should register createGame on the "games.create" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.createGame);
+      expect(pattern).toEqual(['games.create']);
+    });
+
+    it('should register updateGame on the "games.update" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.updateGame);
+      expect(pattern).toEqual(['games.update']);
+    });
+
+    it('should register deleteGame on the "games.delete" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, GamesController.prototype.deleteGame);
+      expect(pattern).toEqual(['games.delete']);
+    });
   });
 
   describe('listGames', () => {
     it('should invalidate the tfstate cache before reading game names', async () => {
       const config = makeConfig();
-      await new GamesController(config, makeEcs(), makeTfvars()).listGames();
+      await new GamesController(config, makeEcs(), makeTfvars(), makeGamesWrite()).listGames();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should invalidate the TfvarsService cache before reading game names', async () => {
       const tfvars = makeTfvars();
-      await new GamesController(makeConfig(), makeEcs(), tfvars).listGames();
+      await new GamesController(makeConfig(), makeEcs(), tfvars, makeGamesWrite()).listGames();
       expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should return the deployed game names from Terraform outputs when nothing is declared in tfvars', async () => {
-      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars()).listGames();
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars(), makeGamesWrite()).listGames();
       expect(result).toEqual({
         games: [
           { name: 'minecraft', declared: false, deployed: true },
@@ -121,19 +154,19 @@ describe('GamesController', () => {
     });
 
     it('should return an empty games array when Terraform has not been applied yet and nothing is declared', async () => {
-      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars()).listGames();
+      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars(), makeGamesWrite()).listGames();
       expect(result).toEqual({ games: [] });
     });
 
     it('should return a game that exists only in tfvars (declared but not yet applied)', async () => {
       const ark = buildGameServer('ark');
-      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars([ark])).listGames();
+      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars([ark]), makeGamesWrite()).listGames();
       expect(result).toEqual({ games: [{ name: 'ark', declared: true, deployed: false, config: ark }] });
     });
 
     it('should merge declared tfvars games with deployed tfstate games', async () => {
       const palworld = buildGameServer('palworld');
-      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars([palworld])).listGames();
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars([palworld]), makeGamesWrite()).listGames();
       expect(result).toEqual({
         games: [
           { name: 'palworld', declared: true, deployed: true, config: palworld },
@@ -146,32 +179,32 @@ describe('GamesController', () => {
   describe('listStatus', () => {
     it('should invalidate cache before querying ECS', async () => {
       const config = makeConfig();
-      await new GamesController(config, makeEcs(), makeTfvars()).listStatus();
+      await new GamesController(config, makeEcs(), makeTfvars(), makeGamesWrite()).listStatus();
       expect(config.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should invalidate the TfvarsService cache before querying ECS', async () => {
       const tfvars = makeTfvars();
-      await new GamesController(makeConfig(), makeEcs(), tfvars).listStatus();
+      await new GamesController(makeConfig(), makeEcs(), tfvars, makeGamesWrite()).listStatus();
       expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
     });
 
     it('should query ECS status for every game in the Terraform outputs', async () => {
       const ecs = makeEcs();
-      await new GamesController(makeConfig(), ecs, makeTfvars()).listStatus();
+      await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).listStatus();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
       expect(ecs.getStatus).toHaveBeenCalledWith('palworld');
     });
 
     it('should return an empty array when tfstate is absent', async () => {
-      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars()).listStatus();
+      const result = await new GamesController(makeConfig(null), makeEcs(), makeTfvars(), makeGamesWrite()).listStatus();
       expect(result).toEqual([]);
     });
 
     it('should return status entries in the same order as game_names', async () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockImplementation(async (g) => ({ game: g, state: 'stopped' as const }));
-      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).listStatus();
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).listStatus();
       expect(result.map((s) => s.game)).toEqual(['minecraft', 'palworld']);
     });
   });
@@ -181,7 +214,7 @@ describe('GamesController', () => {
       const config = makeConfig();
       const ecs = makeEcs();
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      await new GamesController(config, ecs, makeTfvars()).getStatus('minecraft');
+      await new GamesController(config, ecs, makeTfvars(), makeGamesWrite()).getStatus('minecraft');
       expect(config.invalidateCache).not.toHaveBeenCalled();
       expect(ecs.getStatus).toHaveBeenCalledWith('minecraft');
     });
@@ -190,7 +223,7 @@ describe('GamesController', () => {
       const ecs = makeEcs();
       vi.mocked(ecs.getStatus).mockResolvedValue({ game: 'minecraft', state: 'running' });
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).getStatus('minecraft');
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).getStatus('minecraft');
       expect(result).toEqual({ game: 'minecraft', state: 'running' });
     });
   });
@@ -199,7 +232,7 @@ describe('GamesController', () => {
     it('should delegate to EcsService.start with the game name received via the IPC payload', async () => {
       const ecs = makeEcs();
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      await new GamesController(makeConfig(), ecs, makeTfvars()).start('palworld');
+      await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).start('palworld');
       expect(ecs.start).toHaveBeenCalledWith('palworld');
     });
 
@@ -207,7 +240,7 @@ describe('GamesController', () => {
       const ecs = makeEcs();
       vi.mocked(ecs.start).mockResolvedValue({ success: true, message: 'running', taskArn: 'arn:task' });
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).start('minecraft');
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).start('minecraft');
       expect(result).toMatchObject({ success: true, taskArn: 'arn:task' });
     });
   });
@@ -216,7 +249,7 @@ describe('GamesController', () => {
     it('should delegate to EcsService.stop with the game name received via the IPC payload', async () => {
       const ecs = makeEcs();
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      await new GamesController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
+      await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).stop('minecraft');
       expect(ecs.stop).toHaveBeenCalledWith('minecraft');
     });
 
@@ -224,8 +257,72 @@ describe('GamesController', () => {
       const ecs = makeEcs();
       vi.mocked(ecs.stop).mockResolvedValue({ success: true, message: 'stopped' });
       // Simulates ElectronIPCTransport: @Payload() delivers the game name as the sole argument.
-      const result = await new GamesController(makeConfig(), ecs, makeTfvars()).stop('minecraft');
+      const result = await new GamesController(makeConfig(), ecs, makeTfvars(), makeGamesWrite()).stop('minecraft');
       expect(result).toMatchObject({ success: true, message: 'stopped' });
+    });
+  });
+
+  describe('createGame', () => {
+    it('should forward the payload verbatim to GamesWriteService.createGame via the IPC transport', async () => {
+      const gamesWrite = makeGamesWrite();
+      const config = { name: 'ark', image: 'ark/server:latest', cpu: 1024, memory: 2048, ports: [], volumes: [] };
+      const payload = { name: 'ark', config, expectedVersionId: 'etag-1' };
+      // Simulates ElectronIPCTransport: @Payload() delivers the single-object payload as the sole argument.
+      await new GamesController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite).createGame(payload);
+      expect(gamesWrite.createGame).toHaveBeenCalledWith(payload);
+    });
+
+    it('should return whatever GamesWriteService.createGame returns via the IPC transport', async () => {
+      const gamesWrite = makeGamesWrite();
+      const failure: GameWriteResult = { ok: false, code: 'validation', issues: [{ path: 'name', message: 'required' }] };
+      vi.mocked(gamesWrite.createGame).mockResolvedValue(failure);
+      const config = { name: 'ark', image: 'ark/server:latest', cpu: 1024, memory: 2048, ports: [], volumes: [] };
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite).createGame({ name: 'ark', config });
+      expect(result).toEqual(failure);
+    });
+  });
+
+  describe('updateGame', () => {
+    it('should forward the payload verbatim to GamesWriteService.updateGame via the IPC transport', async () => {
+      const gamesWrite = makeGamesWrite();
+      const config = { name: 'ark', image: 'ark/server:latest', cpu: 1024, memory: 2048, ports: [], volumes: [] };
+      const payload = { name: 'ark', config, expectedVersionId: 'etag-1' };
+      // Simulates ElectronIPCTransport: @Payload() delivers the single-object payload as the sole argument.
+      await new GamesController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite).updateGame(payload);
+      expect(gamesWrite.updateGame).toHaveBeenCalledWith(payload);
+    });
+
+    it('should return whatever GamesWriteService.updateGame returns via the IPC transport', async () => {
+      const gamesWrite = makeGamesWrite();
+      const conflict: GameWriteResult = {
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'etag-1',
+        currentVersionId: 'etag-2',
+        message: 'stale version',
+      };
+      vi.mocked(gamesWrite.updateGame).mockResolvedValue(conflict);
+      const config = { name: 'ark', image: 'ark/server:latest', cpu: 1024, memory: 2048, ports: [], volumes: [] };
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite).updateGame({ name: 'ark', config });
+      expect(result).toEqual(conflict);
+    });
+  });
+
+  describe('deleteGame', () => {
+    it('should forward the payload verbatim to GamesWriteService.deleteGame via the IPC transport', async () => {
+      const gamesWrite = makeGamesWrite();
+      const payload = { name: 'ark', expectedVersionId: 'etag-1' };
+      // Simulates ElectronIPCTransport: @Payload() delivers the single-object payload as the sole argument.
+      await new GamesController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite).deleteGame(payload);
+      expect(gamesWrite.deleteGame).toHaveBeenCalledWith(payload);
+    });
+
+    it('should return whatever GamesWriteService.deleteGame returns via the IPC transport', async () => {
+      const gamesWrite = makeGamesWrite();
+      const notFound: GameWriteResult = { ok: false, code: 'not_found', message: 'no such game' };
+      vi.mocked(gamesWrite.deleteGame).mockResolvedValue(notFound);
+      const result = await new GamesController(makeConfig(), makeEcs(), makeTfvars(), gamesWrite).deleteGame({ name: 'ark' });
+      expect(result).toEqual(notFound);
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/games.controller.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.ts
@@ -1,8 +1,9 @@
 import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
-import type { GameListEntry } from '@hyveon/shared';
+import type { CreateGamePayload, DeleteGamePayload, GameListEntry, GameWriteResult, UpdateGamePayload } from '@hyveon/shared';
 import { ConfigService } from '../services/ConfigService.js';
 import { EcsService } from '../services/EcsService.js';
+import { GamesWriteService } from '../services/GamesWriteService.js';
 import { TfvarsService } from '../services/TfvarsService.js';
 import { mergeGameLists } from '../services/mergeGameLists.js';
 
@@ -22,6 +23,7 @@ export class GamesController {
     private readonly config: ConfigService,
     private readonly ecs: EcsService,
     private readonly tfvars: TfvarsService,
+    private readonly gamesWrite: GamesWriteService,
   ) {}
 
   /**
@@ -93,5 +95,46 @@ export class GamesController {
   @MessagePattern('games.stop')
   stop(@Payload() game: string) {
     return this.ecs.stop(game);
+  }
+
+  /**
+   * Adds a brand-new `game_servers` entry. Delegates entirely to
+   * {@link GamesWriteService.createGame} and returns its `GameWriteResult`
+   * verbatim — never throws, since `ipcMain.handle` strips custom error
+   * properties during serialization and the renderer needs the full
+   * discriminated union (including `code` and `issues`/etags) to react
+   * correctly.
+   *
+   * Reachable via the Electron IPC transport (`games.create`).
+   */
+  @MessagePattern('games.create')
+  createGame(@Payload() payload: CreateGamePayload): Promise<GameWriteResult> {
+    return this.gamesWrite.createGame(payload);
+  }
+
+  /**
+   * Replaces an existing `game_servers` entry's value in place. Delegates
+   * entirely to {@link GamesWriteService.updateGame} and returns its
+   * `GameWriteResult` verbatim — never throws, for the same
+   * serialization-safety reason as {@link createGame}.
+   *
+   * Reachable via the Electron IPC transport (`games.update`).
+   */
+  @MessagePattern('games.update')
+  updateGame(@Payload() payload: UpdateGamePayload): Promise<GameWriteResult> {
+    return this.gamesWrite.updateGame(payload);
+  }
+
+  /**
+   * Removes a `game_servers` entry. Delegates entirely to
+   * {@link GamesWriteService.deleteGame} and returns its `GameWriteResult`
+   * verbatim — never throws, for the same serialization-safety reason as
+   * {@link createGame}.
+   *
+   * Reachable via the Electron IPC transport (`games.delete`).
+   */
+  @MessagePattern('games.delete')
+  deleteGame(@Payload() payload: DeleteGamePayload): Promise<GameWriteResult> {
+    return this.gamesWrite.deleteGame(payload);
   }
 }

--- a/app/packages/desktop-main/src/services/GamesWriteService.test.ts
+++ b/app/packages/desktop-main/src/services/GamesWriteService.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import type { GameServer } from '@hyveon/shared';
+import { OptimisticLockError } from '@hyveon/shared';
+import { GamesWriteService } from './GamesWriteService.js';
+import type { ConfigService, TfOutputs } from './ConfigService.js';
+import type { TfvarsService } from './TfvarsService.js';
+import { HclSurgeonError } from './hclSurgeon.js';
+import { logger } from '../logger.js';
+
+/** Minimal, valid `GameServer` fixture matching the Fargate cpu/memory pairing table. */
+function buildGameServer(name: string, overrides: Partial<GameServer> = {}): GameServer {
+  return {
+    name,
+    image: 'example/image:latest',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'saves', container_path: '/data' }],
+    ...overrides,
+  };
+}
+
+/** Structurally-valid config payload (everything but `name`) for a `CreateGamePayload`/`UpdateGamePayload`. */
+function buildConfig(overrides: Partial<Omit<GameServer, 'name'>> = {}): Omit<GameServer, 'name'> {
+  const { name: _name, ...config } = buildGameServer('unused', overrides);
+  return config;
+}
+
+/** Build a ConfigService stub with `invalidateCache`, `getTfOutputs`, and `getTfvarsBucket` pre-wired. */
+function makeConfig(options: { outputs?: Partial<TfOutputs> | null; bucket?: string | null } = {}): ConfigService {
+  const { outputs = { game_names: [] }, bucket = null } = options;
+  return {
+    invalidateCache: vi.fn(),
+    getTfOutputs: vi.fn().mockReturnValue(outputs),
+    getTfvarsBucket: vi.fn().mockReturnValue(bucket),
+  } as Partial<ConfigService> as ConfigService;
+}
+
+/** Build a TfvarsService stub with every method `GamesWriteService` touches pre-wired to succeed. */
+function makeTfvars(declared: GameServer[] = []): TfvarsService {
+  return {
+    invalidateCache: vi.fn(),
+    getGameServers: vi.fn().mockResolvedValue(declared),
+    addGameServer: vi.fn().mockResolvedValue(undefined),
+    updateGameServer: vi.fn().mockResolvedValue(undefined),
+    removeGameServer: vi.fn().mockResolvedValue(undefined),
+  } as Partial<TfvarsService> as TfvarsService;
+}
+
+describe('GamesWriteService', () => {
+  beforeEach(() => {
+    vi.mocked(logger.info).mockClear();
+  });
+
+  describe('createGame', () => {
+    it('should write the new entry and return the updated game plus the refreshed games list on success', async () => {
+      const tfvars = makeTfvars();
+      const config = makeConfig({ outputs: { game_names: ['minecraft'] } });
+      const service = new GamesWriteService(config, tfvars);
+
+      const result = await service.createGame({ name: 'ark', config: buildConfig(), expectedVersionId: 'v1' });
+
+      expect(tfvars.addGameServer).toHaveBeenCalledWith('ark', buildConfig(), 'v1');
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
+      expect(config.invalidateCache).toHaveBeenCalledOnce();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.game).toEqual(buildGameServer('ark'));
+        expect(result.games).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'minecraft' })]));
+      }
+    });
+
+    it('should emit a structured audit log entry noting local mode when no tfvars bucket is configured', async () => {
+      const service = new GamesWriteService(makeConfig({ bucket: null }), makeTfvars());
+
+      await service.createGame({ name: 'ark', config: buildConfig() });
+
+      expect(logger.info).toHaveBeenCalledWith('Game server write', { action: 'create', game: 'ark', mode: 'local' });
+    });
+
+    it('should emit a structured audit log entry noting s3 mode when a tfvars bucket is configured', async () => {
+      const service = new GamesWriteService(makeConfig({ bucket: 'my-bucket' }), makeTfvars());
+
+      await service.createGame({ name: 'ark', config: buildConfig() });
+
+      expect(logger.info).toHaveBeenCalledWith('Game server write', { action: 'create', game: 'ark', mode: 's3' });
+    });
+
+    it('should return a validation failure without writing when the proposed config fails business-rule validation', async () => {
+      const tfvars = makeTfvars();
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.createGame({ name: 'ark', config: buildConfig({ cpu: 256, memory: 4096 }) });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'validation',
+        issues: expect.arrayContaining([expect.objectContaining({ path: 'memory' })]),
+      });
+      expect(tfvars.addGameServer).not.toHaveBeenCalled();
+    });
+
+    it('should return a conflict result with both etags when the write raises OptimisticLockError', async () => {
+      const tfvars = makeTfvars();
+      tfvars.addGameServer = vi.fn().mockRejectedValue(new OptimisticLockError('old-etag', 'new-etag'));
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.createGame({ name: 'ark', config: buildConfig(), expectedVersionId: 'old-etag' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'old-etag',
+        currentVersionId: 'new-etag',
+      });
+    });
+
+    it('should return a validation failure with a name-path issue when the entry name already exists', async () => {
+      const tfvars = makeTfvars();
+      tfvars.addGameServer = vi
+        .fn()
+        .mockRejectedValue(
+          new HclSurgeonError('Entry "ark" already exists in "game_servers" — use updateGameServer() instead.'),
+        );
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.createGame({ name: 'ark', config: buildConfig() });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'validation',
+        issues: [{ path: 'name', message: expect.stringContaining('already exists') }],
+      });
+    });
+
+    it('should return a catch-all error result when the write raises an unexpected error', async () => {
+      const tfvars = makeTfvars();
+      tfvars.addGameServer = vi.fn().mockRejectedValue(new Error('disk full'));
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.createGame({ name: 'ark', config: buildConfig() });
+
+      expect(result).toEqual({ ok: false, code: 'error', message: 'disk full' });
+    });
+  });
+
+  describe('updateGame', () => {
+    it('should write the updated entry and return the updated game plus the refreshed games list on success', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      const config = makeConfig({ outputs: { game_names: ['minecraft'] } });
+      const service = new GamesWriteService(config, tfvars);
+      const newConfig = buildConfig({ cpu: 2048, memory: 4096 });
+
+      const result = await service.updateGame({ name: 'minecraft', config: newConfig, expectedVersionId: 'v1' });
+
+      expect(tfvars.updateGameServer).toHaveBeenCalledWith('minecraft', newConfig, 'v1');
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
+      expect(config.invalidateCache).toHaveBeenCalledOnce();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.game).toEqual(buildGameServer('minecraft', { cpu: 2048, memory: 4096 }));
+      }
+    });
+
+    it('should return a validation failure without writing when the proposed config fails business-rule validation', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.updateGame({
+        name: 'minecraft',
+        config: buildConfig({ cpu: 256, memory: 4096 }),
+      });
+
+      expect(result).toMatchObject({ ok: false, code: 'validation' });
+      expect(tfvars.updateGameServer).not.toHaveBeenCalled();
+    });
+
+    it('should return a conflict result with both etags when the write raises OptimisticLockError', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      tfvars.updateGameServer = vi.fn().mockRejectedValue(new OptimisticLockError('old-etag', 'new-etag'));
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.updateGame({
+        name: 'minecraft',
+        config: buildConfig(),
+        expectedVersionId: 'old-etag',
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'old-etag',
+        currentVersionId: 'new-etag',
+      });
+    });
+
+    it('should return a not_found result when the target game does not exist in game_servers', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      tfvars.updateGameServer = vi.fn().mockRejectedValue(new HclSurgeonError('Entry "ark" not found in "game_servers".'));
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.updateGame({
+        name: 'ark',
+        config: buildConfig({ ports: [{ container: 7777, protocol: 'udp' }] }),
+      });
+
+      expect(result).toEqual({ ok: false, code: 'not_found', message: expect.stringContaining('not found') });
+    });
+  });
+
+  describe('deleteGame', () => {
+    it('should remove the entry and return the refreshed games list without a game field on success', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      const config = makeConfig({ outputs: { game_names: [] } });
+      const service = new GamesWriteService(config, tfvars);
+
+      const result = await service.deleteGame({ name: 'minecraft', expectedVersionId: 'v1' });
+
+      expect(tfvars.removeGameServer).toHaveBeenCalledWith('minecraft', 'v1');
+      expect(tfvars.invalidateCache).toHaveBeenCalledOnce();
+      expect(config.invalidateCache).toHaveBeenCalledOnce();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.game).toBeUndefined();
+      }
+    });
+
+    it('should emit a structured audit log entry with the game name even though no game object is returned', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      const service = new GamesWriteService(makeConfig({ bucket: 'my-bucket' }), tfvars);
+
+      await service.deleteGame({ name: 'minecraft' });
+
+      expect(logger.info).toHaveBeenCalledWith('Game server write', { action: 'delete', game: 'minecraft', mode: 's3' });
+    });
+
+    it('should return a conflict result with both etags when the write raises OptimisticLockError', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      tfvars.removeGameServer = vi.fn().mockRejectedValue(new OptimisticLockError('old-etag', 'new-etag'));
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.deleteGame({ name: 'minecraft', expectedVersionId: 'old-etag' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: 'conflict',
+        expectedVersionId: 'old-etag',
+        currentVersionId: 'new-etag',
+      });
+    });
+
+    it('should return a not_found result when the target game does not exist in game_servers', async () => {
+      const tfvars = makeTfvars([]);
+      tfvars.removeGameServer = vi.fn().mockRejectedValue(new HclSurgeonError('Entry "ark" not found in "game_servers".'));
+      const service = new GamesWriteService(makeConfig(), tfvars);
+
+      const result = await service.deleteGame({ name: 'ark' });
+
+      expect(result).toEqual({ ok: false, code: 'not_found', message: expect.stringContaining('not found') });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/GamesWriteService.test.ts
+++ b/app/packages/desktop-main/src/services/GamesWriteService.test.ts
@@ -125,7 +125,10 @@ describe('GamesWriteService', () => {
       tfvars.addGameServer = vi
         .fn()
         .mockRejectedValue(
-          new HclSurgeonError('Entry "ark" already exists in "game_servers" — use updateGameServer() instead.'),
+          new HclSurgeonError(
+            'Entry "ark" already exists in "game_servers" — use updateGameServer() instead.',
+            'duplicate-name',
+          ),
         );
       const service = new GamesWriteService(makeConfig(), tfvars);
 
@@ -140,12 +143,36 @@ describe('GamesWriteService', () => {
 
     it('should return a catch-all error result when the write raises an unexpected error', async () => {
       const tfvars = makeTfvars();
-      tfvars.addGameServer = vi.fn().mockRejectedValue(new Error('disk full'));
+      const originalError = new Error('disk full');
+      tfvars.addGameServer = vi.fn().mockRejectedValue(originalError);
       const service = new GamesWriteService(makeConfig(), tfvars);
+      const loggerErrorSpy = vi.spyOn(logger, 'error');
 
       const result = await service.createGame({ name: 'ark', config: buildConfig() });
 
-      expect(result).toEqual({ ok: false, code: 'error', message: 'disk full' });
+      expect(result).toEqual({
+        ok: false,
+        code: 'error',
+        message: 'An unexpected error occurred while writing the game server configuration',
+      });
+      expect(loggerErrorSpy).toHaveBeenCalledWith('Game server write failed', { err: originalError });
+    });
+
+    it('should return a catch-all error result (not a name-validation issue) when addGameServer() throws a structural HclSurgeonError', async () => {
+      const tfvars = makeTfvars();
+      const structuralError = new HclSurgeonError('"game_servers" map not found in tfvars source.');
+      tfvars.addGameServer = vi.fn().mockRejectedValue(structuralError);
+      const service = new GamesWriteService(makeConfig(), tfvars);
+      const loggerErrorSpy = vi.spyOn(logger, 'error');
+
+      const result = await service.createGame({ name: 'ark', config: buildConfig() });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'error',
+        message: 'An unexpected error occurred while writing the game server configuration',
+      });
+      expect(loggerErrorSpy).toHaveBeenCalledWith('Game server write failed', { err: structuralError });
     });
   });
 

--- a/app/packages/desktop-main/src/services/GamesWriteService.ts
+++ b/app/packages/desktop-main/src/services/GamesWriteService.ts
@@ -1,0 +1,192 @@
+/**
+ * Write-side orchestrator for the `games.create` / `games.update` /
+ * `games.delete` IPC channels (and their HTTP equivalents) — see issue #98.
+ *
+ * Each operation follows the same shape:
+ *  1. Validate the proposed entry via `validateGameServer()` (skipped for
+ *     `deleteGame`, which has no config to validate), using the current
+ *     declared `game_servers` list (`TfvarsService.getGameServers()`) as the
+ *     sibling set for the cross-game port-collision check.
+ *  2. Delegate the actual HCL mutation to `TfvarsService.addGameServer()` /
+ *     `updateGameServer()` / `removeGameServer()`, forwarding
+ *     `expectedVersionId` so the S3-mode conditional-put guard is honoured.
+ *  3. Translate the handful of error shapes those calls can throw into the
+ *     matching `GameWriteResult` failure variant (see the per-method docs
+ *     below for the exact mapping).
+ *  4. On success, invalidate both the `TfvarsService` and `ConfigService`
+ *     caches, emit a structured audit log entry, and return the updated game
+ *     plus a freshly `mergeGameLists()`d games list so callers can refresh
+ *     their view without a second round trip.
+ */
+import { Injectable } from '@nestjs/common';
+import type { CreateGamePayload, DeleteGamePayload, GameServer, GameWriteResult, UpdateGamePayload } from '@hyveon/shared';
+import { OptimisticLockError, validateGameServer } from '@hyveon/shared';
+import { logger } from '../logger.js';
+import { ConfigService } from './ConfigService.js';
+import { TfvarsService } from './TfvarsService.js';
+import { HclSurgeonError } from './hclSurgeon.js';
+import { mergeGameLists } from './mergeGameLists.js';
+
+/** The three write operations this service performs — used to tag the audit log entry. */
+type GameWriteAction = 'create' | 'update' | 'delete';
+
+/**
+ * Validates and writes `game_servers` create/update/delete requests — see
+ * the file-level doc comment above for the full flow. A thin orchestration
+ * layer over `TfvarsService` (the actual HCL mutation) and
+ * `validateGameServer` (the shared structural/business-rule validator);
+ * holds no state of its own.
+ */
+@Injectable()
+export class GamesWriteService {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly tfvars: TfvarsService,
+  ) {}
+
+  /**
+   * Adds a brand-new `game_servers` entry. Validates `payload.config` via
+   * `validateGameServer()` against every currently-declared game (so a port
+   * collision against an existing game is caught), then delegates to
+   * `TfvarsService.addGameServer()`.
+   *
+   * Failure mapping:
+   *  - Structural/business-rule validation failure → `{ code: 'validation' }`
+   *    with the full issue list.
+   *  - `OptimisticLockError` (stale `expectedVersionId`) → `{ code: 'conflict' }`
+   *    with both etags.
+   *  - `HclSurgeonError` (name already exists in `game_servers`) →
+   *    `{ code: 'validation' }` with a single `path: 'name'` issue.
+   */
+  async createGame(payload: CreateGamePayload): Promise<GameWriteResult> {
+    const siblings = await this.tfvars.getGameServers();
+    const validation = validateGameServer(payload.name, payload.config, siblings);
+    if (!validation.success) {
+      return { ok: false, code: 'validation', issues: validation.issues };
+    }
+
+    const { name, ...config } = validation.data;
+    try {
+      await this.tfvars.addGameServer(name, config, payload.expectedVersionId);
+    } catch (err) {
+      if (err instanceof OptimisticLockError) {
+        return this.conflictResult(err);
+      }
+      if (err instanceof HclSurgeonError) {
+        return { ok: false, code: 'validation', issues: [{ path: 'name', message: err.message }] };
+      }
+      return this.errorResult(err);
+    }
+
+    return this.successResult('create', name, validation.data);
+  }
+
+  /**
+   * Replaces an existing `game_servers` entry's value in place. Validates
+   * `payload.config` via `validateGameServer()` against every declared game
+   * (the entry being edited is skipped for self-collisions by
+   * `validateGameServer()` itself), then delegates to
+   * `TfvarsService.updateGameServer()`.
+   *
+   * Failure mapping:
+   *  - Structural/business-rule validation failure → `{ code: 'validation' }`
+   *    with the full issue list.
+   *  - `OptimisticLockError` (stale `expectedVersionId`) → `{ code: 'conflict' }`
+   *    with both etags.
+   *  - `HclSurgeonError` (`payload.name` doesn't exist in `game_servers`) →
+   *    `{ code: 'not_found' }`.
+   */
+  async updateGame(payload: UpdateGamePayload): Promise<GameWriteResult> {
+    const siblings = await this.tfvars.getGameServers();
+    const validation = validateGameServer(payload.name, payload.config, siblings);
+    if (!validation.success) {
+      return { ok: false, code: 'validation', issues: validation.issues };
+    }
+
+    const { name, ...config } = validation.data;
+    try {
+      await this.tfvars.updateGameServer(name, config, payload.expectedVersionId);
+    } catch (err) {
+      if (err instanceof OptimisticLockError) {
+        return this.conflictResult(err);
+      }
+      if (err instanceof HclSurgeonError) {
+        return { ok: false, code: 'not_found', message: err.message };
+      }
+      return this.errorResult(err);
+    }
+
+    return this.successResult('update', name, validation.data);
+  }
+
+  /**
+   * Removes a `game_servers` entry. Skips `validateGameServer()` entirely —
+   * there's no proposed config to validate — and delegates straight to
+   * `TfvarsService.removeGameServer()`.
+   *
+   * Failure mapping:
+   *  - `OptimisticLockError` (stale `expectedVersionId`) → `{ code: 'conflict' }`
+   *    with both etags.
+   *  - `HclSurgeonError` (`payload.name` doesn't exist in `game_servers`) →
+   *    `{ code: 'not_found' }`.
+   */
+  async deleteGame(payload: DeleteGamePayload): Promise<GameWriteResult> {
+    try {
+      await this.tfvars.removeGameServer(payload.name, payload.expectedVersionId);
+    } catch (err) {
+      if (err instanceof OptimisticLockError) {
+        return this.conflictResult(err);
+      }
+      if (err instanceof HclSurgeonError) {
+        return { ok: false, code: 'not_found', message: err.message };
+      }
+      return this.errorResult(err);
+    }
+
+    return this.successResult('delete', payload.name);
+  }
+
+  /**
+   * Shared success path for all three operations: invalidates both the
+   * `TfvarsService` and `ConfigService` caches so the next read reflects the
+   * write, emits a structured audit log entry (action, game name, and
+   * whether the write went to the S3 tfvars backend or the local file — see
+   * `ConfigService.getTfvarsBucket()`), and builds the refreshed
+   * `mergeGameLists()` list. `game` is omitted for `'delete'`, matching
+   * `GameWriteSuccess.game`'s "omitted for a delete" contract — `name` is
+   * passed separately so the audit entry still records which game was
+   * affected even when there's no `game` object to pull it from.
+   */
+  private async successResult(action: GameWriteAction, name: string, game?: GameServer): Promise<GameWriteResult> {
+    this.tfvars.invalidateCache();
+    this.config.invalidateCache();
+
+    logger.info('Game server write', {
+      action,
+      game: name,
+      mode: this.config.getTfvarsBucket() ? 's3' : 'local',
+    });
+
+    const declared = await this.tfvars.getGameServers();
+    const outputs = this.config.getTfOutputs();
+    const games = mergeGameLists(declared, outputs?.game_names ?? []);
+
+    return { ok: true, game, games };
+  }
+
+  /** Builds a `GameWriteConflict` from a caught {@link OptimisticLockError}, forwarding both etags. */
+  private conflictResult(err: OptimisticLockError): GameWriteResult {
+    return {
+      ok: false,
+      code: 'conflict',
+      expectedVersionId: err.expectedEtag,
+      currentVersionId: err.currentEtag,
+      message: err.message,
+    };
+  }
+
+  /** Builds the catch-all `GameWriteFailure` for any error that isn't a conflict/validation/not-found (e.g. filesystem I/O). */
+  private errorResult(err: unknown): GameWriteResult {
+    return { ok: false, code: 'error', message: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/app/packages/desktop-main/src/services/GamesWriteService.ts
+++ b/app/packages/desktop-main/src/services/GamesWriteService.ts
@@ -55,8 +55,12 @@ export class GamesWriteService {
    *    with the full issue list.
    *  - `OptimisticLockError` (stale `expectedVersionId`) → `{ code: 'conflict' }`
    *    with both etags.
-   *  - `HclSurgeonError` (name already exists in `game_servers`) →
+   *  - `HclSurgeonError` with `reason: 'invalid-name'` or `'duplicate-name'`
+   *    (the proposed name is malformed, or already exists in `game_servers`) →
    *    `{ code: 'validation' }` with a single `path: 'name'` issue.
+   *  - `HclSurgeonError` with `reason: 'structural'` (e.g. the `game_servers`
+   *    map itself can't be located in the source HCL) → the catch-all
+   *    `{ code: 'error' }`, since it isn't a name problem at all.
    */
   async createGame(payload: CreateGamePayload): Promise<GameWriteResult> {
     const siblings = await this.tfvars.getGameServers();
@@ -72,7 +76,7 @@ export class GamesWriteService {
       if (err instanceof OptimisticLockError) {
         return this.conflictResult(err);
       }
-      if (err instanceof HclSurgeonError) {
+      if (err instanceof HclSurgeonError && (err.reason === 'invalid-name' || err.reason === 'duplicate-name')) {
         return { ok: false, code: 'validation', issues: [{ path: 'name', message: err.message }] };
       }
       return this.errorResult(err);
@@ -185,8 +189,15 @@ export class GamesWriteService {
     };
   }
 
-  /** Builds the catch-all `GameWriteFailure` for any error that isn't a conflict/validation/not-found (e.g. filesystem I/O). */
+  /**
+   * Builds the catch-all `GameWriteFailure` for any error that isn't a
+   * conflict/validation/not-found (e.g. filesystem I/O). Logs the original
+   * error server-side but returns a stable, generic message to the caller —
+   * the raw error can contain filesystem paths or other infra details that
+   * shouldn't be forwarded verbatim as an HTTP 500 body.
+   */
   private errorResult(err: unknown): GameWriteResult {
-    return { ok: false, code: 'error', message: err instanceof Error ? err.message : String(err) };
+    logger.error('Game server write failed', { err });
+    return { ok: false, code: 'error', message: 'An unexpected error occurred while writing the game server configuration' };
   }
 }

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -404,11 +404,15 @@ export class TfvarsService {
     if (!HCL_IDENTIFIER_PATTERN.test(name)) {
       throw new HclSurgeonError(
         `Entry name "${name}" is not a valid HCL identifier — must match ${HCL_IDENTIFIER_PATTERN}.`,
+        'invalid-name',
       );
     }
 
     if (locateEntry(hcl, 'game_servers', name)) {
-      throw new HclSurgeonError(`Entry "${name}" already exists in "game_servers" — use updateGameServer() instead.`);
+      throw new HclSurgeonError(
+        `Entry "${name}" already exists in "game_servers" — use updateGameServer() instead.`,
+        'duplicate-name',
+      );
     }
 
     const mapBody = locateMapBody(hcl, 'game_servers');

--- a/app/packages/desktop-main/src/services/hclSurgeon.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.ts
@@ -24,8 +24,29 @@
  * `GameServer` object) are out of scope here and belong in `TfvarsService`.
  */
 
-/** Thrown when the requested map/entry can't be located or the source HCL is malformed (unterminated bracket/string/heredoc). */
-export class HclSurgeonError extends Error {}
+/**
+ * Categorizes why a {@link HclSurgeonError} was thrown, so callers (e.g.
+ * `GamesWriteService.createGame()`) can distinguish a name-specific failure
+ * from a structural one instead of collapsing every `HclSurgeonError` into
+ * the same result shape:
+ *  - `'invalid-name'` — the proposed entry key isn't a valid bare HCL
+ *    identifier.
+ *  - `'duplicate-name'` — the proposed entry key already exists in the map.
+ *  - `'structural'` — everything else: the map/entry couldn't be located, or
+ *    the source HCL itself is malformed (unterminated bracket/string/heredoc).
+ */
+export type HclSurgeonErrorReason = 'invalid-name' | 'duplicate-name' | 'structural';
+
+/** Thrown when the requested map/entry can't be located or the source HCL is malformed (unterminated bracket/string/heredoc). See {@link HclSurgeonErrorReason} for the `reason` this carries. */
+export class HclSurgeonError extends Error {
+  /** Why this error was thrown — see {@link HclSurgeonErrorReason}. Defaults to `'structural'` for call sites that don't have a more specific reason to report. */
+  readonly reason: HclSurgeonErrorReason;
+
+  constructor(message: string, reason: HclSurgeonErrorReason = 'structural') {
+    super(message);
+    this.reason = reason;
+  }
+}
 
 /**
  * Byte span of a single `entryKey = <value>` assignment inside a map's

--- a/app/packages/desktop-main/src/services/hclSurgeon.ts
+++ b/app/packages/desktop-main/src/services/hclSurgeon.ts
@@ -37,7 +37,7 @@
  */
 export type HclSurgeonErrorReason = 'invalid-name' | 'duplicate-name' | 'structural';
 
-/** Thrown when the requested map/entry can't be located or the source HCL is malformed (unterminated bracket/string/heredoc). See {@link HclSurgeonErrorReason} for the `reason` this carries. */
+/** Thrown for any failure this module detects — invalid/duplicate entry names as well as structural issues (map/entry not found, malformed source HCL). See {@link HclSurgeonErrorReason} for the specific `reason` this carries. */
 export class HclSurgeonError extends Error {
   /** Why this error was thrown — see {@link HclSurgeonErrorReason}. Defaults to `'structural'` for call sites that don't have a more specific reason to report. */
   readonly reason: HclSurgeonErrorReason;

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -262,6 +262,143 @@ export interface GameListEntry {
   config?: GameServer;
 }
 
+/**
+ * A single structural or business-rule validation failure for a proposed
+ * `game_servers` entry.
+ *
+ * Mirrors `GameServerValidationIssue` in
+ * `@hyveon/shared/src/gameServerValidator.ts` — that file is the source of
+ * truth; keep this copy in sync with it.
+ */
+export interface GameServerValidationIssue {
+  path: string;
+  message: string;
+}
+
+/**
+ * Successful create/update/delete. `game` is the affected entry's
+ * post-write config (omitted for a delete); `games` is the full, freshly
+ * merged games list so callers can refresh their view without a second
+ * round trip.
+ *
+ * Mirrors `GameWriteSuccess` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteSuccess {
+  ok: true;
+  game?: GameServer;
+  games: GameListEntry[];
+}
+
+/**
+ * The write was rejected because the caller's `expectedVersionId` didn't
+ * match the current tfvars file version — someone else edited
+ * `terraform.tfvars` since the caller last read it. `currentVersionId` lets
+ * the caller re-fetch and retry.
+ *
+ * Mirrors `GameWriteConflict` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteConflict {
+  ok: false;
+  code: 'conflict';
+  expectedVersionId?: string;
+  currentVersionId?: string;
+  message: string;
+}
+
+/**
+ * The proposed `game_servers` entry failed {@link GameServerValidationIssue}-shaped
+ * structural or business-rule validation.
+ *
+ * Mirrors `GameWriteValidationFailure` in `@hyveon/shared/src/gamesWrite.ts`
+ * — that file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteValidationFailure {
+  ok: false;
+  code: 'validation';
+  issues: GameServerValidationIssue[];
+}
+
+/**
+ * The named game does not exist (e.g. update/delete targeting an
+ * undeclared game).
+ *
+ * Mirrors `GameWriteNotFound` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteNotFound {
+  ok: false;
+  code: 'not_found';
+  message: string;
+}
+
+/**
+ * Catch-all failure for errors that aren't a conflict, validation failure,
+ * or not-found (e.g. filesystem I/O).
+ *
+ * Mirrors `GameWriteFailure` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteFailure {
+  ok: false;
+  code: 'error';
+  message: string;
+}
+
+/**
+ * Discriminated union returned by the `games.create` / `games.update` /
+ * `games.delete` handlers. Discriminate on `ok` first, then `code` for the
+ * failure branches.
+ *
+ * Mirrors `GameWriteResult` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export type GameWriteResult =
+  | GameWriteSuccess
+  | GameWriteConflict
+  | GameWriteValidationFailure
+  | GameWriteNotFound
+  | GameWriteFailure;
+
+/**
+ * Request payload for `games.create`. `expectedVersionId`, when supplied,
+ * is checked against the current tfvars file version and a
+ * {@link GameWriteConflict} is returned on mismatch.
+ *
+ * Mirrors `CreateGamePayload` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface CreateGamePayload {
+  name: string;
+  config: Omit<GameServer, 'name'>;
+  expectedVersionId?: string;
+}
+
+/**
+ * Request payload for `games.update`. Same shape as {@link CreateGamePayload}
+ * — `name` identifies the existing game to overwrite with `config`.
+ *
+ * Mirrors `UpdateGamePayload` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface UpdateGamePayload {
+  name: string;
+  config: Omit<GameServer, 'name'>;
+  expectedVersionId?: string;
+}
+
+/**
+ * Request payload for `games.delete`.
+ *
+ * Mirrors `DeleteGamePayload` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface DeleteGamePayload {
+  name: string;
+  expectedVersionId?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Per-namespace sub-interfaces
 // ---------------------------------------------------------------------------
@@ -278,6 +415,12 @@ export interface GsdGamesApi {
   start: (game: string) => Promise<StartResult>;
   /** Stops the running ECS task for `game`. */
   stop: (game: string) => Promise<StartResult>;
+  /** Adds a new entry to the tfvars `game_servers` map. */
+  create: (payload: CreateGamePayload) => Promise<GameWriteResult>;
+  /** Overwrites an existing entry in the tfvars `game_servers` map. */
+  update: (payload: UpdateGamePayload) => Promise<GameWriteResult>;
+  /** Removes an entry from the tfvars `game_servers` map. */
+  delete: (payload: DeleteGamePayload) => Promise<GameWriteResult>;
 }
 
 /** Cost endpoints: forward-looking Fargate estimates and historical CE data. */

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -137,6 +137,39 @@ describe('preload dispatcher', () => {
 
       expect(ipcInvoke).toHaveBeenCalledWith('env.get');
     });
+
+    it('should forward games.create with a single payload object to ipcRenderer.invoke', async () => {
+      const writeResult = { ok: true, games: [] };
+      ipcInvoke.mockResolvedValue(writeResult);
+      const games = bridge['games'] as { create: (payload: unknown) => Promise<unknown> };
+      const payload = { name: 'minecraft', config: { image: 'itzg/minecraft-server', cpu: 512, memory: 1024, ports: [], volumes: [] } };
+      const result = await games.create(payload);
+
+      expect(ipcInvoke).toHaveBeenCalledWith('games.create', payload);
+      expect(result).toEqual(writeResult);
+    });
+
+    it('should forward games.update with a single payload object to ipcRenderer.invoke', async () => {
+      const writeResult = { ok: true, games: [] };
+      ipcInvoke.mockResolvedValue(writeResult);
+      const games = bridge['games'] as { update: (payload: unknown) => Promise<unknown> };
+      const payload = { name: 'minecraft', config: { image: 'itzg/minecraft-server', cpu: 512, memory: 1024, ports: [], volumes: [] } };
+      const result = await games.update(payload);
+
+      expect(ipcInvoke).toHaveBeenCalledWith('games.update', payload);
+      expect(result).toEqual(writeResult);
+    });
+
+    it('should forward games.delete with a single payload object to ipcRenderer.invoke', async () => {
+      const writeResult = { ok: true, games: [] };
+      ipcInvoke.mockResolvedValue(writeResult);
+      const games = bridge['games'] as { delete: (payload: unknown) => Promise<unknown> };
+      const payload = { name: 'minecraft' };
+      const result = await games.delete(payload);
+
+      expect(ipcInvoke).toHaveBeenCalledWith('games.delete', payload);
+      expect(result).toEqual(writeResult);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -222,6 +255,48 @@ describe('preload dispatcher', () => {
 
       await expect(games.list()).rejects.toThrow('mock-error');
       expect(ipcInvoke).not.toHaveBeenCalled();
+    });
+
+    it('should call the registered games.create mock with the single payload object instead of ipcRenderer.invoke', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      const mockHandler = vi.fn().mockResolvedValue({ ok: true, games: [] });
+      testApi.mock('games.create', mockHandler);
+
+      const games = bridge['games'] as { create: (payload: unknown) => Promise<unknown> };
+      const payload = { name: 'valheim', config: { image: 'lloesche/valheim-server', cpu: 1024, memory: 2048, ports: [], volumes: [] } };
+      const result = await games.create(payload);
+
+      expect(mockHandler).toHaveBeenCalledWith(payload);
+      expect(ipcInvoke).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true, games: [] });
+    });
+
+    it('should call the registered games.update mock with the single payload object instead of ipcRenderer.invoke', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      const mockHandler = vi.fn().mockResolvedValue({ ok: true, games: [] });
+      testApi.mock('games.update', mockHandler);
+
+      const games = bridge['games'] as { update: (payload: unknown) => Promise<unknown> };
+      const payload = { name: 'valheim', config: { image: 'lloesche/valheim-server', cpu: 1024, memory: 2048, ports: [], volumes: [] } };
+      const result = await games.update(payload);
+
+      expect(mockHandler).toHaveBeenCalledWith(payload);
+      expect(ipcInvoke).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true, games: [] });
+    });
+
+    it('should call the registered games.delete mock with the single payload object instead of ipcRenderer.invoke', async () => {
+      const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+      const mockHandler = vi.fn().mockResolvedValue({ ok: true, games: [] });
+      testApi.mock('games.delete', mockHandler);
+
+      const games = bridge['games'] as { delete: (payload: unknown) => Promise<unknown> };
+      const payload = { name: 'valheim' };
+      const result = await games.delete(payload);
+
+      expect(mockHandler).toHaveBeenCalledWith(payload);
+      expect(ipcInvoke).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true, games: [] });
     });
   });
 

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -17,7 +17,14 @@
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
-import type { GsdApi, GsdTestApi, LogChunk } from './gsd-api.js';
+import type {
+  CreateGamePayload,
+  DeleteGamePayload,
+  GsdApi,
+  GsdTestApi,
+  LogChunk,
+  UpdateGamePayload,
+} from './gsd-api.js';
 
 /**
  * Per-channel mock registry populated by tests via `window.gsd.__test.mock(channel, handler)`.
@@ -155,6 +162,12 @@ const api: GsdApi = {
     getStatus: (game: string) => invoke('games.getStatus', game),
     start: (game: string) => invoke('games.start', game),
     stop: (game: string) => invoke('games.stop', game),
+    // Transport note: `nestjs-electron-ipc-transport` only delivers the first
+    // argument to `@Payload`, so each write op passes a single payload object
+    // rather than separate positional arguments.
+    create: (payload: CreateGamePayload) => invoke('games.create', payload),
+    update: (payload: UpdateGamePayload) => invoke('games.update', payload),
+    delete: (payload: DeleteGamePayload) => invoke('games.delete', payload),
   },
 
   costs: {

--- a/app/packages/desktop-preload/src/test-mock-registry.test.ts
+++ b/app/packages/desktop-preload/src/test-mock-registry.test.ts
@@ -10,6 +10,9 @@ function makeGamesStub(): GsdGamesApi {
     getStatus: vi.fn().mockResolvedValue({ game: 'minecraft', state: 'stopped' }),
     start: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
     stop: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    create: vi.fn().mockResolvedValue({ ok: true, games: [] }),
+    update: vi.fn().mockResolvedValue({ ok: true, games: [] }),
+    delete: vi.fn().mockResolvedValue({ ok: true, games: [] }),
   };
 }
 

--- a/app/packages/shared/src/gamesWrite.ts
+++ b/app/packages/shared/src/gamesWrite.ts
@@ -1,0 +1,96 @@
+/**
+ * Request payload and result types shared between the desktop-main
+ * `games.create` / `games.update` / `games.delete` IPC handlers (and their
+ * HTTP equivalents) and the web client. Keeping these here — rather than in
+ * `desktop-main` or `web` — means both sides of the wire agree on the exact
+ * discriminated union without either package importing the other.
+ */
+
+import type { GameServer, GameListEntry } from './tfvars.js';
+import type { GameServerValidationIssue } from './gameServerValidator.js';
+
+/**
+ * Successful create/update/delete. `game` is the affected entry's
+ * post-write config (omitted for a delete); `games` is the full, freshly
+ * merged games list so callers can refresh their view without a second
+ * round trip.
+ */
+export interface GameWriteSuccess {
+  ok: true;
+  game?: GameServer;
+  games: GameListEntry[];
+}
+
+/**
+ * The write was rejected because the caller's `expectedVersionId` didn't
+ * match the current tfvars file version — someone else edited
+ * `terraform.tfvars` since the caller last read it. `currentVersionId` lets
+ * the caller re-fetch and retry.
+ */
+export interface GameWriteConflict {
+  ok: false;
+  code: 'conflict';
+  expectedVersionId?: string;
+  currentVersionId?: string;
+  message: string;
+}
+
+/** The proposed `game_servers` entry failed {@link GameServerValidationIssue}-shaped structural or business-rule validation. */
+export interface GameWriteValidationFailure {
+  ok: false;
+  code: 'validation';
+  issues: GameServerValidationIssue[];
+}
+
+/** The named game does not exist (e.g. update/delete targeting an undeclared game). */
+export interface GameWriteNotFound {
+  ok: false;
+  code: 'not_found';
+  message: string;
+}
+
+/** Catch-all failure for errors that aren't a conflict, validation failure, or not-found (e.g. filesystem I/O). */
+export interface GameWriteFailure {
+  ok: false;
+  code: 'error';
+  message: string;
+}
+
+/**
+ * Discriminated union returned by the `games.create` / `games.update` /
+ * `games.delete` handlers. Discriminate on `ok` first, then `code` for the
+ * failure branches.
+ */
+export type GameWriteResult =
+  | GameWriteSuccess
+  | GameWriteConflict
+  | GameWriteValidationFailure
+  | GameWriteNotFound
+  | GameWriteFailure;
+
+/**
+ * Request payload for `games.create`. `expectedVersionId`, when supplied,
+ * is checked against the current tfvars file version and a
+ * {@link GameWriteConflict} is returned on mismatch.
+ */
+export interface CreateGamePayload {
+  name: string;
+  config: Omit<GameServer, 'name'>;
+  expectedVersionId?: string;
+}
+
+/**
+ * Request payload for `games.update`. Same shape as {@link CreateGamePayload}
+ * — `name` identifies the existing game to overwrite with `config`.
+ */
+export interface UpdateGamePayload {
+  name: string;
+  config: Omit<GameServer, 'name'>;
+  expectedVersionId?: string;
+}
+
+/** Request payload for `games.delete`. */
+export interface DeleteGamePayload {
+  name: string;
+  expectedVersionId?: string;
+}

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from './types.js';
 export * from './errors.js';
 export * from './tfvars.js';
 export * from './gameServerValidator.js';
+export * from './gamesWrite.js';
 export * from './drift.js';
 export * from './cloud.js';
 export * from './sanitize.js';


### PR DESCRIPTION
Closes #98

## Summary

- Adds `GamesWriteService` (desktop-main) wiring `GameServerValidator` → `TfvarsService.addGameServer`/`updateGameServer`/`removeGameServer` into a single validate → write → audit-log → result-union flow shared by both transports.
- Wires `games.create` / `games.update` / `games.delete` on the IPC `GamesController`, mirrored by `POST /api/games`, `PATCH /api/games/:name`, and `DELETE /api/games/:name` on the HTTP shim controller, and exposes `window.gsd.games.create/update/delete` from the preload bridge.
- Adds shared request/result types (`@hyveon/shared/gamesWrite.ts`) so both controllers and the preload bridge agree on the create/update/delete payload and the success/conflict/validation-error result union.

## Changes

```
 app/packages/desktop-main/src/app.module.ts        |   2 +
 .../src/controllers/games-http.controller.test.ts  | 266 ++++++++++++++++++--
 .../src/controllers/games-http.controller.ts       | 108 ++++++++-
 .../games.controller.integration.test.ts           | 222 ++++++++++++++++-
 .../src/controllers/games.controller.test.ts       | 133 ++++++++--
 .../src/controllers/games.controller.ts            |  45 +++-
 .../src/services/GamesWriteService.test.ts         | 267 +++++++++++++++++++++
 .../desktop-main/src/services/GamesWriteService.ts | 192 +++++++++++++++
 app/packages/desktop-preload/src/gsd-api.ts        | 143 +++++++++++
 app/packages/desktop-preload/src/preload.test.ts   |  75 ++++++
 app/packages/desktop-preload/src/preload.ts        |  15 +-
 .../desktop-preload/src/test-mock-registry.test.ts |   3 +
 app/packages/shared/src/gamesWrite.ts              |  96 ++++++++
 app/packages/shared/src/index.ts                   |   1 +
 14 files changed, 1526 insertions(+), 42 deletions(-)
```

## Test plan

- [x] Add / edit / remove a game via the API succeed and reflect in `/api/games` — covered by `games.controller.integration.test.ts` (merged-list reflection after create/update/delete).
- [x] Conflict response carries enough detail for the UI to show "someone else changed this — refresh" — `OptimisticLockError` mapped to a conflict result with current/expected version ids in both `GamesWriteService.test.ts` and the controller specs.
- [x] Validation errors return 422 with per-field messages — `GameServerValidator` failures surfaced as a field-level error map in `GamesWriteService.test.ts` and `games-http.controller.test.ts`.
- [x] Auth + admin-role gating verified — existing `ApiTokenGuard` continues to cover the new HTTP routes (no controller-level bypass added); IPC handlers go through the same guarded `GamesController`.
- [x] `npm run app:test` passing for the touched workspaces (desktop-main, desktop-preload, shared).
