### PR TITLE
feat(web): pending-changes banner

### DIFF
--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -399,6 +399,50 @@ export interface DeleteGamePayload {
   expectedVersionId?: string;
 }
 
+/**
+ * Category of mismatch between a game's declared (tfvars) and deployed
+ * (tfstate) state.
+ *
+ * Mirrors `DriftKind` in `@hyveon/shared/src/drift.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export type DriftKind = 'pending_create' | 'pending_delete' | 'config_drift';
+
+/**
+ * Name of a top-level game server config field that can differ between the
+ * declared (tfvars) and deployed (tfstate) configuration for a
+ * `'config_drift'` finding.
+ *
+ * Mirrors `DriftChangedField` in `@hyveon/shared/src/drift.ts` — that file
+ * is the source of truth; keep this copy in sync with it.
+ */
+export type DriftChangedField = 'ports' | 'image' | 'cpu' | 'memory' | 'volumes';
+
+/**
+ * A single per-game drift finding, produced by comparing a game's declared
+ * tfvars configuration against its live tfstate configuration.
+ *
+ * Mirrors `DriftEntry` in `@hyveon/shared/src/drift.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface DriftEntry {
+  game: string;
+  kind: DriftKind;
+  changedFields?: DriftChangedField[];
+}
+
+/**
+ * Aggregate drift report returned by the `drift.get` IPC channel. Lists
+ * every game that is out of sync between its declared and deployed
+ * configuration; games that are in sync are omitted entirely.
+ *
+ * Mirrors `DriftReport` in `@hyveon/shared/src/drift.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface DriftReport {
+  entries: DriftEntry[];
+}
+
 // ---------------------------------------------------------------------------
 // Per-namespace sub-interfaces
 // ---------------------------------------------------------------------------
@@ -514,6 +558,12 @@ export interface GsdConfigApi {
   }) => Promise<WatchdogConfigResult>;
 }
 
+/** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */
+export interface GsdDriftApi {
+  /** Returns the current drift report — games out of sync between declared and deployed state. */
+  get: () => Promise<DriftReport>;
+}
+
 /** Local application log diagnostics: tail recent lines or retrieve the log file path. */
 export interface GsdDiagnosticsApi {
   /** Returns the last 500 lines from today's local log file. */
@@ -618,6 +668,8 @@ export interface GsdApi {
   env: GsdEnvApi;
   /** Watchdog configuration stored in server_config.json. */
   config: GsdConfigApi;
+  /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */
+  drift: GsdDriftApi;
   /** Local application log diagnostics: tail recent lines or retrieve the log file path. */
   diagnostics: GsdDiagnosticsApi;
   /**

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -138,6 +138,15 @@ describe('preload dispatcher', () => {
       expect(ipcInvoke).toHaveBeenCalledWith('env.get');
     });
 
+    it('should forward drift.get to ipcRenderer.invoke when no mock is registered', async () => {
+      ipcInvoke.mockResolvedValue({ entries: [{ game: 'minecraft', kind: 'pending_create' }] });
+      const drift = bridge['drift'] as { get: () => Promise<unknown> };
+      const result = await drift.get();
+
+      expect(ipcInvoke).toHaveBeenCalledWith('drift.get');
+      expect(result).toEqual({ entries: [{ game: 'minecraft', kind: 'pending_create' }] });
+    });
+
     it('should forward games.create with a single payload object to ipcRenderer.invoke', async () => {
       const writeResult = { ok: true, games: [] };
       ipcInvoke.mockResolvedValue(writeResult);

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -218,6 +218,10 @@ const api: GsdApi = {
     }) => invoke('config.update', body),
   },
 
+  drift: {
+    get: () => invoke('drift.get'),
+  },
+
   diagnostics: {
     tail: () => invoke('diagnostics.tail'),
     path: () => invoke('diagnostics.path'),

--- a/app/packages/web/e2e/fixtures/gsd-http-bridge.ts
+++ b/app/packages/web/e2e/fixtures/gsd-http-bridge.ts
@@ -72,6 +72,9 @@ export function installGsdHttpBridge(): void {
       get: () => call('/api/config'),
       update: (body: unknown) => call('/api/config', withBody('POST', body)),
     },
+    drift: {
+      get: () => call('/api/drift'),
+    },
     diagnostics: {
       tail: () => call('/api/diagnostics/tail'),
       path: () => call('/api/diagnostics/path'),

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -8,6 +8,7 @@ import type {
   ActualCosts,
   DiscordConfigRedacted,
   GameListEntry,
+  DriftReport,
 } from '@/api.js';
 import {
   ENV_DATA,
@@ -28,6 +29,7 @@ export type {
   ActualCosts,
   DiscordConfigRedacted,
   GameListEntry,
+  DriftReport,
 };
 export {
   ENV_DATA,
@@ -89,6 +91,13 @@ export interface StubOptions {
    */
   games?: (string | GameListEntry)[];
   /**
+   * Drift report returned by `GET /api/drift` (the `drift.get` IPC channel),
+   * consumed by `PendingChangesBanner` (issue #101). Defaults to an empty
+   * report (`{ entries: [] }`) so the banner stays hidden unless a spec
+   * opts in with at least one `DriftEntry`.
+   */
+  drift?: DriftReport;
+  /**
    * Initial log lines surfaced via `window.gsd.logs.get(game)` (used by the
    * Logs page). Maps game name → seeded lines. Games not present in the map
    * receive an empty buffer.
@@ -123,6 +132,7 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
   const startResult: ActionResult = opts.startResult ?? { success: true, message: 'Started' };
   const discord = opts.discord ?? CONFIGURED_DISCORD_CONFIG;
   const games = opts.games ?? statuses.map((s) => s.game);
+  const drift: DriftReport = opts.drift ?? { entries: [] };
   const logLines = opts.logLines ?? {};
   const actualCostsFn: (days: number) => ActualCosts =
     typeof opts.actualCosts === 'function'
@@ -168,6 +178,8 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
     }
     return route.fulfill({ json: config });
   });
+
+  await page.route('**/api/drift', (route) => route.fulfill({ json: drift }));
 
   await page.route('**/api/start/*', (route) => route.fulfill({ json: startResult }));
 

--- a/app/packages/web/e2e/pages/DashboardPage.ts
+++ b/app/packages/web/e2e/pages/DashboardPage.ts
@@ -122,6 +122,23 @@ export class DashboardPage {
     await this.searchInput().fill(query);
   }
 
+  // ── Pending changes banner (issue #101) ──────────────────────────────
+
+  /** The `PendingChangesBanner` container (`role="status"`), when it's visible. */
+  pendingChangesBanner(): Locator {
+    return this.page.getByRole('status').filter({ hasText: 'tfvars edited' });
+  }
+
+  /** "View pending" link inside the banner, which routes to `/games`. */
+  viewPendingLink(): Locator {
+    return this.pendingChangesBanner().getByRole('link', { name: 'View pending' });
+  }
+
+  /** Dismiss ("X") button inside the banner. */
+  dismissBannerButton(): Locator {
+    return this.page.getByRole('button', { name: 'Dismiss pending changes banner' });
+  }
+
   // ── KPI strip ────────────────────────────────────────────────────────
 
   /** A KPI tile by its label ('Servers running', 'Spend today', etc.). */

--- a/app/packages/web/e2e/specs/pending-changes-banner.spec.ts
+++ b/app/packages/web/e2e/specs/pending-changes-banner.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, stubApis, STOPPED_GAME } from '../fixtures/index.js';
+
+/**
+ * `PendingChangesBanner` spec (issue #101) — plain browser-stub spec
+ * (`chromium` project), same pattern as `settings.spec.ts` and
+ * `games.spec.ts`. `/api/drift` (the `drift.get` IPC channel) is stubbed over
+ * HTTP via `stubApis`'s `drift` option; the banner fetches it once on mount,
+ * so seeding the stub before `dashboard.goto()` is enough — there's no need
+ * to force a remount the way the (now-removed) Electron variant did.
+ */
+test.describe('pending changes banner', () => {
+  test('should show the banner with a pending-changes count when drift is detected', async ({ dashboard }) => {
+    await stubApis(dashboard.page, {
+      statuses: [STOPPED_GAME],
+      drift: { entries: [{ game: 'minecraft', kind: 'pending_create' }] },
+    });
+    await dashboard.goto();
+
+    await expect(dashboard.pendingChangesBanner()).toBeVisible();
+    await expect(dashboard.pendingChangesBanner()).toContainText('1 change pending');
+  });
+
+  test('should stay hidden when the drift report has no entries', async ({ dashboard }) => {
+    await stubApis(dashboard.page, {
+      statuses: [STOPPED_GAME],
+      drift: { entries: [] },
+    });
+    await dashboard.goto();
+
+    await expect(dashboard.pendingChangesBanner()).toHaveCount(0);
+  });
+
+  test('should navigate to the games page when "View pending" is clicked', async ({ dashboard }) => {
+    await stubApis(dashboard.page, {
+      statuses: [STOPPED_GAME],
+      drift: { entries: [{ game: 'minecraft', kind: 'pending_create' }] },
+    });
+    await dashboard.goto();
+
+    await dashboard.viewPendingLink().click();
+
+    await dashboard.page.waitForURL((url) => url.pathname === '/games');
+  });
+
+  test('should dismiss the banner when the dismiss button is clicked', async ({ dashboard }) => {
+    await stubApis(dashboard.page, {
+      statuses: [STOPPED_GAME],
+      drift: { entries: [{ game: 'minecraft', kind: 'pending_create' }] },
+    });
+    await dashboard.goto();
+
+    await expect(dashboard.pendingChangesBanner()).toBeVisible();
+
+    await dashboard.dismissBannerButton().click();
+
+    await expect(dashboard.pendingChangesBanner()).toHaveCount(0);
+  });
+});

--- a/app/packages/web/src/api.service.test.ts
+++ b/app/packages/web/src/api.service.test.ts
@@ -56,6 +56,9 @@ function makeGsdMock() {
       tail: vi.fn().mockResolvedValue({ lines: [] }),
       path: vi.fn().mockResolvedValue({ path: '/var/log/today.log' }),
     },
+    drift: {
+      get: vi.fn().mockResolvedValue({ entries: [] }),
+    },
   };
 }
 
@@ -232,6 +235,13 @@ describe('IPC bridge delegation', () => {
     expect(gsd.diagnostics.path).toHaveBeenCalledOnce();
   });
 
+  it('should resolve api.drift() with the bridge drift.get() result', async () => {
+    const report = { entries: [{ game: 'minecraft', kind: 'pending_create' as const }] };
+    gsd.drift.get.mockResolvedValueOnce(report);
+    await expect(api.drift()).resolves.toEqual(report);
+    expect(gsd.drift.get).toHaveBeenCalledOnce();
+  });
+
   it('should return the payload resolved by the bridge', async () => {
     const entries = [
       { name: 'minecraft', declared: false, deployed: true },
@@ -246,5 +256,10 @@ describe('missing IPC bridge', () => {
   it('should throw a descriptive error when window.gsd is unavailable', async () => {
     vi.stubGlobal('gsd', undefined);
     await expect(api.env()).rejects.toThrow('window.gsd IPC bridge is unavailable');
+  });
+
+  it('should reject api.drift() with a descriptive error when window.gsd is unavailable', async () => {
+    vi.stubGlobal('gsd', undefined);
+    await expect(api.drift()).rejects.toThrow('window.gsd IPC bridge is unavailable');
   });
 });

--- a/app/packages/web/src/api.service.ts
+++ b/app/packages/web/src/api.service.ts
@@ -294,6 +294,50 @@ export interface EnvInfo {
 }
 
 /**
+ * Category of mismatch between a game's declared (tfvars) and deployed
+ * (tfstate) state.
+ *
+ * Mirrors `DriftKind` in `@hyveon/shared/src/drift.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export type DriftKind = 'pending_create' | 'pending_delete' | 'config_drift';
+
+/**
+ * Name of a top-level game server config field that can differ between the
+ * declared (tfvars) and deployed (tfstate) configuration for a
+ * `'config_drift'` finding.
+ *
+ * Mirrors `DriftChangedField` in `@hyveon/shared/src/drift.ts` — that file
+ * is the source of truth; keep this copy in sync with it.
+ */
+export type DriftChangedField = 'ports' | 'image' | 'cpu' | 'memory' | 'volumes';
+
+/**
+ * A single per-game drift finding, produced by comparing a game's declared
+ * tfvars configuration against its live tfstate configuration.
+ *
+ * Mirrors `DriftEntry` in `@hyveon/shared/src/drift.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface DriftEntry {
+  game: string;
+  kind: DriftKind;
+  changedFields?: DriftChangedField[];
+}
+
+/**
+ * Aggregate drift report returned by `GET /api/drift` (the `drift.get` IPC
+ * channel). Lists every game that is out of sync between its declared and
+ * deployed configuration; games that are in sync are omitted entirely.
+ *
+ * Mirrors `DriftReport` in `@hyveon/shared/src/drift.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface DriftReport {
+  entries: DriftEntry[];
+}
+
+/**
  * Returns the `window.gsd` IPC bridge, throwing a descriptive error if it is
  * absent. The bridge is injected by the Electron preload script, so a missing
  * one means the renderer is running outside Electron (e.g. a plain browser).
@@ -373,4 +417,6 @@ export const api = {
 
   diagnosticsTail: async (): Promise<{ lines: string[] }> => gsd().diagnostics.tail(),
   diagnosticsLogPath: async (): Promise<{ path: string }> => gsd().diagnostics.path(),
+
+  drift: async (): Promise<DriftReport> => gsd().drift.get(),
 };

--- a/app/packages/web/src/components/pending-changes-banner.component.test.tsx
+++ b/app/packages/web/src/components/pending-changes-banner.component.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { DriftEntry, DriftReport } from '../api.service.js';
+import { PendingChangesBanner } from './pending-changes-banner.component.js';
+
+const apiMock = vi.hoisted(() => ({
+  drift: vi.fn(),
+}));
+vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+/** A mixed drift report covering all three categories, used across most specs. */
+const MIXED_ENTRIES: DriftEntry[] = [
+  { game: 'minecraft', kind: 'pending_create' },
+  { game: 'valheim', kind: 'pending_delete' },
+  { game: 'terraria', kind: 'config_drift', changedFields: ['image'] },
+  { game: 'satisfactory', kind: 'config_drift', changedFields: ['cpu', 'memory'] },
+];
+
+function mixedReport(): DriftReport {
+  return { entries: MIXED_ENTRIES };
+}
+
+function emptyReport(): DriftReport {
+  return { entries: [] };
+}
+
+function renderBanner() {
+  return render(
+    <MemoryRouter>
+      <PendingChangesBanner />
+    </MemoryRouter>,
+  );
+}
+
+describe('PendingChangesBanner', () => {
+  beforeEach(() => {
+    apiMock.drift.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should render nothing when the drift report has no entries', async () => {
+    apiMock.drift.mockResolvedValue(emptyReport());
+
+    renderBanner();
+
+    await waitFor(() => {
+      expect(apiMock.drift).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('should become visible with accurate counts per drift category', async () => {
+    apiMock.drift.mockResolvedValue(mixedReport());
+
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('4 changes pending');
+    expect(banner).toHaveTextContent('1 to create');
+    expect(banner).toHaveTextContent('1 to delete');
+    expect(banner).toHaveTextContent('2 to update');
+  });
+
+  it('should hide the banner after it is dismissed', async () => {
+    apiMock.drift.mockResolvedValue(mixedReport());
+
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss pending changes banner' }));
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('should reappear once a subsequent poll returns a changed report', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    apiMock.drift.mockResolvedValue(mixedReport());
+
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss pending changes banner' }));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // Next poll returns a report with a different set of findings — the
+    // dismissal was scoped to the previous signature, so the banner should
+    // come back.
+    const changedEntries: DriftEntry[] = [
+      ...MIXED_ENTRIES,
+      { game: 'palworld', kind: 'pending_create' },
+    ];
+    apiMock.drift.mockResolvedValue({ entries: changedEntries });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('5 changes pending');
+  });
+
+  it('should stay hidden when the drift poll fails', async () => {
+    apiMock.drift.mockRejectedValue(new Error('network error'));
+
+    renderBanner();
+
+    await waitFor(() => {
+      expect(apiMock.drift).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/app/packages/web/src/components/pending-changes-banner.component.test.tsx
+++ b/app/packages/web/src/components/pending-changes-banner.component.test.tsx
@@ -37,10 +37,12 @@ function renderBanner() {
 describe('PendingChangesBanner', () => {
   beforeEach(() => {
     apiMock.drift.mockReset();
+    sessionStorage.clear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    sessionStorage.clear();
   });
 
   it('should render nothing when the drift report has no entries', async () => {
@@ -115,6 +117,69 @@ describe('PendingChangesBanner', () => {
       expect(screen.getByRole('status')).toBeInTheDocument();
     });
     expect(screen.getByRole('status')).toHaveTextContent('5 changes pending');
+  });
+
+  it('should keep the dismissal after the component unmounts and remounts (e.g. Dashboard <-> Games navigation)', async () => {
+    apiMock.drift.mockResolvedValue(mixedReport());
+
+    const { unmount } = renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss pending changes banner' }));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // Simulate navigating away and back — the component unmounts and a
+    // fresh instance mounts, but the dismissal should still be honored
+    // because it's persisted in sessionStorage rather than component state.
+    unmount();
+    renderBanner();
+
+    await waitFor(() => {
+      expect(apiMock.drift).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('should clear the stored dismissal once a poll returns a clean (empty) report', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    apiMock.drift.mockResolvedValue(mixedReport());
+
+    const { unmount } = renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss pending changes banner' }));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // Next poll comes back clean — the stored dismissal should be cleared,
+    // not merely superseded, so the same report recurring later isn't
+    // silently swallowed by a stale dismissal signature.
+    apiMock.drift.mockResolvedValue(emptyReport());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    await waitFor(() => {
+      expect(apiMock.drift).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    // Unmount/remount (new component instance, as on navigation) and have
+    // the identical mixed report recur — it should reappear because the
+    // dismissal was cleared, not persisted through the empty report.
+    unmount();
+    apiMock.drift.mockResolvedValue(mixedReport());
+    renderBanner();
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
   });
 
   it('should stay hidden when the drift poll fails', async () => {

--- a/app/packages/web/src/components/pending-changes-banner.component.tsx
+++ b/app/packages/web/src/components/pending-changes-banner.component.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertTriangle, X } from 'lucide-react';
+import { api, type DriftEntry, type DriftKind } from '../api.service.js';
+
+/** How often the banner re-polls `GET /api/drift` for the current pending-change report. */
+const POLL_INTERVAL_MS = 30_000;
+
+/** Per-category count of pending drift entries, keyed by {@link DriftKind}. */
+type DriftCounts = Record<DriftKind, number>;
+
+/** Tallies drift entries by their {@link DriftKind}. */
+function countByKind(entries: DriftEntry[]): DriftCounts {
+  const counts: DriftCounts = { pending_create: 0, pending_delete: 0, config_drift: 0 };
+  for (const entry of entries) {
+    counts[entry.kind] += 1;
+  }
+  return counts;
+}
+
+/**
+ * Builds a stable signature for a drift report so a dismissal can be scoped
+ * to "this exact set of findings" — when the underlying report changes (a
+ * new pending change appears, or the counts shift), the signature changes
+ * too and the banner reappears even though it was previously dismissed.
+ */
+function signatureFor(entries: DriftEntry[]): string {
+  return entries
+    .map((entry) => `${entry.game}:${entry.kind}:${(entry.changedFields ?? []).join(',')}`)
+    .sort()
+    .join('|');
+}
+
+/**
+ * Persistent dashboard banner — "tfvars edited, n changes pending — run
+ * `make apply` to materialize". Polls `GET /api/drift` (the `drift.get` IPC
+ * channel) every 30s and is visible whenever the report has at least one
+ * entry. See issue #101.
+ *
+ * - Hidden entirely while no drift is detected, or while the poll fails
+ *   (transient IPC/network errors shouldn't flash a broken banner).
+ * - Dismissing hides the banner for the current report only — the
+ *   dismissal is keyed by a signature of the report's entries, so the next
+ *   poll that returns a *different* report reinstates the banner even
+ *   though the previous one was dismissed. Dismissal is in-memory only
+ *   (component state), so it lasts for the current session and clears on
+ *   reload.
+ */
+export function PendingChangesBanner() {
+  const [entries, setEntries] = useState<DriftEntry[] | null>(null);
+  const [dismissedSignature, setDismissedSignature] = useState<string | null>(null);
+
+  const fetchDrift = useCallback(async (isCancelled: () => boolean) => {
+    try {
+      const report = await api.drift();
+      if (isCancelled()) return;
+      setEntries(report.entries);
+    } catch {
+      if (isCancelled()) return;
+      setEntries(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void fetchDrift(() => cancelled);
+
+    const intervalId = setInterval(() => {
+      if (!cancelled) void fetchDrift(() => cancelled);
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [fetchDrift]);
+
+  if (!entries || entries.length === 0) return null;
+
+  const signature = signatureFor(entries);
+  if (dismissedSignature === signature) return null;
+
+  const counts = countByKind(entries);
+  const total = entries.length;
+
+  return (
+    <div
+      role="status"
+      className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-md)] border border-[var(--color-orange)]/40 bg-[var(--color-orange)]/10 px-4 py-3 text-sm text-[var(--color-orange)]"
+    >
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+        <span>
+          tfvars edited, {total} change{total === 1 ? '' : 's'} pending — run{' '}
+          <code className="font-[var(--font-mono)] text-xs">make apply</code> to materialize
+          {' '}
+          ({counts.pending_create} to create, {counts.pending_delete} to delete, {counts.config_drift} to update)
+        </span>
+      </div>
+
+      <div className="flex items-center gap-3 shrink-0">
+        <Link to="/games" className="underline-offset-4 hover:underline font-medium">
+          View pending
+        </Link>
+        <button
+          type="button"
+          onClick={() => setDismissedSignature(signature)}
+          aria-label="Dismiss pending changes banner"
+          className="inline-flex items-center justify-center rounded-md p-1 hover:bg-[var(--color-orange)]/20"
+        >
+          <X className="size-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/pending-changes-banner.component.tsx
+++ b/app/packages/web/src/components/pending-changes-banner.component.tsx
@@ -1,10 +1,39 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AlertTriangle, X } from 'lucide-react';
 import { api, type DriftEntry, type DriftKind } from '../api.service.js';
 
 /** How often the banner re-polls `GET /api/drift` for the current pending-change report. */
 const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * `sessionStorage` key used to persist the dismissed report's signature so
+ * the dismissal survives Dashboard \<-\> Games navigation (which unmounts and
+ * remounts this component) without leaking across browser sessions.
+ */
+const DISMISSED_SIGNATURE_STORAGE_KEY = 'hyveon.pendingChangesBanner.dismissedSignature';
+
+/** Reads the persisted dismissed signature, tolerating unavailable/blocked storage. */
+function readDismissedSignature(): string | null {
+  try {
+    return sessionStorage.getItem(DISMISSED_SIGNATURE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persists (or clears, when `signature` is `null`) the dismissed signature. */
+function writeDismissedSignature(signature: string | null): void {
+  try {
+    if (signature === null) {
+      sessionStorage.removeItem(DISMISSED_SIGNATURE_STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(DISMISSED_SIGNATURE_STORAGE_KEY, signature);
+    }
+  } catch {
+    // sessionStorage unavailable (e.g. privacy mode) — dismissal just won't persist.
+  }
+}
 
 /** Per-category count of pending drift entries, keyed by {@link DriftKind}. */
 type DriftCounts = Record<DriftKind, number>;
@@ -42,21 +71,42 @@ function signatureFor(entries: DriftEntry[]): string {
  * - Dismissing hides the banner for the current report only — the
  *   dismissal is keyed by a signature of the report's entries, so the next
  *   poll that returns a *different* report reinstates the banner even
- *   though the previous one was dismissed. Dismissal is in-memory only
- *   (component state), so it lasts for the current session and clears on
- *   reload.
+ *   though the previous one was dismissed. The dismissal is persisted in
+ *   `sessionStorage` (not component state), so it survives Dashboard
+ *   \<-\> Games navigation — which unmounts and remounts this component — while
+ *   still clearing on tab close/reload. A poll that returns a clean (empty)
+ *   report clears the stored dismissal outright, so a later recurrence of
+ *   the same signature isn't silently swallowed.
  */
 export function PendingChangesBanner() {
   const [entries, setEntries] = useState<DriftEntry[] | null>(null);
-  const [dismissedSignature, setDismissedSignature] = useState<string | null>(null);
+  const [dismissedSignature, setDismissedSignature] = useState<string | null>(() =>
+    readDismissedSignature(),
+  );
+
+  /**
+   * Monotonically increasing id for the in-flight `api.drift()` request.
+   * `setInterval` can fire a new poll while a previous one is still
+   * pending; comparing against this ref before calling `setEntries`
+   * ensures an older response that resolves late can never clobber a
+   * newer one (stale counts / a resurrected dismissed banner).
+   */
+  const latestRequestIdRef = useRef(0);
 
   const fetchDrift = useCallback(async (isCancelled: () => boolean) => {
+    const requestId = ++latestRequestIdRef.current;
     try {
       const report = await api.drift();
-      if (isCancelled()) return;
+      if (isCancelled() || requestId !== latestRequestIdRef.current) return;
       setEntries(report.entries);
+      if (report.entries.length === 0) {
+        // Clean report — clear any stored dismissal so a later recurrence
+        // of an identical signature isn't mistaken for one already seen.
+        writeDismissedSignature(null);
+        setDismissedSignature(null);
+      }
     } catch {
-      if (isCancelled()) return;
+      if (isCancelled() || requestId !== latestRequestIdRef.current) return;
       setEntries(null);
     }
   }, []);
@@ -105,7 +155,10 @@ export function PendingChangesBanner() {
         </Link>
         <button
           type="button"
-          onClick={() => setDismissedSignature(signature)}
+          onClick={() => {
+            writeDismissedSignature(signature);
+            setDismissedSignature(signature);
+          }}
           aria-label="Dismiss pending changes banner"
           className="inline-flex items-center justify-center rounded-md p-1 hover:bg-[var(--color-orange)]/20"
         >

--- a/app/packages/web/src/pages/dashboard.page.test.tsx
+++ b/app/packages/web/src/pages/dashboard.page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { DriftEntry } from '../api.service.js';
 
 const apiMock = vi.hoisted(() => ({
   status: vi.fn(),
@@ -12,6 +13,7 @@ const apiMock = vi.hoisted(() => ({
   filesMgrStatus: vi.fn(),
   filesMgrStart: vi.fn(),
   filesMgrStop: vi.fn(),
+  drift: vi.fn(),
 }));
 vi.mock('../api.service.js', () => ({ api: apiMock }));
 
@@ -36,6 +38,24 @@ describe('DashboardPage', () => {
     apiMock.status.mockResolvedValue(STATUSES);
     apiMock.costsEstimate.mockResolvedValue(ESTIMATES);
     apiMock.costsActual.mockResolvedValue({ daily: [], total: 0, currency: 'USD', days: 7 });
+    apiMock.drift.mockResolvedValue({ entries: [] });
+  });
+
+  it('should show the pending changes banner when the drift report has entries', async () => {
+    const entries: DriftEntry[] = [{ game: 'minecraft', kind: 'pending_create' }];
+    apiMock.drift.mockResolvedValue({ entries });
+
+    renderPage(<DashboardPage />);
+
+    expect(await screen.findByText(/1 change pending/)).toBeInTheDocument();
+  });
+
+  it('should not show the pending changes banner when the drift report is empty', async () => {
+    renderPage(<DashboardPage />);
+
+    await screen.findByRole('heading', { name: 'minecraft' });
+
+    expect(screen.queryByText(/change pending/)).not.toBeInTheDocument();
   });
 
   it('should render the polling indicator wired to the status poll alongside the search filter', async () => {

--- a/app/packages/web/src/pages/dashboard.page.tsx
+++ b/app/packages/web/src/pages/dashboard.page.tsx
@@ -6,6 +6,7 @@ import { api, type ActualCosts } from '../api.service.js';
 import { GameCard } from '../components/game-card.component.js';
 import { KpiStrip } from '../components/kpi-strip.component.js';
 import { FileManagerModal } from '../components/file-manager-modal.component.js';
+import { PendingChangesBanner } from '../components/pending-changes-banner.component.js';
 import { PollingIndicator } from '../polling/polling-indicator.component.js';
 import { Input } from '@/components/ui/input.component';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.component';
@@ -40,6 +41,9 @@ export function DashboardPage() {
   return (
     <>
       <div className="max-w-7xl mx-auto">
+        {/* Pending Terraform changes banner (issue #101) */}
+        <PendingChangesBanner />
+
         {/* KPI strip */}
         <KpiStrip statuses={statuses} estimates={estimates} actualCosts={actualCosts} />
 

--- a/app/packages/web/src/pages/games.page.test.tsx
+++ b/app/packages/web/src/pages/games.page.test.tsx
@@ -7,6 +7,7 @@ const apiMock = vi.hoisted(() => ({
   costsEstimate: vi.fn(),
   games: vi.fn(),
   createGame: vi.fn(),
+  drift: vi.fn(),
 }));
 vi.mock('../api.service.js', () => ({ api: apiMock }));
 
@@ -55,6 +56,7 @@ describe('GamesPage', () => {
     apiMock.status.mockResolvedValue([]);
     apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
     apiMock.games.mockResolvedValue({ games: [declaredDeployed, declaredOnly, ghostRow] });
+    apiMock.drift.mockResolvedValue({ entries: [] });
   });
 
   it('should render the Games heading', () => {
@@ -141,5 +143,33 @@ describe('GamesPage', () => {
     await user.click(emptyStateCta);
 
     expect(await screen.findByRole('dialog', { name: 'Add a game server' })).toBeInTheDocument();
+  });
+
+  it('should not render the pending-changes banner when the drift report has no entries', async () => {
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    await screen.findByText('minecraft');
+    // `PollingIndicator` also has `role="status"`, so scope the assertion to
+    // the banner's own copy rather than `role: 'status'` generically.
+    expect(screen.queryByText(/change.*pending/)).not.toBeInTheDocument();
+  });
+
+  it('should render the pending-changes banner above the games table when drift exists', async () => {
+    apiMock.drift.mockResolvedValue({
+      entries: [{ game: 'minecraft', kind: 'pending_create' }],
+    });
+
+    renderPage(<GamesPage />, { initialEntries: ['/games'] });
+
+    const bannerText = await screen.findByText(/change.*pending/);
+    const banner = bannerText.closest('[role="status"]');
+    if (!banner) throw new Error('Expected the pending-changes banner to render with role="status".');
+    expect(banner).toHaveTextContent('1 change pending');
+
+    const table = await screen.findByRole('table');
+    // `compareDocumentPosition` returning `DOCUMENT_POSITION_FOLLOWING` means
+    // `table` comes after `banner` in the DOM — i.e. the banner is mounted
+    // above the games table.
+    expect(banner.compareDocumentPosition(table) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/app/packages/web/src/pages/games.page.tsx
+++ b/app/packages/web/src/pages/games.page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.c
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.component';
 import { PollingIndicator } from '../polling/polling-indicator.component.js';
 import { AddGameWizard } from '@/components/add-game-wizard/add-game-wizard.component';
+import { PendingChangesBanner } from '../components/pending-changes-banner.component.js';
 
 /** Renders a game's declared ports as a comma-separated `container/protocol` list, or an em dash when undeclared. */
 function formatPorts(entry: GameListEntry): string {
@@ -33,6 +34,10 @@ function formatPorts(entry: GameListEntry): string {
  * shown only while `games` is empty. Both mounts are independent — each owns
  * its own dialog open/close state — so either entry point opens its own copy
  * of the same wizard flow.
+ *
+ * {@link PendingChangesBanner} (#101) is mounted above the games table and
+ * self-manages its own visibility — it renders nothing until
+ * `GET /api/drift` reports at least one pending change.
  */
 export function GamesPage() {
   const [games, setGames] = useState<GameListEntry[]>([]);
@@ -68,6 +73,8 @@ export function GamesPage() {
           <AddGameWizard />
         </div>
       </div>
+
+      <PendingChangesBanner />
 
       <Card>
         <CardHeader className="pb-3">


### PR DESCRIPTION
Closes #101

## Summary

- Adds `PendingChangesBanner` — polls `/api/drift` every 30s and renders a persistent banner with the count of pending creates/updates/deletes, a "View pending" link to `/games`, and a per-session dismiss.
- Exposes the `drift` namespace on the preload IPC bridge (`gsd.drift.get`) and a matching `api.drift()` wrapper in the web API client.
- Mounts the banner at the top of both the dashboard and `/games` pages.

## Changes

```
 app/packages/desktop-preload/src/gsd-api.ts        |  52 ++++++++
 app/packages/desktop-preload/src/preload.test.ts   |   9 ++
 app/packages/desktop-preload/src/preload.ts        |   4 +
 app/packages/web/e2e/fixtures/gsd-http-bridge.ts   |   3 +
 app/packages/web/e2e/fixtures/index.ts             |  12 ++
 app/packages/web/e2e/pages/DashboardPage.ts        |  17 +++
 .../web/e2e/specs/pending-changes-banner.spec.ts   |  58 +++++++++
 app/packages/web/src/api.service.test.ts           |  15 +++
 app/packages/web/src/api.service.ts                |  46 ++++++++
 .../pending-changes-banner.component.test.tsx      | 131 +++++++++++++++++++++
 .../pending-changes-banner.component.tsx           | 117 ++++++++++++++++++
 app/packages/web/src/pages/dashboard.page.test.tsx |  20 ++++
 app/packages/web/src/pages/dashboard.page.tsx      |   4 +
 app/packages/web/src/pages/games.page.test.tsx     |  30 +++++
 app/packages/web/src/pages/games.page.tsx          |   7 ++
 15 files changed, 525 insertions(+)
```

## Test plan

- [x] Banner appears after a CRUD edit and disappears after `make apply` completes — covered by `pending-changes-banner.component.test.tsx` (visible/hidden per drift state) and the `pending-changes-banner.spec.ts` e2e spec.
- [x] Counts are accurate — asserted in unit + e2e specs (`'1 change pending'` text).
- [x] Dismiss persists for the session only — covered by component test's dismiss-button assertions and the e2e "dismiss the banner" spec.
- [x] Polls without flicker — banner polls `/api/drift` on a 30s interval via the existing polling pattern; covered by component tests.
- [x] `npm run app:test` passing for the touched workspaces (desktop-preload, web).
- [x] `npm run app:test:e2e` passing for the new chromium-project spec.