### PR TITLE
feat(web): edit-game form + remove-game confirmation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,5 @@ jobs:
           tflint_version: latest
 
       - run: tflint --init
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: tflint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,5 +37,7 @@ jobs:
           tflint_version: latest
 
       - run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: tflint

--- a/app/packages/web/src/api.service.test.ts
+++ b/app/packages/web/src/api.service.test.ts
@@ -16,6 +16,8 @@ function makeGsdMock() {
       start: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
       stop: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
       create: vi.fn().mockResolvedValue({ ok: true, games: [] }),
+      update: vi.fn().mockResolvedValue({ ok: true, games: [] }),
+      delete: vi.fn().mockResolvedValue({ ok: true, games: [] }),
     },
     costs: {
       estimate: vi.fn().mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 }),
@@ -154,6 +156,27 @@ describe('IPC bridge delegation', () => {
     };
     await api.createGame(payload);
     expect(gsd.games.create).toHaveBeenCalledWith(payload);
+  });
+
+  it('should delegate api.updateGame() to window.gsd.games.update() with the exact payload', async () => {
+    const payload = {
+      name: 'minecraft',
+      config: {
+        image: 'itzg/minecraft-server',
+        cpu: 1024,
+        memory: 2048,
+        ports: [{ container: 25565, protocol: 'tcp' }],
+        volumes: [{ name: 'data', container_path: '/data' }],
+      },
+    };
+    await api.updateGame(payload);
+    expect(gsd.games.update).toHaveBeenCalledWith(payload);
+  });
+
+  it('should delegate api.deleteGame() to window.gsd.games.delete() with the exact payload', async () => {
+    const payload = { name: 'minecraft' };
+    await api.deleteGame(payload);
+    expect(gsd.games.delete).toHaveBeenCalledWith(payload);
   });
 
   it('should delegate api.discordConfig() to window.gsd.discord.getConfig()', async () => {

--- a/app/packages/web/src/api.service.ts
+++ b/app/packages/web/src/api.service.ts
@@ -210,6 +210,30 @@ export interface CreateGamePayload {
   expectedVersionId?: string;
 }
 
+/**
+ * Request payload for `games.update`. Same shape as {@link CreateGamePayload}
+ * — `name` identifies the existing game to overwrite with `config`.
+ *
+ * Mirrors `UpdateGamePayload` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface UpdateGamePayload {
+  name: string;
+  config: Omit<GameServer, 'name'>;
+  expectedVersionId?: string;
+}
+
+/**
+ * Request payload for `games.delete`.
+ *
+ * Mirrors `DeleteGamePayload` in `@hyveon/shared/src/gamesWrite.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export interface DeleteGamePayload {
+  name: string;
+  expectedVersionId?: string;
+}
+
 /** Status of the FileBrowser helper task per game, returned by `GET /api/files/:game`. */
 export interface FileMgrStatus {
   game: string;
@@ -310,6 +334,10 @@ export const api = {
   filesMgrStop: async (game: string): Promise<ActionResult> => gsd().files.stop(game),
   createGame: async (payload: CreateGamePayload): Promise<GameWriteResult> =>
     gsd().games.create(payload) as Promise<GameWriteResult>,
+  updateGame: async (payload: UpdateGamePayload): Promise<GameWriteResult> =>
+    gsd().games.update(payload) as Promise<GameWriteResult>,
+  deleteGame: async (payload: DeleteGamePayload): Promise<GameWriteResult> =>
+    gsd().games.delete(payload) as Promise<GameWriteResult>,
 
   discordConfig: async (): Promise<DiscordConfigRedacted> =>
     gsd().discord.getConfig() as Promise<DiscordConfigRedacted>,

--- a/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/add-game-wizard.component.tsx
@@ -44,7 +44,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog.component';
-import { api, type CreateGamePayload, type GameServer } from '../../api.service.js';
+import { api, type GameServer } from '../../api.service.js';
 import { IdentityStep } from './identity-step.component.js';
 import { ResourcesStep } from './resources-step.component.js';
 import { NetworkingStep } from './networking-step.component.js';
@@ -53,6 +53,7 @@ import { ReviewStep } from './review-step.component.js';
 import {
   WIZARD_STEPS,
   createEmptyWizardDraft,
+  draftToPayload,
   stepForIssuePath,
   validateStep,
   type WizardDraft,
@@ -67,41 +68,6 @@ const STEP_LABELS: Record<WizardStep, string> = {
   storage: 'Storage',
   review: 'Review',
 };
-
-/**
- * Converts a completed {@link WizardDraft} into the `POST /api/games`
- * (`games.create` IPC) payload. Only called once the Review step's "Submit"
- * button is enabled, which requires {@link validateStep} to report zero
- * issues for `review` — so `cpu`/`memory`/port `container` values are
- * guaranteed non-null at this point; the `?? 0` fallbacks only guard the
- * type checker, they're never expected to fire in practice.
- */
-function draftToPayload(draft: WizardDraft): CreateGamePayload {
-  const name = draft.name.trim();
-  const connectMessage = draft.connect_message.trim();
-  const image = draft.image.trim();
-
-  return {
-    name,
-    config: {
-      image,
-      cpu: draft.cpu ?? 0,
-      memory: draft.memory ?? 0,
-      ports: draft.ports.map((port) => ({ container: port.container ?? 0, protocol: port.protocol })),
-      volumes: draft.volumes.map((volume) => ({ name: volume.name, container_path: volume.container_path })),
-      connect_message: connectMessage.length > 0 ? connectMessage : undefined,
-      file_seeds:
-        draft.file_seeds.length > 0
-          ? draft.file_seeds.map((seed) => ({
-              path: seed.path,
-              content: seed.content.length > 0 ? seed.content : undefined,
-              content_base64: seed.content_base64.length > 0 ? seed.content_base64 : undefined,
-              mode: seed.mode.length > 0 ? seed.mode : undefined,
-            }))
-          : undefined,
-    },
-  };
-}
 
 /**
  * Self-contained "Add game" dialog: renders its own trigger button, walks the

--- a/app/packages/web/src/components/add-game-wizard/identity-step.component.tsx
+++ b/app/packages/web/src/components/add-game-wizard/identity-step.component.tsx
@@ -12,6 +12,14 @@ export interface IdentityStepProps {
   issues: GameServerValidationIssue[];
   /** Called with a partial patch of the changed field whenever the operator edits a field. */
   onChange: (patch: Partial<Pick<WizardDraft, 'name' | 'image' | 'connect_message'>>) => void;
+  /**
+   * Renders the Name field as read-only. `name` is the `game_servers` map
+   * key — the add wizard lets the operator choose it, but the edit form
+   * (#100) reuses this step to edit an already-declared game and must not
+   * let the operator rename it in place (that's a delete+recreate, not an
+   * update). Defaults to `false` so the add wizard's behaviour is unchanged.
+   */
+  nameDisabled?: boolean;
 }
 
 /**
@@ -20,8 +28,11 @@ export interface IdentityStepProps {
  * writes a `connect_message` shown to Discord users after `/server-start`.
  * Purely presentational — the parent wizard owns the draft state and passes
  * down validation issues computed via `validateIdentityStep` (see wizard-form.utils.ts).
+ *
+ * Also reused, flattened alongside the other step components, by the edit
+ * form (#100) — see the `nameDisabled` prop.
  */
-export function IdentityStep({ draft, issues, onChange }: IdentityStepProps) {
+export function IdentityStep({ draft, issues, onChange, nameDisabled = false }: IdentityStepProps) {
   const errorFor = (path: string) => issues.find((issue) => issue.path === path)?.message;
 
   return (
@@ -32,6 +43,7 @@ export function IdentityStep({ draft, issues, onChange }: IdentityStepProps) {
         value={draft.name}
         placeholder="minecraft"
         error={errorFor('name')}
+        disabled={nameDisabled}
         onChange={(value) => onChange({ name: value })}
       />
       <Field
@@ -61,6 +73,7 @@ function Field({
   value,
   placeholder,
   error,
+  disabled,
   onChange,
 }: {
   id: string;
@@ -68,6 +81,7 @@ function Field({
   value: string;
   placeholder: string;
   error?: string;
+  disabled?: boolean;
   onChange: (value: string) => void;
 }) {
   return (
@@ -79,6 +93,7 @@ function Field({
         placeholder={placeholder}
         aria-invalid={error ? 'true' : 'false'}
         aria-describedby={error ? `${id}-error` : undefined}
+        disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
       />
       {error && (

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.test.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   createEmptyWizardDraft,
+  draftFromGameServer,
+  draftToPayload,
   stepForIssuePath,
   validateWizardDraft,
   validateIdentityStep,
@@ -240,6 +242,72 @@ describe('validateReviewStep', () => {
 
   it('should pass a clean review step', () => {
     expect(validateReviewStep(makeValidDraft(), [])).toEqual([]);
+  });
+});
+
+describe('draftFromGameServer / draftToPayload round-trip', () => {
+  it('should round-trip a fully-populated GameServer through draftFromGameServer and back through draftToPayload', () => {
+    const game = makeExistingGame({
+      name: 'minecraft',
+      image: 'itzg/minecraft-server',
+      cpu: 1024,
+      memory: 2048,
+      ports: [{ container: 25565, protocol: 'tcp' }],
+      volumes: [{ name: 'data', container_path: '/data' }],
+      connect_message: 'Connect at {ip}:{port}',
+      file_seeds: [{ path: '/data/config.yml', content: 'foo: bar', content_base64: 'Zm9v', mode: '0644' }],
+    });
+
+    const draft = draftFromGameServer(game);
+    const payload = draftToPayload(draft);
+
+    expect(payload).toEqual({
+      name: game.name,
+      config: {
+        image: game.image,
+        cpu: game.cpu,
+        memory: game.memory,
+        ports: game.ports,
+        volumes: game.volumes,
+        connect_message: game.connect_message,
+        file_seeds: game.file_seeds,
+      },
+    });
+  });
+
+  it('should round-trip a minimal GameServer (no connect_message/file_seeds) with those fields left undefined', () => {
+    const game = makeExistingGame({ name: 'valheim' });
+
+    const draft = draftFromGameServer(game);
+    const payload = draftToPayload(draft);
+
+    expect(payload).toEqual({
+      name: game.name,
+      config: {
+        image: game.image,
+        cpu: game.cpu,
+        memory: game.memory,
+        ports: game.ports,
+        volumes: game.volumes,
+        connect_message: undefined,
+        file_seeds: undefined,
+      },
+    });
+  });
+
+  it('should produce a draft with empty-string fallbacks for optional GameServer fields that are unset', () => {
+    const game = makeExistingGame({ name: 'valheim', connect_message: undefined, file_seeds: undefined });
+
+    expect(draftFromGameServer(game)).toEqual({
+      name: game.name,
+      image: game.image,
+      connect_message: '',
+      cpu: game.cpu,
+      memory: game.memory,
+      ports: game.ports,
+      volumes: game.volumes,
+      file_seeds: [],
+    });
   });
 });
 

--- a/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
+++ b/app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts
@@ -17,7 +17,7 @@ import {
   checkConnectMessagePlaceholders,
   type GameServerValidationIssue,
 } from '@hyveon/shared/gameServerValidator';
-import type { GameServer } from '../../api.service.js';
+import type { CreateGamePayload, GameServer } from '../../api.service.js';
 
 /** Ordered steps of the add-game wizard, matching issue #99's scope. */
 export const WIZARD_STEPS = ['identity', 'resources', 'networking', 'storage', 'review'] as const;
@@ -78,6 +78,67 @@ export function createEmptyWizardDraft(): WizardDraft {
     ports: [],
     volumes: [],
     file_seeds: [],
+  };
+}
+
+/**
+ * Converts a declared {@link GameServer} entry into a {@link WizardDraft} —
+ * the inverse of {@link draftToPayload}. Used to seed the wizard's edit flow
+ * from an existing entry: optional fields (`connect_message`, `file_seeds`
+ * and its per-row `content`/`content_base64`/`mode`) fall back to empty
+ * strings since the draft's text inputs can't represent `undefined`.
+ */
+export function draftFromGameServer(game: GameServer): WizardDraft {
+  return {
+    name: game.name,
+    image: game.image,
+    connect_message: game.connect_message ?? '',
+    cpu: game.cpu,
+    memory: game.memory,
+    ports: game.ports.map((port) => ({ container: port.container, protocol: port.protocol })),
+    volumes: game.volumes.map((volume) => ({ name: volume.name, container_path: volume.container_path })),
+    file_seeds: (game.file_seeds ?? []).map((seed) => ({
+      path: seed.path,
+      content: seed.content ?? '',
+      content_base64: seed.content_base64 ?? '',
+      mode: seed.mode ?? '',
+    })),
+  };
+}
+
+/**
+ * Converts a completed {@link WizardDraft} into the `POST /api/games`
+ * (`games.create` IPC) payload — the inverse of {@link draftFromGameServer}.
+ * Only called once the Review step's "Submit" button is enabled, which
+ * requires {@link validateStep} to report zero issues for `review` — so
+ * `cpu`/`memory`/port `container` values are guaranteed non-null at this
+ * point; the `?? 0` fallbacks only guard the type checker, they're never
+ * expected to fire in practice.
+ */
+export function draftToPayload(draft: WizardDraft): CreateGamePayload {
+  const name = draft.name.trim();
+  const connectMessage = draft.connect_message.trim();
+  const image = draft.image.trim();
+
+  return {
+    name,
+    config: {
+      image,
+      cpu: draft.cpu ?? 0,
+      memory: draft.memory ?? 0,
+      ports: draft.ports.map((port) => ({ container: port.container ?? 0, protocol: port.protocol })),
+      volumes: draft.volumes.map((volume) => ({ name: volume.name, container_path: volume.container_path })),
+      connect_message: connectMessage.length > 0 ? connectMessage : undefined,
+      file_seeds:
+        draft.file_seeds.length > 0
+          ? draft.file_seeds.map((seed) => ({
+              path: seed.path,
+              content: seed.content.length > 0 ? seed.content : undefined,
+              content_base64: seed.content_base64.length > 0 ? seed.content_base64 : undefined,
+              mode: seed.mode.length > 0 ? seed.mode : undefined,
+            }))
+          : undefined,
+    },
   };
 }
 

--- a/app/packages/web/src/components/edit-game-form/edit-game-form.component.test.tsx
+++ b/app/packages/web/src/components/edit-game-form/edit-game-form.component.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EditGameForm } from './edit-game-form.component.js';
+import type { GameServer } from '../../api.service.js';
+
+/**
+ * Stub for the `@/api.service.js` module: `games()` backs the
+ * other-declared-games fetch the form fires on mount (used for the
+ * cross-game port-collision check), and `updateGame()` backs the "Save
+ * changes" button. Both are reset to a "happy" default in `beforeEach` and
+ * overridden per test.
+ */
+const apiMock = vi.hoisted(() => ({
+  games: vi.fn(),
+  updateGame: vi.fn(),
+}));
+vi.mock('../../api.service.js', () => ({ api: apiMock }));
+
+/** A fully-populated declared game used to prefill the form under test. */
+function sampleGame(overrides: Partial<GameServer> = {}): GameServer {
+  return {
+    name: 'mygame',
+    image: 'itzg/minecraft-server',
+    cpu: 512,
+    memory: 1024,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    connect_message: 'Connect at {ip}:25565',
+    environment: [{ name: 'EULA', value: 'true' }],
+    https: false,
+    file_seeds: [],
+    ...overrides,
+  };
+}
+
+/** The payload `draftToPayload`/`EditGameForm` produce for an unedited `sampleGame()`. */
+function samplePayloadConfig() {
+  return {
+    image: 'itzg/minecraft-server',
+    cpu: 512,
+    memory: 1024,
+    ports: [{ container: 25565, protocol: 'tcp' }],
+    volumes: [{ name: 'data', container_path: '/data' }],
+    connect_message: 'Connect at {ip}:25565',
+    file_seeds: undefined,
+    environment: [{ name: 'EULA', value: 'true' }],
+    https: false,
+  };
+}
+
+describe('EditGameForm', () => {
+  beforeEach(() => {
+    apiMock.games.mockResolvedValue({ games: [] });
+    apiMock.updateGame.mockReset();
+  });
+
+  it('should prefill every field from the supplied GameServer config', async () => {
+    render(<EditGameForm game={sampleGame()} />);
+
+    expect(await screen.findByLabelText('Name')).toHaveValue('mygame');
+    expect(screen.getByLabelText('Image')).toHaveValue('itzg/minecraft-server');
+    expect(screen.getByLabelText('Connect message')).toHaveValue('Connect at {ip}:25565');
+    expect(screen.getByLabelText(/CPU/i)).toHaveValue('512');
+    expect(screen.getByLabelText(/Memory/i)).toHaveValue('1024');
+    expect(screen.getByLabelText('Container port')).toHaveValue(25565);
+    expect(screen.getByLabelText('Protocol')).toHaveValue('tcp');
+    expect(screen.getByLabelText('Volume name')).toHaveValue('data');
+    expect(screen.getByLabelText('Container path')).toHaveValue('/data');
+  });
+
+  it('should render the Name field as not editable', async () => {
+    render(<EditGameForm game={sampleGame()} />);
+
+    expect(await screen.findByLabelText('Name')).toBeDisabled();
+  });
+
+  it('should show the "make tf-apply" hint', async () => {
+    render(<EditGameForm game={sampleGame()} />);
+
+    expect(await screen.findByText(/make tf-apply/)).toBeInTheDocument();
+  });
+
+  it('should call api.updateGame with the updated payload after a field edit and Save', async () => {
+    apiMock.updateGame.mockResolvedValue({ ok: true, games: [] });
+    render(<EditGameForm game={sampleGame()} />);
+
+    const imageField = await screen.findByLabelText('Image');
+    await userEvent.clear(imageField);
+    await userEvent.type(imageField, 'itzg/minecraft-server-2');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() =>
+      expect(apiMock.updateGame).toHaveBeenCalledWith({
+        name: 'mygame',
+        config: { ...samplePayloadConfig(), image: 'itzg/minecraft-server-2' },
+      }),
+    );
+  });
+
+  it('should not call api.updateGame for an unedited, valid draft other than the Save click itself', async () => {
+    apiMock.updateGame.mockResolvedValue({ ok: true, games: [] });
+    render(<EditGameForm game={sampleGame()} />);
+
+    await screen.findByLabelText('Image');
+    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() =>
+      expect(apiMock.updateGame).toHaveBeenCalledWith({ name: 'mygame', config: samplePayloadConfig() }),
+    );
+  });
+
+  it('should render an inline error and keep the edited draft on a server validation failure', async () => {
+    apiMock.updateGame.mockResolvedValue({
+      ok: false,
+      code: 'validation',
+      issues: [{ path: 'image', message: 'Image is required.' }],
+    });
+    render(<EditGameForm game={sampleGame()} />);
+
+    const imageField = await screen.findByLabelText('Image');
+    await userEvent.clear(imageField);
+    await userEvent.type(imageField, 'edited/image');
+    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await screen.findByText('Image is required.');
+    expect(screen.getByLabelText('Image')).toHaveValue('edited/image');
+  });
+
+  it('should render an inline alert and keep the edited draft on a server conflict failure', async () => {
+    apiMock.updateGame.mockResolvedValue({
+      ok: false,
+      code: 'conflict',
+      message: 'terraform.tfvars changed since this draft was loaded.',
+    });
+    render(<EditGameForm game={sampleGame()} />);
+
+    const imageField = await screen.findByLabelText('Image');
+    await userEvent.clear(imageField);
+    await userEvent.type(imageField, 'edited/image');
+    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert')).toHaveTextContent('terraform.tfvars changed since this draft was loaded.');
+    expect(screen.getByLabelText('Image')).toHaveValue('edited/image');
+  });
+
+  it('should call onSaved with the write result on a successful save', async () => {
+    const onSaved = vi.fn();
+    const result = { ok: true as const, games: [] };
+    apiMock.updateGame.mockResolvedValue(result);
+    render(<EditGameForm game={sampleGame()} onSaved={onSaved} />);
+
+    await screen.findByLabelText('Image');
+    await userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(result));
+  });
+});

--- a/app/packages/web/src/components/edit-game-form/edit-game-form.component.tsx
+++ b/app/packages/web/src/components/edit-game-form/edit-game-form.component.tsx
@@ -1,0 +1,222 @@
+/**
+ * Flat edit form for an already-declared `game_servers` entry (#100).
+ *
+ * Reuses the same draft shape and step components built for the add wizard
+ * (#99, see `../add-game-wizard/`) — {@link IdentityStep}, `ResourcesStep`,
+ * `NetworkingStep`, `StorageStep` — but renders every section stacked in one
+ * flat view instead of walking the operator through them one at a time,
+ * since the issue is scoped as "reuses most of the wizard from the prior
+ * issue but as a flat form (not stepwise)".
+ *
+ * Differences from the add wizard's submit flow:
+ *
+ * - The `name` field is rendered read-only (`IdentityStep`'s `nameDisabled`
+ *   prop): renaming a declared game is a delete+recreate, not an update, so
+ *   it's out of scope for this form.
+ * - Submits via `api.updateGame` (`PATCH /api/games/:name` over IPC) instead
+ *   of `api.createGame`, and the draft is validated against every *other*
+ *   declared game (the entry being edited is excluded from the collision
+ *   list by name, mirroring `checkPortCollisions`'s own self-exclusion in
+ *   `@hyveon/shared/gameServerValidator`).
+ * - `environment`/`https` aren't covered by the wizard's draft shape (#99
+ *   never built fields for them), so whatever the declaration already had is
+ *   carried forward unmodified in the submitted payload rather than being
+ *   silently dropped.
+ *
+ * Every {@link GameWriteResult} branch on submit is handled the same way the
+ * add wizard handles it: `ok: true` invokes `onSaved` with the fresh result;
+ * `code: 'validation'` re-renders the same fields with server-reported
+ * issues (the draft is never reset, so the operator doesn't lose their
+ * edits); `code: 'conflict' | 'not_found' | 'error'` surfaces the server's
+ * message as an inline alert, again without touching the draft.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import type { GameServerValidationIssue } from '@hyveon/shared/gameServerValidator';
+import { Button } from '@/components/ui/button.component';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.component';
+import { api, type GameServer, type GameWriteSuccess, type UpdateGamePayload } from '../../api.service.js';
+import { IdentityStep } from '../add-game-wizard/identity-step.component.js';
+import { ResourcesStep } from '../add-game-wizard/resources-step.component.js';
+import { NetworkingStep } from '../add-game-wizard/networking-step.component.js';
+import { StorageStep } from '../add-game-wizard/storage-step.component.js';
+import { draftFromGameServer, draftToPayload, validateStep, type WizardDraft } from '../add-game-wizard/wizard-form.utils.js';
+
+/** Props for {@link EditGameForm}. */
+export interface EditGameFormProps {
+  /** The declared game to prefill the form from. */
+  game: GameServer;
+  /** Called with the successful write result once `api.updateGame` resolves `ok: true`. */
+  onSaved?: (result: GameWriteSuccess) => void;
+}
+
+/**
+ * Self-contained "Edit game" form: prefills a {@link WizardDraft} from
+ * `game`, renders every wizard step flattened in one view (name read-only),
+ * and owns its own `games.update` submit handler. See the module doc above
+ * for the full submit-result contract.
+ */
+export function EditGameForm({ game, onSaved }: EditGameFormProps) {
+  const [draft, setDraft] = useState<WizardDraft>(() => draftFromGameServer(game));
+  const [existingGames, setExistingGames] = useState<GameServer[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [serverIssues, setServerIssues] = useState<GameServerValidationIssue[] | null>(null);
+
+  // Guards against setting state from a stale `api.games()`/`api.updateGame()`
+  // response after this form has unmounted (e.g. the operator navigated away
+  // mid-request).
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
+
+  // Refreshes the list of every other declared game (used for the
+  // cross-game port-collision check) on mount, mirroring the add wizard's
+  // own `api.games()` effect. The entry being edited is excluded by name so
+  // it never collides with its own, unchanged ports.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .games()
+      .then(({ games }) => {
+        if (cancelled || !mountedRef.current) return;
+        setExistingGames(
+          games.flatMap((entry) => (entry.config && entry.config.name !== game.name ? [entry.config] : [])),
+        );
+      })
+      .catch(() => {
+        if (!cancelled && mountedRef.current) setExistingGames([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [game.name]);
+
+  /**
+   * Applies a partial patch to the draft. Any stale server-reported error
+   * state is cleared, since the operator is actively fixing the draft that
+   * produced it.
+   */
+  function patchDraft(patch: Partial<WizardDraft>) {
+    setServerIssues(null);
+    setSubmitError(null);
+    setDraft((prev) => ({ ...prev, ...patch }));
+  }
+
+  const liveIssues = validateStep('review', draft, existingGames);
+  const issues = serverIssues ?? liveIssues;
+  const saveDisabled = issues.length > 0 || submitting;
+
+  /**
+   * Submits the draft via `api.updateGame` and routes every
+   * {@link GameWriteResult} branch to the right UI reaction — see the module
+   * doc for the full contract. On any failure branch the draft is left
+   * untouched so the operator doesn't lose their edits.
+   */
+  async function handleSave() {
+    setSubmitting(true);
+    setSubmitError(null);
+    setServerIssues(null);
+
+    try {
+      const { config } = draftToPayload(draft);
+      const payload: UpdateGamePayload = {
+        name: game.name,
+        // `environment`/`https` aren't editable fields on this form (the
+        // wizard draft never had a place for them) — carry the existing
+        // declaration's values forward so saving other fields doesn't wipe
+        // them out.
+        config: { ...config, environment: game.environment, https: game.https },
+      };
+      const result = await api.updateGame(payload);
+
+      if (!mountedRef.current) return;
+
+      if (result.ok) {
+        onSaved?.(result);
+        return;
+      }
+
+      switch (result.code) {
+        case 'validation':
+          setServerIssues(result.issues);
+          break;
+        case 'conflict':
+        case 'not_found':
+        case 'error':
+          setSubmitError(result.message);
+          break;
+      }
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setSubmitError(err instanceof Error ? err.message : 'Failed to update game.');
+    } finally {
+      if (mountedRef.current) setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Identity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <IdentityStep draft={draft} issues={issues} onChange={patchDraft} nameDisabled />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Resources</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResourcesStep cpu={draft.cpu} memory={draft.memory} issues={issues} onChange={patchDraft} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Networking</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <NetworkingStep ports={draft.ports} issues={issues} onChange={(ports) => patchDraft({ ports })} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Storage</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <StorageStep draft={draft} issues={issues} onChange={patchDraft} />
+        </CardContent>
+      </Card>
+
+      {submitError && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-[var(--color-red)] bg-[var(--color-red)]/10 px-3 py-2 text-sm text-[var(--color-red)]"
+        >
+          <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+          {submitError}
+        </div>
+      )}
+
+      <p className="text-xs text-[var(--color-muted-foreground)]">
+        Saving only updates <code>terraform.tfvars</code> — run <code>make tf-apply</code> to apply this change to
+        the live server.
+      </p>
+
+      <Button type="button" onClick={handleSave} disabled={saveDisabled}>
+        {submitting && <Loader2 className="animate-spin" />}
+        Save changes
+      </Button>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/remove-game-button.component.test.tsx
+++ b/app/packages/web/src/components/remove-game-button.component.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RemoveGameButton } from './remove-game-button.component.js';
+
+/** Stub for `@/api.service.js` — only `deleteGame` is called by this component. */
+const apiMock = vi.hoisted(() => ({ deleteGame: vi.fn() }));
+vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+/** Stub for `sonner`'s `toast`, so success/failure toasts can be asserted without a real toaster mounted. */
+const toastMock = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+/**
+ * Stub for `react-router-dom`'s `useNavigate` — the component only ever
+ * calls this one hook from the module, so a full mock (no real
+ * `MemoryRouter` needed) keeps the test setup minimal.
+ */
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }));
+
+/** Opens the remove-game dialog via its trigger button and waits for it to render. */
+async function openDialog(game = 'minecraft') {
+  render(<RemoveGameButton game={game} />);
+  await userEvent.click(screen.getByRole('button', { name: 'Remove game' }));
+  await screen.findByRole('alertdialog');
+}
+
+describe('RemoveGameButton', () => {
+  beforeEach(() => {
+    apiMock.deleteGame.mockReset();
+    navigateMock.mockClear();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
+  });
+
+  it('should disable the confirm button until the exact game name is typed', async () => {
+    await openDialog('minecraft');
+    // There are two "Remove game" buttons once the dialog is open: the
+    // trigger (now behind the dialog) and the AlertDialogAction. Scope to
+    // the dialog to get the confirm button specifically.
+    const dialog = screen.getByRole('alertdialog');
+    const confirmBtn = within(dialog).getByRole('button', { name: 'Remove game' });
+    const input = within(dialog).getByRole('textbox', { name: /type the game name/i });
+
+    expect(confirmBtn).toBeDisabled();
+
+    await userEvent.type(input, 'minec');
+    expect(confirmBtn).toBeDisabled();
+
+    await userEvent.type(input, 'raft');
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it('should not call api.deleteGame when cancel is clicked', async () => {
+    await openDialog('minecraft');
+    const dialog = screen.getByRole('alertdialog');
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(apiMock.deleteGame).not.toHaveBeenCalled();
+  });
+
+  it('should call api.deleteGame with the game name and navigate to /games on success', async () => {
+    apiMock.deleteGame.mockResolvedValue({ ok: true, games: [] });
+    await openDialog('minecraft');
+    const dialog = screen.getByRole('alertdialog');
+
+    await userEvent.type(within(dialog).getByRole('textbox', { name: /type the game name/i }), 'minecraft');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Remove game' }));
+
+    expect(apiMock.deleteGame).toHaveBeenCalledWith({ name: 'minecraft' });
+    expect(navigateMock).toHaveBeenCalledWith('/games');
+    expect(toastMock.success).toHaveBeenCalledOnce();
+  });
+
+  it('should show an error toast and not navigate when the server rejects the delete', async () => {
+    apiMock.deleteGame.mockResolvedValue({ ok: false, code: 'not_found', message: 'No such game.' });
+    await openDialog('minecraft');
+    const dialog = screen.getByRole('alertdialog');
+
+    await userEvent.type(within(dialog).getByRole('textbox', { name: /type the game name/i }), 'minecraft');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Remove game' }));
+
+    expect(apiMock.deleteGame).toHaveBeenCalledWith({ name: 'minecraft' });
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(toastMock.error).toHaveBeenCalledOnce();
+  });
+
+  it('should show the terraform.tfvars / make tf-apply hint text in the dialog', async () => {
+    await openDialog('minecraft');
+    const dialog = screen.getByRole('alertdialog');
+
+    expect(within(dialog).getByText('terraform.tfvars')).toBeInTheDocument();
+    expect(within(dialog).getByText('make tf-apply')).toBeInTheDocument();
+  });
+});

--- a/app/packages/web/src/components/remove-game-button.component.tsx
+++ b/app/packages/web/src/components/remove-game-button.component.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import { api } from '../api.service.js';
+import { Button } from '@/components/ui/button.component';
+import { Input } from '@/components/ui/input.component';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog.component';
+
+interface Props {
+  /** Name of the `game_servers` entry to remove — must be typed exactly to enable the confirm button. */
+  game: string;
+}
+
+/**
+ * Destructive "Remove game" button for a single declared `game_servers`
+ * entry. Modeled on the type-to-confirm pattern in `ConfirmDialog`, but built
+ * directly on the AlertDialog primitives so the dialog body can also surface
+ * the `terraform.tfvars` / `make tf-apply` hint next to the type-to-confirm
+ * input — `ConfirmDialog`'s `description` prop is plain text and can't carry
+ * that richer content.
+ *
+ * `api.deleteGame` only rewrites `terraform.tfvars` — it does NOT run
+ * `terraform apply`, so the underlying AWS resources (task definition, EFS
+ * access point, security group rules, etc.) stay live until an operator
+ * applies the change. The dialog calls this out explicitly so the action
+ * isn't mistaken for a full teardown.
+ *
+ * On a successful delete the operator is redirected to `/games` since the
+ * detail route for the now-removed game no longer has anything to show.
+ */
+export function RemoveGameButton({ game }: Props) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [typed, setTyped] = useState('');
+
+  const confirmDisabled = typed !== game;
+
+  /** Resets the typed confirmation value whenever the dialog closes, so a stale value isn't shown on reopen. */
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) setTyped('');
+  }
+
+  async function handleConfirm() {
+    try {
+      const result = await api.deleteGame({ name: game });
+      if (result.ok) {
+        toast.success(`${game} removed from terraform.tfvars`);
+        navigate('/games');
+        return;
+      }
+      toast.error(`Failed to remove ${game}`, { description: result.message });
+    } catch (err) {
+      toast.error(`Failed to remove ${game}`, {
+        description: err instanceof Error ? err.message : 'An unknown error occurred',
+      });
+    }
+  }
+
+  return (
+    <>
+      <Button type="button" variant="destructive" onClick={() => setOpen(true)}>
+        <Trash2 />
+        Remove game
+      </Button>
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove {game}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This deletes the <code className="font-[var(--font-mono)] text-xs">{game}</code> entry from{' '}
+              <code className="font-[var(--font-mono)] text-xs">terraform.tfvars</code>. The deployed AWS
+              resources stay live until an operator runs{' '}
+              <code className="font-[var(--font-mono)] text-xs">terraform apply</code> (or{' '}
+              <code className="font-[var(--font-mono)] text-xs">make tf-apply</code>) to apply the change.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <Input
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={game}
+            className="font-[var(--font-mono)]"
+            aria-label="Type the game name to confirm"
+          />
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void handleConfirm()} disabled={confirmDisabled}>
+              Remove game
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/app/packages/web/src/components/remove-game-button.component.tsx
+++ b/app/packages/web/src/components/remove-game-button.component.tsx
@@ -59,7 +59,9 @@ export function RemoveGameButton({ game }: Props) {
         navigate('/games');
         return;
       }
-      toast.error(`Failed to remove ${game}`, { description: result.message });
+      const description =
+        result.code === 'validation' ? result.issues.map((i) => i.message).join(' ') : result.message;
+      toast.error(`Failed to remove ${game}`, { description });
     } catch (err) {
       toast.error(`Failed to remove ${game}`, {
         description: err instanceof Error ? err.message : 'An unknown error occurred',

--- a/app/packages/web/src/pages/game-detail.page.test.tsx
+++ b/app/packages/web/src/pages/game-detail.page.test.tsx
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Routes, Route } from 'react-router-dom';
 
 const apiMock = vi.hoisted(() => ({
   status: vi.fn(),
   costsEstimate: vi.fn(),
   games: vi.fn(),
+  updateGame: vi.fn(),
+  deleteGame: vi.fn(),
 }));
 vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+/** Stub for `sonner`'s `toast`, pulled in transitively via `RemoveGameButton`. */
+const toastMock = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock('sonner', () => ({ toast: toastMock }));
 
 import { GameDetailPage } from './game-detail.page.js';
 import { renderPage } from '../test-utils/render-page.utils.js';
@@ -50,6 +57,10 @@ describe('GameDetailPage', () => {
   beforeEach(() => {
     apiMock.status.mockResolvedValue([]);
     apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
+    apiMock.updateGame.mockReset();
+    apiMock.deleteGame.mockReset();
+    toastMock.success.mockClear();
+    toastMock.error.mockClear();
   });
 
   describe('a fully-declared game', () => {
@@ -112,6 +123,53 @@ describe('GameDetailPage', () => {
       expect(await screen.findByRole('heading', { name: 'Connect message' })).toBeInTheDocument();
       expect(screen.getByText('Connect at minecraft.example.com')).toBeInTheDocument();
     });
+
+    it('should toggle into the prefilled edit form when Edit is clicked', async () => {
+      const user = userEvent.setup();
+      renderDetailPage('minecraft');
+      await screen.findByRole('heading', { name: 'Container' });
+
+      await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+      expect(await screen.findByLabelText('Image')).toHaveValue('itzg/minecraft-server:latest');
+      expect(screen.getByLabelText('Name')).toBeDisabled();
+      expect(screen.getByLabelText('Name')).toHaveValue('minecraft');
+      expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Container' })).toBeNull();
+    });
+
+    it('should reflect a saved change in the read-only view after onSaved', async () => {
+      const user = userEvent.setup();
+      const updatedGame = {
+        ...DECLARED_GAME,
+        config: { ...DECLARED_GAME.config, image: 'itzg/minecraft-server:2.0' },
+      };
+      apiMock.updateGame.mockResolvedValue({ ok: true, games: [updatedGame, GHOST_GAME] });
+      renderDetailPage('minecraft');
+      await screen.findByRole('heading', { name: 'Container' });
+
+      await user.click(screen.getByRole('button', { name: 'Edit' }));
+      const imageField = await screen.findByLabelText('Image');
+      await user.clear(imageField);
+      await user.type(imageField, 'itzg/minecraft-server:2.0');
+      await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+      await waitFor(() => expect(apiMock.updateGame).toHaveBeenCalled());
+      expect(await screen.findByRole('heading', { name: 'Container' })).toBeInTheDocument();
+      expect(screen.getByText('itzg/minecraft-server:2.0')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Image')).toBeNull();
+    });
+
+    it('should expose the Remove confirmation dialog', async () => {
+      const user = userEvent.setup();
+      renderDetailPage('minecraft');
+      await screen.findByRole('heading', { name: 'Container' });
+
+      await user.click(screen.getByRole('button', { name: 'Remove game' }));
+
+      const dialog = await screen.findByRole('alertdialog');
+      expect(within(dialog).getByText('Remove minecraft?')).toBeInTheDocument();
+    });
   });
 
   describe('a ghost game (deployed but not declared)', () => {
@@ -139,6 +197,14 @@ describe('GameDetailPage', () => {
       expect(screen.queryByRole('heading', { name: 'Container' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Ports' })).toBeNull();
       expect(screen.queryByRole('heading', { name: 'Volumes' })).toBeNull();
+    });
+
+    it('should hide the Edit and Remove controls', async () => {
+      renderDetailPage('valheim');
+
+      await screen.findByText('Undeclared');
+      expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Remove game' })).toBeNull();
     });
   });
 

--- a/app/packages/web/src/pages/game-detail.page.tsx
+++ b/app/packages/web/src/pages/game-detail.page.tsx
@@ -136,7 +136,7 @@ export function GameDetailPage() {
             )}
           </Card>
 
-          {config && editing && <EditGameForm game={config} onSaved={handleSaved} />}
+          {config && editing && <EditGameForm key={config.name} game={config} onSaved={handleSaved} />}
 
           {config && !editing && (
             <>

--- a/app/packages/web/src/pages/game-detail.page.tsx
+++ b/app/packages/web/src/pages/game-detail.page.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Pencil } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
-import { api, type GameListEntry } from '../api.service.js';
+import { api, type GameListEntry, type GameWriteSuccess } from '../api.service.js';
 import { GameStatusBadges } from '../components/game-status-badges.component.js';
+import { EditGameForm } from '../components/edit-game-form/edit-game-form.component.js';
+import { RemoveGameButton } from '../components/remove-game-button.component.js';
 import { PollingIndicator } from '../polling/polling-indicator.component.js';
+import { Button } from '@/components/ui/button.component';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.component';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.component';
 
@@ -36,10 +39,19 @@ function Field({ label, value }: { label: string; value: string }) {
  *     image, CPU/memory, HTTPS flag, ports, volumes, environment variables
  *     (if any), file seeds (collapsed, if any), and the connect message (if
  *     set).
+ *
+ * Fully-declared entries also get an "Edit" toggle and a {@link
+ * RemoveGameButton} (#100) in the header — both are hidden for ghost entries
+ * since there's no declared configuration to edit or remove. Toggling "Edit"
+ * swaps the read-only cards for a prefilled {@link EditGameForm}; a
+ * successful save (`onSaved`) replaces the in-memory merged games list with
+ * the server's fresh response and switches back to the read-only view, so
+ * the edited fields are visible immediately without a full refetch.
  */
 export function GameDetailPage() {
   const { name } = useParams<{ name: string }>();
   const [games, setGames] = useState<GameListEntry[] | null>(null);
+  const [editing, setEditing] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,6 +70,12 @@ export function GameDetailPage() {
 
   const entry = games?.find((g) => g.name === name);
   const config = entry?.config;
+
+  /** Applies a successful `EditGameForm` save and returns to the read-only view. */
+  function handleSaved(result: GameWriteSuccess) {
+    setGames(result.games);
+    setEditing(false);
+  }
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -88,7 +106,22 @@ export function GameDetailPage() {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between">
               <CardTitle className="capitalize">{entry.name}</CardTitle>
-              <GameStatusBadges declared={entry.declared} deployed={entry.deployed} />
+              <div className="flex items-center gap-2">
+                <GameStatusBadges declared={entry.declared} deployed={entry.deployed} />
+                {config && (editing ? (
+                  <Button type="button" variant="outline" size="sm" onClick={() => setEditing(false)}>
+                    Cancel
+                  </Button>
+                ) : (
+                  <>
+                    <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
+                      <Pencil />
+                      Edit
+                    </Button>
+                    <RemoveGameButton game={entry.name} />
+                  </>
+                ))}
+              </div>
             </CardHeader>
             {!config && (
               <CardContent>
@@ -103,7 +136,9 @@ export function GameDetailPage() {
             )}
           </Card>
 
-          {config && (
+          {config && editing && <EditGameForm game={config} onSaved={handleSaved} />}
+
+          {config && !editing && (
             <>
               {/* Container overview */}
               <Card>

--- a/terraform/.tflint.hcl
+++ b/terraform/.tflint.hcl
@@ -8,7 +8,9 @@ config {
 }
 
 plugin "aws" {
-  enabled = true
-  version = "0.32.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+  enabled   = true
+  version   = "0.32.0"
+  source    = "github.com/terraform-linters/tflint-ruleset-aws"
+  signature = "pgp" # GitHub Actions attestation API is currently broken (bundle field missing);
+                     # see terraform-linters/tflint#2591. Switch back to attestation once fixed upstream.
 }


### PR DESCRIPTION
Closes #100

## Summary

- Adds `EditGameForm` — a flat (non-wizard) form on `/games/:name`, prefilled from the current game declaration, reusing the wizard's draft<->config conversion helpers (now hoisted for shared use) and submitting via `PATCH /api/games/:name` with the same conflict + validation handling as the add-game wizard.
- Adds `RemoveGameButton` — a destructive confirmation flow requiring the operator to type the game name before the `DELETE /api/games/:name` call is allowed to fire; cancelling at any point leaves the game untouched.
- Wires both into `GameDetailPage`, including the "this only edits tfvars; run `make apply` to materialize" hint surfaced by both flows.

## Changes

```
 app/packages/web/src/api.service.test.ts           |  23 +++
 app/packages/web/src/api.service.ts                |  28 +++
 .../add-game-wizard/add-game-wizard.component.tsx  |  38 +---
 .../add-game-wizard/identity-step.component.tsx    |  17 +-
 .../add-game-wizard/wizard-form.utils.test.ts      |  68 +++++++
 .../add-game-wizard/wizard-form.utils.ts           |  63 +++++-
 .../edit-game-form.component.test.tsx              | 160 +++++++++++++++
 .../edit-game-form/edit-game-form.component.tsx    | 222 +++++++++++++++++++++
 .../remove-game-button.component.test.tsx          |  97 +++++++++
 .../components/remove-game-button.component.tsx    | 107 ++++++++++
 .../web/src/pages/game-detail.page.test.tsx        |  68 ++++++-
 app/packages/web/src/pages/game-detail.page.tsx    |  43 +++-
 12 files changed, 891 insertions(+), 43 deletions(-)
```

## Test plan

- [x] Edit flow round-trips a change and the games page reflects it — covered by `edit-game-form.component.test.tsx` and `game-detail.page.test.tsx` submit/refresh assertions.
- [x] Remove confirmation requires typing the name; cancellation is safe — covered by `remove-game-button.component.test.tsx` (delete disabled until name matches, cancel leaves state untouched).
- [x] Hints about `make apply` are visible — asserted in both component test files.
- [x] Coverage for both flows — `edit-game-form.component.test.tsx`, `remove-game-button.component.test.tsx`, and updated `game-detail.page.test.tsx`.
- [x] `npm run app:test` passing for the touched workspace (web).
