### PR TITLE
feat(web): add-game wizard

### DIFF
--- a/app/packages/shared/package.json
+++ b/app/packages/shared/package.json
@@ -6,7 +6,11 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./gameServerValidator": {
+      "types": "./dist/gameServerValidator.d.ts",
+      "default": "./dist/gameServerValidator.js"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/app/packages/shared/src/gameServerValidator.test.ts
+++ b/app/packages/shared/src/gameServerValidator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateGameServer } from './gameServerValidator.js';
+import { validateGameServer, getFargateCpuOptions, getFargateMemoryOptions } from './gameServerValidator.js';
 import type { GameServer } from './tfvars.js';
 
 /** Build a minimal, fully-valid proposed entry; override any fields per test. */
@@ -139,6 +139,30 @@ describe('validateGameServer', () => {
       if (!result.success) {
         expect(result.issues.some((i) => i.path === 'cpu')).toBe(true);
       }
+    });
+  });
+
+  describe('getFargateCpuOptions', () => {
+    it('should return every supported Fargate CPU unit, ascending', () => {
+      expect(getFargateCpuOptions()).toEqual([256, 512, 1024, 2048, 4096, 8192, 16384]);
+    });
+  });
+
+  describe('getFargateMemoryOptions', () => {
+    it('should return the exact discrete memory values for cpu=256', () => {
+      expect(getFargateMemoryOptions(256)).toEqual([512, 1024, 2048]);
+    });
+
+    it('should return the exact stepped memory range for cpu=512', () => {
+      expect(getFargateMemoryOptions(512)).toEqual([1024, 2048, 3072, 4096]);
+    });
+
+    it('should return the exact stepped memory range for cpu=8192', () => {
+      expect(getFargateMemoryOptions(8192)).toEqual([16384, 20480, 24576, 28672, 32768, 36864, 40960, 45056, 49152, 53248, 57344, 61440]);
+    });
+
+    it('should return an empty array for an unsupported cpu', () => {
+      expect(getFargateMemoryOptions(100)).toEqual([]);
     });
   });
 

--- a/app/packages/shared/src/gameServerValidator.ts
+++ b/app/packages/shared/src/gameServerValidator.ts
@@ -126,6 +126,38 @@ const FARGATE_CPU_MEMORY_TABLE: Readonly<
   16384: { min: 32768, max: 122880, step: 8192 },
 };
 
+/**
+ * Every Fargate CPU unit accepted by {@link FARGATE_CPU_MEMORY_TABLE}, ascending
+ * (e.g. `256, 512, 1024, ...`). Intended for populating a "cpu" dropdown in a
+ * game-creation form so the UI never drifts from the validator's own table.
+ */
+export function getFargateCpuOptions(): number[] {
+  return Object.keys(FARGATE_CPU_MEMORY_TABLE)
+    .map(Number)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * Every valid Fargate memory (MiB) value for a given `cpu` tier, expanded
+ * from {@link FARGATE_CPU_MEMORY_TABLE} — the discrete `values` list as-is
+ * for `cpu=256`, or every step from `min` to `max` (inclusive) for the
+ * ranged tiers. Returns `[]` if `cpu` isn't one of {@link getFargateCpuOptions}.
+ */
+export function getFargateMemoryOptions(cpu: number): number[] {
+  const range = FARGATE_CPU_MEMORY_TABLE[cpu];
+  if (!range) {
+    return [];
+  }
+  if ('values' in range) {
+    return [...range.values];
+  }
+  const options: number[] = [];
+  for (let memory = range.min; memory <= range.max; memory += range.step) {
+    options.push(memory);
+  }
+  return options;
+}
+
 /** Human-readable description of the valid memory values/range for a given Fargate `cpu` tier. */
 function describeFargateMemoryOptions(cpu: number): string {
   const range = FARGATE_CPU_MEMORY_TABLE[cpu];

--- a/app/packages/shared/src/gameServerValidator.ts
+++ b/app/packages/shared/src/gameServerValidator.ts
@@ -225,19 +225,27 @@ function checkAbsolutePaths(entry: GameServerEntryInput): GameServerValidationIs
 }
 
 /** Placeholder tokens allowed inside `connect_message`, matching the Terraform variable's doc comment. */
-const ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS: ReadonlySet<string> = new Set(['host', 'ip', 'port', 'game']);
+export const ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS: ReadonlySet<string> = new Set(['host', 'ip', 'port', 'game']);
 
 /** Matches every `{token}` occurrence in a string, capturing the token itself. */
-const PLACEHOLDER_TOKEN_PATTERN = /\{([^{}]*)\}/g;
+export const PLACEHOLDER_TOKEN_PATTERN = /\{([^{}]*)\}/g;
 
-/** Rejects any `{token}` in `connect_message` outside `{host}`/`{ip}`/`{port}`/`{game}`. */
-function checkConnectMessagePlaceholders(entry: GameServerEntryInput): GameServerValidationIssue[] {
-  if (!entry.connect_message) {
+/**
+ * Rejects any `{token}` in `connectMessage` outside `{host}`/`{ip}`/`{port}`/`{game}`.
+ * Exported (and taking a bare string rather than a full {@link GameServerEntryInput})
+ * so callers that need to run this rule independently of the rest of
+ * {@link validateGameServer} — e.g. the add-game wizard's per-step validation in
+ * `@hyveon/web`, which must surface a bad placeholder before `cpu`/`memory`/`volumes`
+ * are filled in and so can't wait for a full structural parse to succeed — reuse this
+ * exact rule and message instead of hand-duplicating it.
+ */
+export function checkConnectMessagePlaceholders(connectMessage: string | undefined): GameServerValidationIssue[] {
+  if (!connectMessage) {
     return [];
   }
 
   const issues: GameServerValidationIssue[] = [];
-  for (const match of entry.connect_message.matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
+  for (const match of connectMessage.matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
     const token = match[1] ?? '';
     if (!ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS.has(token)) {
       issues.push({
@@ -332,7 +340,7 @@ export function validateGameServer(
   } else {
     issues.push(...checkFargateCpuMemoryPairing(parsed.data));
     issues.push(...checkAbsolutePaths(parsed.data));
-    issues.push(...checkConnectMessagePlaceholders(parsed.data));
+    issues.push(...checkConnectMessagePlaceholders(parsed.data.connect_message));
   }
 
   // Port-collision detection only needs `ports` to be structurally valid, so

--- a/app/packages/web/package.json
+++ b/app/packages/web/package.json
@@ -11,6 +11,7 @@
     "test:integration": "playwright test --config playwright.integration.config.ts"
   },
   "dependencies": {
+    "@hyveon/shared": "*",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/app/packages/web/src/api.service.test.ts
+++ b/app/packages/web/src/api.service.test.ts
@@ -15,6 +15,7 @@ function makeGsdMock() {
       getStatus: vi.fn().mockResolvedValue({ game: 'minecraft', state: 'stopped' }),
       start: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
       stop: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+      create: vi.fn().mockResolvedValue({ ok: true, games: [] }),
     },
     costs: {
       estimate: vi.fn().mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 }),
@@ -138,6 +139,21 @@ describe('IPC bridge delegation', () => {
   it('should delegate api.filesMgrStop() to window.gsd.files.stop() with the game id', async () => {
     await api.filesMgrStop('minecraft');
     expect(gsd.files.stop).toHaveBeenCalledWith('minecraft');
+  });
+
+  it('should delegate api.createGame() to window.gsd.games.create() with the exact payload', async () => {
+    const payload = {
+      name: 'minecraft',
+      config: {
+        image: 'itzg/minecraft-server',
+        cpu: 1024,
+        memory: 2048,
+        ports: [{ container: 25565, protocol: 'tcp' }],
+        volumes: [{ name: 'data', container_path: '/data' }],
+      },
+    };
+    await api.createGame(payload);
+    expect(gsd.games.create).toHaveBeenCalledWith(payload);
   });
 
   it('should delegate api.discordConfig() to window.gsd.discord.getConfig()', async () => {

--- a/app/packages/web/src/api.service.ts
+++ b/app/packages/web/src/api.service.ts
@@ -97,6 +97,119 @@ export interface GameListEntry {
   config?: GameServer;
 }
 
+/**
+ * A single structural or business-rule validation failure for a proposed
+ * `game_servers` entry.
+ *
+ * Mirrors `GameServerValidationIssue` in
+ * `@hyveon/shared/src/gameServerValidator.ts` — that file is the source of
+ * truth; keep this copy in sync with it.
+ */
+export interface GameServerValidationIssue {
+  path: string;
+  message: string;
+}
+
+/**
+ * Successful create/update/delete. `game` is the affected entry's
+ * post-write config (omitted for a delete); `games` is the full, freshly
+ * merged games list so callers can refresh their view without a second
+ * round trip.
+ *
+ * Mirrors `GameWriteSuccess` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteSuccess {
+  ok: true;
+  game?: GameServer;
+  games: GameListEntry[];
+}
+
+/**
+ * The write was rejected because the caller's `expectedVersionId` didn't
+ * match the current tfvars file version — someone else edited
+ * `terraform.tfvars` since the caller last read it. `currentVersionId` lets
+ * the caller re-fetch and retry.
+ *
+ * Mirrors `GameWriteConflict` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteConflict {
+  ok: false;
+  code: 'conflict';
+  expectedVersionId?: string;
+  currentVersionId?: string;
+  message: string;
+}
+
+/**
+ * The proposed `game_servers` entry failed {@link GameServerValidationIssue}-shaped
+ * structural or business-rule validation.
+ *
+ * Mirrors `GameWriteValidationFailure` in `@hyveon/shared/src/gamesWrite.ts`
+ * — that file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteValidationFailure {
+  ok: false;
+  code: 'validation';
+  issues: GameServerValidationIssue[];
+}
+
+/**
+ * The named game does not exist (e.g. update/delete targeting an
+ * undeclared game).
+ *
+ * Mirrors `GameWriteNotFound` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteNotFound {
+  ok: false;
+  code: 'not_found';
+  message: string;
+}
+
+/**
+ * Catch-all failure for errors that aren't a conflict, validation failure,
+ * or not-found (e.g. filesystem I/O).
+ *
+ * Mirrors `GameWriteFailure` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface GameWriteFailure {
+  ok: false;
+  code: 'error';
+  message: string;
+}
+
+/**
+ * Discriminated union returned by the `games.create` / `games.update` /
+ * `games.delete` handlers. Discriminate on `ok` first, then `code` for the
+ * failure branches.
+ *
+ * Mirrors `GameWriteResult` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export type GameWriteResult =
+  | GameWriteSuccess
+  | GameWriteConflict
+  | GameWriteValidationFailure
+  | GameWriteNotFound
+  | GameWriteFailure;
+
+/**
+ * Request payload for `games.create`. `expectedVersionId`, when supplied,
+ * is checked against the current tfvars file version and a
+ * {@link GameWriteConflict} is returned on mismatch.
+ *
+ * Mirrors `CreateGamePayload` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface CreateGamePayload {
+  name: string;
+  config: Omit<GameServer, 'name'>;
+  expectedVersionId?: string;
+}
+
 /** Status of the FileBrowser helper task per game, returned by `GET /api/files/:game`. */
 export interface FileMgrStatus {
   game: string;
@@ -195,6 +308,8 @@ export const api = {
   filesMgrStatus: async (game: string): Promise<FileMgrStatus> => gsd().files.list(game),
   filesMgrStart: async (game: string): Promise<ActionResult> => gsd().files.start(game),
   filesMgrStop: async (game: string): Promise<ActionResult> => gsd().files.stop(game),
+  createGame: async (payload: CreateGamePayload): Promise<GameWriteResult> =>
+    gsd().games.create(payload) as Promise<GameWriteResult>,
 
   discordConfig: async (): Promise<DiscordConfigRedacted> =>
     gsd().discord.getConfig() as Promise<DiscordConfigRedacted>,

--- a/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AddGameWizard } from './add-game-wizard.component.js';
+
+/**
+ * Stub for the `@/api.service.js` module: `games()` backs the existing-games
+ * fetch the wizard fires whenever it opens (used for client-side collision
+ * checks), and `createGame()` backs the Review step's Submit button. Both
+ * are reset to a "happy" default in `beforeEach` and overridden per test.
+ */
+const apiMock = vi.hoisted(() => ({
+  games: vi.fn(),
+  createGame: vi.fn(),
+}));
+vi.mock('../../api.service.js', () => ({ api: apiMock }));
+
+/** Stub for `sonner`'s `toast`, so success/failure toasts can be asserted without a real toaster mounted. */
+const toastMock = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+/**
+ * Stub for `react-router-dom`'s `useNavigate` — the wizard only ever calls
+ * this one hook from the module, so a full mock (no real `MemoryRouter`
+ * needed) keeps the test setup minimal.
+ */
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }));
+
+/** Opens the wizard dialog via its trigger button and waits for the first step to render. */
+async function openWizard() {
+  render(<AddGameWizard />);
+  await userEvent.click(screen.getByRole('button', { name: /add game/i }));
+  await screen.findByRole('heading', { name: 'Add a game server' });
+}
+
+/** Fills the Identity step's required fields (`name`, `image`) with valid values. */
+async function fillIdentityStep(name = 'mygame', image = 'some/image') {
+  await userEvent.type(screen.getByLabelText('Name'), name);
+  await userEvent.type(screen.getByLabelText('Image'), image);
+}
+
+/** Clicks the dialog footer's "Next" button. */
+async function goNext() {
+  await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+}
+
+/** Selects a valid Fargate cpu/memory pairing on the Resources step. */
+async function fillResourcesStep() {
+  await userEvent.selectOptions(screen.getByLabelText(/CPU/i), '256');
+  await userEvent.selectOptions(screen.getByLabelText(/Memory/i), '512');
+}
+
+/** Adds and fills a single volume row on the Storage step (the server requires at least one). */
+async function fillStorageStep() {
+  await userEvent.click(screen.getByRole('button', { name: 'Add volume' }));
+  await userEvent.type(screen.getByLabelText('Volume name'), 'data');
+  await userEvent.type(screen.getByLabelText('Container path'), '/data');
+}
+
+/**
+ * Drives the wizard from a freshly-opened dialog through every step up to
+ * (and including landing on) Review, filling in the minimum set of fields
+ * needed to pass client-side validation at each step. Leaves the dialog
+ * open on the Review step, ready for the caller to click Submit.
+ */
+async function fillHappyPathToReview() {
+  await fillIdentityStep();
+  await goNext(); // -> resources
+  await fillResourcesStep();
+  await goNext(); // -> networking (no ports required)
+  await goNext(); // -> storage
+  await fillStorageStep();
+  await goNext(); // -> review
+  await screen.findByText('Step 5 of 5: Review');
+}
+
+describe('AddGameWizard — blocked-advance validation', () => {
+  beforeEach(() => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    apiMock.createGame.mockReset();
+    navigateMock.mockClear();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  it('should disable Next on the Identity step while name and image are blank', async () => {
+    await openWizard();
+
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('should enable Next on the Identity step once name and image are filled in', async () => {
+    await openWizard();
+
+    await fillIdentityStep();
+
+    expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled();
+  });
+
+  it('should keep Next disabled when the name does not match the required identifier pattern', async () => {
+    await openWizard();
+
+    await fillIdentityStep('1nvalid name', 'some/image');
+
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+});
+
+describe('AddGameWizard — submit success path', () => {
+  beforeEach(() => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    apiMock.createGame.mockReset();
+    navigateMock.mockClear();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  it('should show a success toast, redirect to the new game page, and close the dialog', async () => {
+    apiMock.createGame.mockResolvedValue({ ok: true, games: [] });
+    await openWizard();
+    await fillHappyPathToReview();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(toastMock.success).toHaveBeenCalledWith('mygame created'));
+    expect(navigateMock).toHaveBeenCalledWith('/games/mygame');
+    expect(screen.queryByRole('heading', { name: 'Add a game server' })).not.toBeInTheDocument();
+  });
+});
+
+describe('AddGameWizard — submit failure paths', () => {
+  beforeEach(() => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    apiMock.createGame.mockReset();
+    navigateMock.mockClear();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  it('should leave the dialog open, jump to the offending step, and highlight the field on a validation failure', async () => {
+    apiMock.createGame.mockResolvedValue({
+      ok: false,
+      code: 'validation',
+      issues: [{ path: 'name', message: 'A game named "mygame" already exists.' }],
+    });
+    await openWizard();
+    await fillHappyPathToReview();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await screen.findByText('Step 1 of 5: Identity');
+    expect(screen.getByText('A game named "mygame" already exists.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Add a game server' })).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it('should leave the dialog open on the Review step and surface the server message on a conflict/error failure', async () => {
+    apiMock.createGame.mockResolvedValue({
+      ok: false,
+      code: 'conflict',
+      message: 'terraform.tfvars changed since this draft was loaded.',
+    });
+    await openWizard();
+    await fillHappyPathToReview();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert')).toHaveTextContent('terraform.tfvars changed since this draft was loaded.');
+    expect(screen.getByText('Step 5 of 5: Review')).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
@@ -1,0 +1,274 @@
+/**
+ * Wizard shell for declaring a new `game_servers` entry (#99): a self-contained
+ * `<Dialog>` — trigger, five-step navigation, and the submit handler — built
+ * from the step components and validation utilities already assembled for
+ * this issue (`identity-step`, `resources-step`, `networking-step`,
+ * `storage-step`, `review-step`, `wizard-form.utils`).
+ *
+ * The wizard owns every piece of its own state (open/closed, current step,
+ * in-progress {@link WizardDraft}, the existing-games list used for
+ * client-side collision checks, and submit status) so it can be dropped in
+ * anywhere — e.g. on `/games` — without the caller wiring anything beyond
+ * rendering `<AddGameWizard />`.
+ *
+ * "Next" (or, on the final step, "Submit") is disabled whenever
+ * {@link canAdvance} finds outstanding validation issues on the active step,
+ * mirroring the same zod schema + business rules the server enforces (see
+ * `wizard-form.utils.ts`). On submit, every {@link GameWriteResult} branch is
+ * handled explicitly:
+ *
+ * - `ok: true` — success toast, redirect to `/games/:name`, dialog closes and
+ *   the draft resets.
+ * - `code: 'validation'` — the dialog stays open; the returned issues are
+ *   stored and the wizard jumps to the earliest step whose fields they
+ *   belong to (via {@link stepForIssuePath}) so the offending fields render
+ *   highlighted.
+ * - `code: 'conflict' | 'not_found' | 'error'` — the dialog stays open, the
+ *   wizard jumps to the Review step, and the server's message is surfaced
+ *   via {@link ReviewStep}'s `submitError` prop.
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Plus, Loader2 } from 'lucide-react';
+import type { GameServerValidationIssue } from '@hyveon/shared/gameServerValidator';
+import { Button } from '@/components/ui/button.component';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog.component';
+import { api, type CreateGamePayload, type GameServer } from '../../api.service.js';
+import { IdentityStep } from './identity-step.component.js';
+import { ResourcesStep } from './resources-step.component.js';
+import { NetworkingStep } from './networking-step.component.js';
+import { StorageStep } from './storage-step.component.js';
+import { ReviewStep } from './review-step.component.js';
+import {
+  WIZARD_STEPS,
+  canAdvance,
+  createEmptyWizardDraft,
+  stepForIssuePath,
+  validateStep,
+  type WizardDraft,
+  type WizardStep,
+} from './wizard-form.utils.js';
+
+/** Human-readable heading for each {@link WizardStep}, shown in the dialog description. */
+const STEP_LABELS: Record<WizardStep, string> = {
+  identity: 'Identity',
+  resources: 'Resources',
+  networking: 'Networking',
+  storage: 'Storage',
+  review: 'Review',
+};
+
+/**
+ * Converts a completed {@link WizardDraft} into the `POST /api/games`
+ * (`games.create` IPC) payload. Only called once the Review step's "Submit"
+ * button is enabled, which requires {@link validateStep} to report zero
+ * issues for `review` — so `cpu`/`memory`/port `container` values are
+ * guaranteed non-null at this point; the `?? 0` fallbacks only guard the
+ * type checker, they're never expected to fire in practice.
+ */
+function draftToPayload(draft: WizardDraft): CreateGamePayload {
+  const name = draft.name.trim();
+  const connectMessage = draft.connect_message.trim();
+
+  return {
+    name,
+    config: {
+      image: draft.image,
+      cpu: draft.cpu ?? 0,
+      memory: draft.memory ?? 0,
+      ports: draft.ports.map((port) => ({ container: port.container ?? 0, protocol: port.protocol })),
+      volumes: draft.volumes.map((volume) => ({ name: volume.name, container_path: volume.container_path })),
+      connect_message: connectMessage.length > 0 ? connectMessage : undefined,
+      file_seeds:
+        draft.file_seeds.length > 0
+          ? draft.file_seeds.map((seed) => ({
+              path: seed.path,
+              content: seed.content.length > 0 ? seed.content : undefined,
+              content_base64: seed.content_base64.length > 0 ? seed.content_base64 : undefined,
+              mode: seed.mode.length > 0 ? seed.mode : undefined,
+            }))
+          : undefined,
+    },
+  };
+}
+
+/**
+ * Self-contained "Add game" dialog: renders its own trigger button, walks the
+ * operator through the five wizard steps, and owns the `games.create` submit
+ * handler. See the module doc above for the full submit-result contract.
+ */
+export function AddGameWizard() {
+  const navigate = useNavigate();
+
+  const [open, setOpen] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [draft, setDraft] = useState<WizardDraft>(createEmptyWizardDraft());
+  const [existingGames, setExistingGames] = useState<GameServer[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [serverIssues, setServerIssues] = useState<GameServerValidationIssue[] | null>(null);
+
+  const step = WIZARD_STEPS[stepIndex];
+
+  // Refreshes the existing-games list (used for name/port collision checks)
+  // every time the dialog opens, so a game declared in a previous session
+  // is taken into account without requiring a page reload.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    api
+      .games()
+      .then(({ games }) => {
+        if (cancelled) return;
+        setExistingGames(games.flatMap((entry) => (entry.config ? [entry.config] : [])));
+      })
+      .catch(() => {
+        if (!cancelled) setExistingGames([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  /** Resets every piece of wizard state back to a blank first step. */
+  function resetWizard() {
+    setStepIndex(0);
+    setDraft(createEmptyWizardDraft());
+    setSubmitError(null);
+    setServerIssues(null);
+    setSubmitting(false);
+  }
+
+  /** Handles the dialog's own open/close, resetting the draft on close. */
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) resetWizard();
+  }
+
+  /**
+   * Applies a partial patch to the draft. Any stale server-reported error
+   * state is cleared, since the operator is actively fixing the draft that
+   * produced it.
+   */
+  function patchDraft(patch: Partial<WizardDraft>) {
+    setServerIssues(null);
+    setSubmitError(null);
+    setDraft((prev) => ({ ...prev, ...patch }));
+  }
+
+  const liveIssues = validateStep(step, draft, existingGames);
+  const stepIssues = serverIssues
+    ? step === 'review'
+      ? serverIssues
+      : serverIssues.filter((issue) => stepForIssuePath(issue.path) === step)
+    : liveIssues;
+
+  const advanceDisabled = !canAdvance(step, draft, existingGames);
+
+  function goNext() {
+    setStepIndex((index) => Math.min(index + 1, WIZARD_STEPS.length - 1));
+  }
+
+  function goBack() {
+    setStepIndex((index) => Math.max(index - 1, 0));
+  }
+
+  /**
+   * Submits the draft via `api.createGame` and routes every
+   * {@link GameWriteResult} branch to the right UI reaction — see the module
+   * doc for the full contract.
+   */
+  async function handleSubmit() {
+    setSubmitting(true);
+    setSubmitError(null);
+    setServerIssues(null);
+
+    try {
+      const payload = draftToPayload(draft);
+      const result = await api.createGame(payload);
+
+      if (result.ok) {
+        toast.success(`${payload.name} created`);
+        handleOpenChange(false);
+        navigate(`/games/${payload.name}`);
+        return;
+      }
+
+      switch (result.code) {
+        case 'validation': {
+          setServerIssues(result.issues);
+          const firstIssuePath = result.issues[0]?.path;
+          const targetStep = firstIssuePath ? stepForIssuePath(firstIssuePath) : 'review';
+          setStepIndex(WIZARD_STEPS.indexOf(targetStep));
+          break;
+        }
+        case 'conflict':
+        case 'not_found':
+        case 'error':
+          setSubmitError(result.message);
+          setStepIndex(WIZARD_STEPS.length - 1);
+          break;
+      }
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to create game.');
+      setStepIndex(WIZARD_STEPS.length - 1);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button type="button">
+          <Plus />
+          Add game
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add a game server</DialogTitle>
+          <DialogDescription>
+            Step {stepIndex + 1} of {WIZARD_STEPS.length}: {STEP_LABELS[step]}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'identity' && <IdentityStep draft={draft} issues={stepIssues} onChange={patchDraft} />}
+        {step === 'resources' && (
+          <ResourcesStep cpu={draft.cpu} memory={draft.memory} issues={stepIssues} onChange={patchDraft} />
+        )}
+        {step === 'networking' && (
+          <NetworkingStep ports={draft.ports} issues={stepIssues} onChange={(ports) => patchDraft({ ports })} />
+        )}
+        {step === 'storage' && <StorageStep draft={draft} issues={stepIssues} onChange={patchDraft} />}
+        {step === 'review' && <ReviewStep draft={draft} submitError={submitError} />}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0 || submitting}>
+            Back
+          </Button>
+          {step === 'review' ? (
+            <Button type="button" onClick={handleSubmit} disabled={advanceDisabled || submitting}>
+              {submitting && <Loader2 className="animate-spin" />}
+              Submit
+            </Button>
+          ) : (
+            <Button type="button" onClick={goNext} disabled={advanceDisabled}>
+              Next
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
@@ -11,10 +11,11 @@
  * anywhere — e.g. on `/games` — without the caller wiring anything beyond
  * rendering `<AddGameWizard />`.
  *
- * "Next" (or, on the final step, "Submit") is disabled whenever
- * {@link canAdvance} finds outstanding validation issues on the active step,
- * mirroring the same zod schema + business rules the server enforces (see
- * `wizard-form.utils.ts`). On submit, every {@link GameWriteResult} branch is
+ * "Next" (or, on the final step, "Submit") is disabled whenever the active
+ * step has outstanding issues — either from client-side `validateStep`
+ * (mirroring the same zod schema + business rules the server enforces, see
+ * `wizard-form.utils.ts`) or from a server-reported validation failure the
+ * client didn't catch. On submit, every {@link GameWriteResult} branch is
  * handled explicitly:
  *
  * - `ok: true` — success toast, redirect to `/games/:name`, dialog closes and
@@ -51,7 +52,6 @@ import { StorageStep } from './storage-step.component.js';
 import { ReviewStep } from './review-step.component.js';
 import {
   WIZARD_STEPS,
-  canAdvance,
   createEmptyWizardDraft,
   stepForIssuePath,
   validateStep,
@@ -182,7 +182,7 @@ export function AddGameWizard() {
       : serverIssues.filter((issue) => stepForIssuePath(issue.path) === step)
     : liveIssues;
 
-  const advanceDisabled = !canAdvance(step, draft, existingGames);
+  const advanceDisabled = stepIssues.length > 0;
 
   function goNext() {
     setStepIndex((index) => Math.min(index + 1, WIZARD_STEPS.length - 1));

--- a/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
@@ -28,7 +28,7 @@
  *   via {@link ReviewStep}'s `submitError` prop.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Plus, Loader2 } from 'lucide-react';
@@ -119,6 +119,13 @@ export function AddGameWizard() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [serverIssues, setServerIssues] = useState<GameServerValidationIssue[] | null>(null);
 
+  // Mirrors `open` synchronously (not via effect) so an in-flight
+  // `handleSubmit` can tell — the instant its promise settles — whether the
+  // dialog was closed (Escape/overlay click, which Radix permits even while
+  // `submitting`) while it was awaiting the server. Without this, a late
+  // result would mutate the freshly-reset draft with stale step/error state.
+  const openRef = useRef(open);
+
   const step = WIZARD_STEPS[stepIndex];
 
   // Refreshes the existing-games list (used for name/port collision checks)
@@ -152,6 +159,7 @@ export function AddGameWizard() {
 
   /** Handles the dialog's own open/close, resetting the draft on close. */
   function handleOpenChange(next: boolean) {
+    openRef.current = next;
     setOpen(next);
     if (!next) resetWizard();
   }
@@ -198,6 +206,12 @@ export function AddGameWizard() {
       const payload = draftToPayload(draft);
       const result = await api.createGame(payload);
 
+      // The dialog may have been closed (Escape/overlay click) while this
+      // request was in flight — Radix allows that even with `submitting`
+      // true. `resetWizard()` already ran via `handleOpenChange`, so this
+      // stale result must not overwrite the freshly-reset draft.
+      if (!openRef.current) return;
+
       if (result.ok) {
         toast.success(`${payload.name} created`);
         handleOpenChange(false);
@@ -221,10 +235,11 @@ export function AddGameWizard() {
           break;
       }
     } catch (err) {
+      if (!openRef.current) return;
       setSubmitError(err instanceof Error ? err.message : 'Failed to create game.');
       setStepIndex(WIZARD_STEPS.length - 1);
     } finally {
-      setSubmitting(false);
+      if (openRef.current) setSubmitting(false);
     }
   }
 

--- a/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
@@ -79,11 +79,12 @@ const STEP_LABELS: Record<WizardStep, string> = {
 function draftToPayload(draft: WizardDraft): CreateGamePayload {
   const name = draft.name.trim();
   const connectMessage = draft.connect_message.trim();
+  const image = draft.image.trim();
 
   return {
     name,
     config: {
-      image: draft.image,
+      image,
       cpu: draft.cpu ?? 0,
       memory: draft.memory ?? 0,
       ports: draft.ports.map((port) => ({ container: port.container ?? 0, protocol: port.protocol })),

--- a/app/packages/web/src/components/add-game-wizard/identity-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/identity-step.component.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IdentityStep } from './identity-step.component.js';
+import { createEmptyWizardDraft, type WizardDraft } from './wizard-form.utils.js';
+
+/** Builds a blank draft with any fields overridden, so each test only specifies what it cares about. */
+function makeDraft(overrides: Partial<WizardDraft> = {}): WizardDraft {
+  return { ...createEmptyWizardDraft(), ...overrides };
+}
+
+describe('IdentityStep', () => {
+  it('should render the draft name value', () => {
+    render(<IdentityStep draft={makeDraft({ name: 'minecraft' })} issues={[]} onChange={vi.fn()} />);
+
+    expect(screen.getByLabelText('Name')).toHaveValue('minecraft');
+  });
+
+  it('should render the draft image value', () => {
+    render(<IdentityStep draft={makeDraft({ image: 'itzg/minecraft-server' })} issues={[]} onChange={vi.fn()} />);
+
+    expect(screen.getByLabelText('Image')).toHaveValue('itzg/minecraft-server');
+  });
+
+  it('should render the draft connect_message value', () => {
+    render(
+      <IdentityStep draft={makeDraft({ connect_message: 'Connect at {ip}:25565' })} issues={[]} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByLabelText('Connect message')).toHaveValue('Connect at {ip}:25565');
+  });
+
+  it('should propagate a name edit via onChange', async () => {
+    const onChange = vi.fn();
+    render(<IdentityStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+    await userEvent.type(screen.getByLabelText('Name'), 'a');
+
+    expect(onChange).toHaveBeenCalledWith({ name: 'a' });
+  });
+
+  it('should propagate an image edit via onChange', async () => {
+    const onChange = vi.fn();
+    render(<IdentityStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+    await userEvent.type(screen.getByLabelText('Image'), 'x');
+
+    expect(onChange).toHaveBeenCalledWith({ image: 'x' });
+  });
+
+  it('should propagate a connect_message edit via onChange', async () => {
+    const onChange = vi.fn();
+    render(<IdentityStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+    await userEvent.type(screen.getByLabelText('Connect message'), 'c');
+
+    expect(onChange).toHaveBeenCalledWith({ connect_message: 'c' });
+  });
+
+  it('should display the name error message when an issue path matches "name"', () => {
+    render(
+      <IdentityStep
+        draft={makeDraft()}
+        issues={[{ path: 'name', message: 'Name is required.' }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Name is required.')).toBeInTheDocument();
+  });
+
+  it('should display the image error message when an issue path matches "image"', () => {
+    render(
+      <IdentityStep
+        draft={makeDraft()}
+        issues={[{ path: 'image', message: 'Image is required.' }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Image is required.')).toBeInTheDocument();
+  });
+
+  it('should display the connect_message error message when an issue path matches "connect_message"', () => {
+    render(
+      <IdentityStep
+        draft={makeDraft()}
+        issues={[{ path: 'connect_message', message: 'Unknown placeholder in connect message.' }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Unknown placeholder in connect message.')).toBeInTheDocument();
+  });
+
+  it('should not display an error for a field whose path has no matching issue', () => {
+    render(
+      <IdentityStep
+        draft={makeDraft()}
+        issues={[{ path: 'image', message: 'Image is required.' }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Image is required.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).not.toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/identity-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/identity-step.component.test.tsx
@@ -102,7 +102,7 @@ describe('IdentityStep', () => {
       />,
     );
 
-    expect(screen.queryByText('Image is required.')).toBeInTheDocument();
+    expect(screen.queryByText('Name is required.')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Name')).not.toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/app/packages/web/src/components/add-game-wizard/identity-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/identity-step.component.tsx
@@ -1,0 +1,91 @@
+import { AlertCircle } from 'lucide-react';
+import { Label } from '@/components/ui/label.component';
+import { Input } from '@/components/ui/input.component';
+import type { GameServerValidationIssue } from '@hyveon/shared/gameServerValidator';
+import type { WizardDraft } from './wizard-form.utils.js';
+
+/** Props for {@link IdentityStep}. */
+export interface IdentityStepProps {
+  /** The wizard's in-progress draft; only `name`/`image`/`connect_message` are read here. */
+  draft: WizardDraft;
+  /** Validation issues for the whole draft — filtered by `path` to find the message for each field. */
+  issues: GameServerValidationIssue[];
+  /** Called with a partial patch of the changed field whenever the operator edits a field. */
+  onChange: (patch: Partial<Pick<WizardDraft, 'name' | 'image' | 'connect_message'>>) => void;
+}
+
+/**
+ * First step of the add-game wizard (#99): the operator names the new
+ * `game_servers` entry, points at the container image to run, and optionally
+ * writes a `connect_message` shown to Discord users after `/server-start`.
+ * Purely presentational — the parent wizard owns the draft state and passes
+ * down validation issues computed via `validateIdentityStep` (see wizard-form.utils.ts).
+ */
+export function IdentityStep({ draft, issues, onChange }: IdentityStepProps) {
+  const errorFor = (path: string) => issues.find((issue) => issue.path === path)?.message;
+
+  return (
+    <div className="space-y-5">
+      <Field
+        id="wizard-identity-name"
+        label="Name"
+        value={draft.name}
+        placeholder="minecraft"
+        error={errorFor('name')}
+        onChange={(value) => onChange({ name: value })}
+      />
+      <Field
+        id="wizard-identity-image"
+        label="Image"
+        value={draft.image}
+        placeholder="itzg/minecraft-server"
+        error={errorFor('image')}
+        onChange={(value) => onChange({ image: value })}
+      />
+      <Field
+        id="wizard-identity-connect-message"
+        label="Connect message"
+        value={draft.connect_message}
+        placeholder="Connect at {ip}:25565"
+        error={errorFor('connect_message')}
+        onChange={(value) => onChange({ connect_message: value })}
+      />
+    </div>
+  );
+}
+
+/** A single labeled text input with an optional path-matched validation error rendered underneath. */
+function Field({
+  id,
+  label,
+  value,
+  placeholder,
+  error,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  error?: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        aria-invalid={error ? 'true' : 'false'}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {error && (
+        <p className="text-xs text-[var(--color-red)] flex items-center gap-1">
+          <AlertCircle className="size-3.5" />
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/packages/web/src/components/add-game-wizard/identity-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/identity-step.component.tsx
@@ -78,10 +78,11 @@ function Field({
         value={value}
         placeholder={placeholder}
         aria-invalid={error ? 'true' : 'false'}
+        aria-describedby={error ? `${id}-error` : undefined}
         onChange={(e) => onChange(e.target.value)}
       />
       {error && (
-        <p className="text-xs text-[var(--color-red)] flex items-center gap-1">
+        <p id={`${id}-error`} role="alert" className="text-xs text-[var(--color-red)] flex items-center gap-1">
           <AlertCircle className="size-3.5" />
           {error}
         </p>

--- a/app/packages/web/src/components/add-game-wizard/networking-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/networking-step.component.test.tsx
@@ -38,7 +38,7 @@ describe('NetworkingStep', () => {
     const onChange = vi.fn();
     render(<NetworkingStep ports={makePorts()} issues={[]} onChange={onChange} />);
 
-    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    const removeButtons = screen.getAllByRole('button', { name: /Remove port/ });
     await user.click(removeButtons[0]);
 
     expect(onChange).toHaveBeenCalledWith([{ container: 25566, protocol: 'udp' }]);

--- a/app/packages/web/src/components/add-game-wizard/networking-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/networking-step.component.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NetworkingStep } from './networking-step.component.js';
+import type { WizardDraftPort } from './wizard-form.utils.js';
+
+/** Two-row port fixture used across most cases below. */
+function makePorts(): WizardDraftPort[] {
+  return [
+    { container: 25565, protocol: 'tcp' },
+    { container: 25566, protocol: 'udp' },
+  ];
+}
+
+describe('NetworkingStep', () => {
+  it('should render "No ports configured yet" when the ports array is empty', () => {
+    render(<NetworkingStep ports={[]} issues={[]} onChange={vi.fn()} />);
+
+    expect(screen.getByText('No ports configured yet.')).toBeInTheDocument();
+  });
+
+  it('should append a blank row when "Add port" is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NetworkingStep ports={makePorts()} issues={[]} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Add port' }));
+
+    expect(onChange).toHaveBeenCalledWith([
+      { container: 25565, protocol: 'tcp' },
+      { container: 25566, protocol: 'udp' },
+      { container: null, protocol: 'tcp' },
+    ]);
+  });
+
+  it('should remove the corresponding row when its "Remove" button is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NetworkingStep ports={makePorts()} issues={[]} onChange={onChange} />);
+
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    await user.click(removeButtons[0]);
+
+    expect(onChange).toHaveBeenCalledWith([{ container: 25566, protocol: 'udp' }]);
+  });
+
+  it('should update the container port for the edited row when its number input changes', () => {
+    const onChange = vi.fn();
+    render(<NetworkingStep ports={makePorts()} issues={[]} onChange={onChange} />);
+
+    const containerInput = screen.getByLabelText('Container port', {
+      selector: '#port-container-1',
+    });
+    fireEvent.change(containerInput, { target: { value: '9000' } });
+
+    expect(onChange).toHaveBeenCalledWith([
+      { container: 25565, protocol: 'tcp' },
+      { container: 9000, protocol: 'udp' },
+    ]);
+  });
+
+  it('should update the protocol for the edited row when its select changes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<NetworkingStep ports={makePorts()} issues={[]} onChange={onChange} />);
+
+    const protocolSelect = screen.getByLabelText('Protocol', { selector: '#port-protocol-0' });
+    await user.selectOptions(protocolSelect, 'udp');
+
+    expect(onChange).toHaveBeenCalledWith([
+      { container: 25565, protocol: 'udp' },
+      { container: 25566, protocol: 'udp' },
+    ]);
+  });
+
+  it('should highlight only the second row when the error path is ports[1]', () => {
+    render(
+      <NetworkingStep
+        ports={makePorts()}
+        issues={[{ path: 'ports[1]', message: 'Port 25566/udp collides with ports[0].' }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const firstRow = screen.getByTestId('port-row-0');
+    const secondRow = screen.getByTestId('port-row-1');
+
+    expect(firstRow.className).not.toContain('border-[var(--color-red)]');
+    expect(secondRow.className).toContain('border-[var(--color-red)]');
+    expect(screen.getByRole('alert')).toHaveTextContent('Port 25566/udp collides with ports[0].');
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/networking-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/networking-step.component.test.tsx
@@ -89,4 +89,21 @@ describe('NetworkingStep', () => {
     expect(secondRow.className).toContain('border-[var(--color-red)]');
     expect(screen.getByRole('alert')).toHaveTextContent('Port 25566/udp collides with ports[0].');
   });
+
+  it('should highlight the row and surface the message when the error path is a field-level ports[N].field', () => {
+    render(
+      <NetworkingStep
+        ports={makePorts()}
+        issues={[{ path: 'ports[0].container', message: 'Expected number, received null' }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const firstRow = screen.getByTestId('port-row-0');
+    const secondRow = screen.getByTestId('port-row-1');
+
+    expect(firstRow.className).toContain('border-[var(--color-red)]');
+    expect(secondRow.className).not.toContain('border-[var(--color-red)]');
+    expect(screen.getByRole('alert')).toHaveTextContent('Expected number, received null');
+  });
 });

--- a/app/packages/web/src/components/add-game-wizard/networking-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/networking-step.component.tsx
@@ -36,9 +36,17 @@ export interface NetworkingStepProps {
   onChange: (ports: WizardDraftPort[]) => void;
 }
 
-/** Finds the issue (if any) whose path is exactly `ports[index]`, i.e. a row-level (not field-level) error. */
+/**
+ * Finds the first issue (if any) that belongs to this row — either a
+ * row-level path (`ports[index]`) or a field-level path nested under it
+ * (`ports[index].container`, `ports[index].protocol`, ...). Field-level
+ * issues are how zod reports e.g. a blank container-port ("Expected number,
+ * received null"), so both forms must be matched or the row highlights with
+ * no visible message.
+ */
 function rowError(issues: GameServerValidationIssue[], index: number): GameServerValidationIssue | undefined {
-  return issues.find((issue) => issue.path === `ports[${index}]`);
+  const prefix = `ports[${index}]`;
+  return issues.find((issue) => issue.path === prefix || issue.path.startsWith(`${prefix}.`));
 }
 
 /**

--- a/app/packages/web/src/components/add-game-wizard/networking-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/networking-step.component.tsx
@@ -98,6 +98,8 @@ export function NetworkingStep({ ports, issues, onChange }: NetworkingStepProps)
                   id={`port-container-${index}`}
                   type="number"
                   value={port.container ?? ''}
+                  aria-invalid={Boolean(issue)}
+                  aria-describedby={issue ? `port-error-${index}` : undefined}
                   onChange={(event) => {
                     const raw = event.target.value;
                     updateRow(index, { container: raw === '' ? null : Number(raw) });
@@ -121,12 +123,18 @@ export function NetworkingStep({ ports, issues, onChange }: NetworkingStepProps)
                 </select>
               </div>
 
-              <Button type="button" variant="outline" size="sm" onClick={() => removeRow(index)}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                aria-label={`Remove port ${index + 1}`}
+                onClick={() => removeRow(index)}
+              >
                 Remove
               </Button>
 
               {issue && (
-                <p role="alert" className="w-full text-xs text-[var(--color-red)]">
+                <p id={`port-error-${index}`} role="alert" className="w-full text-xs text-[var(--color-red)]">
                   {issue.message}
                 </p>
               )}

--- a/app/packages/web/src/components/add-game-wizard/networking-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/networking-step.component.tsx
@@ -1,0 +1,135 @@
+/**
+ * "Networking" step of the add-game wizard (#99) — a row editor for
+ * {@link WizardDraftPort} entries (`container` port + `protocol`). Each row
+ * exposes a container-port number input and a protocol select, plus a
+ * "Remove" button; a trailing "Add port" button appends a blank row.
+ *
+ * The component itself holds no state — every edit (add/remove/edit) is
+ * expressed as a brand-new `ports` array passed to `onChange`, mirroring the
+ * rest of the wizard's "lift state up to the draft" pattern (see
+ * `wizard-form.utils.ts`). Validation issues are supplied by the caller
+ * (typically `validateNetworkingStep()`); a `ports[N]`-pathed issue
+ * highlights only that row, via {@link stepForIssuePath}'s sibling
+ * path-indexing scheme (`ports[0]`, `ports[1]`, ...).
+ */
+
+import type { GameServerValidationIssue } from '@hyveon/shared/gameServerValidator';
+import { Button } from '@/components/ui/button.component';
+import { Input } from '@/components/ui/input.component';
+import { Label } from '@/components/ui/label.component';
+import { cn } from '@/lib/utils.utils';
+import type { WizardDraftPort } from './wizard-form.utils.js';
+
+/** Protocol options offered in each row's dropdown; `game_servers[].ports[].protocol` is a plain string server-side, but only these two are meaningful for an ECS/Fargate task definition. */
+const PROTOCOL_OPTIONS = ['tcp', 'udp'] as const;
+
+/** Blank row appended by the "Add port" button. */
+const EMPTY_PORT: WizardDraftPort = { container: null, protocol: 'tcp' };
+
+/** Props for {@link NetworkingStep}. */
+export interface NetworkingStepProps {
+  /** Current draft port rows. */
+  ports: WizardDraftPort[];
+  /** Validation issues for this step (e.g. from `validateNetworkingStep()`), positioned via `ports[N]` / `ports[N].field` paths. */
+  issues: GameServerValidationIssue[];
+  /** Called with the full replacement `ports` array on every add/remove/edit. */
+  onChange: (ports: WizardDraftPort[]) => void;
+}
+
+/** Finds the issue (if any) whose path is exactly `ports[index]`, i.e. a row-level (not field-level) error. */
+function rowError(issues: GameServerValidationIssue[], index: number): GameServerValidationIssue | undefined {
+  return issues.find((issue) => issue.path === `ports[${index}]`);
+}
+
+/**
+ * Row editor for the wizard's "Networking" step. Renders one row per port
+ * with a container-port input, protocol select, and remove button, plus an
+ * "Add port" button that appends {@link EMPTY_PORT}.
+ */
+export function NetworkingStep({ ports, issues, onChange }: NetworkingStepProps) {
+  function addRow() {
+    onChange([...ports, { ...EMPTY_PORT }]);
+  }
+
+  function removeRow(index: number) {
+    onChange(ports.filter((_, i) => i !== index));
+  }
+
+  function updateRow(index: number, patch: Partial<WizardDraftPort>) {
+    onChange(ports.map((port, i) => (i === index ? { ...port, ...patch } : port)));
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-semibold text-[var(--color-foreground)]">Networking</h3>
+        <p className="text-xs text-[var(--color-muted-foreground)]">
+          Declare every container port the server listens on.
+        </p>
+      </div>
+
+      {ports.length === 0 && (
+        <p className="text-xs text-[var(--color-muted-foreground)]">No ports configured yet.</p>
+      )}
+
+      <div className="space-y-3">
+        {ports.map((port, index) => {
+          const issue = rowError(issues, index);
+          return (
+            <div
+              key={index}
+              data-testid={`port-row-${index}`}
+              className={cn(
+                'flex items-end gap-3 rounded-[var(--radius-sm)] border p-3',
+                issue ? 'border-[var(--color-red)]' : 'border-[var(--color-border)]',
+              )}
+            >
+              <div className="flex-1">
+                <Label htmlFor={`port-container-${index}`}>Container port</Label>
+                <Input
+                  id={`port-container-${index}`}
+                  type="number"
+                  value={port.container ?? ''}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    updateRow(index, { container: raw === '' ? null : Number(raw) });
+                  }}
+                />
+              </div>
+
+              <div className="flex-1">
+                <Label htmlFor={`port-protocol-${index}`}>Protocol</Label>
+                <select
+                  id={`port-protocol-${index}`}
+                  value={port.protocol}
+                  onChange={(event) => updateRow(index, { protocol: event.target.value })}
+                  className="flex h-9 w-full rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 py-1 text-sm text-[var(--color-foreground)]"
+                >
+                  {PROTOCOL_OPTIONS.map((protocol) => (
+                    <option key={protocol} value={protocol}>
+                      {protocol.toUpperCase()}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <Button type="button" variant="outline" size="sm" onClick={() => removeRow(index)}>
+                Remove
+              </Button>
+
+              {issue && (
+                <p role="alert" className="w-full text-xs text-[var(--color-red)]">
+                  {issue.message}
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <Button type="button" variant="secondary" size="sm" onClick={addRow}>
+        Add port
+      </Button>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/add-game-wizard/resources-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/resources-step.component.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getFargateMemoryOptions } from '@hyveon/shared/gameServerValidator';
+import { ResourcesStep } from './resources-step.component.js';
+
+/** Reads every non-placeholder `<option>` text from a select element, in DOM order. */
+function optionValues(select: HTMLElement): string[] {
+  return Array.from(select.querySelectorAll('option'))
+    .map((option) => option.value)
+    .filter((value) => value !== '');
+}
+
+describe('ResourcesStep', () => {
+  it('should only offer Fargate-valid memory pairings for the selected cpu (256 -> 512/1024/2048)', () => {
+    render(<ResourcesStep cpu={256} memory={null} onChange={() => undefined} issues={[]} />);
+
+    const memorySelect = screen.getByLabelText('Memory (MiB)');
+    expect(optionValues(memorySelect)).toEqual(['512', '1024', '2048']);
+  });
+
+  it('should only offer Fargate-valid memory pairings for the selected cpu (512 -> 1024/2048/3072/4096)', () => {
+    render(<ResourcesStep cpu={512} memory={null} onChange={() => undefined} issues={[]} />);
+
+    const memorySelect = screen.getByLabelText('Memory (MiB)');
+    expect(optionValues(memorySelect)).toEqual(
+      getFargateMemoryOptions(512).map((value) => String(value)),
+    );
+  });
+
+  it('should offer no memory options and disable the memory select when no cpu is selected', () => {
+    render(<ResourcesStep cpu={null} memory={null} onChange={() => undefined} issues={[]} />);
+
+    const memorySelect = screen.getByLabelText('Memory (MiB)');
+    expect(optionValues(memorySelect)).toEqual([]);
+    expect(memorySelect).toBeDisabled();
+  });
+
+  it('should reset memory to unset when a cpu change makes the current memory value invalid', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // cpu=256/memory=512 is a valid pairing; cpu=512 does not accept 512 MiB.
+    render(<ResourcesStep cpu={256} memory={512} onChange={onChange} issues={[]} />);
+
+    await user.selectOptions(screen.getByLabelText('CPU (vCPU units)'), '512');
+
+    expect(onChange).toHaveBeenCalledWith({ cpu: 512, memory: null });
+  });
+
+  it('should keep the current memory value when a cpu change still supports it', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // cpu=512/memory=2048 is valid; cpu=1024 also accepts 2048.
+    render(<ResourcesStep cpu={512} memory={2048} onChange={onChange} issues={[]} />);
+
+    await user.selectOptions(screen.getByLabelText('CPU (vCPU units)'), '1024');
+
+    expect(onChange).toHaveBeenCalledWith({ cpu: 1024, memory: 2048 });
+  });
+
+  it('should report a plain cpu change with the same memory when memory is unset', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ResourcesStep cpu={null} memory={null} onChange={onChange} issues={[]} />);
+
+    await user.selectOptions(screen.getByLabelText('CPU (vCPU units)'), '256');
+
+    expect(onChange).toHaveBeenCalledWith({ cpu: 256, memory: null });
+  });
+
+  it('should call onChange with the selected memory value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ResourcesStep cpu={256} memory={null} onChange={onChange} issues={[]} />);
+
+    await user.selectOptions(screen.getByLabelText('Memory (MiB)'), '1024');
+
+    expect(onChange).toHaveBeenCalledWith({ cpu: 256, memory: 1024 });
+  });
+
+  it('should surface a cpu validation issue beneath the cpu select', () => {
+    render(
+      <ResourcesStep
+        cpu={100}
+        memory={512}
+        onChange={() => undefined}
+        issues={[{ path: 'cpu', message: 'cpu must be one of the supported Fargate CPU units.' }]}
+      />,
+    );
+
+    expect(screen.getByText('cpu must be one of the supported Fargate CPU units.')).toBeInTheDocument();
+  });
+
+  it('should surface a memory validation issue beneath the memory select', () => {
+    render(
+      <ResourcesStep
+        cpu={256}
+        memory={1536}
+        onChange={() => undefined}
+        issues={[{ path: 'memory', message: 'memory 1536 MiB is not a valid Fargate pairing for cpu=256.' }]}
+      />,
+    );
+
+    expect(
+      screen.getByText('memory 1536 MiB is not a valid Fargate pairing for cpu=256.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/resources-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/resources-step.component.tsx
@@ -55,6 +55,8 @@ export function ResourcesStep({ cpu, memory, onChange, issues }: Props) {
           id="wizard-resources-cpu"
           value={cpu ?? ''}
           onChange={(e) => handleCpuChange(e.target.value)}
+          aria-invalid={cpuError ? 'true' : 'false'}
+          aria-describedby={cpuError ? 'wizard-resources-cpu-error' : undefined}
           className="h-9 w-56 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 text-sm text-[var(--color-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
         >
           <option value="">Select CPU…</option>
@@ -64,7 +66,11 @@ export function ResourcesStep({ cpu, memory, onChange, issues }: Props) {
             </option>
           ))}
         </select>
-        {cpuError && <p className="text-sm text-[var(--color-red)]">{cpuError}</p>}
+        {cpuError && (
+          <p id="wizard-resources-cpu-error" role="alert" className="text-sm text-[var(--color-red)]">
+            {cpuError}
+          </p>
+        )}
       </div>
 
       <div className="flex flex-col gap-1">
@@ -76,6 +82,8 @@ export function ResourcesStep({ cpu, memory, onChange, issues }: Props) {
           value={memory ?? ''}
           onChange={(e) => handleMemoryChange(e.target.value)}
           disabled={cpu === null}
+          aria-invalid={memoryError ? 'true' : 'false'}
+          aria-describedby={memoryError ? 'wizard-resources-memory-error' : undefined}
           className="h-9 w-56 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 text-sm text-[var(--color-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)] disabled:opacity-50"
         >
           <option value="">Select memory…</option>
@@ -85,7 +93,11 @@ export function ResourcesStep({ cpu, memory, onChange, issues }: Props) {
             </option>
           ))}
         </select>
-        {memoryError && <p className="text-sm text-[var(--color-red)]">{memoryError}</p>}
+        {memoryError && (
+          <p id="wizard-resources-memory-error" role="alert" className="text-sm text-[var(--color-red)]">
+            {memoryError}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/app/packages/web/src/components/add-game-wizard/resources-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/resources-step.component.tsx
@@ -1,0 +1,92 @@
+import {
+  getFargateCpuOptions,
+  getFargateMemoryOptions,
+  type GameServerValidationIssue,
+} from '@hyveon/shared/gameServerValidator';
+
+/** Updates the "Resources" step emits — always both fields, since a cpu change may also reset memory. */
+export interface ResourcesStepChange {
+  cpu: number | null;
+  memory: number | null;
+}
+
+interface Props {
+  cpu: number | null;
+  memory: number | null;
+  onChange: (change: ResourcesStepChange) => void;
+  issues: GameServerValidationIssue[];
+}
+
+/**
+ * "Resources" step of the add-game wizard (#99): cpu/memory selects backed
+ * directly by {@link getFargateCpuOptions}/{@link getFargateMemoryOptions} so
+ * the dropdowns can never offer a pairing the shared Fargate validator would
+ * reject. The memory select is rebuilt from the *currently selected* cpu on
+ * every render, and picking a new cpu that no longer supports the current
+ * memory value resets memory back to unset rather than leaving a stale,
+ * now-invalid value sitting in the draft.
+ */
+export function ResourcesStep({ cpu, memory, onChange, issues }: Props) {
+  const cpuOptions = getFargateCpuOptions();
+  const memoryOptions = cpu !== null ? getFargateMemoryOptions(cpu) : [];
+
+  const cpuError = issues.find((issue) => issue.path === 'cpu')?.message;
+  const memoryError = issues.find((issue) => issue.path === 'memory')?.message;
+
+  /** Applies a new cpu selection, resetting `memory` to unset if it isn't a valid pairing for the new cpu. */
+  function handleCpuChange(rawValue: string) {
+    const nextCpu = rawValue === '' ? null : Number(rawValue);
+    const validMemories = nextCpu !== null ? getFargateMemoryOptions(nextCpu) : [];
+    const nextMemory = memory !== null && validMemories.includes(memory) ? memory : null;
+    onChange({ cpu: nextCpu, memory: nextMemory });
+  }
+
+  function handleMemoryChange(rawValue: string) {
+    onChange({ cpu, memory: rawValue === '' ? null : Number(rawValue) });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="wizard-resources-cpu" className="text-sm font-medium text-[var(--color-foreground)]">
+          CPU (vCPU units)
+        </label>
+        <select
+          id="wizard-resources-cpu"
+          value={cpu ?? ''}
+          onChange={(e) => handleCpuChange(e.target.value)}
+          className="h-9 w-56 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 text-sm text-[var(--color-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+        >
+          <option value="">Select CPU…</option>
+          {cpuOptions.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+        {cpuError && <p className="text-sm text-[var(--color-red)]">{cpuError}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="wizard-resources-memory" className="text-sm font-medium text-[var(--color-foreground)]">
+          Memory (MiB)
+        </label>
+        <select
+          id="wizard-resources-memory"
+          value={memory ?? ''}
+          onChange={(e) => handleMemoryChange(e.target.value)}
+          disabled={cpu === null}
+          className="h-9 w-56 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 text-sm text-[var(--color-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)] disabled:opacity-50"
+        >
+          <option value="">Select memory…</option>
+          {memoryOptions.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+        {memoryError && <p className="text-sm text-[var(--color-red)]">{memoryError}</p>}
+      </div>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/add-game-wizard/review-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/review-step.component.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { WizardDraft } from './wizard-form.utils.js';
+import { ReviewStep } from './review-step.component.js';
+
+/** Builds a fully-populated draft covering every field, including the optional ones; override per test. */
+function makeFullDraft(overrides: Partial<WizardDraft> = {}): WizardDraft {
+  return {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server',
+    connect_message: 'Connect at {hostname}',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    file_seeds: [{ path: '/data/server.properties', content: 'foo=bar', content_base64: '', mode: '' }],
+    ...overrides,
+  };
+}
+
+describe('ReviewStep — fully-populated draft', () => {
+  it('should render every field of a fully-populated draft, including optional sections', () => {
+    render(<ReviewStep draft={makeFullDraft()} />);
+
+    expect(screen.getByText('minecraft')).toBeInTheDocument();
+    expect(screen.getByText('itzg/minecraft-server')).toBeInTheDocument();
+    expect(screen.getByText('Connect at {hostname}')).toBeInTheDocument();
+    expect(screen.getByText('1024')).toBeInTheDocument();
+    expect(screen.getByText('2048')).toBeInTheDocument();
+    expect(screen.getByText('25565')).toBeInTheDocument();
+    expect(screen.getByText('tcp')).toBeInTheDocument();
+    expect(screen.getByText('data')).toBeInTheDocument();
+    expect(screen.getByText('/data')).toBeInTheDocument();
+    expect(screen.getByText('File seeds')).toBeInTheDocument();
+    expect(screen.getByText('/data/server.properties')).toBeInTheDocument();
+  });
+});
+
+describe('ReviewStep — empty optional sections', () => {
+  it('should not render a Connect message row when connect_message is blank', () => {
+    render(<ReviewStep draft={makeFullDraft({ connect_message: '' })} />);
+
+    expect(screen.queryByText('Connect message')).not.toBeInTheDocument();
+  });
+
+  it('should not render a Connect message row when connect_message is only whitespace', () => {
+    render(<ReviewStep draft={makeFullDraft({ connect_message: '   ' })} />);
+
+    expect(screen.queryByText('Connect message')).not.toBeInTheDocument();
+  });
+
+  it('should not render the File seeds section when file_seeds is empty', () => {
+    render(<ReviewStep draft={makeFullDraft({ file_seeds: [] })} />);
+
+    expect(screen.queryByText('File seeds')).not.toBeInTheDocument();
+  });
+
+  it('should show a "no ports configured" placeholder when ports is empty', () => {
+    render(<ReviewStep draft={makeFullDraft({ ports: [] })} />);
+
+    expect(screen.getByText('No ports configured.')).toBeInTheDocument();
+  });
+
+  it('should show a "no volumes configured" placeholder when volumes is empty', () => {
+    render(<ReviewStep draft={makeFullDraft({ volumes: [] })} />);
+
+    expect(screen.getByText('No volumes configured.')).toBeInTheDocument();
+  });
+});
+
+describe('ReviewStep — submit errors', () => {
+  it('should not render an alert when submitError is not provided', () => {
+    render(<ReviewStep draft={makeFullDraft()} />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('should display the provided submit error message', () => {
+    const message = 'A game named "minecraft" already exists.';
+    render(<ReviewStep draft={makeFullDraft()} submitError={message} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(message);
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/review-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/review-step.component.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card.component';
+import type { WizardDraft } from './wizard-form.utils.js';
+
+/** Props for {@link ReviewStep}. */
+export interface ReviewStepProps {
+  /** The fully-assembled wizard draft to summarize before submit. */
+  draft: WizardDraft;
+  /** Server-side error message from a failed submit attempt (e.g. a name collision), surfaced above the summary so the operator can fix and retry without losing the draft. Submit/navigation controls themselves live in the wizard shell's footer, not here. */
+  submitError?: string | null;
+}
+
+/** One label/value pair in a summary section. */
+function SummaryRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-1.5 text-sm">
+      <span className="text-[var(--color-muted-foreground)]">{label}</span>
+      <span className="font-[var(--font-mono)] text-right text-[var(--color-foreground)] break-all">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Final step of the add-game wizard (#99): renders a read-only summary of
+ * every field entered across the Identity, Resources, Networking, and
+ * Storage steps. Optional fields that were left blank — `connect_message`
+ * and `file_seeds` — are omitted entirely rather than shown with a
+ * placeholder, so the summary only surfaces what the operator actually
+ * configured. A `submitError` from a failed submit attempt (surfaced by the
+ * wizard container after `POST /api/games` fails) is rendered as an alert
+ * below the summary so the draft isn't lost. This component is purely
+ * presentational — Submit/navigation controls are owned exclusively by the
+ * wizard shell's footer, not by this step.
+ */
+export function ReviewStep({ draft, submitError = null }: ReviewStepProps) {
+  const hasConnectMessage = draft.connect_message.trim().length > 0;
+  const hasFileSeeds = draft.file_seeds.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Identity</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <SummaryRow label="Name" value={draft.name || '—'} />
+          <SummaryRow label="Image" value={draft.image || '—'} />
+          {hasConnectMessage && <SummaryRow label="Connect message" value={draft.connect_message} />}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Resources</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1">
+          <SummaryRow label="CPU" value={draft.cpu ?? '—'} />
+          <SummaryRow label="Memory" value={draft.memory ?? '—'} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Networking</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {draft.ports.length === 0 ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">No ports configured.</p>
+          ) : (
+            <ul className="space-y-1">
+              {draft.ports.map((port, index) => (
+                <li key={index} className="flex items-center justify-between gap-4 py-1 text-sm">
+                  <span className="font-[var(--font-mono)]">{port.container ?? '—'}</span>
+                  <span className="uppercase text-[var(--color-muted-foreground)]">{port.protocol}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Storage</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {draft.volumes.length === 0 ? (
+            <p className="text-sm text-[var(--color-muted-foreground)]">No volumes configured.</p>
+          ) : (
+            <ul className="space-y-1">
+              {draft.volumes.map((volume, index) => (
+                <li key={index} className="flex items-center justify-between gap-4 py-1 text-sm">
+                  <span>{volume.name}</span>
+                  <span className="font-[var(--font-mono)] text-[var(--color-muted-foreground)]">
+                    {volume.container_path}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {hasFileSeeds && (
+            <div>
+              <h4 className="text-xs uppercase tracking-wider text-[var(--color-muted-foreground)] mb-1">
+                File seeds
+              </h4>
+              <ul className="space-y-1">
+                {draft.file_seeds.map((seed, index) => (
+                  <li key={index} className="font-[var(--font-mono)] text-sm">
+                    {seed.path}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {submitError && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-[var(--color-red)] bg-[var(--color-red)]/10 px-3 py-2 text-sm text-[var(--color-red)]"
+        >
+          <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+          {submitError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/packages/web/src/components/add-game-wizard/storage-step.component.test.tsx
+++ b/app/packages/web/src/components/add-game-wizard/storage-step.component.test.tsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StorageStep } from './storage-step.component.js';
+import type { WizardDraft } from './wizard-form.utils.js';
+
+/** Builds a minimal draft for the Storage step; only `volumes`/`file_seeds` matter here. */
+function makeDraft(overrides: Partial<WizardDraft> = {}): WizardDraft {
+  return {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server',
+    connect_message: '',
+    cpu: 1024,
+    memory: 2048,
+    ports: [],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    file_seeds: [],
+    ...overrides,
+  };
+}
+
+describe('StorageStep', () => {
+  describe('volumes', () => {
+    it('should disable the remove button on the only volume row', () => {
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={vi.fn()} />);
+
+      expect(screen.getByRole('button', { name: /Remove volume 1/ })).toBeDisabled();
+    });
+
+    it('should enable remove buttons when there are multiple volume rows', () => {
+      render(
+        <StorageStep
+          draft={makeDraft({
+            volumes: [
+              { name: 'data', container_path: '/data' },
+              { name: 'saves', container_path: '/saves' },
+            ],
+          })}
+          issues={[]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const removeButtons = screen.getAllByRole('button', { name: /Remove volume/ });
+      expect(removeButtons).toHaveLength(2);
+      expect(removeButtons[0]).not.toBeDisabled();
+      expect(removeButtons[1]).not.toBeDisabled();
+    });
+
+    it('should call onChange with the row removed when a non-last volume row is removed', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <StorageStep
+          draft={makeDraft({
+            volumes: [
+              { name: 'data', container_path: '/data' },
+              { name: 'saves', container_path: '/saves' },
+            ],
+          })}
+          issues={[]}
+          onChange={onChange}
+        />,
+      );
+
+      const removeButtons = screen.getAllByRole('button', { name: /Remove volume/ });
+      await user.click(removeButtons[1]);
+
+      expect(onChange).toHaveBeenCalledWith({ volumes: [{ name: 'data', container_path: '/data' }] });
+    });
+
+    it('should not remove the last volume row even if its disabled remove button is clicked', () => {
+      const onChange = vi.fn();
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Remove volume 1/ }));
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should append a blank volume row when "Add volume" is clicked', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+      await user.click(screen.getByRole('button', { name: 'Add volume' }));
+
+      expect(onChange).toHaveBeenCalledWith({
+        volumes: [
+          { name: 'data', container_path: '/data' },
+          { name: '', container_path: '' },
+        ],
+      });
+    });
+
+    it('should update the name field for the edited volume row', () => {
+      const onChange = vi.fn();
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+      fireEvent.change(screen.getByLabelText('Volume name'), { target: { value: 'world' } });
+
+      expect(onChange).toHaveBeenCalledWith({ volumes: [{ name: 'world', container_path: '/data' }] });
+    });
+
+    it('should update the container_path field for the edited volume row', () => {
+      const onChange = vi.fn();
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+      fireEvent.change(screen.getByLabelText('Container path'), { target: { value: '/world' } });
+
+      expect(onChange).toHaveBeenCalledWith({ volumes: [{ name: 'data', container_path: '/world' }] });
+    });
+
+    it('should render a general error banner when the issue path is exactly "volumes"', () => {
+      render(
+        <StorageStep
+          draft={makeDraft({ volumes: [] })}
+          issues={[
+            {
+              path: 'volumes',
+              message: 'Each game server must have at least one volume entry with non-empty name and container_path.',
+            },
+          ]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Each game server must have at least one volume entry with non-empty name and container_path.',
+      );
+    });
+
+    it('should attach an indexed volumes[1].container_path error to only the second row', () => {
+      render(
+        <StorageStep
+          draft={makeDraft({
+            volumes: [
+              { name: 'data', container_path: '/data' },
+              { name: 'saves', container_path: 'saves' },
+            ],
+          })}
+          issues={[{ path: 'volumes[1].container_path', message: 'volumes[1].container_path must be an absolute path.' }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const firstRow = screen.getByTestId('volume-row-0');
+      const secondRow = screen.getByTestId('volume-row-1');
+
+      expect(within(firstRow).queryByText('volumes[1].container_path must be an absolute path.')).toBeNull();
+      expect(within(secondRow).getByText('volumes[1].container_path must be an absolute path.')).toBeInTheDocument();
+    });
+
+    it('should attach an indexed volumes[0].name error to only the first row', () => {
+      render(
+        <StorageStep
+          draft={makeDraft({
+            volumes: [
+              { name: '', container_path: '/data' },
+              { name: 'saves', container_path: '/saves' },
+            ],
+          })}
+          issues={[{ path: 'volumes[0].name', message: 'volumes[].name must not be empty.' }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const firstRow = screen.getByTestId('volume-row-0');
+      const secondRow = screen.getByTestId('volume-row-1');
+
+      expect(within(firstRow).getByText('volumes[].name must not be empty.')).toBeInTheDocument();
+      expect(within(secondRow).queryByText('volumes[].name must not be empty.')).toBeNull();
+    });
+  });
+
+  describe('file_seeds', () => {
+    it('should render "No file seeds configured." when file_seeds is empty', () => {
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={vi.fn()} />);
+
+      expect(screen.getByText('No file seeds configured.')).toBeInTheDocument();
+    });
+
+    it('should append a blank file seed row when "Add file seed" is clicked', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(<StorageStep draft={makeDraft()} issues={[]} onChange={onChange} />);
+
+      await user.click(screen.getByRole('button', { name: 'Add file seed' }));
+
+      expect(onChange).toHaveBeenCalledWith({
+        file_seeds: [{ path: '', content: '', content_base64: '', mode: '' }],
+      });
+    });
+
+    it('should never disable a file seed row\'s remove button, even when it is the only row', () => {
+      render(
+        <StorageStep
+          draft={makeDraft({ file_seeds: [{ path: '/data/config.yml', content: '', content_base64: '', mode: '' }] })}
+          issues={[]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /Remove file seed 1/ })).not.toBeDisabled();
+    });
+
+    it('should call onChange with an empty file_seeds array when the only row is removed', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <StorageStep
+          draft={makeDraft({ file_seeds: [{ path: '/data/config.yml', content: '', content_base64: '', mode: '' }] })}
+          issues={[]}
+          onChange={onChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /Remove file seed 1/ }));
+
+      expect(onChange).toHaveBeenCalledWith({ file_seeds: [] });
+    });
+
+    it('should update every field of a file seed row via onChange', () => {
+      const onChange = vi.fn();
+      const seed = { path: '/data/config.yml', content: 'foo: bar', content_base64: '', mode: '' };
+      render(<StorageStep draft={makeDraft({ file_seeds: [seed] })} issues={[]} onChange={onChange} />);
+
+      fireEvent.change(screen.getByLabelText('Path'), { target: { value: '/data/other.yml' } });
+      expect(onChange).toHaveBeenLastCalledWith({ file_seeds: [{ ...seed, path: '/data/other.yml' }] });
+
+      fireEvent.change(screen.getByLabelText('Content'), { target: { value: 'baz: qux' } });
+      expect(onChange).toHaveBeenLastCalledWith({ file_seeds: [{ ...seed, content: 'baz: qux' }] });
+
+      fireEvent.change(screen.getByLabelText('Content (base64)'), { target: { value: 'YmF6' } });
+      expect(onChange).toHaveBeenLastCalledWith({ file_seeds: [{ ...seed, content_base64: 'YmF6' }] });
+
+      fireEvent.change(screen.getByLabelText('Mode'), { target: { value: '0644' } });
+      expect(onChange).toHaveBeenLastCalledWith({ file_seeds: [{ ...seed, mode: '0644' }] });
+    });
+
+    it('should attach an indexed file_seeds[0].path error to only the first file seed row', () => {
+      render(
+        <StorageStep
+          draft={makeDraft({
+            file_seeds: [
+              { path: 'config.yml', content: '', content_base64: '', mode: '' },
+              { path: '/data/other.yml', content: '', content_base64: '', mode: '' },
+            ],
+          })}
+          issues={[{ path: 'file_seeds[0].path', message: 'file_seeds[0].path must be an absolute path.' }]}
+          onChange={vi.fn()}
+        />,
+      );
+
+      const firstRow = screen.getByTestId('file-seed-row-0');
+      const secondRow = screen.getByTestId('file-seed-row-1');
+
+      expect(within(firstRow).getByText('file_seeds[0].path must be an absolute path.')).toBeInTheDocument();
+      expect(within(secondRow).queryByText('file_seeds[0].path must be an absolute path.')).toBeNull();
+      expect(firstRow.className).toContain('border-[var(--color-red)]');
+      expect(secondRow.className).not.toContain('border-[var(--color-red)]');
+    });
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/storage-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/storage-step.component.tsx
@@ -1,0 +1,276 @@
+/**
+ * "Storage" step of the add-game wizard (#99): editable `volumes` rows
+ * (`name` + `container_path`) plus fully-optional `file_seeds` rows (`path`
+ * + `content` + `content_base64` + `mode`).
+ *
+ * The server requires at least one volume
+ * (`gameServerSchema.volumes.min(1)`, see `gameServerValidator.ts`), so the
+ * "Remove" button on the last remaining volume row is disabled — unlike
+ * `file_seeds`, which are genuinely optional and can be removed down to
+ * zero rows.
+ *
+ * Purely presentational, mirroring the rest of the wizard's "lift state up
+ * to the draft" pattern: every add/remove/edit is expressed as a
+ * `{ volumes }` or `{ file_seeds }` patch passed to `onChange`. Validation
+ * issues are supplied by the caller (typically `validateStorageStep()`) and
+ * matched back to the row/field they belong to by exact path —
+ * `volumes[0].container_path`, `file_seeds[1].path`, or the array-level
+ * `volumes` issue for the min-1 rule.
+ */
+
+import type { GameServerValidationIssue } from '@hyveon/shared/gameServerValidator';
+import { Button } from '@/components/ui/button.component';
+import { Input } from '@/components/ui/input.component';
+import { Label } from '@/components/ui/label.component';
+import { cn } from '@/lib/utils.utils';
+import type { WizardDraft, WizardDraftFileSeed, WizardDraftVolume } from './wizard-form.utils.js';
+
+/** Blank row appended by the "Add volume" button. */
+const EMPTY_VOLUME: WizardDraftVolume = { name: '', container_path: '' };
+
+/** Blank row appended by the "Add file seed" button. */
+const EMPTY_FILE_SEED: WizardDraftFileSeed = { path: '', content: '', content_base64: '', mode: '' };
+
+/** Props for {@link StorageStep}. */
+export interface StorageStepProps {
+  /** The wizard's in-progress draft; only `volumes`/`file_seeds` are read here. */
+  draft: WizardDraft;
+  /** Validation issues for this step (e.g. from `validateStorageStep()`), positioned via `volumes`/`volumes[N].field`/`file_seeds[N].field` paths. */
+  issues: GameServerValidationIssue[];
+  /** Called with a partial patch of the changed field whenever the operator adds, removes, or edits a row. */
+  onChange: (patch: Partial<Pick<WizardDraft, 'volumes' | 'file_seeds'>>) => void;
+}
+
+/** Finds the message (if any) whose issue path is exactly `path`. */
+function messageFor(issues: GameServerValidationIssue[], path: string): string | undefined {
+  return issues.find((issue) => issue.path === path)?.message;
+}
+
+/**
+ * Row editor for the wizard's "Storage" step: a `volumes` list (at least one
+ * row required, enforced by disabling the last row's remove button) and an
+ * optional `file_seeds` list.
+ */
+export function StorageStep({ draft, issues, onChange }: StorageStepProps) {
+  const { volumes, file_seeds: fileSeeds } = draft;
+
+  const volumesArrayError = messageFor(issues, 'volumes');
+
+  function addVolume() {
+    onChange({ volumes: [...volumes, { ...EMPTY_VOLUME }] });
+  }
+
+  function removeVolume(index: number) {
+    if (volumes.length <= 1) return;
+    onChange({ volumes: volumes.filter((_, i) => i !== index) });
+  }
+
+  function updateVolume(index: number, patch: Partial<WizardDraftVolume>) {
+    onChange({ volumes: volumes.map((volume, i) => (i === index ? { ...volume, ...patch } : volume)) });
+  }
+
+  function addFileSeed() {
+    onChange({ file_seeds: [...fileSeeds, { ...EMPTY_FILE_SEED }] });
+  }
+
+  function removeFileSeed(index: number) {
+    onChange({ file_seeds: fileSeeds.filter((_, i) => i !== index) });
+  }
+
+  function updateFileSeed(index: number, patch: Partial<WizardDraftFileSeed>) {
+    onChange({ file_seeds: fileSeeds.map((seed, i) => (i === index ? { ...seed, ...patch } : seed)) });
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-semibold text-[var(--color-foreground)]">Volumes</h3>
+          <p className="text-xs text-[var(--color-muted-foreground)]">
+            Every game server needs at least one EFS-backed volume for its save data.
+          </p>
+        </div>
+
+        {volumesArrayError && (
+          <p role="alert" className="text-xs text-[var(--color-red)]">
+            {volumesArrayError}
+          </p>
+        )}
+
+        <div className="space-y-3">
+          {volumes.map((volume, index) => {
+            const nameError = messageFor(issues, `volumes[${index}].name`);
+            const pathError = messageFor(issues, `volumes[${index}].container_path`);
+            const canRemove = volumes.length > 1;
+
+            return (
+              <div
+                key={index}
+                data-testid={`volume-row-${index}`}
+                className="flex items-end gap-3 rounded-[var(--radius-sm)] border border-[var(--color-border)] p-3"
+              >
+                <div className="flex-1 space-y-1">
+                  <Label htmlFor={`volume-name-${index}`}>Volume name</Label>
+                  <Input
+                    id={`volume-name-${index}`}
+                    value={volume.name}
+                    placeholder="data"
+                    onChange={(event) => updateVolume(index, { name: event.target.value })}
+                  />
+                  {nameError && (
+                    <p role="alert" className="text-xs text-[var(--color-red)]">
+                      {nameError}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex-1 space-y-1">
+                  <Label htmlFor={`volume-path-${index}`}>Container path</Label>
+                  <Input
+                    id={`volume-path-${index}`}
+                    value={volume.container_path}
+                    placeholder="/data"
+                    onChange={(event) => updateVolume(index, { container_path: event.target.value })}
+                  />
+                  {pathError && (
+                    <p role="alert" className="text-xs text-[var(--color-red)]">
+                      {pathError}
+                    </p>
+                  )}
+                </div>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!canRemove}
+                  aria-label={canRemove ? `Remove volume ${index + 1}` : `Remove volume ${index + 1} (at least one volume is required)`}
+                  onClick={() => removeVolume(index)}
+                >
+                  Remove
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+
+        <Button type="button" variant="secondary" size="sm" onClick={addVolume}>
+          Add volume
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-semibold text-[var(--color-foreground)]">File seeds</h3>
+          <p className="text-xs text-[var(--color-muted-foreground)]">
+            Optional — files written into a volume the first time the server starts.
+          </p>
+        </div>
+
+        {fileSeeds.length === 0 && (
+          <p className="text-xs text-[var(--color-muted-foreground)]">No file seeds configured.</p>
+        )}
+
+        <div className="space-y-3">
+          {fileSeeds.map((seed, index) => {
+            const pathError = messageFor(issues, `file_seeds[${index}].path`);
+            const contentError = messageFor(issues, `file_seeds[${index}].content`);
+            const base64Error = messageFor(issues, `file_seeds[${index}].content_base64`);
+            const modeError = messageFor(issues, `file_seeds[${index}].mode`);
+
+            return (
+              <div
+                key={index}
+                data-testid={`file-seed-row-${index}`}
+                className={cn(
+                  'space-y-3 rounded-[var(--radius-sm)] border p-3',
+                  pathError ? 'border-[var(--color-red)]' : 'border-[var(--color-border)]',
+                )}
+              >
+                <div className="flex items-end gap-3">
+                  <div className="flex-1 space-y-1">
+                    <Label htmlFor={`file-seed-path-${index}`}>Path</Label>
+                    <Input
+                      id={`file-seed-path-${index}`}
+                      value={seed.path}
+                      placeholder="/data/config.yml"
+                      onChange={(event) => updateFileSeed(index, { path: event.target.value })}
+                    />
+                    {pathError && (
+                      <p role="alert" className="text-xs text-[var(--color-red)]">
+                        {pathError}
+                      </p>
+                    )}
+                  </div>
+
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label={`Remove file seed ${index + 1}`}
+                    onClick={() => removeFileSeed(index)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+
+                <div className="space-y-1">
+                  <Label htmlFor={`file-seed-content-${index}`}>Content</Label>
+                  <textarea
+                    id={`file-seed-content-${index}`}
+                    value={seed.content}
+                    placeholder="Plain-text file contents"
+                    rows={3}
+                    onChange={(event) => updateFileSeed(index, { content: event.target.value })}
+                    className="flex w-full rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 py-1.5 text-sm text-[var(--color-foreground)] font-[var(--font-mono)] placeholder:text-[var(--color-muted-foreground)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-primary)]"
+                  />
+                  {contentError && (
+                    <p role="alert" className="text-xs text-[var(--color-red)]">
+                      {contentError}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex gap-3">
+                  <div className="flex-1 space-y-1">
+                    <Label htmlFor={`file-seed-base64-${index}`}>Content (base64)</Label>
+                    <Input
+                      id={`file-seed-base64-${index}`}
+                      value={seed.content_base64}
+                      placeholder="Base64-encoded binary contents"
+                      onChange={(event) => updateFileSeed(index, { content_base64: event.target.value })}
+                    />
+                    {base64Error && (
+                      <p role="alert" className="text-xs text-[var(--color-red)]">
+                        {base64Error}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="w-28 space-y-1">
+                    <Label htmlFor={`file-seed-mode-${index}`}>Mode</Label>
+                    <Input
+                      id={`file-seed-mode-${index}`}
+                      value={seed.mode}
+                      placeholder="0644"
+                      onChange={(event) => updateFileSeed(index, { mode: event.target.value })}
+                    />
+                    {modeError && (
+                      <p role="alert" className="text-xs text-[var(--color-red)]">
+                        {modeError}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <Button type="button" variant="secondary" size="sm" onClick={addFileSeed}>
+          Add file seed
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.test.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.test.ts
@@ -111,6 +111,20 @@ describe('validateIdentityStep', () => {
     expect(issues.some((issue) => issue.path === 'connect_message')).toBe(true);
   });
 
+  it('should flag an unknown connect_message placeholder even when cpu/memory/volumes are still unset', () => {
+    // Regression test: on a fresh Identity step, cpu/memory are null and
+    // volumes is empty, so validateGameServer's structural schema parse
+    // fails before it ever reaches its own connect_message check. The
+    // wizard must still catch a bad placeholder here rather than letting
+    // Next stay enabled and only surfacing (or not surfacing) the problem
+    // at Review.
+    const issues = validateIdentityStep(
+      makeValidDraft({ connect_message: 'Connect via {password}', cpu: null, memory: null, volumes: [] }),
+      [],
+    );
+    expect(issues.some((issue) => issue.path === 'connect_message')).toBe(true);
+  });
+
   it('should pass a clean identity step', () => {
     expect(validateIdentityStep(makeValidDraft(), [])).toEqual([]);
   });

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.test.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEmptyWizardDraft,
+  stepForIssuePath,
+  validateWizardDraft,
+  validateIdentityStep,
+  validateResourcesStep,
+  validateNetworkingStep,
+  validateStorageStep,
+  validateReviewStep,
+  canAdvance,
+  type WizardDraft,
+} from './wizard-form.utils.js';
+import type { GameServer } from '../../api.service.js';
+
+/** Builds a fully-valid draft; override any fields per test. */
+function makeValidDraft(overrides: Partial<WizardDraft> = {}): WizardDraft {
+  return {
+    name: 'minecraft',
+    image: 'itzg/minecraft-server',
+    connect_message: '',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    file_seeds: [],
+    ...overrides,
+  };
+}
+
+/** Builds a minimal existing declared GameServer entry; override any fields per test. */
+function makeExistingGame(overrides: Partial<GameServer> = {}): GameServer {
+  return {
+    name: 'valheim',
+    image: 'lloesche/valheim-server',
+    cpu: 1024,
+    memory: 2048,
+    ports: [{ container: 2456, protocol: 'udp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    ...overrides,
+  };
+}
+
+describe('createEmptyWizardDraft', () => {
+  it('should return a blank draft with empty strings, null cpu/memory, and empty arrays', () => {
+    expect(createEmptyWizardDraft()).toEqual({
+      name: '',
+      image: '',
+      connect_message: '',
+      cpu: null,
+      memory: null,
+      ports: [],
+      volumes: [],
+      file_seeds: [],
+    });
+  });
+});
+
+describe('stepForIssuePath', () => {
+  it.each([
+    ['name', 'identity'],
+    ['image', 'identity'],
+    ['connect_message', 'identity'],
+    ['cpu', 'resources'],
+    ['memory', 'resources'],
+    ['ports', 'networking'],
+    ['ports[0]', 'networking'],
+    ['ports[1].protocol', 'networking'],
+    ['volumes', 'storage'],
+    ['volumes[0].container_path', 'storage'],
+    ['file_seeds', 'storage'],
+    ['file_seeds[0].path', 'storage'],
+  ] as const)('should map path %s to the %s step', (path, step) => {
+    expect(stepForIssuePath(path)).toBe(step);
+  });
+
+  it('should fall back to the review step for an unrecognized field family', () => {
+    expect(stepForIssuePath('somethingUnknown')).toBe('review');
+  });
+});
+
+describe('validateWizardDraft', () => {
+  it('should return no issues for a fully valid draft', () => {
+    expect(validateWizardDraft(makeValidDraft(), [])).toEqual([]);
+  });
+});
+
+describe('validateIdentityStep', () => {
+  it('should flag a blank name as required', () => {
+    const issues = validateIdentityStep(makeValidDraft({ name: '' }), []);
+    expect(issues).toContainEqual({ path: 'name', message: 'Name is required.' });
+  });
+
+  it('should flag a name containing invalid characters', () => {
+    const issues = validateIdentityStep(makeValidDraft({ name: 'my game!' }), []);
+    expect(issues.some((issue) => issue.path === 'name')).toBe(true);
+  });
+
+  it('should flag a name that collides with an already-declared game', () => {
+    const issues = validateIdentityStep(makeValidDraft({ name: 'valheim' }), [makeExistingGame({ name: 'valheim' })]);
+    expect(issues.some((issue) => issue.path === 'name' && issue.message.includes('already exists'))).toBe(true);
+  });
+
+  it('should flag a blank image', () => {
+    const issues = validateIdentityStep(makeValidDraft({ image: '' }), []);
+    expect(issues.some((issue) => issue.path === 'image')).toBe(true);
+  });
+
+  it('should flag an unknown connect_message placeholder', () => {
+    const issues = validateIdentityStep(makeValidDraft({ connect_message: 'Connect via {password}' }), []);
+    expect(issues.some((issue) => issue.path === 'connect_message')).toBe(true);
+  });
+
+  it('should pass a clean identity step', () => {
+    expect(validateIdentityStep(makeValidDraft(), [])).toEqual([]);
+  });
+
+  it('should not report resources/networking/storage issues even when those fields are invalid', () => {
+    const issues = validateIdentityStep(makeValidDraft({ cpu: null, ports: [], volumes: [] }), []);
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validateResourcesStep', () => {
+  it('should flag a missing cpu', () => {
+    const issues = validateResourcesStep(makeValidDraft({ cpu: null }), []);
+    expect(issues.some((issue) => issue.path === 'cpu')).toBe(true);
+  });
+
+  it('should flag a missing memory', () => {
+    const issues = validateResourcesStep(makeValidDraft({ memory: null }), []);
+    expect(issues.some((issue) => issue.path === 'memory')).toBe(true);
+  });
+
+  it('should flag a memory value that is not a valid Fargate pairing for the chosen cpu', () => {
+    const issues = validateResourcesStep(makeValidDraft({ cpu: 256, memory: 1536 }), []);
+    expect(issues.some((issue) => issue.path === 'memory')).toBe(true);
+  });
+
+  it('should flag a cpu value outside the supported Fargate tiers', () => {
+    const issues = validateResourcesStep(makeValidDraft({ cpu: 100, memory: 512 }), []);
+    expect(issues.some((issue) => issue.path === 'cpu')).toBe(true);
+  });
+
+  it('should pass a clean resources step', () => {
+    expect(validateResourcesStep(makeValidDraft(), [])).toEqual([]);
+  });
+});
+
+describe('validateNetworkingStep', () => {
+  it('should flag two ports within the draft that collide on container/protocol', () => {
+    const issues = validateNetworkingStep(
+      makeValidDraft({
+        ports: [
+          { container: 25565, protocol: 'tcp' },
+          { container: 25565, protocol: 'TCP' },
+        ],
+      }),
+      [],
+    );
+    expect(issues.some((issue) => issue.path === 'ports[1]')).toBe(true);
+  });
+
+  it('should flag a port that collides with an already-declared game (cross-game collision)', () => {
+    const existing = makeExistingGame({ name: 'valheim', ports: [{ container: 25565, protocol: 'tcp' }] });
+    const issues = validateNetworkingStep(
+      makeValidDraft({ name: 'minecraft', ports: [{ container: 25565, protocol: 'tcp' }] }),
+      [existing],
+    );
+    expect(issues.some((issue) => issue.path === 'ports[0]' && issue.message.includes('valheim'))).toBe(true);
+  });
+
+  it('should not flag a self-collision when re-validating an already-declared game under its own name', () => {
+    const existing = makeExistingGame({ name: 'minecraft', ports: [{ container: 25565, protocol: 'tcp' }] });
+    const issues = validateNetworkingStep(
+      makeValidDraft({ name: 'minecraft', ports: [{ container: 25565, protocol: 'tcp' }] }),
+      [existing],
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('should pass a clean networking step', () => {
+    expect(validateNetworkingStep(makeValidDraft(), [])).toEqual([]);
+  });
+
+  it('should not report identity/resources/storage issues even when those fields are invalid', () => {
+    const issues = validateNetworkingStep(makeValidDraft({ name: '', cpu: null, volumes: [] }), []);
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('validateStorageStep', () => {
+  it('should flag an empty volumes array (volumes-min-1 rule)', () => {
+    const issues = validateStorageStep(makeValidDraft({ volumes: [] }), []);
+    expect(issues.some((issue) => issue.path === 'volumes')).toBe(true);
+  });
+
+  it('should flag a relative volumes[].container_path', () => {
+    const issues = validateStorageStep(makeValidDraft({ volumes: [{ name: 'data', container_path: 'data' }] }), []);
+    expect(issues.some((issue) => issue.path === 'volumes[0].container_path')).toBe(true);
+  });
+
+  it('should flag a relative file_seeds[].path', () => {
+    const issues = validateStorageStep(
+      makeValidDraft({ file_seeds: [{ path: 'config.yml', content: 'foo: bar', content_base64: '', mode: '' }] }),
+      [],
+    );
+    expect(issues.some((issue) => issue.path === 'file_seeds[0].path')).toBe(true);
+  });
+
+  it('should pass a clean storage step', () => {
+    expect(validateStorageStep(makeValidDraft(), [])).toEqual([]);
+  });
+});
+
+describe('validateReviewStep', () => {
+  it('should aggregate issues from every step', () => {
+    // `name` (checked outside the shared schema) and `volumes` (a zod
+    // structural failure) are both evaluated regardless of whether the rest
+    // of the entry parses, so combining them here proves aggregation works
+    // across the "always runs" and "schema-gated" halves of validateWizardDraft.
+    const issues = validateReviewStep(makeValidDraft({ name: '', volumes: [] }), []);
+    expect(issues.some((issue) => issue.path === 'name')).toBe(true);
+    expect(issues.some((issue) => issue.path === 'volumes')).toBe(true);
+  });
+
+  it('should pass a clean review step', () => {
+    expect(validateReviewStep(makeValidDraft(), [])).toEqual([]);
+  });
+});
+
+describe('canAdvance', () => {
+  it('should return true for a step with no outstanding issues', () => {
+    expect(canAdvance('resources', makeValidDraft(), [])).toBe(true);
+  });
+
+  it('should return false for a step with an outstanding issue', () => {
+    expect(canAdvance('resources', makeValidDraft({ cpu: null }), [])).toBe(false);
+  });
+});

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
@@ -1,0 +1,242 @@
+/**
+ * Draft state shape + per-step validation for the add-game wizard (#99).
+ *
+ * The wizard walks the operator through five steps — identity, resources,
+ * networking, storage, review — that together assemble one `game_servers`
+ * entry. Rather than re-implement the business rules already enforced
+ * server-side, this module builds a proposed entry from the in-progress
+ * {@link WizardDraft} and delegates to {@link validateGameServer} (the same
+ * zod schema + business-rule validator used by `GamesWriteService`), then
+ * buckets the returned issues back onto the step whose fields they belong
+ * to via {@link stepForIssuePath}. This keeps the wizard's validation in
+ * lockstep with the server without duplicating the rules.
+ */
+
+import {
+  validateGameServer,
+  type GameServerValidationIssue,
+} from '@hyveon/shared/gameServerValidator';
+import type { GameServer } from '../../api.service.js';
+
+/** Ordered steps of the add-game wizard, matching issue #99's scope. */
+export const WIZARD_STEPS = ['identity', 'resources', 'networking', 'storage', 'review'] as const;
+
+/** One step of the add-game wizard. */
+export type WizardStep = (typeof WIZARD_STEPS)[number];
+
+/** Placeholder name used to validate a draft before the operator has typed one, so the port-collision self-exclusion check never accidentally matches a real existing game. */
+const DRAFT_NAME_PLACEHOLDER = '__draft__';
+
+/** Bare HCL identifier pattern a `game_servers` map key must match (mirrors `HCL_IDENTIFIER_PATTERN` in `TfvarsService`) — letters, digits, underscores, and hyphens, not starting with a digit. */
+const NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+/** Draft form of a single `GameServerPort` row. `container` is `null` until the operator fills in the field, so an empty row can be told apart from a mistyped one. */
+export interface WizardDraftPort {
+  container: number | null;
+  protocol: string;
+}
+
+/** Draft form of a single `GameServerVolume` row. */
+export interface WizardDraftVolume {
+  name: string;
+  container_path: string;
+}
+
+/** Draft form of a single `GameServerFileSeed` row. Empty strings mean "not set" and are stripped before validation/submit. */
+export interface WizardDraftFileSeed {
+  path: string;
+  content: string;
+  content_base64: string;
+  mode: string;
+}
+
+/**
+ * In-progress state of the add-game wizard, covering every field across all
+ * five steps. Field names mirror `GameServer` (snake_case) since the draft
+ * is converted directly into a proposed entry for {@link validateGameServer}.
+ */
+export interface WizardDraft {
+  name: string;
+  image: string;
+  connect_message: string;
+  cpu: number | null;
+  memory: number | null;
+  ports: WizardDraftPort[];
+  volumes: WizardDraftVolume[];
+  file_seeds: WizardDraftFileSeed[];
+}
+
+/** Builds a blank {@link WizardDraft} — the wizard's initial state before the operator has entered anything. */
+export function createEmptyWizardDraft(): WizardDraft {
+  return {
+    name: '',
+    image: '',
+    connect_message: '',
+    cpu: null,
+    memory: null,
+    ports: [],
+    volumes: [],
+    file_seeds: [],
+  };
+}
+
+/**
+ * Maps a validation issue's `path` (e.g. `volumes[0].container_path`,
+ * `ports[1]`, `memory`, `name`) to the wizard step whose fields own it, by
+ * looking at the first path segment (the field family). Every top-level
+ * field on {@link WizardDraft} is covered: `name`/`image`/`connect_message`
+ * → identity, `cpu`/`memory` → resources, `ports` → networking,
+ * `volumes`/`file_seeds` → storage. Anything unrecognized falls back to
+ * `review` so it's still surfaced somewhere rather than silently dropped.
+ */
+export function stepForIssuePath(path: string): WizardStep {
+  const family = path.split(/[.[]/)[0];
+  switch (family) {
+    case 'name':
+    case 'image':
+    case 'connect_message':
+      return 'identity';
+    case 'cpu':
+    case 'memory':
+      return 'resources';
+    case 'ports':
+      return 'networking';
+    case 'volumes':
+    case 'file_seeds':
+      return 'storage';
+    default:
+      return 'review';
+  }
+}
+
+/**
+ * Validates `name` against the rules `TfvarsService.insertGameServerEntry()`
+ * enforces server-side: non-empty, a valid bare HCL identifier, and not
+ * already used by another declared game. This lives outside
+ * {@link validateGameServer} because that function treats `name` purely as
+ * the map key for self-exclusion in the port-collision check, not as a
+ * field to validate in its own right.
+ */
+function checkName(name: string, existingGames: GameServer[]): GameServerValidationIssue[] {
+  const trimmed = name.trim();
+
+  if (trimmed.length === 0) {
+    return [{ path: 'name', message: 'Name is required.' }];
+  }
+
+  const issues: GameServerValidationIssue[] = [];
+
+  if (!NAME_PATTERN.test(trimmed)) {
+    issues.push({
+      path: 'name',
+      message:
+        'Name must start with a letter or underscore and contain only letters, numbers, underscores, and hyphens.',
+    });
+  }
+
+  if (existingGames.some((game) => game.name === trimmed)) {
+    issues.push({ path: 'name', message: `A game named "${trimmed}" already exists.` });
+  }
+
+  return issues;
+}
+
+/** Converts a {@link WizardDraft} into the plain-object shape {@link validateGameServer} expects for its `proposed` parameter, stripping unset optional fields so they don't trip type checks with empty strings. */
+function toProposedEntry(draft: WizardDraft): Record<string, unknown> {
+  return {
+    image: draft.image,
+    cpu: draft.cpu,
+    memory: draft.memory,
+    ports: draft.ports.map((port) => ({ container: port.container, protocol: port.protocol })),
+    volumes: draft.volumes.map((volume) => ({ name: volume.name, container_path: volume.container_path })),
+    connect_message: draft.connect_message.trim().length > 0 ? draft.connect_message : undefined,
+    file_seeds:
+      draft.file_seeds.length > 0
+        ? draft.file_seeds.map((seed) => ({
+            path: seed.path,
+            content: seed.content.length > 0 ? seed.content : undefined,
+            content_base64: seed.content_base64.length > 0 ? seed.content_base64 : undefined,
+            mode: seed.mode.length > 0 ? seed.mode : undefined,
+          }))
+        : undefined,
+  };
+}
+
+/**
+ * Validates `image` isn't blank. The shared `gameServerSchema` types `image`
+ * as a plain `z.string()` with no minimum length (an empty string is a valid
+ * server-side value structurally), but a blank image reference is never
+ * usable, so the wizard enforces non-emptiness itself.
+ */
+function checkImage(image: string): GameServerValidationIssue[] {
+  if (image.trim().length === 0) {
+    return [{ path: 'image', message: 'Image is required.' }];
+  }
+  return [];
+}
+
+/**
+ * Validates the entire draft: `name` (via {@link checkName}), `image` (via
+ * {@link checkImage}) plus every structural/business rule
+ * {@link validateGameServer} enforces (Fargate cpu/memory pairing, absolute
+ * volume/file_seed paths, connect_message placeholder allowlisting, and
+ * port collisions — both within the draft's own `ports` list and against
+ * `existingGames`). Returns every issue found, unfiltered by step.
+ */
+export function validateWizardDraft(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
+  const issues = [...checkName(draft.name, existingGames), ...checkImage(draft.image)];
+
+  const name = draft.name.trim().length > 0 ? draft.name.trim() : DRAFT_NAME_PLACEHOLDER;
+  const result = validateGameServer(name, toProposedEntry(draft), existingGames);
+  if (!result.success) {
+    issues.push(...result.issues);
+  }
+
+  return issues;
+}
+
+/**
+ * Validates the draft and filters the result down to issues belonging to
+ * `step` (via {@link stepForIssuePath}), so a step component only sees — and
+ * only blocks advancement on — errors in its own fields.
+ */
+export function validateStep(
+  step: WizardStep,
+  draft: WizardDraft,
+  existingGames: GameServer[],
+): GameServerValidationIssue[] {
+  if (step === 'review') {
+    return validateWizardDraft(draft, existingGames);
+  }
+  return validateWizardDraft(draft, existingGames).filter((issue) => stepForIssuePath(issue.path) === step);
+}
+
+/** Convenience wrapper: `true` when `step` has no outstanding validation issues, so the wizard can gate its "Next" button. */
+export function canAdvance(step: WizardStep, draft: WizardDraft, existingGames: GameServer[]): boolean {
+  return validateStep(step, draft, existingGames).length === 0;
+}
+
+/** Validates the "Identity" step: `name`, `image`, `connect_message`. */
+export function validateIdentityStep(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
+  return validateStep('identity', draft, existingGames);
+}
+
+/** Validates the "Resources" step: `cpu`/`memory`, including the Fargate cpu/memory pairing rule. */
+export function validateResourcesStep(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
+  return validateStep('resources', draft, existingGames);
+}
+
+/** Validates the "Networking" step: `ports`, including collisions within the draft and against `existingGames`. */
+export function validateNetworkingStep(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
+  return validateStep('networking', draft, existingGames);
+}
+
+/** Validates the "Storage" step: `volumes` (including the at-least-one-volume rule) and `file_seeds`. */
+export function validateStorageStep(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
+  return validateStep('storage', draft, existingGames);
+}
+
+/** Validates the "Review" step: every issue across the whole draft, since review is the final gate before submit. */
+export function validateReviewStep(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
+  return validateStep('review', draft, existingGames);
+}

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
@@ -14,6 +14,7 @@
 
 import {
   validateGameServer,
+  checkConnectMessagePlaceholders,
   type GameServerValidationIssue,
 } from '@hyveon/shared/gameServerValidator';
 import type { GameServer } from '../../api.service.js';
@@ -176,62 +177,21 @@ function checkImage(image: string): GameServerValidationIssue[] {
 }
 
 /**
- * Placeholder tokens allowed inside `connect_message`. Mirrors
- * `ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS` in
- * `@hyveon/shared/gameServerValidator` — kept in sync manually since this
- * check (see {@link checkConnectMessagePlaceholders}) has to run independently
- * of that module's own copy (see its doc comment for why).
- */
-const ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS: ReadonlySet<string> = new Set(['host', 'ip', 'port', 'game']);
-
-/** Matches every `{token}` occurrence in a string, capturing the token itself. Mirrors the shared validator's pattern of the same name. */
-const PLACEHOLDER_TOKEN_PATTERN = /\{([^{}]*)\}/g;
-
-/**
- * Validates `connect_message` placeholders on its own, independent of
- * {@link validateGameServer}'s structural schema parse. That parse — and
- * with it `validateGameServer`'s own copy of this same rule — fails
- * structurally whenever `cpu`/`memory` are still `null` or `volumes` is still
- * empty, which is exactly the case on the Identity step before the operator
- * has reached Resources/Storage. Without running this check unconditionally,
- * an invalid placeholder like `{password}` went unflagged until Review,
- * where a structural parse failure disables Submit but surfaces no message
- * anywhere (#99 review finding). This only reads `connect_message`, so it's
- * safe to run before the rest of the draft is fillable.
- */
-function checkConnectMessagePlaceholders(connectMessage: string): GameServerValidationIssue[] {
-  if (!connectMessage) {
-    return [];
-  }
-
-  const issues: GameServerValidationIssue[] = [];
-  for (const match of connectMessage.matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
-    const token = match[1] ?? '';
-    if (!ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS.has(token)) {
-      issues.push({
-        path: 'connect_message',
-        message: `Unknown placeholder "{${token}}" in connect_message; allowed placeholders are {host}, {ip}, {port}, {game}.`,
-      });
-    }
-  }
-  return issues;
-}
-
-/**
  * Validates the entire draft: `name` (via {@link checkName}), `image` (via
- * {@link checkImage}), `connect_message` placeholders (via
- * {@link checkConnectMessagePlaceholders}, run unconditionally — see its doc
- * comment) plus every structural/business rule {@link validateGameServer}
- * enforces (Fargate cpu/memory pairing, absolute volume/file_seed paths, its
- * own connect_message placeholder check, and port collisions — both within
- * the draft's own `ports` list and against `existingGames`). Returns every
- * issue found, unfiltered by step, deduped by `path`+`message` — this only
- * matters because `validateGameServer`'s failure result isn't limited to
- * structural parse failures: a structurally complete draft can still fail on
- * a pure business-rule violation, and in that case `validateGameServer`'s own
- * connect_message placeholder check already ran, so appending our own copy
- * unconditionally on `!result.success` would otherwise double up identical
- * issues.
+ * {@link checkImage}), `connect_message` placeholders (via the shared
+ * {@link checkConnectMessagePlaceholders}, imported from
+ * `@hyveon/shared/gameServerValidator` and run unconditionally here) plus
+ * every structural/business rule {@link validateGameServer} enforces
+ * (Fargate cpu/memory pairing, absolute volume/file_seed paths, its own
+ * internal call to the same connect_message placeholder check, and port
+ * collisions — both within the draft's own `ports` list and against
+ * `existingGames`). Returns every issue found, unfiltered by step, deduped
+ * by `path`+`message` — this only matters because `validateGameServer`'s
+ * failure result isn't limited to structural parse failures: a structurally
+ * complete draft can still fail on a pure business-rule violation, and in
+ * that case `validateGameServer`'s own connect_message placeholder check
+ * already ran, so appending our own call unconditionally on
+ * `!result.success` would otherwise double up identical issues.
  */
 export function validateWizardDraft(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
   const issues = [...checkName(draft.name, existingGames), ...checkImage(draft.image)];
@@ -243,8 +203,8 @@ export function validateWizardDraft(draft: WizardDraft, existingGames: GameServe
     // validateGameServer only runs its own connect_message placeholder check
     // once the full entry parses structurally, so a structural failure here
     // (e.g. cpu/memory still null) means that check may never have run. Run
-    // our own copy so an invalid placeholder is still caught on the Identity
-    // step; duplicates against an already-run copy are removed below.
+    // the same shared check so an invalid placeholder is still caught on the
+    // Identity step; duplicates against an already-run copy are removed below.
     issues.push(...checkConnectMessagePlaceholders(draft.connect_message));
   }
 
@@ -255,9 +215,10 @@ export function validateWizardDraft(draft: WizardDraft, existingGames: GameServe
  * Removes duplicate issues (same `path` and `message`) while preserving
  * first-seen order. Needed because {@link validateWizardDraft} can surface
  * the same `connect_message` placeholder issue twice: once from
- * `validateGameServer`'s own check (when the structural parse succeeded) and
- * once from this module's independent {@link checkConnectMessagePlaceholders}
- * copy (run unconditionally on any failure, structural or not).
+ * `validateGameServer`'s own internal call to the shared
+ * {@link checkConnectMessagePlaceholders} (when the structural parse
+ * succeeded) and once from the unconditional call above (run on any
+ * failure, structural or not).
  */
 function dedupeIssues(issues: GameServerValidationIssue[]): GameServerValidationIssue[] {
   const seen = new Set<string>();

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
@@ -176,12 +176,56 @@ function checkImage(image: string): GameServerValidationIssue[] {
 }
 
 /**
+ * Placeholder tokens allowed inside `connect_message`. Mirrors
+ * `ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS` in
+ * `@hyveon/shared/gameServerValidator` — kept in sync manually since this
+ * check (see {@link checkConnectMessagePlaceholders}) has to run independently
+ * of that module's own copy (see its doc comment for why).
+ */
+const ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS: ReadonlySet<string> = new Set(['host', 'ip', 'port', 'game']);
+
+/** Matches every `{token}` occurrence in a string, capturing the token itself. Mirrors the shared validator's pattern of the same name. */
+const PLACEHOLDER_TOKEN_PATTERN = /\{([^{}]*)\}/g;
+
+/**
+ * Validates `connect_message` placeholders on its own, independent of
+ * {@link validateGameServer}'s structural schema parse. That parse — and
+ * with it `validateGameServer`'s own copy of this same rule — fails
+ * structurally whenever `cpu`/`memory` are still `null` or `volumes` is still
+ * empty, which is exactly the case on the Identity step before the operator
+ * has reached Resources/Storage. Without running this check unconditionally,
+ * an invalid placeholder like `{password}` went unflagged until Review,
+ * where a structural parse failure disables Submit but surfaces no message
+ * anywhere (#99 review finding). This only reads `connect_message`, so it's
+ * safe to run before the rest of the draft is fillable.
+ */
+function checkConnectMessagePlaceholders(connectMessage: string): GameServerValidationIssue[] {
+  if (!connectMessage) {
+    return [];
+  }
+
+  const issues: GameServerValidationIssue[] = [];
+  for (const match of connectMessage.matchAll(PLACEHOLDER_TOKEN_PATTERN)) {
+    const token = match[1] ?? '';
+    if (!ALLOWED_CONNECT_MESSAGE_PLACEHOLDERS.has(token)) {
+      issues.push({
+        path: 'connect_message',
+        message: `Unknown placeholder "{${token}}" in connect_message; allowed placeholders are {host}, {ip}, {port}, {game}.`,
+      });
+    }
+  }
+  return issues;
+}
+
+/**
  * Validates the entire draft: `name` (via {@link checkName}), `image` (via
- * {@link checkImage}) plus every structural/business rule
- * {@link validateGameServer} enforces (Fargate cpu/memory pairing, absolute
- * volume/file_seed paths, connect_message placeholder allowlisting, and
- * port collisions — both within the draft's own `ports` list and against
- * `existingGames`). Returns every issue found, unfiltered by step.
+ * {@link checkImage}), `connect_message` placeholders (via
+ * {@link checkConnectMessagePlaceholders}, run unconditionally — see its doc
+ * comment) plus every structural/business rule {@link validateGameServer}
+ * enforces (Fargate cpu/memory pairing, absolute volume/file_seed paths, its
+ * own connect_message placeholder check, and port collisions — both within
+ * the draft's own `ports` list and against `existingGames`). Returns every
+ * issue found, unfiltered by step.
  */
 export function validateWizardDraft(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
   const issues = [...checkName(draft.name, existingGames), ...checkImage(draft.image)];
@@ -190,6 +234,11 @@ export function validateWizardDraft(draft: WizardDraft, existingGames: GameServe
   const result = validateGameServer(name, toProposedEntry(draft), existingGames);
   if (!result.success) {
     issues.push(...result.issues);
+    // validateGameServer only runs its own connect_message placeholder check
+    // once the full entry parses structurally, so a structural failure here
+    // (e.g. cpu/memory still null) means that check never ran. Run our own
+    // copy so an invalid placeholder is still caught on the Identity step.
+    issues.push(...checkConnectMessagePlaceholders(draft.connect_message));
   }
 
   return issues;

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
@@ -144,7 +144,7 @@ function checkName(name: string, existingGames: GameServer[]): GameServerValidat
 /** Converts a {@link WizardDraft} into the plain-object shape {@link validateGameServer} expects for its `proposed` parameter, stripping unset optional fields so they don't trip type checks with empty strings. */
 function toProposedEntry(draft: WizardDraft): Record<string, unknown> {
   return {
-    image: draft.image,
+    image: draft.image.trim(),
     cpu: draft.cpu,
     memory: draft.memory,
     ports: draft.ports.map((port) => ({ container: port.container, protocol: port.protocol })),
@@ -225,7 +225,13 @@ function checkConnectMessagePlaceholders(connectMessage: string): GameServerVali
  * enforces (Fargate cpu/memory pairing, absolute volume/file_seed paths, its
  * own connect_message placeholder check, and port collisions — both within
  * the draft's own `ports` list and against `existingGames`). Returns every
- * issue found, unfiltered by step.
+ * issue found, unfiltered by step, deduped by `path`+`message` — this only
+ * matters because `validateGameServer`'s failure result isn't limited to
+ * structural parse failures: a structurally complete draft can still fail on
+ * a pure business-rule violation, and in that case `validateGameServer`'s own
+ * connect_message placeholder check already ran, so appending our own copy
+ * unconditionally on `!result.success` would otherwise double up identical
+ * issues.
  */
 export function validateWizardDraft(draft: WizardDraft, existingGames: GameServer[]): GameServerValidationIssue[] {
   const issues = [...checkName(draft.name, existingGames), ...checkImage(draft.image)];
@@ -236,12 +242,34 @@ export function validateWizardDraft(draft: WizardDraft, existingGames: GameServe
     issues.push(...result.issues);
     // validateGameServer only runs its own connect_message placeholder check
     // once the full entry parses structurally, so a structural failure here
-    // (e.g. cpu/memory still null) means that check never ran. Run our own
-    // copy so an invalid placeholder is still caught on the Identity step.
+    // (e.g. cpu/memory still null) means that check may never have run. Run
+    // our own copy so an invalid placeholder is still caught on the Identity
+    // step; duplicates against an already-run copy are removed below.
     issues.push(...checkConnectMessagePlaceholders(draft.connect_message));
   }
 
-  return issues;
+  return dedupeIssues(issues);
+}
+
+/**
+ * Removes duplicate issues (same `path` and `message`) while preserving
+ * first-seen order. Needed because {@link validateWizardDraft} can surface
+ * the same `connect_message` placeholder issue twice: once from
+ * `validateGameServer`'s own check (when the structural parse succeeded) and
+ * once from this module's independent {@link checkConnectMessagePlaceholders}
+ * copy (run unconditionally on any failure, structural or not).
+ */
+function dedupeIssues(issues: GameServerValidationIssue[]): GameServerValidationIssue[] {
+  const seen = new Set<string>();
+  const deduped: GameServerValidationIssue[] = [];
+  for (const issue of issues) {
+    const key = `${issue.path} ${issue.message}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(issue);
+    }
+  }
+  return deduped;
 }
 
 /**

--- a/app/packages/web/src/pages/games.page.test.tsx
+++ b/app/packages/web/src/pages/games.page.test.tsx
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 const apiMock = vi.hoisted(() => ({
   status: vi.fn(),
   costsEstimate: vi.fn(),
   games: vi.fn(),
+  createGame: vi.fn(),
 }));
 vi.mock('../api.service.js', () => ({ api: apiMock }));
 
@@ -102,5 +104,42 @@ describe('GamesPage', () => {
     renderPage(<GamesPage />, { initialEntries: ['/games'] });
 
     expect(await screen.findByText('No games declared or deployed yet.')).toBeInTheDocument();
+  });
+
+  it('should always render the header "Add game" button, regardless of whether games exist', async () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    expect(await screen.findByText('minecraft')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Add game' })).toHaveLength(1);
+  });
+
+  it('should render an additional empty-state "Add game" CTA only when no games are declared or deployed', async () => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    await screen.findByText('No games declared or deployed yet.');
+    expect(screen.getAllByRole('button', { name: 'Add game' })).toHaveLength(2);
+  });
+
+  it('should open the AddGameWizard dialog when the header "Add game" button is clicked', async () => {
+    const user = userEvent.setup();
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    await screen.findByText('minecraft');
+    await user.click(screen.getByRole('button', { name: 'Add game' }));
+
+    expect(await screen.findByRole('dialog', { name: 'Add a game server' })).toBeInTheDocument();
+  });
+
+  it('should open the AddGameWizard dialog when the empty-state "Add game" CTA is clicked', async () => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    const user = userEvent.setup();
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    await screen.findByText('No games declared or deployed yet.');
+    const [, emptyStateCta] = screen.getAllByRole('button', { name: 'Add game' });
+    await user.click(emptyStateCta);
+
+    expect(await screen.findByRole('dialog', { name: 'Add a game server' })).toBeInTheDocument();
   });
 });

--- a/app/packages/web/src/pages/games.page.tsx
+++ b/app/packages/web/src/pages/games.page.tsx
@@ -5,6 +5,7 @@ import { GameStatusBadges } from '../components/game-status-badges.component.js'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.component';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.component';
 import { PollingIndicator } from '../polling/polling-indicator.component.js';
+import { AddGameWizard } from '@/components/add-game-wizard/add-game-wizard.component';
 
 /** Renders a game's declared ports as a comma-separated `container/protocol` list, or an em dash when undeclared. */
 function formatPorts(entry: GameListEntry): string {
@@ -26,6 +27,12 @@ function formatPorts(entry: GameListEntry): string {
  *
  * Each row links to `/games/:name` for the deeper read-only detail view
  * (issue #93's follow-up), still to be implemented.
+ *
+ * The self-contained {@link AddGameWizard} (#99) is mounted twice: as a
+ * persistent header action next to the heading, and as an empty-state CTA
+ * shown only while `games` is empty. Both mounts are independent — each owns
+ * its own dialog open/close state — so either entry point opens its own copy
+ * of the same wizard flow.
  */
 export function GamesPage() {
   const [games, setGames] = useState<GameListEntry[]>([]);
@@ -56,7 +63,10 @@ export function GamesPage() {
     <div className="max-w-6xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-2xl font-semibold">Games</h2>
-        <PollingIndicator />
+        <div className="flex items-center gap-4">
+          <PollingIndicator />
+          <AddGameWizard />
+        </div>
       </div>
 
       <Card>
@@ -74,7 +84,10 @@ export function GamesPage() {
             </div>
           ) : games.length === 0 ? (
             <div className="py-8 text-center text-sm text-[var(--color-muted-foreground)]">
-              No games declared or deployed yet.
+              <p>No games declared or deployed yet.</p>
+              <div className="mt-4 flex justify-center">
+                <AddGameWizard />
+              </div>
             </div>
           ) : (
             <Table>

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       // works without first running `npm run build -w @hyveon/shared`. Runtime
       // (Nest server + Lambda bundles) still use the built dist/ via the
       // package.json "main" field — this alias only applies inside Vitest.
+      // The subpath alias must come first: alias matching replaces the key
+      // with its target, so '@hyveon/shared' (matched via startsWith) would
+      // otherwise shadow '@hyveon/shared/gameServerValidator' and resolve to
+      // an invalid path.
+      '@hyveon/shared/gameServerValidator': resolve(__dirname, 'packages/shared/src/gameServerValidator.ts'),
       '@hyveon/shared': resolve(__dirname, 'packages/shared/src/index.ts'),
       // Same rationale as @hyveon/shared above — desktop-main imports
       // @hyveon/cloud-aws directly, and CI runs `vitest run` without a prior

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,7 @@
       "name": "@hyveon/web",
       "version": "1.0.0",
       "dependencies": {
+        "@hyveon/shared": "*",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",


### PR DESCRIPTION
Closes #99

## Summary

- Adds a multi-step `AddGameWizard` (Identity → Resources → Networking → Storage → Review) mounted on `/games`, reachable from the page header button and the empty-state CTA, backed by shadcn `Dialog`/`Select`/`Input`/`Label` primitives and per-step validation utilities in `wizard-form.utils.ts`.
- Reuses the server's `gameServerValidator` zod schema via a new browser-safe `@hyveon/shared` subpath export so client-side field errors match server validation verbatim, and wires `api.createGame` (with a mirrored `GameWriteResult` type) so submit calls `POST /api/games` and surfaces success/conflict/validation results inline without leaving the dialog on failure.
- Hardens the wizard against edge cases found during implementation: placeholder validation gated on full schema parse, trimmed image field, matched field-level zod error paths, and guarded state updates so a dialog closed mid-submit doesn't mutate stale state.

## Changes

```
 app/packages/shared/package.json                                       |   6 +-
 app/packages/shared/src/gameServerValidator.test.ts                    |  26 +-
 app/packages/shared/src/gameServerValidator.ts                         |  54 +++-
 app/packages/web/package.json                                          |   1 +
 app/packages/web/src/api.service.test.ts                               |  16 ++
 app/packages/web/src/api.service.ts                                    | 115 ++++++++
 .../add-game-wizard/add-game-wizard.component.test.tsx                 | 176 +++++++++++++
 .../add-game-wizard/add-game-wizard.component.tsx                      | 290 +++++++++++++++++++++
 .../add-game-wizard/identity-step.component.test.tsx                   | 108 ++++++++
 .../add-game-wizard/identity-step.component.tsx                        |  91 +++++++
 .../add-game-wizard/networking-step.component.test.tsx                 | 109 ++++++++
 .../add-game-wizard/networking-step.component.tsx                      | 143 ++++++++++
 .../add-game-wizard/resources-step.component.test.tsx                  | 108 ++++++++
 .../add-game-wizard/resources-step.component.tsx                       |  92 +++++++
 .../add-game-wizard/review-step.component.test.tsx                     |  84 ++++++
 .../add-game-wizard/review-step.component.tsx                          | 131 ++++++++++
 .../add-game-wizard/storage-step.component.test.tsx                    | 264 +++++++++++++++++++
 .../add-game-wizard/storage-step.component.tsx                         | 276 ++++++++++++++++++++
 .../add-game-wizard/wizard-form.utils.test.ts                          | 254 ++++++++++++++++++
 .../add-game-wizard/wizard-form.utils.ts                               | 280 ++++++++++++++++++++
 app/packages/web/src/pages/games.page.test.tsx                         |  39 +++
 app/packages/web/src/pages/games.page.tsx                              |  17 +-
 app/vitest.config.ts                                                   |   5 +
 package-lock.json                                                      |   1 +
 24 files changed, 2675 insertions(+), 11 deletions(-)
```

## Test plan

- [x] Each step has form-level validation that doesn't let the user advance with errors — covered by per-step `*-step.component.test.tsx` specs and `wizard-form.utils.test.ts`.
- [x] Submit calls `POST /api/games`; success and error paths handled — `api.createGame` wrapper (`api.service.test.ts`) plus `add-game-wizard.component.test.tsx` covering the submit handler.
- [x] Toast on success; modal stays open with errors highlighted on failure — behavioural tests assert dialog stays open and field errors render on server validation/conflict responses.
- [x] Test coverage for the validation flow and submit handler — `add-game-wizard.component.test.tsx`, `wizard-form.utils.test.ts`, and each step's test file.
- [x] `npm run app:test` passing for the touched workspaces (shared, web).