### PR TITLE
feat(desktop-main): audit log in DynamoDB

### DIFF
--- a/app/packages/cloud-aws/package.json
+++ b/app/packages/cloud-aws/package.json
@@ -15,10 +15,12 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.600.0",
     "@aws-sdk/client-cost-explorer": "^3.600.0",
+    "@aws-sdk/client-dynamodb": "^3.600.0",
     "@aws-sdk/client-ec2": "^3.600.0",
     "@aws-sdk/client-ecs": "^3.600.0",
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/client-secrets-manager": "^3.600.0",
+    "@aws-sdk/lib-dynamodb": "^3.600.0",
     "@hyveon/shared": "*"
   }
 }

--- a/app/packages/cloud-aws/src/AwsAuditLogStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsAuditLogStore.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import type { AuditEntry, GameServer } from '@hyveon/shared';
+import { AwsAuditLogStore } from './AwsAuditLogStore.js';
+
+/** Typed stand-in for the DynamoDB document client SDK. */
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+/**
+ * Build an {@link AwsAuditLogStore} whose config-resolution callback returns
+ * a fixed table name/region, avoiding any need to read/mutate `process.env`
+ * in tests.
+ */
+function makeStore(tableName = 'hyveon-audit', region = 'us-east-1'): AwsAuditLogStore {
+  return new AwsAuditLogStore(() => ({ tableName, region }));
+}
+
+/** Minimal valid `GameServer` fixture used to populate `before`/`after`. */
+const sampleGameServer: GameServer = {
+  name: 'minecraft',
+  image: 'itzg/minecraft-server',
+  cpu: 1024,
+  memory: 2048,
+  ports: [{ container: 25565, protocol: 'tcp' }],
+  volumes: [{ name: 'data', container_path: '/data' }],
+};
+
+/** Builds a sample {@link AuditEntry}, overridable per-test. */
+function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    sk: '2026-07-17T00:00:00.000Z#01J000000000000000000000',
+    timestamp: '2026-07-17T00:00:00.000Z',
+    actor: 'alice',
+    action: 'add',
+    game: 'minecraft',
+    before: null,
+    after: sampleGameServer,
+    ...overrides,
+  };
+}
+
+describe('AwsAuditLogStore', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  describe('putEntry', () => {
+    it('should send a PutCommand with pk AUDIT, the entry sk, and before/after serialized as JSON strings', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const entry = makeEntry({
+        before: { ...sampleGameServer, cpu: 512 },
+        after: sampleGameServer,
+      });
+      await store.putEntry(entry);
+
+      const calls = ddbMock.commandCalls(PutCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-audit');
+      expect(input.Item).toEqual({
+        pk: 'AUDIT',
+        sk: entry.sk,
+        timestamp: entry.timestamp,
+        actor: entry.actor,
+        action: entry.action,
+        game: entry.game,
+        before: JSON.stringify({ ...sampleGameServer, cpu: 512 }),
+        after: JSON.stringify(sampleGameServer),
+      });
+    });
+
+    it('should write null (not the string "null") for before/after when the entry field is null', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const entry = makeEntry({ action: 'remove', before: sampleGameServer, after: null });
+      await store.putEntry(entry);
+
+      const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
+      expect(input.Item?.['before']).toBe(JSON.stringify(sampleGameServer));
+      expect(input.Item?.['after']).toBeNull();
+    });
+
+    it('should include versionId on the written item when present on the entry', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const entry = makeEntry({ versionId: 'v-123' });
+      await store.putEntry(entry);
+
+      const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
+      expect(input.Item?.['versionId']).toBe('v-123');
+    });
+  });
+
+  describe('listEntries', () => {
+    it('should query pk = AUDIT newest-first with the given Limit and no sk condition on the first page', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const store = makeStore();
+      await store.listEntries(20);
+
+      const calls = ddbMock.commandCalls(QueryCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-audit');
+      expect(input.KeyConditionExpression).toBe('pk = :pk');
+      expect(input.ExpressionAttributeValues).toEqual({ ':pk': 'AUDIT' });
+      expect(input.ScanIndexForward).toBe(false);
+      expect(input.Limit).toBe(20);
+    });
+
+    it('should return an empty page with no nextBefore when the table is empty', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const store = makeStore();
+      const result = await store.listEntries(20);
+
+      expect(result).toEqual({ entries: [] });
+    });
+
+    it('should deserialize before/after from JSON strings and omit nextBefore when no more rows exist', async () => {
+      const entry = makeEntry();
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            pk: 'AUDIT',
+            sk: entry.sk,
+            timestamp: entry.timestamp,
+            actor: entry.actor,
+            action: entry.action,
+            game: entry.game,
+            before: null,
+            after: JSON.stringify(sampleGameServer),
+          },
+        ],
+      });
+
+      const store = makeStore();
+      const result = await store.listEntries(20);
+
+      expect(result.nextBefore).toBeUndefined();
+      expect(result.entries).toEqual([entry]);
+    });
+
+    it('should add sk < before to the KeyConditionExpression when a cursor is given', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const store = makeStore();
+      await store.listEntries(20, 'cursor-sk');
+
+      const input = ddbMock.commandCalls(QueryCommand)[0]!.args[0].input;
+      expect(input.KeyConditionExpression).toBe('pk = :pk AND sk < :before');
+      expect(input.ExpressionAttributeValues).toEqual({ ':pk': 'AUDIT', ':before': 'cursor-sk' });
+    });
+
+    it('should return nextBefore set to the oldest entry in the page when DynamoDB reports a LastEvaluatedKey', async () => {
+      const first = makeEntry({ sk: 'sk-1' });
+      const second = makeEntry({ sk: 'sk-2' });
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { pk: 'AUDIT', ...first, after: JSON.stringify(sampleGameServer) },
+          { pk: 'AUDIT', ...second, after: JSON.stringify(sampleGameServer) },
+        ],
+        LastEvaluatedKey: { pk: 'AUDIT', sk: 'sk-2' },
+      });
+
+      const store = makeStore();
+      const result = await store.listEntries(2);
+
+      expect(result.nextBefore).toBe('sk-2');
+      expect(result.entries.map((e) => e.sk)).toEqual(['sk-1', 'sk-2']);
+    });
+  });
+});

--- a/app/packages/cloud-aws/src/AwsAuditLogStore.ts
+++ b/app/packages/cloud-aws/src/AwsAuditLogStore.ts
@@ -1,0 +1,151 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import type { AuditAction, AuditEntry, AuditLogStore, AuditPageResult, GameServer } from '@hyveon/shared';
+
+/**
+ * The single DynamoDB partition every audit entry lives under (`pk = AUDIT`).
+ * The table's sort key (`sk`, see `buildAuditSk` in `@hyveon/shared/audit.js`)
+ * is `<ISO timestamp>#<ULID>`, so a query scoped to this partition with
+ * `ScanIndexForward: false` naturally returns entries newest-first.
+ */
+const PARTITION_KEY = 'AUDIT';
+
+/**
+ * AWS implementation of the cloud-agnostic {@link AuditLogStore} contract,
+ * backed by the DynamoDB audit table provisioned in
+ * `terraform/aws/audit_store.tf` (`pk = AUDIT`, `sk` = `buildAuditSk()`). No
+ * `@aws-sdk/*` shapes appear outside this class's private fields/method
+ * bodies, so callers depend only on {@link AuditLogStore}.
+ */
+export class AwsAuditLogStore implements AuditLogStore {
+  private client: DynamoDBDocumentClient | null = null;
+  private clientRegion: string | null = null;
+
+  /**
+   * @param getConfig - Resolves the DynamoDB table (and optional region)
+   *   this store reads/writes, on every call — so a table rename picked up
+   *   between calls (e.g. after a Terraform re-apply) isn't stuck targeting
+   *   a stale table. Optional so the class remains constructible with no
+   *   arguments, mirroring `AwsSecretsStore`/`AwsRemoteFileStore`'s
+   *   zero-arg-constructible pattern. When omitted (or when it returns no
+   *   `tableName`), every method throws a clear "table not configured"
+   *   error rather than sending a malformed request. `region` falls back to
+   *   `AWS_REGION_` (Lambda's reserved-name workaround, see CLAUDE.md), then
+   *   `AWS_REGION`, then `AWS_DEFAULT_REGION`, then `us-east-1` when
+   *   omitted.
+   */
+  constructor(private readonly getConfig?: () => { tableName: string; region?: string }) {}
+
+  /**
+   * Resolves the configured table name, throwing a clear error instead of
+   * letting an unconfigured table fall through to a malformed DynamoDB
+   * request.
+   */
+  private getTableName(): string {
+    const tableName = this.getConfig?.()?.tableName;
+    if (!tableName) {
+      throw new Error(
+        'AwsAuditLogStore: table not configured. Supply a getConfig callback that resolves { tableName }.',
+      );
+    }
+    return tableName;
+  }
+
+  /**
+   * Lazily constructs the DynamoDB document client, recreating it whenever
+   * the freshly-resolved region differs from the region the cached client
+   * was built with — mirrors `AwsSecretsStore.getClient`'s
+   * rebuild-on-region-change pattern.
+   */
+  private getClient(): DynamoDBDocumentClient {
+    const region =
+      this.getConfig?.()?.region ??
+      process.env['AWS_REGION_'] ??
+      process.env['AWS_REGION'] ??
+      process.env['AWS_DEFAULT_REGION'] ??
+      'us-east-1';
+
+    if (!this.client || this.clientRegion !== region) {
+      this.client = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+      this.clientRegion = region;
+    }
+    return this.client;
+  }
+
+  /**
+   * Appends a single audit entry to the log.
+   *
+   * `before`/`after` are serialized to JSON strings before being written —
+   * DynamoDB's native map type would work too, but a JSON string keeps the
+   * item shape stable across `GameServer` schema changes and avoids
+   * DynamoDB's empty-string/empty-set quirks on optional `GameServer`
+   * fields.
+   *
+   * @param entry - The entry to persist, including its `sk` (see `buildAuditSk`).
+   */
+  async putEntry(entry: AuditEntry): Promise<void> {
+    await this.getClient().send(
+      new PutCommand({
+        TableName: this.getTableName(),
+        Item: {
+          pk: PARTITION_KEY,
+          sk: entry.sk,
+          timestamp: entry.timestamp,
+          actor: entry.actor,
+          action: entry.action,
+          game: entry.game,
+          before: entry.before !== null ? JSON.stringify(entry.before) : null,
+          after: entry.after !== null ? JSON.stringify(entry.after) : null,
+          ...(entry.versionId !== undefined ? { versionId: entry.versionId } : {}),
+        },
+      }),
+    );
+  }
+
+  /**
+   * Lists audit entries newest-first, optionally paginated.
+   *
+   * Queries the `AUDIT` partition with `ScanIndexForward: false` so results
+   * come back newest-first without an in-memory sort. When `before` is
+   * supplied, the query is additionally constrained to `sk < :before` so
+   * only entries older than the cursor are returned. `nextBefore` is only
+   * populated when DynamoDB reports a `LastEvaluatedKey` — i.e. there are
+   * more rows beyond this page — and is set to the oldest (last) entry's
+   * `sk` in the page, matching what `LastEvaluatedKey.sk` would resolve to
+   * for this single-partition query.
+   *
+   * @param limit  - The maximum number of entries to return.
+   * @param before - When provided, only entries older than this cursor
+   *   (an {@link AuditEntry.sk} value, typically taken from a prior page's
+   *   `nextBefore`) are returned.
+   * @returns The requested page of entries plus a cursor for the next page.
+   */
+  async listEntries(limit: number, before?: string): Promise<AuditPageResult> {
+    const resp = await this.getClient().send(
+      new QueryCommand({
+        TableName: this.getTableName(),
+        KeyConditionExpression: before ? 'pk = :pk AND sk < :before' : 'pk = :pk',
+        ExpressionAttributeValues: before
+          ? { ':pk': PARTITION_KEY, ':before': before }
+          : { ':pk': PARTITION_KEY },
+        ScanIndexForward: false,
+        Limit: limit,
+      }),
+    );
+
+    const entries: AuditEntry[] = (resp.Items ?? []).map((item) => ({
+      sk: item['sk'] as string,
+      timestamp: item['timestamp'] as string,
+      actor: item['actor'] as string,
+      action: item['action'] as AuditAction,
+      game: item['game'] as string,
+      before: item['before'] ? (JSON.parse(item['before'] as string) as GameServer) : null,
+      after: item['after'] ? (JSON.parse(item['after'] as string) as GameServer) : null,
+      ...(item['versionId'] !== undefined ? { versionId: item['versionId'] as string } : {}),
+    }));
+
+    const nextBefore = resp.LastEvaluatedKey ? entries[entries.length - 1]?.sk : undefined;
+
+    return nextBefore ? { entries, nextBefore } : { entries };
+  }
+}

--- a/app/packages/cloud-aws/src/AwsAuditLogStore.ts
+++ b/app/packages/cloud-aws/src/AwsAuditLogStore.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { AuditAction, AuditEntry, AuditLogStore, AuditPageResult, GameServer } from '@hyveon/shared';
+import { resolveDefaultAwsRegion } from './awsRegionEnv.js';
 
 /**
  * The single DynamoDB partition every audit entry lives under (`pk = AUDIT`).
@@ -29,10 +30,10 @@ export class AwsAuditLogStore implements AuditLogStore {
    *   arguments, mirroring `AwsSecretsStore`/`AwsRemoteFileStore`'s
    *   zero-arg-constructible pattern. When omitted (or when it returns no
    *   `tableName`), every method throws a clear "table not configured"
-   *   error rather than sending a malformed request. `region` falls back to
-   *   `AWS_REGION_` (Lambda's reserved-name workaround, see CLAUDE.md), then
-   *   `AWS_REGION`, then `AWS_DEFAULT_REGION`, then `us-east-1` when
-   *   omitted.
+   *   error rather than sending a malformed request. When `region` is
+   *   omitted, it falls back to {@link resolveDefaultAwsRegion} — never read
+   *   from `process.env` directly here, per CLAUDE.md's "no raw
+   *   `process.env` in business logic" guideline.
    */
   constructor(private readonly getConfig?: () => { tableName: string; region?: string }) {}
 
@@ -55,15 +56,12 @@ export class AwsAuditLogStore implements AuditLogStore {
    * Lazily constructs the DynamoDB document client, recreating it whenever
    * the freshly-resolved region differs from the region the cached client
    * was built with — mirrors `AwsSecretsStore.getClient`'s
-   * rebuild-on-region-change pattern.
+   * rebuild-on-region-change pattern. Region defaults come from the
+   * dedicated {@link resolveDefaultAwsRegion} environment accessor rather
+   * than reading `process.env` inline.
    */
   private getClient(): DynamoDBDocumentClient {
-    const region =
-      this.getConfig?.()?.region ??
-      process.env['AWS_REGION_'] ??
-      process.env['AWS_REGION'] ??
-      process.env['AWS_DEFAULT_REGION'] ??
-      'us-east-1';
+    const region = this.getConfig?.()?.region ?? resolveDefaultAwsRegion();
 
     if (!this.client || this.clientRegion !== region) {
       this.client = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));

--- a/app/packages/cloud-aws/src/AwsRemoteFileStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRemoteFileStore.test.ts
@@ -129,6 +129,26 @@ describe('AwsRemoteFileStore', () => {
       expect(input.IfMatch).toBeUndefined();
     });
 
+    it('should return the versionId when S3 supplies one', async () => {
+      s3Mock.on(PutObjectCommand).resolves({ ETag: '"etag-1"', VersionId: 'v1' });
+
+      const store = makeStore();
+      await expect(store.put('foo.txt', new Uint8Array([1, 2, 3]))).resolves.toEqual({
+        etag: 'etag-1',
+        versionId: 'v1',
+      });
+    });
+
+    it('should return undefined versionId when S3 does not supply one', async () => {
+      s3Mock.on(PutObjectCommand).resolves({ ETag: '"etag-1"' });
+
+      const store = makeStore();
+      await expect(store.put('foo.txt', new Uint8Array([1, 2, 3]))).resolves.toEqual({
+        etag: 'etag-1',
+        versionId: undefined,
+      });
+    });
+
     it('should send IfMatch when opts.ifMatch is provided', async () => {
       s3Mock.on(PutObjectCommand).resolves({ ETag: '"etag-2"' });
 

--- a/app/packages/cloud-aws/src/AwsRemoteFileStore.ts
+++ b/app/packages/cloud-aws/src/AwsRemoteFileStore.ts
@@ -115,7 +115,11 @@ export class AwsRemoteFileStore implements RemoteFileStore {
    * @throws {@link RemoteFileConflictError} when `opts.ifMatch` is provided but no longer
    *   matches the etag currently stored at `path`.
    */
-  async put(path: string, body: Uint8Array, opts?: { ifMatch?: string }): Promise<{ etag: string }> {
+  async put(
+    path: string,
+    body: Uint8Array,
+    opts?: { ifMatch?: string },
+  ): Promise<{ etag: string; versionId?: string }> {
     try {
       const resp = await this.getClient().send(
         new PutObjectCommand({
@@ -128,7 +132,7 @@ export class AwsRemoteFileStore implements RemoteFileStore {
       if (!resp.ETag) {
         throw new Error(`S3 PutObject for path "${path}" did not return an ETag.`);
       }
-      return { etag: unquoteEtag(resp.ETag) };
+      return { etag: unquoteEtag(resp.ETag), versionId: resp.VersionId };
     } catch (err) {
       if (
         err instanceof S3ServiceException &&

--- a/app/packages/cloud-aws/src/awsRegionEnv.ts
+++ b/app/packages/cloud-aws/src/awsRegionEnv.ts
@@ -1,0 +1,19 @@
+/**
+ * Dedicated environment accessor for the AWS region fallback chain.
+ *
+ * Business-logic classes (e.g. {@link AwsAuditLogStore}) must not read
+ * `process.env` directly — CLAUDE.md's "no raw `process.env` in business
+ * logic" guideline requires environment access to be wrapped behind a
+ * service method so tests can stub it via `vi.spyOn` instead of mutating
+ * `process.env`. This module is that wrapper for the region-resolution
+ * fallback shared by the `cloud-aws` client constructors.
+ *
+ * Resolution order: `AWS_REGION_` (Lambda's reserved-name workaround, see
+ * CLAUDE.md), then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then
+ * `us-east-1` when none are set.
+ */
+export function resolveDefaultAwsRegion(): string {
+  return (
+    process.env['AWS_REGION_'] ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'] ?? 'us-east-1'
+  );
+}

--- a/app/packages/cloud-aws/src/awsRegionEnv.ts
+++ b/app/packages/cloud-aws/src/awsRegionEnv.ts
@@ -14,6 +14,9 @@
  */
 export function resolveDefaultAwsRegion(): string {
   return (
-    process.env['AWS_REGION_'] ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'] ?? 'us-east-1'
+    process.env['AWS_REGION_']?.trim() ||
+    process.env['AWS_REGION']?.trim() ||
+    process.env['AWS_DEFAULT_REGION']?.trim() ||
+    'us-east-1'
   );
 }

--- a/app/packages/cloud-aws/src/index.ts
+++ b/app/packages/cloud-aws/src/index.ts
@@ -1,3 +1,4 @@
+export * from './AwsAuditLogStore.js';
 export * from './AwsCloudProvider.js';
 export * from './AwsDiscordEventReceiver.js';
 export * from './AwsRemoteFileStore.js';

--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -27,6 +27,7 @@ import { DriftService } from './services/DriftService.js';
 import { GamesWriteService } from './services/GamesWriteService.js';
 import { SafeStorageService } from './services/SafeStorageService.js';
 import { ElectronStoreService } from './services/ElectronStoreService.js';
+import { AuditService } from './services/AuditService.js';
 
 /**
  * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`,
@@ -70,6 +71,7 @@ import { ElectronStoreService } from './services/ElectronStoreService.js';
     GamesWriteService,
     SafeStorageService,
     ElectronStoreService,
+    AuditService,
   ],
 })
 export class AppModule {}

--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -22,6 +22,8 @@ import { DiagnosticsController } from './controllers/diagnostics.controller.js';
 import { DiagnosticsHttpController } from './controllers/diagnostics-http.controller.js';
 import { DriftController } from './controllers/drift.controller.js';
 import { DriftHttpController } from './controllers/drift-http.controller.js';
+import { AuditController } from './controllers/audit.controller.js';
+import { AuditHttpController } from './controllers/audit-http.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
 import { DriftService } from './services/DriftService.js';
 import { GamesWriteService } from './services/GamesWriteService.js';
@@ -53,6 +55,8 @@ import { AuditService } from './services/AuditService.js';
     DiagnosticsHttpController,
     DriftController,
     DriftHttpController,
+    AuditController,
+    AuditHttpController,
   ],
   providers: [
     {

--- a/app/packages/desktop-main/src/controllers/audit-http.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/audit-http.controller.test.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import type { AuditPageResult } from '@hyveon/shared';
+import { AuditHttpController } from './audit-http.controller.js';
+import type { AuditService } from '../services/AuditService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Default audit page used by most tests. */
+const DEFAULT_PAGE: AuditPageResult = {
+  entries: [
+    {
+      sk: '2026-07-17T00:00:00.000Z#01J',
+      timestamp: '2026-07-17T00:00:00.000Z',
+      actor: 'chris',
+      action: 'add',
+      game: 'minecraft',
+      before: null,
+      after: null,
+    },
+  ],
+};
+
+/** Build an AuditService stub with `list` pre-wired to resolve `page`. */
+function makeAudit(page: AuditPageResult = DEFAULT_PAGE): AuditService {
+  return {
+    list: vi.fn().mockResolvedValue(page),
+  } as Partial<AuditService> as AuditService;
+}
+
+describe('AuditHttpController', () => {
+  describe('list', () => {
+    it('should return the AuditPageResult from AuditService', async () => {
+      const result = await new AuditHttpController(makeAudit()).list();
+      expect(result).toEqual(DEFAULT_PAGE);
+    });
+
+    it('should call AuditService.list with limit/before undefined when the query is empty', async () => {
+      const audit = makeAudit();
+      await new AuditHttpController(audit).list();
+      expect(audit.list).toHaveBeenCalledWith({ limit: undefined, before: undefined });
+    });
+
+    it('should parse a valid limit query string into a number', async () => {
+      const audit = makeAudit();
+      await new AuditHttpController(audit).list('10');
+      expect(audit.list).toHaveBeenCalledWith({ limit: 10, before: undefined });
+    });
+
+    it('should forward the before cursor verbatim', async () => {
+      const audit = makeAudit();
+      await new AuditHttpController(audit).list(undefined, 'cursor-value');
+      expect(audit.list).toHaveBeenCalledWith({ limit: undefined, before: 'cursor-value' });
+    });
+
+    it('should treat an empty before string the same as an absent query param', async () => {
+      const audit = makeAudit();
+      await new AuditHttpController(audit).list(undefined, '');
+      expect(audit.list).toHaveBeenCalledWith({ limit: undefined, before: undefined });
+    });
+
+    it('should throw BadRequestException when limit is not a number', async () => {
+      const audit = makeAudit();
+      expect(() => new AuditHttpController(audit).list('not-a-number')).toThrow(BadRequestException);
+      expect(audit.list).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when limit is zero or negative', async () => {
+      const audit = makeAudit();
+      expect(() => new AuditHttpController(audit).list('0')).toThrow(BadRequestException);
+      expect(() => new AuditHttpController(audit).list('-5')).toThrow(BadRequestException);
+    });
+
+    it('should return an empty entries list when there is no audit history', async () => {
+      const audit = makeAudit({ entries: [] });
+      const result = await new AuditHttpController(audit).list();
+      expect(result).toEqual({ entries: [] });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/audit-http.controller.ts
+++ b/app/packages/desktop-main/src/controllers/audit-http.controller.ts
@@ -1,0 +1,47 @@
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import type { AuditPageResult } from '@hyveon/shared';
+import { AuditService } from '../services/AuditService.js';
+
+/**
+ * Parses the `limit` query parameter into a number for `AuditService.list`.
+ * Returns `undefined` when the parameter is absent — `AuditService` applies
+ * its own default (25) and hard maximum (100) in that case. Throws
+ * `BadRequestException` when `raw` is present but isn't a finite positive
+ * number, since `Number('abc')` etc. would otherwise silently fall through
+ * to the service's default and mask a client-side bug.
+ */
+function parseLimit(raw?: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new BadRequestException({ success: false, error: 'limit must be a positive number' });
+  }
+  return parsed;
+}
+
+/**
+ * HTTP shim that exposes the audit log as a plain REST endpoint
+ * (`GET /api/audit?limit=N&before=`). The browser client (`api.service.ts`)
+ * and the integration-test server consume this route over HTTP; the
+ * Electron main-process host uses the IPC {@link AuditController}
+ * (`@MessagePattern`) handler instead.
+ *
+ * Both controllers delegate to the same {@link AuditService} provider — the
+ * heavy lifting lives in that service, not in the thin orchestration
+ * duplicated here.
+ */
+@Controller('audit')
+export class AuditHttpController {
+  constructor(private readonly audit: AuditService) {}
+
+  /**
+   * Returns a page of audit entries, newest-first. `limit` is parsed via
+   * {@link parseLimit} (400 on a malformed value); `before` is forwarded
+   * verbatim as the pagination cursor, treating an empty string the same as
+   * an absent query param.
+   */
+  @Get()
+  list(@Query('limit') limitRaw?: string, @Query('before') before?: string): Promise<AuditPageResult> {
+    return this.audit.list({ limit: parseLimit(limitRaw), before: before || undefined });
+  }
+}

--- a/app/packages/desktop-main/src/controllers/audit.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/audit.controller.test.ts
@@ -1,0 +1,75 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import type { AuditPageResult } from '@hyveon/shared';
+import { AuditController } from './audit.controller.js';
+import type { AuditService } from '../services/AuditService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Default audit page used by most tests. */
+const DEFAULT_PAGE: AuditPageResult = {
+  entries: [
+    {
+      sk: '2026-07-17T00:00:00.000Z#01J',
+      timestamp: '2026-07-17T00:00:00.000Z',
+      actor: 'chris',
+      action: 'add',
+      game: 'minecraft',
+      before: null,
+      after: null,
+    },
+  ],
+};
+
+/** Build an AuditService stub with `list` pre-wired to resolve `page`. */
+function makeAudit(page: AuditPageResult = DEFAULT_PAGE): AuditService {
+  return {
+    list: vi.fn().mockResolvedValue(page),
+  } as Partial<AuditService> as AuditService;
+}
+
+/**
+ * The metadata key NestJS stores on each method decorated with
+ * `@MessagePattern`. Asserting this value is the only automated guard
+ * that prevents a typo in the controller from silently breaking IPC —
+ * calling the method directly (as every other test does) would succeed
+ * regardless of what string is registered with the transport.
+ */
+const PATTERN_METADATA_KEY = 'microservices:pattern';
+
+describe('AuditController', () => {
+  describe('@MessagePattern channel names', () => {
+    it('should register list on the "audit.list" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, AuditController.prototype.list);
+      expect(pattern).toEqual(['audit.list']);
+    });
+  });
+
+  describe('list', () => {
+    it('should return the AuditPageResult from AuditService', async () => {
+      const result = await new AuditController(makeAudit()).list();
+      expect(result).toEqual(DEFAULT_PAGE);
+    });
+
+    it('should delegate to AuditService.list with the given opts', async () => {
+      const audit = makeAudit();
+      const opts = { limit: 10, before: 'cursor-value' };
+      await new AuditController(audit).list(opts);
+      expect(audit.list).toHaveBeenCalledWith(opts);
+    });
+
+    it('should default to an empty opts object when called with no arguments', async () => {
+      const audit = makeAudit();
+      await new AuditController(audit).list();
+      expect(audit.list).toHaveBeenCalledWith({});
+    });
+
+    it('should return an empty entries list when there is no audit history', async () => {
+      const audit = makeAudit({ entries: [] });
+      const result = await new AuditController(audit).list();
+      expect(result).toEqual({ entries: [] });
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/audit.controller.ts
+++ b/app/packages/desktop-main/src/controllers/audit.controller.ts
@@ -1,0 +1,31 @@
+import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import type { AuditPageResult } from '@hyveon/shared';
+import { AuditService } from '../services/AuditService.js';
+import type { ListAuditEntriesOpts } from '../services/AuditService.js';
+
+/**
+ * IPC-only controller exposing the `game_servers` mutation audit log for the
+ * Electron main-process host. The single handler is bound to an IPC channel
+ * via `@MessagePattern` — no HTTP routes are registered here. The browser
+ * client and the integration-test server reach the same operation over REST
+ * through the {@link AuditHttpController} shim, which delegates to the
+ * identical {@link AuditService} provider.
+ */
+@Controller()
+export class AuditController {
+  constructor(private readonly audit: AuditService) {}
+
+  /**
+   * Returns a page of audit entries, newest-first — see
+   * `AuditService.list()`. `opts` mirrors {@link ListAuditEntriesOpts}
+   * (`limit`/`before`) and defaults to `{}` when the renderer invokes
+   * `audit.list` with no arguments.
+   *
+   * Reachable via the Electron IPC transport (`audit.list`).
+   */
+  @MessagePattern('audit.list')
+  list(@Payload() opts: ListAuditEntriesOpts = {}): Promise<AuditPageResult> {
+    return this.audit.list(opts ?? {});
+  }
+}

--- a/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
+++ b/app/packages/desktop-main/src/controllers/games.controller.integration.test.ts
@@ -34,6 +34,7 @@ import { TfvarsService } from '../services/TfvarsService.js';
 import { GamesWriteService } from '../services/GamesWriteService.js';
 import type { ConfigService, TfOutputs } from '../services/ConfigService.js';
 import type { EcsService } from '../services/EcsService.js';
+import type { AuditService } from '../services/AuditService.js';
 
 /** Strongly-typed mock handles for the `fs` module. */
 const mockExists = vi.mocked(existsSync);
@@ -122,6 +123,11 @@ function makeConfig(gameNames: string[], bucket: string | null = null): ConfigSe
 /** Minimal `EcsService` stub — none of the specs in this file call it, but the constructor requires it. */
 function makeEcs(): EcsService {
   return {} as EcsService;
+}
+
+/** Minimal `AuditService` stub — none of the specs in this file assert on it, but `GamesWriteService`'s constructor requires it. */
+function makeAudit(): AuditService {
+  return { record: vi.fn().mockResolvedValue(undefined) } as Partial<AuditService> as AuditService;
 }
 
 /** Valid, structurally-distinct config used by the `games.create` specs below (a different game from `ark`). */
@@ -228,7 +234,7 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
-    const gamesWrite = new GamesWriteService(config, tfvars);
+    const gamesWrite = new GamesWriteService(config, tfvars, makeAudit());
     const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
 
     const createResult = await controller.createGame({ name: 'minecraft', config: VALID_MINECRAFT_CONFIG });
@@ -278,7 +284,7 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
-    const gamesWrite = new GamesWriteService(config, tfvars);
+    const gamesWrite = new GamesWriteService(config, tfvars, makeAudit());
     const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
 
     const updateResult = await controller.updateGame({ name: 'ark', config: UPDATED_ARK_CONFIG });
@@ -311,7 +317,7 @@ describe('GamesController + GamesWriteService write-then-list round trip', () =>
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
-    const gamesWrite = new GamesWriteService(config, tfvars);
+    const gamesWrite = new GamesWriteService(config, tfvars, makeAudit());
     const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
 
     const deleteResult = await controller.deleteGame({ name: 'ark' });
@@ -349,7 +355,7 @@ describe('GamesController + GamesWriteService games.create failure paths', () =>
 
     const config = makeConfig([]);
     const tfvars = new TfvarsService(config, makeRemoteFileStore());
-    const gamesWrite = new GamesWriteService(config, tfvars);
+    const gamesWrite = new GamesWriteService(config, tfvars, makeAudit());
     const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
 
     const result = await controller.createGame({
@@ -381,7 +387,7 @@ describe('GamesController + GamesWriteService games.create failure paths', () =>
 
     const config = makeConfig([], 'my-tfvars-bucket');
     const tfvars = new TfvarsService(config, remoteFileStore);
-    const gamesWrite = new GamesWriteService(config, tfvars);
+    const gamesWrite = new GamesWriteService(config, tfvars, makeAudit());
     const controller = new GamesController(config, makeEcs(), tfvars, gamesWrite);
 
     const result = await controller.createGame({

--- a/app/packages/desktop-main/src/modules/cloud-provider.module.test.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.module.test.ts
@@ -1,25 +1,35 @@
 import 'reflect-metadata';
 import { describe, it, expect, afterEach } from 'vitest';
-import { AwsSecretsStore, AwsRemoteFileStore, AwsDiscordEventReceiver, AwsCloudProvider } from '@hyveon/cloud-aws';
+import {
+  AwsSecretsStore,
+  AwsRemoteFileStore,
+  AwsDiscordEventReceiver,
+  AwsCloudProvider,
+  AwsAuditLogStore,
+} from '@hyveon/cloud-aws';
 import type {
   CloudProvider,
   SecretsStore,
   RemoteFileStore,
   DiscordEventReceiver,
+  AuditLogStore,
   StartOpts,
   WorkloadHandle,
   WorkloadStatus,
   LogChunk,
   CostBreakdown,
   DateRange,
+  AuditEntry,
+  AuditPageResult,
 } from '@hyveon/shared';
 import {
   CLOUD_BINDINGS,
   resolveCloudBindings,
   resolveTfvarsFileStoreConfig,
+  resolveAuditLogStoreConfig,
   type CloudBindings,
 } from './cloud-provider.module.js';
-import type { ConfigService, ActiveCloud } from '../services/ConfigService.js';
+import type { ConfigService, ActiveCloud, TfOutputs } from '../services/ConfigService.js';
 
 /**
  * Build a minimal `ConfigService` stub reporting the given cloud as active.
@@ -27,11 +37,16 @@ import type { ConfigService, ActiveCloud } from '../services/ConfigService.js';
  * to be stubbed. The cast lets tests exercise an unregistered/fake cloud
  * value without widening `ActiveCloud` itself.
  */
-function makeConfig(activeCloud: ActiveCloud, tfvarsBucket: string | null = 'test-tfvars-bucket'): ConfigService {
+function makeConfig(
+  activeCloud: ActiveCloud,
+  tfvarsBucket: string | null = 'test-tfvars-bucket',
+  auditTableName = 'test-audit-table',
+): ConfigService {
   const stub: Partial<ConfigService> = {
     getActiveCloud: () => activeCloud,
     getRegion: () => 'us-east-1',
     getTfvarsBucket: () => tfvarsBucket,
+    getTfOutputs: () => ({ audit_table_name: auditTableName } as TfOutputs),
   };
   return stub as ConfigService;
 }
@@ -99,6 +114,16 @@ class FakeDiscordEventReceiver implements DiscordEventReceiver {
   }
 }
 
+/** Hand-rolled fake `AuditLogStore` — see {@link FakeCloudProvider}. */
+class FakeAuditLogStore implements AuditLogStore {
+  putEntry(_entry: AuditEntry): Promise<void> {
+    throw new Error('not implemented in fake');
+  }
+  listEntries(_limit: number, _before?: string): Promise<AuditPageResult> {
+    throw new Error('not implemented in fake');
+  }
+}
+
 /** Registered `CLOUD_BINDINGS` key used to exercise the fake-cloud routing case. */
 const FAKE_CLOUD = 'fake-test-cloud';
 
@@ -108,6 +133,7 @@ const FAKE_BINDINGS: CloudBindings = {
   secretsStore: () => new FakeSecretsStore(),
   remoteFileStore: () => new FakeRemoteFileStore(),
   discordReceiver: () => new FakeDiscordEventReceiver(),
+  auditLogStore: () => new FakeAuditLogStore(),
 };
 
 describe('resolveCloudBindings', () => {
@@ -154,6 +180,25 @@ describe('resolveCloudBindings', () => {
       const bindings = resolveCloudBindings(config);
       expect(bindings.discordReceiver(config)).toBeInstanceOf(AwsDiscordEventReceiver);
     });
+
+    it('should produce an AwsAuditLogStore from the aws auditLogStore factory', () => {
+      const config = makeConfig('aws');
+      const bindings = resolveCloudBindings(config);
+      expect(bindings.auditLogStore(config)).toBeInstanceOf(AwsAuditLogStore);
+    });
+
+    it('should resolve the audit log store table from ConfigService.getTfOutputs().audit_table_name and region from getRegion()', () => {
+      const config = makeConfig('aws', 'test-tfvars-bucket', 'my-audit-table');
+      expect(resolveAuditLogStoreConfig(config)).toEqual({ tableName: 'my-audit-table', region: 'us-east-1' });
+    });
+
+    it('should fall back to an empty table name when getTfOutputs() reports no audit table name', () => {
+      const config: ConfigService = {
+        ...makeConfig('aws'),
+        getTfOutputs: () => null,
+      } as ConfigService;
+      expect(resolveAuditLogStoreConfig(config)).toEqual({ tableName: '', region: 'us-east-1' });
+    });
   });
 
   describe('fake-impl routing', () => {
@@ -168,6 +213,7 @@ describe('resolveCloudBindings', () => {
       expect(bindings.secretsStore(config)).toBeInstanceOf(FakeSecretsStore);
       expect(bindings.remoteFileStore(config)).toBeInstanceOf(FakeRemoteFileStore);
       expect(bindings.discordReceiver(config)).toBeInstanceOf(FakeDiscordEventReceiver);
+      expect(bindings.auditLogStore(config)).toBeInstanceOf(FakeAuditLogStore);
     });
 
     it('should not resolve to the aws bindings once a fake cloud is registered', () => {

--- a/app/packages/desktop-main/src/modules/cloud-provider.module.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { AwsSecretsStore, AwsRemoteFileStore, AwsDiscordEventReceiver } from '@hyveon/cloud-aws';
-import type { CloudProvider, SecretsStore, RemoteFileStore, DiscordEventReceiver } from '@hyveon/shared';
+import { AwsSecretsStore, AwsRemoteFileStore, AwsDiscordEventReceiver, AwsAuditLogStore } from '@hyveon/cloud-aws';
+import type { CloudProvider, SecretsStore, RemoteFileStore, DiscordEventReceiver, AuditLogStore } from '@hyveon/shared';
 import { ConfigModule } from './config.module.js';
 import { ConfigService } from '../services/ConfigService.js';
 import { createAwsCloudProvider } from '../services/EcsService.js';
@@ -9,22 +9,24 @@ import {
   SECRETS_STORE,
   REMOTE_FILE_STORE,
   DISCORD_RECEIVER,
+  AUDIT_LOG_STORE,
 } from './cloud-provider.tokens.js';
 
 /**
- * Per-cloud factories for the four cloud-agnostic contracts (`CloudProvider`,
- * `SecretsStore`, `RemoteFileStore`, `DiscordEventReceiver` — all from
- * `@hyveon/shared/cloud.js`). Keyed by the `ActiveCloud` value `ConfigService`
- * reports; each `CloudBindings` entry supplies one factory per token so
- * {@link resolveCloudBindings} (and, in turn, `CloudProviderModule`'s
+ * Per-cloud factories for the five cloud-agnostic contracts (`CloudProvider`,
+ * `SecretsStore`, `RemoteFileStore`, `DiscordEventReceiver`, `AuditLogStore` —
+ * all from `@hyveon/shared/cloud.js`). Keyed by the `ActiveCloud` value
+ * `ConfigService` reports; each `CloudBindings` entry supplies one factory per
+ * token so {@link resolveCloudBindings} (and, in turn, `CloudProviderModule`'s
  * `useFactory` providers) can look up the right implementation without
- * duplicating the cloud switch four times.
+ * duplicating the cloud switch five times.
  */
 export interface CloudBindings {
   cloudProvider: (config: ConfigService) => CloudProvider;
   secretsStore: (config: ConfigService) => SecretsStore;
   remoteFileStore: (config: ConfigService) => RemoteFileStore;
   discordReceiver: (config: ConfigService) => DiscordEventReceiver;
+  auditLogStore: (config: ConfigService) => AuditLogStore;
 }
 
 /**
@@ -44,6 +46,19 @@ export function resolveTfvarsFileStoreConfig(config: ConfigService): { bucket: s
 }
 
 /**
+ * Resolves the `{ tableName, region }` config the AWS `AuditLogStore`'s
+ * `getConfig` callback needs to target the audit DynamoDB table: the table
+ * name comes from `ConfigService.getTfOutputs()?.audit_table_name` (falling
+ * back to `''` when the tfstate hasn't been applied yet, so `AwsAuditLogStore`
+ * surfaces its own "table not configured" error rather than this factory
+ * silently defaulting somewhere), and the region from `getRegion()`. Exported
+ * as a standalone function — see {@link resolveTfvarsFileStoreConfig} for why.
+ */
+export function resolveAuditLogStoreConfig(config: ConfigService): { tableName: string; region: string } {
+  return { tableName: config.getTfOutputs()?.audit_table_name ?? '', region: config.getRegion() };
+}
+
+/**
  * Registry of per-cloud bindings, keyed by `ActiveCloud` (or any future cloud
  * string). Today only `'aws'` is populated; adding a new cloud provider
  * package means adding an entry here rather than touching the module's
@@ -56,6 +71,7 @@ export const CLOUD_BINDINGS: Record<string, CloudBindings> = {
     secretsStore: (config) => new AwsSecretsStore(() => config.getRegion()),
     remoteFileStore: (config) => new AwsRemoteFileStore(() => resolveTfvarsFileStoreConfig(config)),
     discordReceiver: () => new AwsDiscordEventReceiver(),
+    auditLogStore: (config) => new AwsAuditLogStore(() => resolveAuditLogStoreConfig(config)),
   },
 };
 
@@ -75,7 +91,7 @@ export function resolveCloudBindings(config: ConfigService): CloudBindings {
 }
 
 /**
- * Binds the four cloud-agnostic contracts to concrete implementations for
+ * Binds the five cloud-agnostic contracts to concrete implementations for
  * whichever cloud `ConfigService.getActiveCloud()` reports as active, via
  * {@link resolveCloudBindings} and the {@link CLOUD_BINDINGS} registry. Today
  * that's always `'aws'`, so every token resolves to a `@hyveon/cloud-aws`
@@ -110,7 +126,12 @@ export function resolveCloudBindings(config: ConfigService): CloudBindings {
       useFactory: (config: ConfigService) => resolveCloudBindings(config).discordReceiver(config),
       inject: [ConfigService],
     },
+    {
+      provide: AUDIT_LOG_STORE,
+      useFactory: (config: ConfigService) => resolveCloudBindings(config).auditLogStore(config),
+      inject: [ConfigService],
+    },
   ],
-  exports: [CLOUD_PROVIDER, SECRETS_STORE, REMOTE_FILE_STORE, DISCORD_RECEIVER],
+  exports: [CLOUD_PROVIDER, SECRETS_STORE, REMOTE_FILE_STORE, DISCORD_RECEIVER, AUDIT_LOG_STORE],
 })
 export class CloudProviderModule {}

--- a/app/packages/desktop-main/src/modules/cloud-provider.tokens.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.tokens.ts
@@ -19,3 +19,6 @@ export const REMOTE_FILE_STORE = Symbol('REMOTE_FILE_STORE');
 
 /** Injection token for the `DiscordEventReceiver` implementation bound by `CloudProviderModule`. */
 export const DISCORD_RECEIVER = Symbol('DISCORD_RECEIVER');
+
+/** Injection token for the `AuditLogStore` implementation bound by `CloudProviderModule`. */
+export const AUDIT_LOG_STORE = Symbol('AUDIT_LOG_STORE');

--- a/app/packages/desktop-main/src/services/AuditService.test.ts
+++ b/app/packages/desktop-main/src/services/AuditService.test.ts
@@ -149,5 +149,14 @@ describe('AuditService', () => {
 
       expect(listEntriesMock).toHaveBeenCalledWith(25, undefined);
     });
+
+    it('should return an empty page without calling store.listEntries when audit_table_name is not configured', async () => {
+      const service = makeService(null);
+
+      const result = await service.list();
+
+      expect(result).toEqual({ entries: [] });
+      expect(listEntriesMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/packages/desktop-main/src/services/AuditService.test.ts
+++ b/app/packages/desktop-main/src/services/AuditService.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for `AuditService` — the write/read facade over the cloud-agnostic
+ * `AuditLogStore` (a stub here; the real `AwsAuditLogStore` has its own
+ * tests under `@hyveon/cloud-aws`). Covers the happy path, the
+ * swallow-on-error contract, and the no-table no-op, plus `list()`'s limit
+ * clamping.
+ */
+import * as os from 'node:os';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuditLogStore, AuditPageResult, GameServer } from '@hyveon/shared';
+import { AuditService } from './AuditService.js';
+import { ConfigService, type TfOutputs } from './ConfigService.js';
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    userInfo: vi.fn(() => ({ username: 'test-actor' })),
+  };
+});
+
+/** Minimal `TfOutputs` stub exposing just `audit_table_name`. */
+const TF: TfOutputs = {
+  aws_region: 'us-east-1',
+  ecs_cluster_name: '',
+  ecs_cluster_arn: '',
+  subnet_ids: '',
+  security_group_id: '',
+  file_manager_security_group_id: '',
+  efs_file_system_id: '',
+  efs_access_points: {},
+  domain_name: '',
+  game_names: [],
+  alb_dns_name: null,
+  acm_certificate_arn: null,
+  discord_table_name: '',
+  audit_table_name: 'test-audit',
+  discord_bot_token_secret_arn: '',
+  discord_public_key_secret_arn: '',
+  interactions_invoke_url: null,
+} as TfOutputs;
+
+/** Minimal valid `GameServer` fixture used to populate `before`/`after`. */
+const sampleGameServer: GameServer = {
+  name: 'minecraft',
+  image: 'itzg/minecraft-server',
+  cpu: 1024,
+  memory: 2048,
+  ports: [{ container: 25565, protocol: 'tcp' }],
+  volumes: [{ name: 'data', container_path: '/data' }],
+};
+
+const putEntryMock = vi.fn<AuditLogStore['putEntry']>();
+const listEntriesMock = vi.fn<AuditLogStore['listEntries']>();
+
+/** Builds an `AuditLogStore`-shaped stub backed by the shared mocks above. */
+function makeStore(): AuditLogStore {
+  return { putEntry: putEntryMock, listEntries: listEntriesMock };
+}
+
+/** Builds an `AuditService` with a `ConfigService` stub returning `outputs` and the given (or default) store stub. */
+function makeService(outputs: TfOutputs | null = TF, store: AuditLogStore = makeStore()): AuditService {
+  const config = { getTfOutputs: () => outputs } as Partial<ConfigService> as ConfigService;
+  return new AuditService(config, store);
+}
+
+beforeEach(() => {
+  putEntryMock.mockReset();
+  listEntriesMock.mockReset();
+  vi.mocked(os.userInfo).mockReturnValue({ username: 'test-actor' } as ReturnType<typeof os.userInfo>);
+});
+
+describe('AuditService', () => {
+  describe('record', () => {
+    it('should build an AuditEntry from the actor, timestamp, and sk, and persist it via store.putEntry on the happy path', async () => {
+      putEntryMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.record({
+        action: 'add',
+        game: 'minecraft',
+        before: null,
+        after: sampleGameServer,
+        versionId: 'v1',
+      });
+
+      expect(putEntryMock).toHaveBeenCalledTimes(1);
+      const entry = putEntryMock.mock.calls[0]?.[0];
+      expect(entry).toMatchObject({
+        actor: 'test-actor',
+        action: 'add',
+        game: 'minecraft',
+        before: null,
+        after: sampleGameServer,
+        versionId: 'v1',
+      });
+      expect(entry?.sk).toEqual(expect.stringContaining(entry?.timestamp ?? ''));
+      expect(() => new Date(entry?.timestamp ?? '').toISOString()).not.toThrow();
+    });
+
+    it('should swallow a store.putEntry failure and log a warning instead of throwing', async () => {
+      putEntryMock.mockRejectedValue(new Error('DynamoDB is down'));
+      const service = makeService();
+
+      await expect(
+        service.record({ action: 'edit', game: 'minecraft', before: sampleGameServer, after: sampleGameServer }),
+      ).resolves.toBeUndefined();
+
+      expect(putEntryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should no-op without calling store.putEntry when audit_table_name is not configured', async () => {
+      const service = makeService(null);
+
+      await expect(
+        service.record({ action: 'remove', game: 'minecraft', before: sampleGameServer, after: null }),
+      ).resolves.toBeUndefined();
+
+      expect(putEntryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('list', () => {
+    it('should delegate to store.listEntries with the default limit of 25 when limit is omitted', async () => {
+      const page: AuditPageResult = { entries: [] };
+      listEntriesMock.mockResolvedValue(page);
+      const service = makeService();
+
+      const result = await service.list();
+
+      expect(listEntriesMock).toHaveBeenCalledWith(25, undefined);
+      expect(result).toBe(page);
+    });
+
+    it('should clamp a limit above 100 down to the maximum of 100', async () => {
+      listEntriesMock.mockResolvedValue({ entries: [] });
+      const service = makeService();
+
+      await service.list({ limit: 500, before: 'cursor' });
+
+      expect(listEntriesMock).toHaveBeenCalledWith(100, 'cursor');
+    });
+
+    it('should fall back to the default limit when given a non-positive limit', async () => {
+      listEntriesMock.mockResolvedValue({ entries: [] });
+      const service = makeService();
+
+      await service.list({ limit: 0 });
+
+      expect(listEntriesMock).toHaveBeenCalledWith(25, undefined);
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/AuditService.ts
+++ b/app/packages/desktop-main/src/services/AuditService.ts
@@ -1,0 +1,128 @@
+/**
+ * Write/read facade over the cloud-agnostic `AuditLogStore` contract (see
+ * `@hyveon/shared/cloud.js`), backing the `game_servers` mutation audit log
+ * (`terraform/aws/audit_store.tf`).
+ *
+ * `record()` is intentionally best-effort: an audit-log write failure (or a
+ * not-yet-deployed table) must never block the `game_servers` write it's
+ * describing, so every failure path logs a winston warning and returns
+ * rather than throwing. `list()` is the read side backing the audit log UI.
+ */
+import * as os from 'node:os';
+import { Inject, Injectable } from '@nestjs/common';
+import { buildAuditSk } from '@hyveon/shared';
+import type { AuditAction, AuditEntry, AuditLogStore, AuditPageResult, GameServer } from '@hyveon/shared';
+import { logger } from '../logger.js';
+import { ConfigService } from './ConfigService.js';
+import { AUDIT_LOG_STORE } from '../modules/cloud-provider.tokens.js';
+
+/** Default page size for {@link AuditService.list} when `limit` is omitted or invalid. */
+const DEFAULT_LIMIT = 25;
+
+/** Maximum page size {@link AuditService.list} will honour, regardless of the requested `limit`. */
+const MAX_LIMIT = 100;
+
+/** Input to {@link AuditService.record} — everything about a mutation except who/when, which the service fills in itself. */
+export interface RecordAuditEntryParams {
+  /** The kind of mutation performed. */
+  action: AuditAction;
+  /** The `game_servers` map key the mutation applied to. */
+  game: string;
+  /** The game's configuration before the mutation, or `null` for `add`. */
+  before: GameServer | null;
+  /** The game's configuration after the mutation, or `null` for `remove`. */
+  after: GameServer | null;
+  /** S3 object version id of `terraform.tfvars` produced by the write, if known. */
+  versionId?: string;
+}
+
+/** Input to {@link AuditService.list} — an optional page size and pagination cursor. */
+export interface ListAuditEntriesOpts {
+  /** Requested page size; clamped to `[1, 100]` and defaulted to `25` when omitted or invalid. */
+  limit?: number;
+  /** Cursor (an `AuditEntry.sk` value) to fetch the page older than. */
+  before?: string;
+}
+
+/**
+ * Clamps a requested page size to a sane default (25) and hard maximum
+ * (100). Falls back to the default for anything non-finite or `<= 0`.
+ */
+function clampLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.floor(limit), MAX_LIMIT);
+}
+
+/**
+ * Records `game_servers` mutations to (and lists them back from) the audit
+ * DynamoDB table via the injected {@link AuditLogStore}. See the file-level
+ * doc comment above for the best-effort-write contract.
+ */
+@Injectable()
+export class AuditService {
+  /**
+   * `store` is typed against the cloud-agnostic `AuditLogStore` contract
+   * (not a concrete AWS class) so this service depends only on the
+   * interface; `@Inject(AUDIT_LOG_STORE)` tells Nest which concrete provider
+   * (bound by `CloudProviderModule` for whichever cloud is active) to
+   * resolve for that parameter, since interfaces don't survive to runtime
+   * for Nest's reflection-based DI to key off of.
+   */
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(AUDIT_LOG_STORE) private readonly store: AuditLogStore,
+  ) {}
+
+  /**
+   * Builds an {@link AuditEntry} from `params` (actor from `os.userInfo()`,
+   * timestamp/`sk` from the current time) and persists it via
+   * `store.putEntry`.
+   *
+   * Never throws: when `audit_table_name` isn't in the Terraform outputs
+   * yet (table not deployed) or `store.putEntry` rejects, a winston warning
+   * is logged and the method returns — the caller's own write must not be
+   * blocked or failed by an audit-logging problem.
+   */
+  async record(params: RecordAuditEntryParams): Promise<void> {
+    const tableName = this.config.getTfOutputs()?.audit_table_name;
+    if (!tableName) {
+      logger.warn('AuditService.record: audit_table_name not configured, skipping audit log entry', {
+        action: params.action,
+        game: params.game,
+      });
+      return;
+    }
+
+    const now = new Date();
+    const entry: AuditEntry = {
+      sk: buildAuditSk(now),
+      timestamp: now.toISOString(),
+      actor: os.userInfo().username,
+      action: params.action,
+      game: params.game,
+      before: params.before,
+      after: params.after,
+      ...(params.versionId !== undefined ? { versionId: params.versionId } : {}),
+    };
+
+    try {
+      await this.store.putEntry(entry);
+    } catch (err) {
+      logger.warn('AuditService.record: failed to write audit log entry', {
+        err,
+        action: params.action,
+        game: params.game,
+      });
+    }
+  }
+
+  /**
+   * Lists audit entries newest-first, delegating to `store.listEntries`
+   * after clamping `opts.limit` via {@link clampLimit}.
+   */
+  async list(opts: ListAuditEntriesOpts = {}): Promise<AuditPageResult> {
+    return this.store.listEntries(clampLimit(opts.limit), opts.before);
+  }
+}

--- a/app/packages/desktop-main/src/services/AuditService.ts
+++ b/app/packages/desktop-main/src/services/AuditService.ts
@@ -52,7 +52,7 @@ function clampLimit(limit?: number): number {
   if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
     return DEFAULT_LIMIT;
   }
-  return Math.min(Math.floor(limit), MAX_LIMIT);
+  return Math.max(1, Math.min(Math.floor(limit), MAX_LIMIT));
 }
 
 /**
@@ -95,19 +95,19 @@ export class AuditService {
       return;
     }
 
-    const now = new Date();
-    const entry: AuditEntry = {
-      sk: buildAuditSk(now),
-      timestamp: now.toISOString(),
-      actor: os.userInfo().username,
-      action: params.action,
-      game: params.game,
-      before: params.before,
-      after: params.after,
-      ...(params.versionId !== undefined ? { versionId: params.versionId } : {}),
-    };
-
     try {
+      const now = new Date();
+      const entry: AuditEntry = {
+        sk: buildAuditSk(now),
+        timestamp: now.toISOString(),
+        actor: os.userInfo().username,
+        action: params.action,
+        game: params.game,
+        before: params.before,
+        after: params.after,
+        ...(params.versionId !== undefined ? { versionId: params.versionId } : {}),
+      };
+
       await this.store.putEntry(entry);
     } catch (err) {
       logger.warn('AuditService.record: failed to write audit log entry', {

--- a/app/packages/desktop-main/src/services/AuditService.ts
+++ b/app/packages/desktop-main/src/services/AuditService.ts
@@ -121,8 +121,20 @@ export class AuditService {
   /**
    * Lists audit entries newest-first, delegating to `store.listEntries`
    * after clamping `opts.limit` via {@link clampLimit}.
+   *
+   * Mirrors {@link record}'s missing-table guard: when `audit_table_name`
+   * isn't in the Terraform outputs yet (table not deployed), a winston
+   * warning is logged and an empty page is returned rather than letting
+   * `store.listEntries` throw — the always-visible audit page should render
+   * its empty state on pre-audit-table deployments, not an error state.
    */
   async list(opts: ListAuditEntriesOpts = {}): Promise<AuditPageResult> {
+    const tableName = this.config.getTfOutputs()?.audit_table_name;
+    if (!tableName) {
+      logger.warn('AuditService.list: audit_table_name not configured, returning empty audit log page');
+      return { entries: [] };
+    }
+
     return this.store.listEntries(clampLimit(opts.limit), opts.before);
   }
 }

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -161,6 +161,24 @@ describe('ConfigService', () => {
       mockRead.mockReturnValue('not-json{');
       expect(service.getTfOutputs()).toBeNull();
     });
+
+    it('should parse audit_table_name when the output is present', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(
+        makeState({
+          audit_table_name: { value: 'hyveon-audit' },
+        }),
+      );
+
+      expect(service.getTfOutputs()!.audit_table_name).toBe('hyveon-audit');
+    });
+
+    it('should default audit_table_name to an empty string when the output is missing', () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(makeState({ aws_region: { value: 'us-west-2' } }));
+
+      expect(service.getTfOutputs()!.audit_table_name).toBe('');
+    });
   });
 
   describe('getRegion', () => {

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -36,6 +36,7 @@ export interface TfOutputs {
   alb_dns_name: string | null;
   acm_certificate_arn: string | null;
   discord_table_name: string;
+  audit_table_name: string;
   discord_bot_token_secret_arn: string;
   discord_public_key_secret_arn: string;
   interactions_invoke_url: string | null;
@@ -171,6 +172,7 @@ export class ConfigService {
         alb_dns_name: get('alb_dns_name', null),
         acm_certificate_arn: get('acm_certificate_arn', null),
         discord_table_name: get('discord_table_name', ''),
+        audit_table_name: get('audit_table_name', ''),
         discord_bot_token_secret_arn: get('discord_bot_token_secret_arn', ''),
         discord_public_key_secret_arn: get('discord_public_key_secret_arn', ''),
         interactions_invoke_url: get('interactions_invoke_url', null),

--- a/app/packages/desktop-main/src/services/GamesWriteService.test.ts
+++ b/app/packages/desktop-main/src/services/GamesWriteService.test.ts
@@ -7,6 +7,7 @@ vi.mock('../logger.js', () => ({
 import type { GameServer } from '@hyveon/shared';
 import { OptimisticLockError } from '@hyveon/shared';
 import { GamesWriteService } from './GamesWriteService.js';
+import type { AuditService } from './AuditService.js';
 import type { ConfigService, TfOutputs } from './ConfigService.js';
 import type { TfvarsService } from './TfvarsService.js';
 import { HclSurgeonError } from './hclSurgeon.js';
@@ -41,15 +42,28 @@ function makeConfig(options: { outputs?: Partial<TfOutputs> | null; bucket?: str
   } as Partial<ConfigService> as ConfigService;
 }
 
-/** Build a TfvarsService stub with every method `GamesWriteService` touches pre-wired to succeed. */
-function makeTfvars(declared: GameServer[] = []): TfvarsService {
+/**
+ * Build a TfvarsService stub with every method `GamesWriteService` touches
+ * pre-wired to succeed. The write methods (`addGameServer`/`updateGameServer`/
+ * `removeGameServer`) resolve to `{ etag, versionId }` matching the real
+ * service's return shape, defaulting `versionId` to `'v-new'` so audit
+ * assertions have a concrete value to check against.
+ */
+function makeTfvars(declared: GameServer[] = [], versionId: string | undefined = 'v-new'): TfvarsService {
   return {
     invalidateCache: vi.fn(),
     getGameServers: vi.fn().mockResolvedValue(declared),
-    addGameServer: vi.fn().mockResolvedValue(undefined),
-    updateGameServer: vi.fn().mockResolvedValue(undefined),
-    removeGameServer: vi.fn().mockResolvedValue(undefined),
+    addGameServer: vi.fn().mockResolvedValue({ etag: 'etag-new', versionId }),
+    updateGameServer: vi.fn().mockResolvedValue({ etag: 'etag-new', versionId }),
+    removeGameServer: vi.fn().mockResolvedValue({ etag: 'etag-new', versionId }),
   } as Partial<TfvarsService> as TfvarsService;
+}
+
+/** Build an AuditService stub with `record()` pre-wired to a no-op `vi.fn()`. */
+function makeAudit(): AuditService {
+  return {
+    record: vi.fn().mockResolvedValue(undefined),
+  } as Partial<AuditService> as AuditService;
 }
 
 describe('GamesWriteService', () => {
@@ -61,7 +75,8 @@ describe('GamesWriteService', () => {
     it('should write the new entry and return the updated game plus the refreshed games list on success', async () => {
       const tfvars = makeTfvars();
       const config = makeConfig({ outputs: { game_names: ['minecraft'] } });
-      const service = new GamesWriteService(config, tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(config, tfvars, audit);
 
       const result = await service.createGame({ name: 'ark', config: buildConfig(), expectedVersionId: 'v1' });
 
@@ -75,8 +90,25 @@ describe('GamesWriteService', () => {
       }
     });
 
+    it('should record an audit entry exactly once with a null before, the validated after, and the write versionId', async () => {
+      const tfvars = makeTfvars();
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
+
+      await service.createGame({ name: 'ark', config: buildConfig(), expectedVersionId: 'v1' });
+
+      expect(audit.record).toHaveBeenCalledOnce();
+      expect(audit.record).toHaveBeenCalledWith({
+        action: 'add',
+        game: 'ark',
+        before: null,
+        after: buildGameServer('ark'),
+        versionId: 'v-new',
+      });
+    });
+
     it('should emit a structured audit log entry noting local mode when no tfvars bucket is configured', async () => {
-      const service = new GamesWriteService(makeConfig({ bucket: null }), makeTfvars());
+      const service = new GamesWriteService(makeConfig({ bucket: null }), makeTfvars(), makeAudit());
 
       await service.createGame({ name: 'ark', config: buildConfig() });
 
@@ -84,16 +116,17 @@ describe('GamesWriteService', () => {
     });
 
     it('should emit a structured audit log entry noting s3 mode when a tfvars bucket is configured', async () => {
-      const service = new GamesWriteService(makeConfig({ bucket: 'my-bucket' }), makeTfvars());
+      const service = new GamesWriteService(makeConfig({ bucket: 'my-bucket' }), makeTfvars(), makeAudit());
 
       await service.createGame({ name: 'ark', config: buildConfig() });
 
       expect(logger.info).toHaveBeenCalledWith('Game server write', { action: 'create', game: 'ark', mode: 's3' });
     });
 
-    it('should return a validation failure without writing when the proposed config fails business-rule validation', async () => {
+    it('should return a validation failure without writing or recording an audit entry when the proposed config fails business-rule validation', async () => {
       const tfvars = makeTfvars();
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.createGame({ name: 'ark', config: buildConfig({ cpu: 256, memory: 4096 }) });
 
@@ -103,12 +136,14 @@ describe('GamesWriteService', () => {
         issues: expect.arrayContaining([expect.objectContaining({ path: 'memory' })]),
       });
       expect(tfvars.addGameServer).not.toHaveBeenCalled();
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a conflict result with both etags when the write raises OptimisticLockError', async () => {
+    it('should return a conflict result without recording an audit entry when the write raises OptimisticLockError', async () => {
       const tfvars = makeTfvars();
       tfvars.addGameServer = vi.fn().mockRejectedValue(new OptimisticLockError('old-etag', 'new-etag'));
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.createGame({ name: 'ark', config: buildConfig(), expectedVersionId: 'old-etag' });
 
@@ -118,9 +153,10 @@ describe('GamesWriteService', () => {
         expectedVersionId: 'old-etag',
         currentVersionId: 'new-etag',
       });
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a validation failure with a name-path issue when the entry name already exists', async () => {
+    it('should return a validation failure with a name-path issue without recording an audit entry when the entry name already exists', async () => {
       const tfvars = makeTfvars();
       tfvars.addGameServer = vi
         .fn()
@@ -130,7 +166,8 @@ describe('GamesWriteService', () => {
             'duplicate-name',
           ),
         );
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.createGame({ name: 'ark', config: buildConfig() });
 
@@ -139,13 +176,15 @@ describe('GamesWriteService', () => {
         code: 'validation',
         issues: [{ path: 'name', message: expect.stringContaining('already exists') }],
       });
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a catch-all error result when the write raises an unexpected error', async () => {
+    it('should return a catch-all error result without recording an audit entry when the write raises an unexpected error', async () => {
       const tfvars = makeTfvars();
       const originalError = new Error('disk full');
       tfvars.addGameServer = vi.fn().mockRejectedValue(originalError);
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
       const loggerErrorSpy = vi.spyOn(logger, 'error');
 
       const result = await service.createGame({ name: 'ark', config: buildConfig() });
@@ -156,13 +195,15 @@ describe('GamesWriteService', () => {
         message: 'An unexpected error occurred while writing the game server configuration',
       });
       expect(loggerErrorSpy).toHaveBeenCalledWith('Game server write failed', { err: originalError });
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a catch-all error result (not a name-validation issue) when addGameServer() throws a structural HclSurgeonError', async () => {
+    it('should return a catch-all error result (not a name-validation issue) without recording an audit entry when addGameServer() throws a structural HclSurgeonError', async () => {
       const tfvars = makeTfvars();
       const structuralError = new HclSurgeonError('"game_servers" map not found in tfvars source.');
       tfvars.addGameServer = vi.fn().mockRejectedValue(structuralError);
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
       const loggerErrorSpy = vi.spyOn(logger, 'error');
 
       const result = await service.createGame({ name: 'ark', config: buildConfig() });
@@ -173,6 +214,7 @@ describe('GamesWriteService', () => {
         message: 'An unexpected error occurred while writing the game server configuration',
       });
       expect(loggerErrorSpy).toHaveBeenCalledWith('Game server write failed', { err: structuralError });
+      expect(audit.record).not.toHaveBeenCalled();
     });
   });
 
@@ -180,7 +222,7 @@ describe('GamesWriteService', () => {
     it('should write the updated entry and return the updated game plus the refreshed games list on success', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
       const config = makeConfig({ outputs: { game_names: ['minecraft'] } });
-      const service = new GamesWriteService(config, tfvars);
+      const service = new GamesWriteService(config, tfvars, makeAudit());
       const newConfig = buildConfig({ cpu: 2048, memory: 4096 });
 
       const result = await service.updateGame({ name: 'minecraft', config: newConfig, expectedVersionId: 'v1' });
@@ -194,9 +236,28 @@ describe('GamesWriteService', () => {
       }
     });
 
-    it('should return a validation failure without writing when the proposed config fails business-rule validation', async () => {
+    it('should record an audit entry exactly once with the pre-mutation sibling entry as before, the validated after, and the write versionId', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
+      const newConfig = buildConfig({ cpu: 2048, memory: 4096 });
+
+      await service.updateGame({ name: 'minecraft', config: newConfig, expectedVersionId: 'v1' });
+
+      expect(audit.record).toHaveBeenCalledOnce();
+      expect(audit.record).toHaveBeenCalledWith({
+        action: 'edit',
+        game: 'minecraft',
+        before: buildGameServer('minecraft'),
+        after: buildGameServer('minecraft', { cpu: 2048, memory: 4096 }),
+        versionId: 'v-new',
+      });
+    });
+
+    it('should return a validation failure without writing or recording an audit entry when the proposed config fails business-rule validation', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.updateGame({
         name: 'minecraft',
@@ -205,12 +266,14 @@ describe('GamesWriteService', () => {
 
       expect(result).toMatchObject({ ok: false, code: 'validation' });
       expect(tfvars.updateGameServer).not.toHaveBeenCalled();
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a conflict result with both etags when the write raises OptimisticLockError', async () => {
+    it('should return a conflict result without recording an audit entry when the write raises OptimisticLockError', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
       tfvars.updateGameServer = vi.fn().mockRejectedValue(new OptimisticLockError('old-etag', 'new-etag'));
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.updateGame({
         name: 'minecraft',
@@ -224,12 +287,14 @@ describe('GamesWriteService', () => {
         expectedVersionId: 'old-etag',
         currentVersionId: 'new-etag',
       });
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a not_found result when the target game does not exist in game_servers', async () => {
+    it('should return a not_found result without recording an audit entry when the target game does not exist in game_servers', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
       tfvars.updateGameServer = vi.fn().mockRejectedValue(new HclSurgeonError('Entry "ark" not found in "game_servers".'));
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.updateGame({
         name: 'ark',
@@ -237,6 +302,7 @@ describe('GamesWriteService', () => {
       });
 
       expect(result).toEqual({ ok: false, code: 'not_found', message: expect.stringContaining('not found') });
+      expect(audit.record).not.toHaveBeenCalled();
     });
   });
 
@@ -244,7 +310,7 @@ describe('GamesWriteService', () => {
     it('should remove the entry and return the refreshed games list without a game field on success', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
       const config = makeConfig({ outputs: { game_names: [] } });
-      const service = new GamesWriteService(config, tfvars);
+      const service = new GamesWriteService(config, tfvars, makeAudit());
 
       const result = await service.deleteGame({ name: 'minecraft', expectedVersionId: 'v1' });
 
@@ -257,19 +323,37 @@ describe('GamesWriteService', () => {
       }
     });
 
+    it('should record an audit entry exactly once with the pre-mutation sibling entry as before, a null after, and the write versionId', async () => {
+      const tfvars = makeTfvars([buildGameServer('minecraft')]);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
+
+      await service.deleteGame({ name: 'minecraft', expectedVersionId: 'v1' });
+
+      expect(audit.record).toHaveBeenCalledOnce();
+      expect(audit.record).toHaveBeenCalledWith({
+        action: 'remove',
+        game: 'minecraft',
+        before: buildGameServer('minecraft'),
+        after: null,
+        versionId: 'v-new',
+      });
+    });
+
     it('should emit a structured audit log entry with the game name even though no game object is returned', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
-      const service = new GamesWriteService(makeConfig({ bucket: 'my-bucket' }), tfvars);
+      const service = new GamesWriteService(makeConfig({ bucket: 'my-bucket' }), tfvars, makeAudit());
 
       await service.deleteGame({ name: 'minecraft' });
 
       expect(logger.info).toHaveBeenCalledWith('Game server write', { action: 'delete', game: 'minecraft', mode: 's3' });
     });
 
-    it('should return a conflict result with both etags when the write raises OptimisticLockError', async () => {
+    it('should return a conflict result without recording an audit entry when the write raises OptimisticLockError', async () => {
       const tfvars = makeTfvars([buildGameServer('minecraft')]);
       tfvars.removeGameServer = vi.fn().mockRejectedValue(new OptimisticLockError('old-etag', 'new-etag'));
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.deleteGame({ name: 'minecraft', expectedVersionId: 'old-etag' });
 
@@ -279,16 +363,19 @@ describe('GamesWriteService', () => {
         expectedVersionId: 'old-etag',
         currentVersionId: 'new-etag',
       });
+      expect(audit.record).not.toHaveBeenCalled();
     });
 
-    it('should return a not_found result when the target game does not exist in game_servers', async () => {
+    it('should return a not_found result without recording an audit entry when the target game does not exist in game_servers', async () => {
       const tfvars = makeTfvars([]);
       tfvars.removeGameServer = vi.fn().mockRejectedValue(new HclSurgeonError('Entry "ark" not found in "game_servers".'));
-      const service = new GamesWriteService(makeConfig(), tfvars);
+      const audit = makeAudit();
+      const service = new GamesWriteService(makeConfig(), tfvars, audit);
 
       const result = await service.deleteGame({ name: 'ark' });
 
       expect(result).toEqual({ ok: false, code: 'not_found', message: expect.stringContaining('not found') });
+      expect(audit.record).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/packages/desktop-main/src/services/GamesWriteService.ts
+++ b/app/packages/desktop-main/src/services/GamesWriteService.ts
@@ -14,14 +14,24 @@
  *     matching `GameWriteResult` failure variant (see the per-method docs
  *     below for the exact mapping).
  *  4. On success, invalidate both the `TfvarsService` and `ConfigService`
- *     caches, emit a structured audit log entry, and return the updated game
+ *     caches, emit a structured audit log entry (both the winston log line
+ *     and a persisted `AuditService.record()` call carrying the before/after
+ *     game config and the write's `versionId`), and return the updated game
  *     plus a freshly `mergeGameLists()`d games list so callers can refresh
  *     their view without a second round trip.
  */
 import { Injectable } from '@nestjs/common';
-import type { CreateGamePayload, DeleteGamePayload, GameServer, GameWriteResult, UpdateGamePayload } from '@hyveon/shared';
+import type {
+  AuditAction,
+  CreateGamePayload,
+  DeleteGamePayload,
+  GameServer,
+  GameWriteResult,
+  UpdateGamePayload,
+} from '@hyveon/shared';
 import { OptimisticLockError, validateGameServer } from '@hyveon/shared';
 import { logger } from '../logger.js';
+import { AuditService } from './AuditService.js';
 import { ConfigService } from './ConfigService.js';
 import { TfvarsService } from './TfvarsService.js';
 import { HclSurgeonError } from './hclSurgeon.js';
@@ -29,6 +39,13 @@ import { mergeGameLists } from './mergeGameLists.js';
 
 /** The three write operations this service performs — used to tag the audit log entry. */
 type GameWriteAction = 'create' | 'update' | 'delete';
+
+/** Maps a {@link GameWriteAction} to the {@link AuditAction} recorded via `AuditService.record()`. */
+const AUDIT_ACTION_BY_WRITE_ACTION: Record<GameWriteAction, AuditAction> = {
+  create: 'add',
+  update: 'edit',
+  delete: 'remove',
+};
 
 /**
  * Validates and writes `game_servers` create/update/delete requests — see
@@ -42,6 +59,7 @@ export class GamesWriteService {
   constructor(
     private readonly config: ConfigService,
     private readonly tfvars: TfvarsService,
+    private readonly audit: AuditService,
   ) {}
 
   /**
@@ -70,8 +88,9 @@ export class GamesWriteService {
     }
 
     const { name, ...config } = validation.data;
+    let write: { etag: string; versionId?: string };
     try {
-      await this.tfvars.addGameServer(name, config, payload.expectedVersionId);
+      write = await this.tfvars.addGameServer(name, config, payload.expectedVersionId);
     } catch (err) {
       if (err instanceof OptimisticLockError) {
         return this.conflictResult(err);
@@ -82,7 +101,7 @@ export class GamesWriteService {
       return this.errorResult(err);
     }
 
-    return this.successResult('create', name, validation.data);
+    return this.successResult('create', name, validation.data, { before: null, after: validation.data, versionId: write.versionId });
   }
 
   /**
@@ -107,9 +126,12 @@ export class GamesWriteService {
       return { ok: false, code: 'validation', issues: validation.issues };
     }
 
+    const before = siblings.find((sibling) => sibling.name === payload.name) ?? null;
+
     const { name, ...config } = validation.data;
+    let write: { etag: string; versionId?: string };
     try {
-      await this.tfvars.updateGameServer(name, config, payload.expectedVersionId);
+      write = await this.tfvars.updateGameServer(name, config, payload.expectedVersionId);
     } catch (err) {
       if (err instanceof OptimisticLockError) {
         return this.conflictResult(err);
@@ -120,7 +142,7 @@ export class GamesWriteService {
       return this.errorResult(err);
     }
 
-    return this.successResult('update', name, validation.data);
+    return this.successResult('update', name, validation.data, { before, after: validation.data, versionId: write.versionId });
   }
 
   /**
@@ -135,8 +157,12 @@ export class GamesWriteService {
    *    `{ code: 'not_found' }`.
    */
   async deleteGame(payload: DeleteGamePayload): Promise<GameWriteResult> {
+    const siblings = await this.tfvars.getGameServers();
+    const before = siblings.find((sibling) => sibling.name === payload.name) ?? null;
+
+    let write: { etag: string; versionId?: string };
     try {
-      await this.tfvars.removeGameServer(payload.name, payload.expectedVersionId);
+      write = await this.tfvars.removeGameServer(payload.name, payload.expectedVersionId);
     } catch (err) {
       if (err instanceof OptimisticLockError) {
         return this.conflictResult(err);
@@ -147,21 +173,29 @@ export class GamesWriteService {
       return this.errorResult(err);
     }
 
-    return this.successResult('delete', payload.name);
+    return this.successResult('delete', payload.name, undefined, { before, after: null, versionId: write.versionId });
   }
 
   /**
    * Shared success path for all three operations: invalidates both the
    * `TfvarsService` and `ConfigService` caches so the next read reflects the
-   * write, emits a structured audit log entry (action, game name, and
-   * whether the write went to the S3 tfvars backend or the local file — see
-   * `ConfigService.getTfvarsBucket()`), and builds the refreshed
+   * write, emits the existing structured winston log line (action, game
+   * name, and whether the write went to the S3 tfvars backend or the local
+   * file — see `ConfigService.getTfvarsBucket()`), persists an
+   * `AuditService.record()` entry carrying `audit.before`/`audit.after`/
+   * `audit.versionId` under the mapped {@link AuditAction} (via
+   * {@link AUDIT_ACTION_BY_WRITE_ACTION}), and builds the refreshed
    * `mergeGameLists()` list. `game` is omitted for `'delete'`, matching
    * `GameWriteSuccess.game`'s "omitted for a delete" contract — `name` is
-   * passed separately so the audit entry still records which game was
+   * passed separately so both log lines still record which game was
    * affected even when there's no `game` object to pull it from.
    */
-  private async successResult(action: GameWriteAction, name: string, game?: GameServer): Promise<GameWriteResult> {
+  private async successResult(
+    action: GameWriteAction,
+    name: string,
+    game: GameServer | undefined,
+    audit: { before: GameServer | null; after: GameServer | null; versionId?: string },
+  ): Promise<GameWriteResult> {
     this.tfvars.invalidateCache();
     this.config.invalidateCache();
 
@@ -169,6 +203,14 @@ export class GamesWriteService {
       action,
       game: name,
       mode: this.config.getTfvarsBucket() ? 's3' : 'local',
+    });
+
+    await this.audit.record({
+      action: AUDIT_ACTION_BY_WRITE_ACTION[action],
+      game: name,
+      before: audit.before,
+      after: audit.after,
+      versionId: audit.versionId,
     });
 
     const declared = await this.tfvars.getGameServers();

--- a/app/packages/desktop-main/src/services/TfvarsService.s3.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.s3.test.ts
@@ -19,7 +19,7 @@ import 'reflect-metadata';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- test-only: exercises the real AwsRemoteFileStore against a mocked S3Client (see file header).
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { AwsRemoteFileStore } from '@hyveon/cloud-aws';
 import { TfvarsService } from './TfvarsService.js';
 import type { ConfigService } from './ConfigService.js';
@@ -118,5 +118,32 @@ describe('TfvarsService (S3 path, real AwsRemoteFileStore)', () => {
 
     await expect(service.getGameServers()).resolves.toEqual([]);
     expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(1);
+  });
+
+  it("should propagate the S3 PutObjectCommand response's VersionId through updateGameServer's return value", async () => {
+    s3Mock.on(GetObjectCommand).resolves({
+      Body: fakeBody(new TextEncoder().encode(FIXTURE_TFVARS)) as never,
+      ETag: '"etag-1"',
+    });
+    s3Mock.on(PutObjectCommand).resolves({
+      ETag: '"etag-2"',
+      VersionId: 'v-abc123',
+    });
+
+    const remoteFileStore = new AwsRemoteFileStore(() => ({ bucket: 'my-tfvars-bucket' }));
+    const service = new TfvarsService(
+      makeConfig({ bucket: 'my-tfvars-bucket', path: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    const result = await service.updateGameServer('palworld', {
+      image: 'thijsvanloef/palworld-server-docker:v2',
+      cpu: 4096,
+      memory: 16384,
+      ports: [{ container: 8211, protocol: 'udp' }],
+      volumes: [{ name: 'saves', container_path: '/palworld' }],
+    });
+
+    expect(result).toEqual({ etag: 'etag-2', versionId: 'v-abc123' });
   });
 });

--- a/app/packages/desktop-main/src/services/TfvarsService.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.ts
@@ -253,9 +253,17 @@ export class TfvarsService {
    *   the map key rather than an object attribute).
    * @param expectedVersionId - The etag last read (e.g. via {@link getRawHcl}),
    *   used as the S3-mode conditional-put guard; omit to write unconditionally.
+   * @returns The written file's new `etag` (S3 mode) plus an optional
+   *   `versionId` when the underlying store supports object versioning — see
+   *   {@link writeTfvars}/{@link putRawTfvars}. Local mode returns
+   *   `versionId: undefined` since the filesystem has no equivalent concept.
    */
-  async addGameServer(name: string, config: RawGameServerEntry, expectedVersionId?: string): Promise<void> {
-    await this.writeTfvars(expectedVersionId, (hcl) => this.insertGameServerEntry(hcl, name, config));
+  async addGameServer(
+    name: string,
+    config: RawGameServerEntry,
+    expectedVersionId?: string,
+  ): Promise<{ etag: string; versionId?: string }> {
+    return this.writeTfvars(expectedVersionId, (hcl) => this.insertGameServerEntry(hcl, name, config));
   }
 
   /**
@@ -274,9 +282,17 @@ export class TfvarsService {
    * @param config - The entry's new fields (everything but `name`).
    * @param expectedVersionId - The etag last read (e.g. via {@link getRawHcl}),
    *   used as the S3-mode conditional-put guard; omit to write unconditionally.
+   * @returns The written file's new `etag` (S3 mode) plus an optional
+   *   `versionId` when the underlying store supports object versioning — see
+   *   {@link writeTfvars}/{@link putRawTfvars}. Local mode returns
+   *   `versionId: undefined` since the filesystem has no equivalent concept.
    */
-  async updateGameServer(name: string, config: RawGameServerEntry, expectedVersionId?: string): Promise<void> {
-    await this.writeTfvars(expectedVersionId, (hcl) => this.replaceGameServerEntry(hcl, name, config));
+  async updateGameServer(
+    name: string,
+    config: RawGameServerEntry,
+    expectedVersionId?: string,
+  ): Promise<{ etag: string; versionId?: string }> {
+    return this.writeTfvars(expectedVersionId, (hcl) => this.replaceGameServerEntry(hcl, name, config));
   }
 
   /**
@@ -290,9 +306,16 @@ export class TfvarsService {
    * @param name - The `game_servers` map key to remove.
    * @param expectedVersionId - The etag last read (e.g. via {@link getRawHcl}),
    *   used as the S3-mode conditional-put guard; omit to write unconditionally.
+   * @returns The written file's new `etag` (S3 mode) plus an optional
+   *   `versionId` when the underlying store supports object versioning — see
+   *   {@link writeTfvars}/{@link putRawTfvars}. Local mode returns
+   *   `versionId: undefined` since the filesystem has no equivalent concept.
    */
-  async removeGameServer(name: string, expectedVersionId?: string): Promise<void> {
-    await this.writeTfvars(expectedVersionId, (hcl) => cutEntry(hcl, 'game_servers', name));
+  async removeGameServer(
+    name: string,
+    expectedVersionId?: string,
+  ): Promise<{ etag: string; versionId?: string }> {
+    return this.writeTfvars(expectedVersionId, (hcl) => cutEntry(hcl, 'game_servers', name));
   }
 
   /**
@@ -333,12 +356,18 @@ export class TfvarsService {
    * meaningful — `expectedVersionId` is checked against the store's
    * current etag at write time, so a conflicting write since `fetchRawTfvars`
    * ran is still caught even though `mutate` itself is synchronous.
+   *
+   * @returns The write's `{ etag, versionId }` — see {@link putRawTfvars}.
    */
-  private async writeTfvars(expectedVersionId: string | undefined, mutate: (hcl: string) => string): Promise<void> {
+  private async writeTfvars(
+    expectedVersionId: string | undefined,
+    mutate: (hcl: string) => string,
+  ): Promise<{ etag: string; versionId?: string }> {
     const { hcl } = await this.fetchRawTfvars();
     const mutatedHcl = mutate(hcl);
-    await this.putRawTfvars(mutatedHcl, expectedVersionId);
+    const result = await this.putRawTfvars(mutatedHcl, expectedVersionId);
     this.invalidateCache();
+    return result;
   }
 
   /**
@@ -355,8 +384,15 @@ export class TfvarsService {
    * directly with no conditional guard, since the local filesystem has no
    * etag/versioning concept to condition on (mirroring
    * {@link fetchRawTfvars}'s local-mode `etag`-less read).
+   *
+   * @returns The underlying `RemoteFileStore.put()`'s `{ etag, versionId }`
+   *   in S3 mode. Local mode has no etag/versioning concept, so `etag` is the
+   *   empty string and `versionId` is `undefined`.
    */
-  private async putRawTfvars(hcl: string, expectedVersionId?: string): Promise<void> {
+  private async putRawTfvars(
+    hcl: string,
+    expectedVersionId?: string,
+  ): Promise<{ etag: string; versionId?: string }> {
     const bucket = this.config.getTfvarsBucket();
     const path = this.config.getTfvarsPath();
 
@@ -364,7 +400,7 @@ export class TfvarsService {
       const key = basename(path);
       const body = new TextEncoder().encode(hcl);
       try {
-        await this.remoteFileStore.put(key, body, expectedVersionId ? { ifMatch: expectedVersionId } : undefined);
+        return await this.remoteFileStore.put(key, body, expectedVersionId ? { ifMatch: expectedVersionId } : undefined);
       } catch (err) {
         if (err instanceof RemoteFileConflictError) {
           const current = await this.remoteFileStore.get(key).catch(() => undefined);
@@ -372,10 +408,10 @@ export class TfvarsService {
         }
         throw err;
       }
-      return;
     }
 
     writeFileSync(path, hcl, 'utf-8');
+    return { etag: '', versionId: undefined };
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TfvarsService.write.test.ts
+++ b/app/packages/desktop-main/src/services/TfvarsService.write.test.ts
@@ -143,7 +143,8 @@ describe('TfvarsService write path', () => {
       mockRead.mockReturnValue(FIXTURE_TFVARS);
 
       const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
-      await service.addGameServer('terraria', NEW_ENTRY_CONFIG);
+      const result = await service.addGameServer('terraria', NEW_ENTRY_CONFIG);
+      expect(result).toEqual({ etag: '', versionId: undefined });
 
       expect(mockWrite).toHaveBeenCalledTimes(1);
       const written = mockWrite.mock.calls[0]![1] as string;
@@ -214,6 +215,24 @@ describe('TfvarsService write path', () => {
     });
   });
 
+  describe('local-mode write return value', () => {
+    it('should resolve with versionId: undefined since the local filesystem has no versioning concept', async () => {
+      mockExists.mockReturnValue(true);
+      mockRead.mockReturnValue(FIXTURE_TFVARS);
+
+      const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
+
+      await expect(service.updateGameServer('palworld', UPDATED_ENTRY_CONFIG)).resolves.toEqual({
+        etag: '',
+        versionId: undefined,
+      });
+      await expect(service.removeGameServer('valheim')).resolves.toEqual({
+        etag: '',
+        versionId: undefined,
+      });
+    });
+  });
+
   describe('addGameServer name validation', () => {
     it('should reject a name containing HCL metacharacters instead of writing a corrupt file', async () => {
       mockExists.mockReturnValue(true);
@@ -245,7 +264,10 @@ describe('TfvarsService write path', () => {
 
       const service = new TfvarsService(makeConfig({ bucket: null }), remoteFileStore);
 
-      await expect(service.addGameServer('my-server_2', NEW_ENTRY_CONFIG)).resolves.toBeUndefined();
+      await expect(service.addGameServer('my-server_2', NEW_ENTRY_CONFIG)).resolves.toEqual({
+        etag: '',
+        versionId: undefined,
+      });
       expect(mockWrite).toHaveBeenCalledTimes(1);
     });
   });
@@ -281,6 +303,20 @@ describe('TfvarsService write path', () => {
       await expect(
         service.removeGameServer('valheim', 'etag-1'),
       ).rejects.toThrow(OptimisticLockError);
+    });
+
+    it('should propagate the store put()\'s versionId through to the caller on a successful write', async () => {
+      remoteFileStore.get.mockResolvedValue({
+        body: new TextEncoder().encode(FIXTURE_TFVARS),
+        etag: 'etag-1',
+      });
+      remoteFileStore.put.mockResolvedValueOnce({ etag: 'etag-2', versionId: 'v-123' });
+
+      const service = new TfvarsService(makeConfig({ bucket: 'my-tfvars-bucket' }), remoteFileStore);
+
+      await expect(
+        service.updateGameServer('palworld', UPDATED_ENTRY_CONFIG, 'etag-1'),
+      ).resolves.toEqual({ etag: 'etag-2', versionId: 'v-123' });
     });
 
     it('should throw OptimisticLockError (not a raw RemoteFileConflictError) when the store rejects a conditional put', async () => {

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -443,6 +443,55 @@ export interface DriftReport {
   entries: DriftEntry[];
 }
 
+/**
+ * The kind of mutation an {@link AuditEntry} records.
+ *
+ * Mirrors `AuditAction` in `@hyveon/shared/src/audit.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export type AuditAction = 'add' | 'edit' | 'remove';
+
+/**
+ * A single row in the DynamoDB audit log, recording who changed a game
+ * server's configuration, what changed, and the resulting `terraform.tfvars`
+ * S3 version.
+ *
+ * Mirrors `AuditEntry` in `@hyveon/shared/src/audit.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface AuditEntry {
+  /** Sort key: `<ISO timestamp>#<ULID>`. */
+  sk: string;
+  /** ISO-8601 timestamp of the mutation. */
+  timestamp: string;
+  /** Identifier of the user or system that performed the mutation. */
+  actor: string;
+  /** The kind of mutation performed. */
+  action: AuditAction;
+  /** The `game_servers` map key the mutation applied to. */
+  game: string;
+  /** The game's configuration before the mutation, or `null` for `add`. */
+  before: GameServer | null;
+  /** The game's configuration after the mutation, or `null` for `remove`. */
+  after: GameServer | null;
+  /** S3 object version id of `terraform.tfvars` produced by the write, if known. */
+  versionId?: string;
+}
+
+/**
+ * A page of audit entries, newest-first, plus an optional cursor for
+ * fetching the next page. Returned by the `audit.list` IPC channel.
+ *
+ * Mirrors `AuditPageResult` in `@hyveon/shared/src/audit.ts` — that file is
+ * the source of truth; keep this copy in sync with it.
+ */
+export interface AuditPageResult {
+  /** The page of entries, newest-first. */
+  entries: AuditEntry[];
+  /** Cursor (an {@link AuditEntry.sk} value) to pass as `before` to fetch the next, older page. Absent on the last page. */
+  nextBefore?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Per-namespace sub-interfaces
 // ---------------------------------------------------------------------------
@@ -572,6 +621,17 @@ export interface GsdDiagnosticsApi {
   path: () => Promise<{ path: string }>;
 }
 
+/** Audit log: paginated history of `game_servers` mutations from DynamoDB. */
+export interface GsdAuditApi {
+  /**
+   * Returns a page of audit entries, newest-first. `opts.limit` caps the
+   * number of entries returned; `opts.before` is a pagination cursor (an
+   * {@link AuditEntry.sk} value) from a previous page's `nextBefore`, used
+   * to fetch the next, older page.
+   */
+  list: (opts?: { limit?: number; before?: string }) => Promise<AuditPageResult>;
+}
+
 // ---------------------------------------------------------------------------
 // Test-only injection surface
 // ---------------------------------------------------------------------------
@@ -672,6 +732,8 @@ export interface GsdApi {
   drift: GsdDriftApi;
   /** Local application log diagnostics: tail recent lines or retrieve the log file path. */
   diagnostics: GsdDiagnosticsApi;
+  /** Audit log: paginated history of `game_servers` mutations from DynamoDB. */
+  audit: GsdAuditApi;
   /**
    * Test-only injection surface; `undefined` in production.
    *

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -147,6 +147,25 @@ describe('preload dispatcher', () => {
       expect(result).toEqual({ entries: [{ game: 'minecraft', kind: 'pending_create' }] });
     });
 
+    it('should forward audit.list with the opts argument to ipcRenderer.invoke', async () => {
+      const page = { entries: [{ sk: '2026-07-17T00:00:00.000Z#01J', timestamp: '2026-07-17T00:00:00.000Z', actor: 'user@example.com', action: 'add', game: 'minecraft', before: null, after: {} }] };
+      ipcInvoke.mockResolvedValue(page);
+      const audit = bridge['audit'] as { list: (opts?: { limit?: number; before?: string }) => Promise<unknown> };
+      const opts = { limit: 20, before: 'cursor-value' };
+      const result = await audit.list(opts);
+
+      expect(ipcInvoke).toHaveBeenCalledWith('audit.list', opts);
+      expect(result).toEqual(page);
+    });
+
+    it('should forward audit.list with no arguments when opts is omitted', async () => {
+      ipcInvoke.mockResolvedValue({ entries: [] });
+      const audit = bridge['audit'] as { list: (opts?: { limit?: number; before?: string }) => Promise<unknown> };
+      await audit.list();
+
+      expect(ipcInvoke).toHaveBeenCalledWith('audit.list', undefined);
+    });
+
     it('should forward games.create with a single payload object to ipcRenderer.invoke', async () => {
       const writeResult = { ok: true, games: [] };
       ipcInvoke.mockResolvedValue(writeResult);

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -226,6 +226,10 @@ const api: GsdApi = {
     tail: () => invoke('diagnostics.tail'),
     path: () => invoke('diagnostics.path'),
   },
+
+  audit: {
+    list: (opts?: { limit?: number; before?: string }) => invoke('audit.list', opts),
+  },
 };
 
 /**

--- a/app/packages/shared/package.json
+++ b/app/packages/shared/package.json
@@ -20,6 +20,7 @@
     "@aws-sdk/client-dynamodb": "^3.600.0",
     "@aws-sdk/client-secrets-manager": "^3.600.0",
     "@aws-sdk/lib-dynamodb": "^3.600.0",
+    "ulid": "^3.0.2",
     "zod": "^3.23.8"
   }
 }

--- a/app/packages/shared/src/audit.test.ts
+++ b/app/packages/shared/src/audit.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { buildAuditSk } from './audit.js';
+
+/** Crockford base32 alphabet used by ULID (excludes I, L, O, U). */
+const ULID_CHARS = '0-9A-HJKMNP-TV-Z';
+const AUDIT_SK_PATTERN = new RegExp(`^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z#[${ULID_CHARS}]{26}$`);
+
+describe('buildAuditSk', () => {
+  it('should produce a sort key shaped like <ISO timestamp>#<ULID>', () => {
+    const sk = buildAuditSk(new Date('2026-07-17T12:34:56.789Z'));
+    expect(sk).toMatch(AUDIT_SK_PATTERN);
+  });
+
+  it('should prefix the sort key with the ISO string of the provided timestamp', () => {
+    const now = new Date('2020-01-01T00:00:00.000Z');
+    const sk = buildAuditSk(now);
+    expect(sk.startsWith(`${now.toISOString()}#`)).toBe(true);
+  });
+
+  it('should default to the current time when no timestamp is provided', () => {
+    const before = Date.now();
+    const sk = buildAuditSk();
+    const after = Date.now();
+
+    const [timestamp] = sk.split('#');
+    const encoded = new Date(timestamp!).getTime();
+    expect(encoded).toBeGreaterThanOrEqual(before);
+    expect(encoded).toBeLessThanOrEqual(after);
+  });
+
+  it('should produce sort keys that sort chronologically for increasing timestamps', () => {
+    const earlier = buildAuditSk(new Date('2026-01-01T00:00:00.000Z'));
+    const later = buildAuditSk(new Date('2026-06-01T00:00:00.000Z'));
+    expect(earlier < later).toBe(true);
+  });
+
+  it('should not mutate any shared state across calls (pure)', () => {
+    const first = buildAuditSk(new Date('2026-07-17T12:34:56.789Z'));
+    const second = buildAuditSk(new Date('2026-07-17T12:34:56.789Z'));
+    expect(first.split('#')[0]).toBe(second.split('#')[0]);
+    expect(first).toMatch(AUDIT_SK_PATTERN);
+    expect(second).toMatch(AUDIT_SK_PATTERN);
+  });
+});

--- a/app/packages/shared/src/audit.ts
+++ b/app/packages/shared/src/audit.ts
@@ -1,0 +1,62 @@
+import { ulid } from 'ulid';
+import type { GameServer } from './tfvars.js';
+
+/**
+ * The kind of mutation an {@link AuditEntry} records. Mirrors the CRUD verbs
+ * exposed by the `game_servers` write endpoints in `@hyveon/desktop-main`.
+ */
+export type AuditAction = 'add' | 'edit' | 'remove';
+
+/**
+ * A single row in the DynamoDB audit log (`${project_name}-audit` table,
+ * `pk = AUDIT`, `sk = ` {@link buildAuditSk}). Records who changed a game
+ * server's configuration, what changed, and the resulting `terraform.tfvars`
+ * S3 version — see `terraform/aws/audit.tf` for the table definition.
+ */
+export interface AuditEntry {
+  /** Sort key: `<ISO timestamp>#<ULID>` — see {@link buildAuditSk}. */
+  sk: string;
+  /** ISO-8601 timestamp of the mutation. Duplicated from `sk` for cheap reads without parsing. */
+  timestamp: string;
+  /** Identifier of the user or system that performed the mutation. */
+  actor: string;
+  /** The kind of mutation performed. */
+  action: AuditAction;
+  /** The `game_servers` map key the mutation applied to. */
+  game: string;
+  /** The game's configuration before the mutation, or `null` for `add`. */
+  before: GameServer | null;
+  /** The game's configuration after the mutation, or `null` for `remove`. */
+  after: GameServer | null;
+  /** S3 object version id of `terraform.tfvars` produced by the write, if known. */
+  versionId?: string;
+}
+
+/**
+ * A page of audit entries returned by {@link AuditLogStore.listEntries},
+ * newest-first, plus an optional cursor for fetching the next page.
+ */
+export interface AuditPageResult {
+  /** The page of entries, newest-first. */
+  entries: AuditEntry[];
+  /** Cursor (an {@link AuditEntry.sk} value) to pass as `before` to fetch the next, older page. Absent on the last page. */
+  nextBefore?: string;
+}
+
+/**
+ * Builds a DynamoDB sort key for a new {@link AuditEntry}: the ISO-8601
+ * timestamp of `now` followed by a `#`-separated ULID, e.g.
+ * `2026-07-17T12:34:56.789Z#01J...`. The ISO prefix keeps entries sorted
+ * chronologically within the `AUDIT` partition; the ULID suffix disambiguates
+ * entries written within the same millisecond.
+ *
+ * Pure: takes the timestamp as an (optional) argument rather than reading a
+ * clock internally, so callers can pass a fixed `Date` for deterministic
+ * ordering/testing.
+ *
+ * @param now - The timestamp to encode. Defaults to `new Date()`.
+ * @returns The `<ISO timestamp>#<ULID>` sort key.
+ */
+export function buildAuditSk(now: Date = new Date()): string {
+  return `${now.toISOString()}#${ulid(now.getTime())}`;
+}

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -1,3 +1,5 @@
+import type { AuditEntry, AuditPageResult } from './audit.js';
+
 /** Options for launching a game workload. Intentionally open/opaque for v1; implementations may accept provider-specific keys or refine this via intersection. */
 export interface StartOpts {
   [key: string]: unknown;
@@ -179,4 +181,31 @@ export interface DiscordEventReceiver {
    *   endpoint has been configured or provisioned yet.
    */
   getInteractionEndpointUrl(): Promise<string | null>;
+}
+
+/**
+ * Cloud-agnostic interface for appending to and paginating a game-server
+ * mutation audit log. Implementations may target AWS DynamoDB, Azure Table
+ * Storage, GCP Firestore, or any other backend — callers depend only on this
+ * contract. No `@aws-sdk/*` shapes appear in this interface or its
+ * parameter/return types.
+ */
+export interface AuditLogStore {
+  /**
+   * Appends a single audit entry to the log.
+   *
+   * @param entry - The entry to persist, including its `sk` (see `buildAuditSk`).
+   */
+  putEntry(entry: AuditEntry): Promise<void>;
+
+  /**
+   * Lists audit entries newest-first, optionally paginated.
+   *
+   * @param limit  - The maximum number of entries to return.
+   * @param before - When provided, only entries older than this cursor
+   *   (an {@link AuditEntry.sk} value, typically taken from a prior page's
+   *   `nextBefore`) are returned.
+   * @returns The requested page of entries plus a cursor for the next page.
+   */
+  listEntries(limit: number, before?: string): Promise<AuditPageResult>;
 }

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -120,9 +120,14 @@ export interface RemoteFileStore {
    *   only succeeds when the current stored etag matches this value (optimistic
    *   concurrency guard).
    * @returns An object containing the provider-assigned etag for the newly
-   *   stored version.
+   *   stored version, plus an optional `versionId` when the underlying store
+   *   supports object versioning (e.g. a versioned S3 bucket) and returns one.
    */
-  put(path: string, body: Uint8Array, opts?: { ifMatch?: string }): Promise<{ etag: string }>;
+  put(
+    path: string,
+    body: Uint8Array,
+    opts?: { ifMatch?: string },
+  ): Promise<{ etag: string; versionId?: string }>;
 
   /**
    * Lists all available versions of a file in reverse-chronological order.

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './tfvars.js';
 export * from './gameServerValidator.js';
 export * from './gamesWrite.js';
 export * from './drift.js';
+export * from './audit.js';
 export * from './cloud.js';
 export * from './sanitize.js';
 export * from './canRun.js';

--- a/app/packages/web/e2e/fixtures/gsd-http-bridge.ts
+++ b/app/packages/web/e2e/fixtures/gsd-http-bridge.ts
@@ -75,6 +75,15 @@ export function installGsdHttpBridge(): void {
     drift: {
       get: () => call('/api/drift'),
     },
+    audit: {
+      list: (opts?: { limit?: number; before?: string }) => {
+        const params = new URLSearchParams();
+        if (opts?.limit !== undefined) params.set('limit', String(opts.limit));
+        if (opts?.before !== undefined) params.set('before', opts.before);
+        const qs = params.toString();
+        return call(`/api/audit${qs ? `?${qs}` : ''}`);
+      },
+    },
     diagnostics: {
       tail: () => call('/api/diagnostics/tail'),
       path: () => call('/api/diagnostics/path'),

--- a/app/packages/web/e2e/fixtures/index.ts
+++ b/app/packages/web/e2e/fixtures/index.ts
@@ -9,6 +9,7 @@ import type {
   DiscordConfigRedacted,
   GameListEntry,
   DriftReport,
+  AuditPageResult,
 } from '@/api.js';
 import {
   ENV_DATA,
@@ -18,7 +19,7 @@ import {
   CONFIGURED_DISCORD_CONFIG,
   makeActualCosts,
 } from './game-data.js';
-import { AppLayout, DashboardPage, CostsPage, LogsPage, SettingsPage, GamesPage } from '../pages/index.js';
+import { AppLayout, DashboardPage, CostsPage, LogsPage, SettingsPage, GamesPage, AuditPage } from '../pages/index.js';
 import { installGsdHttpBridge } from './gsd-http-bridge.js';
 
 export type {
@@ -30,6 +31,7 @@ export type {
   DiscordConfigRedacted,
   GameListEntry,
   DriftReport,
+  AuditPageResult,
 };
 export {
   ENV_DATA,
@@ -48,7 +50,7 @@ export {
   VALID_USER_ID,
   SAMPLE_LOG_LINES,
 } from './game-data.js';
-export { AppLayout, DashboardPage, CostsPage, DiscordPage, LogsPage, SettingsPage, GamesPage } from '../pages/index.js';
+export { AppLayout, DashboardPage, CostsPage, DiscordPage, LogsPage, SettingsPage, GamesPage, AuditPage } from '../pages/index.js';
 
 /** Per-spec overrides for the default `/api/*` stubs registered by `stubApis`. */
 export interface StubOptions {
@@ -108,6 +110,15 @@ export interface StubOptions {
    * that yields nothing, so specs drive off the seeded snapshot only.
    */
   logLines?: Record<string, string[]>;
+  /**
+   * Response(s) returned by `GET /api/audit` (the `audit.list` IPC channel),
+   * consumed by the `/audit` page (issue #102). Either a fixed
+   * `AuditPageResult` returned for every call, or a builder receiving the
+   * parsed `limit`/`before` query params so a spec can return a different
+   * page per cursor (e.g. the first page's `nextBefore` becomes the second
+   * page's `before`). Defaults to an empty page (`{ entries: [] }`).
+   */
+  audit?: AuditPageResult | ((opts: { limit?: number; before?: string }) => AuditPageResult);
 }
 
 /**
@@ -140,6 +151,12 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
       : opts.actualCosts !== undefined
         ? () => opts.actualCosts as ActualCosts
         : (days) => makeActualCosts(days);
+  const auditFn: (opts: { limit?: number; before?: string }) => AuditPageResult =
+    typeof opts.audit === 'function'
+      ? opts.audit
+      : opts.audit !== undefined
+        ? () => opts.audit as AuditPageResult
+        : () => ({ entries: [] });
 
   await page.route('**/api/**', (route) =>
     route.fulfill({ status: 404, json: { error: 'not stubbed' } })
@@ -180,6 +197,17 @@ export async function stubApis(page: Page, opts: StubOptions = {}): Promise<void
   });
 
   await page.route('**/api/drift', (route) => route.fulfill({ json: drift }));
+
+  // Trailing `*` matches the `?limit=&before=` query string, same as the
+  // costs/actual route above.
+  await page.route('**/api/audit*', (route) => {
+    const url = new URL(route.request().url());
+    const limitRaw = url.searchParams.get('limit');
+    const before = url.searchParams.get('before') ?? undefined;
+    return route.fulfill({
+      json: auditFn({ limit: limitRaw ? Number(limitRaw) : undefined, before }),
+    });
+  });
 
   await page.route('**/api/start/*', (route) => route.fulfill({ json: startResult }));
 
@@ -254,6 +282,8 @@ type E2EFixtures = {
   settings: SettingsPage;
   /** Page object for the `/games` and `/games/:name` routes. */
   games: GamesPage;
+  /** Page object for the `/audit` route. */
+  audit: AuditPage;
   /** Page object for the persistent nav shell (sidebar + top bar). */
   layout: AppLayout;
 };
@@ -269,6 +299,9 @@ export const test = base.extend<E2EFixtures>({
   },
   logs: async ({ page }, use) => {
     await use(new LogsPage(page));
+  },
+  audit: async ({ page }, use) => {
+    await use(new AuditPage(page));
   },
   settings: async ({ page }, use) => {
     await use(new SettingsPage(page));

--- a/app/packages/web/e2e/fixtures/tfstate.fixture.json
+++ b/app/packages/web/e2e/fixtures/tfstate.fixture.json
@@ -18,6 +18,7 @@
     "alb_dns_name":                   { "value": null,                  "type": "string" },
     "acm_certificate_arn":            { "value": null,                  "type": "string" },
     "discord_table_name":             { "value": "test-discord-table",  "type": "string" },
+    "audit_table_name":               { "value": "test-audit-table",    "type": "string" },
     "discord_bot_token_secret_arn":   { "value": "arn:aws:secretsmanager:us-east-1:123456789012:secret/test/discord/bot-token",   "type": "string" },
     "discord_public_key_secret_arn":  { "value": "arn:aws:secretsmanager:us-east-1:123456789012:secret/test/discord/public-key",  "type": "string" },
     "interactions_invoke_url":        { "value": null,                  "type": "string" }

--- a/app/packages/web/e2e/pages/AuditPage.ts
+++ b/app/packages/web/e2e/pages/AuditPage.ts
@@ -1,0 +1,61 @@
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Page object for the `/audit` route added in issue #102. Wraps the audit
+ * log table's summary rows (rendered by `AuditEntryRow`), the expand/collapse
+ * toggle, the before/after diff detail row, and the "Load more" pagination
+ * button so spec files read as test logic rather than locator soup.
+ */
+export class AuditPage {
+  constructor(public readonly page: Page) {}
+
+  /** Navigate to `/audit` directly via URL. */
+  async goto(): Promise<void> {
+    await this.page.goto('/audit');
+  }
+
+  /** "Audit Log" page heading — used as a "the page mounted" smoke check. */
+  heading(): Locator {
+    return this.page.getByRole('heading', { name: 'Audit Log', level: 2 });
+  }
+
+  /** Empty-state message shown when there are no audit entries. */
+  emptyStateMessage(): Locator {
+    return this.page.getByText('No audit entries yet.');
+  }
+
+  /**
+   * The nth summary row (0-indexed, newest first) rendered by
+   * `AuditEntryRow`. Scoped to `tr[aria-expanded]` — only the summary `<tr>`
+   * carries that attribute in production (the expanded detail row and the
+   * unrelated mobile-nav hamburger button do not), so this stays stable
+   * whether or not other rows are currently expanded.
+   */
+  entryRow(n: number): Locator {
+    return this.page.locator('tr[aria-expanded]').nth(n);
+  }
+
+  /** Expand/collapse toggle button inside the nth summary row. */
+  expandButton(n: number): Locator {
+    return this.entryRow(n).getByRole('button', { name: /(expand|collapse) diff/i });
+  }
+
+  /** Click the nth summary row's expand/collapse toggle. */
+  async expandRow(n: number): Promise<void> {
+    await this.expandButton(n).click();
+  }
+
+  /**
+   * The expanded before/after diff row, rendered as the `<tr>` immediately
+   * following the nth summary row once it's expanded. Contains two `<pre>`
+   * blocks with the raw JSON `before`/`after` config.
+   */
+  detailRow(n: number): Locator {
+    return this.entryRow(n).locator('xpath=following-sibling::tr[1]');
+  }
+
+  /** "Load more" pagination button, visible while a `nextBefore` cursor is present. */
+  loadMoreButton(): Locator {
+    return this.page.getByRole('button', { name: 'Load more' });
+  }
+}

--- a/app/packages/web/e2e/pages/AuditPage.ts
+++ b/app/packages/web/e2e/pages/AuditPage.ts
@@ -26,13 +26,14 @@ export class AuditPage {
 
   /**
    * The nth summary row (0-indexed, newest first) rendered by
-   * `AuditEntryRow`. Scoped to `tr[aria-expanded]` — only the summary `<tr>`
-   * carries that attribute in production (the expanded detail row and the
-   * unrelated mobile-nav hamburger button do not), so this stays stable
-   * whether or not other rows are currently expanded.
+   * `AuditEntryRow`. Scoped to `tr` elements containing an
+   * `aria-expanded` button — only the summary row's expand/collapse
+   * toggle carries that attribute in production (the expanded detail row
+   * has no such button), so this stays stable whether or not other rows
+   * are currently expanded.
    */
   entryRow(n: number): Locator {
-    return this.page.locator('tr[aria-expanded]').nth(n);
+    return this.page.locator('tr:has(button[aria-expanded])').nth(n);
   }
 
   /** Expand/collapse toggle button inside the nth summary row. */

--- a/app/packages/web/e2e/pages/index.ts
+++ b/app/packages/web/e2e/pages/index.ts
@@ -5,3 +5,4 @@ export { DiscordPage } from './DiscordPage.js';
 export { LogsPage, type LogLevelLabel } from './LogsPage.js';
 export { SettingsPage } from './SettingsPage.js';
 export { GamesPage, type DriftLabel } from './GamesPage.js';
+export { AuditPage } from './AuditPage.js';

--- a/app/packages/web/e2e/specs/audit.spec.ts
+++ b/app/packages/web/e2e/specs/audit.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, stubApis } from '../fixtures/index.js';
+import type { AuditPageResult } from '../fixtures/index.js';
+
+/**
+ * Specs for the `/audit` route added in issue #102: the mutation-history
+ * table listing every `game_servers` change (timestamp, actor, action, game,
+ * version), the expandable before/after JSON diff per row, and "Load more"
+ * pagination via the `nextBefore` cursor. Plain browser-stub specs (chromium
+ * project) — `/api/audit` is stubbed over HTTP via `stubApis`, same pattern
+ * as `games.spec.ts`.
+ */
+
+/** First page of two audit entries, with a cursor to an older page. */
+const PAGE_ONE: AuditPageResult = {
+  entries: [
+    {
+      sk: '2026-07-02T00:00:00.000Z#01J001',
+      timestamp: '2026-07-02T00:00:00.000Z',
+      actor: 'alice',
+      action: 'edit',
+      game: 'minecraft',
+      before: {
+        name: 'minecraft',
+        image: 'itzg/minecraft-server:1',
+        cpu: 1024,
+        memory: 2048,
+        ports: [],
+        volumes: [],
+      },
+      after: {
+        name: 'minecraft',
+        image: 'itzg/minecraft-server:2',
+        cpu: 1024,
+        memory: 2048,
+        ports: [],
+        volumes: [],
+      },
+      versionId: 'v-2',
+    },
+    {
+      sk: '2026-07-01T00:00:00.000Z#01J000',
+      timestamp: '2026-07-01T00:00:00.000Z',
+      actor: 'bob',
+      action: 'add',
+      game: 'valheim',
+      before: null,
+      after: {
+        name: 'valheim',
+        image: 'lloesche/valheim-server',
+        cpu: 512,
+        memory: 1024,
+        ports: [],
+        volumes: [],
+      },
+      versionId: 'v-1',
+    },
+  ],
+  nextBefore: '2026-07-01T00:00:00.000Z#01J000',
+};
+
+/**
+ * Second, older page — returned once "Load more" passes PAGE_ONE's cursor
+ * back as `before`. Has no `nextBefore`, so "Load more" disappears once it
+ * loads.
+ */
+const PAGE_TWO: AuditPageResult = {
+  entries: [
+    {
+      sk: '2026-06-30T00:00:00.000Z#01J-1',
+      timestamp: '2026-06-30T00:00:00.000Z',
+      actor: 'carol',
+      action: 'remove',
+      game: 'terraria',
+      before: {
+        name: 'terraria',
+        image: 'ryshe/terraria',
+        cpu: 512,
+        memory: 1024,
+        ports: [],
+        volumes: [],
+      },
+      after: null,
+    },
+  ],
+};
+
+test.describe('audit log page', () => {
+  test('should render the Audit Log heading and an empty state when there are no entries', async ({ audit }) => {
+    await stubApis(audit.page, { audit: { entries: [] } });
+    await audit.goto();
+
+    await expect(audit.heading()).toBeVisible();
+    await expect(audit.emptyStateMessage()).toBeVisible();
+  });
+
+  test('should list stubbed entries showing the timestamp, actor, action, game, and version for each row', async ({ audit }) => {
+    await stubApis(audit.page, { audit: PAGE_ONE });
+    await audit.goto();
+
+    await expect(audit.entryRow(0)).toContainText('alice');
+    await expect(audit.entryRow(0)).toContainText('edit');
+    await expect(audit.entryRow(0)).toContainText('minecraft');
+    await expect(audit.entryRow(0)).toContainText('v-2');
+
+    await expect(audit.entryRow(1)).toContainText('bob');
+    await expect(audit.entryRow(1)).toContainText('add');
+    await expect(audit.entryRow(1)).toContainText('valheim');
+    await expect(audit.entryRow(1)).toContainText('v-1');
+  });
+
+  test('should expand a row to reveal the before/after JSON diff', async ({ audit }) => {
+    await stubApis(audit.page, { audit: PAGE_ONE });
+    await audit.goto();
+    await expect(audit.entryRow(0)).toContainText('alice');
+
+    await audit.expandRow(0);
+
+    await expect(audit.detailRow(0).getByText('itzg/minecraft-server:1')).toBeVisible();
+    await expect(audit.detailRow(0).getByText('itzg/minecraft-server:2')).toBeVisible();
+  });
+
+  test('should not show a "Load more" button when the page has no nextBefore', async ({ audit }) => {
+    await stubApis(audit.page, { audit: PAGE_TWO });
+    await audit.goto();
+
+    await expect(audit.entryRow(0)).toContainText('carol');
+    await expect(audit.loadMoreButton()).toHaveCount(0);
+  });
+
+  test('should append a second page of entries when "Load more" is clicked against a stubbed cursor response', async ({ audit }) => {
+    await stubApis(audit.page, {
+      // The stub route always passes the parsed `before` query param through —
+      // once the app clicks "Load more" it re-requests with
+      // `before: PAGE_ONE.nextBefore`, so branch on that to hand back the
+      // older page and drop the cursor.
+      audit: (opts) => (opts.before === PAGE_ONE.nextBefore ? PAGE_TWO : PAGE_ONE),
+    });
+    await audit.goto();
+
+    await expect(audit.entryRow(0)).toContainText('alice');
+    await expect(audit.loadMoreButton()).toBeVisible();
+
+    await audit.loadMoreButton().click();
+
+    // Both the original page's rows and the newly appended page's row are present.
+    await expect(audit.entryRow(2)).toContainText('carol');
+    await expect(audit.entryRow(0)).toContainText('alice');
+    await expect(audit.entryRow(1)).toContainText('bob');
+
+    // The last page has no nextBefore, so "Load more" is gone.
+    await expect(audit.loadMoreButton()).toHaveCount(0);
+  });
+});

--- a/app/packages/web/src/api.service.test.ts
+++ b/app/packages/web/src/api.service.test.ts
@@ -59,6 +59,9 @@ function makeGsdMock() {
     drift: {
       get: vi.fn().mockResolvedValue({ entries: [] }),
     },
+    audit: {
+      list: vi.fn().mockResolvedValue({ entries: [] }),
+    },
   };
 }
 
@@ -240,6 +243,36 @@ describe('IPC bridge delegation', () => {
     gsd.drift.get.mockResolvedValueOnce(report);
     await expect(api.drift()).resolves.toEqual(report);
     expect(gsd.drift.get).toHaveBeenCalledOnce();
+  });
+
+  it('should delegate api.audit() to window.gsd.audit.list() with the opts', async () => {
+    const opts = { limit: 10, before: '2026-01-01T00:00:00.000Z#01H' };
+    await api.audit(opts);
+    expect(gsd.audit.list).toHaveBeenCalledWith(opts);
+  });
+
+  it('should delegate api.audit() to window.gsd.audit.list() with undefined when opts is omitted', async () => {
+    await api.audit();
+    expect(gsd.audit.list).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should resolve api.audit() with the bridge audit.list() result', async () => {
+    const page = {
+      entries: [
+        {
+          sk: '2026-01-01T00:00:00.000Z#01H',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          actor: 'operator',
+          action: 'edit' as const,
+          game: 'minecraft',
+          before: null,
+          after: null,
+        },
+      ],
+      nextBefore: '2025-12-31T00:00:00.000Z#01G',
+    };
+    gsd.audit.list.mockResolvedValueOnce(page);
+    await expect(api.audit()).resolves.toEqual(page);
   });
 
   it('should return the payload resolved by the bridge', async () => {

--- a/app/packages/web/src/api.service.ts
+++ b/app/packages/web/src/api.service.ts
@@ -338,6 +338,55 @@ export interface DriftReport {
 }
 
 /**
+ * The kind of mutation an {@link AuditEntry} records.
+ *
+ * Mirrors `AuditAction` in `@hyveon/shared/src/audit.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export type AuditAction = 'add' | 'edit' | 'remove';
+
+/**
+ * A single row in the DynamoDB audit log, recording who changed a game
+ * server's configuration, what changed, and the resulting `terraform.tfvars`
+ * S3 version.
+ *
+ * Mirrors `AuditEntry` in `@hyveon/shared/src/audit.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface AuditEntry {
+  /** Sort key: `<ISO timestamp>#<ULID>`. */
+  sk: string;
+  /** ISO-8601 timestamp of the mutation. */
+  timestamp: string;
+  /** Identifier of the user or system that performed the mutation. */
+  actor: string;
+  /** The kind of mutation performed. */
+  action: AuditAction;
+  /** The `game_servers` map key the mutation applied to. */
+  game: string;
+  /** The game's configuration before the mutation, or `null` for `add`. */
+  before: GameServer | null;
+  /** The game's configuration after the mutation, or `null` for `remove`. */
+  after: GameServer | null;
+  /** S3 object version id of `terraform.tfvars` produced by the write, if known. */
+  versionId?: string;
+}
+
+/**
+ * A page of audit entries, newest-first, plus an optional cursor for
+ * fetching the next page. Returned by the `audit.list` IPC channel.
+ *
+ * Mirrors `AuditPageResult` in `@hyveon/shared/src/audit.ts` — that file is
+ * the source of truth; keep this copy in sync with it.
+ */
+export interface AuditPageResult {
+  /** The page of entries, newest-first. */
+  entries: AuditEntry[];
+  /** Cursor (an {@link AuditEntry.sk} value) to pass as `before` to fetch the next, older page. Absent on the last page. */
+  nextBefore?: string;
+}
+
+/**
  * Returns the `window.gsd` IPC bridge, throwing a descriptive error if it is
  * absent. The bridge is injected by the Electron preload script, so a missing
  * one means the renderer is running outside Electron (e.g. a plain browser).
@@ -419,4 +468,7 @@ export const api = {
   diagnosticsLogPath: async (): Promise<{ path: string }> => gsd().diagnostics.path(),
 
   drift: async (): Promise<DriftReport> => gsd().drift.get(),
+
+  audit: async (opts?: { limit?: number; before?: string }): Promise<AuditPageResult> =>
+    gsd().audit.list(opts),
 };

--- a/app/packages/web/src/app.component.tsx
+++ b/app/packages/web/src/app.component.tsx
@@ -7,6 +7,7 @@ import { LogsPage } from './pages/logs.page.js';
 import { SettingsPage } from './pages/settings.page.js';
 import { GamesPage } from './pages/games.page.js';
 import { GameDetailPage } from './pages/game-detail.page.js';
+import { AuditPage } from './pages/audit.page.js';
 import { PollingProvider } from './polling/polling-provider.component.js';
 import { GameStatusProvider } from './polling/game-status-provider.component.js';
 import { Toaster } from './components/ui/sonner.component.js';
@@ -20,6 +21,7 @@ import { Toaster } from './components/ui/sonner.component.js';
  *   - `/settings` → Watchdog + general settings
  *   - `/games` → Games list (read-only settings)
  *   - `/games/:name` → Per-game settings detail (read-only)
+ *   - `/audit` → Audit log
  */
 export default function App() {
   return (
@@ -36,6 +38,7 @@ export default function App() {
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/games" element={<GamesPage />} />
               <Route path="/games/:name" element={<GameDetailPage />} />
+              <Route path="/audit" element={<AuditPage />} />
             </Routes>
           </AppLayout>
         </BrowserRouter>

--- a/app/packages/web/src/components/app-layout.component.test.tsx
+++ b/app/packages/web/src/components/app-layout.component.test.tsx
@@ -94,6 +94,19 @@ describe('AppLayout — skip link and nav landmarks', () => {
     expect(screen.getByRole('link', { name: 'Logs' })).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('link', { name: 'Dashboard' })).not.toHaveAttribute('aria-current');
   });
+
+  it('should render an Audit nav link and highlight it on /audit', () => {
+    render(
+      <PollingProvider>
+        <MemoryRouter initialEntries={['/audit']}>
+          <AppLayout>content</AppLayout>
+        </MemoryRouter>
+      </PollingProvider>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Audit' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Dashboard' })).not.toHaveAttribute('aria-current');
+  });
 });
 
 describe('AppLayout — LiveIndicator', () => {

--- a/app/packages/web/src/components/app-layout.component.tsx
+++ b/app/packages/web/src/components/app-layout.component.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   Menu,
   X,
+  History,
 } from 'lucide-react';
 
 interface NavItem {
@@ -36,6 +37,7 @@ const monitoringItems: NavItem[] = [
 const configItems: NavItem[] = [
   { to: '/games', icon: Gamepad2, label: 'Games' },
   { to: '/discord', icon: MessageSquare, label: 'Discord' },
+  { to: '/audit', icon: History, label: 'Audit' },
   { to: '/settings', icon: Settings, label: 'Settings' },
 ];
 

--- a/app/packages/web/src/components/audit-entry-row.component.test.tsx
+++ b/app/packages/web/src/components/audit-entry-row.component.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AuditEntry } from '../api.service.js';
+import { AuditEntryRow } from './audit-entry-row.component.js';
+
+/** A minimal `edit` audit entry fixture with both `before` and `after` populated. */
+const EDIT_ENTRY: AuditEntry = {
+  sk: '2026-07-01T00:00:00.000Z#01J000',
+  timestamp: '2026-07-01T00:00:00.000Z',
+  actor: 'alice',
+  action: 'edit',
+  game: 'minecraft',
+  before: { name: 'minecraft', image: 'itzg/minecraft-server:1', cpu: 1024, memory: 2048, ports: [], volumes: [] },
+  after: { name: 'minecraft', image: 'itzg/minecraft-server:2', cpu: 1024, memory: 2048, ports: [], volumes: [] },
+  versionId: 'v-123',
+};
+
+/** An `add` audit entry fixture — `before` is `null` and `versionId` is absent. */
+const ADD_ENTRY: AuditEntry = {
+  sk: '2026-07-02T00:00:00.000Z#01J001',
+  timestamp: '2026-07-02T00:00:00.000Z',
+  actor: 'bob',
+  action: 'add',
+  game: 'valheim',
+  before: null,
+  after: { name: 'valheim', image: 'lloesche/valheim-server', cpu: 512, memory: 1024, ports: [], volumes: [] },
+};
+
+/** Renders `AuditEntryRow` inside a minimal `<table>` shell, matching production usage. */
+function renderRow(entry: AuditEntry) {
+  return render(
+    <table>
+      <tbody>
+        <AuditEntryRow entry={entry} />
+      </tbody>
+    </table>,
+  );
+}
+
+describe('AuditEntryRow', () => {
+  it('should render the timestamp, actor, action, game, and versionId summary columns', () => {
+    renderRow(EDIT_ENTRY);
+
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('edit')).toBeInTheDocument();
+    expect(screen.getByText('minecraft')).toBeInTheDocument();
+    expect(screen.getByText('v-123')).toBeInTheDocument();
+  });
+
+  it('should render an em dash for a missing versionId', () => {
+    renderRow(ADD_ENTRY);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('should not render the before/after diff until expanded', () => {
+    renderRow(EDIT_ENTRY);
+
+    expect(screen.queryByText(/itzg\/minecraft-server:1/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/itzg\/minecraft-server:2/)).not.toBeInTheDocument();
+  });
+
+  it('should expand to show the before/after JSON diff in two pre blocks when the row is clicked', async () => {
+    renderRow(EDIT_ENTRY);
+
+    await userEvent.click(screen.getByRole('button', { name: /expand diff/i }));
+
+    const pres = screen.getAllByText(/itzg\/minecraft-server/, { selector: 'pre' });
+    expect(pres).toHaveLength(2);
+    expect(pres[0]).toHaveTextContent('itzg/minecraft-server:1');
+    expect(pres[1]).toHaveTextContent('itzg/minecraft-server:2');
+  });
+
+  it('should render "null" for a before value that is null (e.g. an add entry)', async () => {
+    renderRow(ADD_ENTRY);
+
+    await userEvent.click(screen.getByRole('button', { name: /expand diff/i }));
+
+    const pres = screen.getAllByRole('button', { name: /collapse diff/i });
+    expect(pres).toHaveLength(1);
+    expect(screen.getByText('null', { selector: 'pre' })).toBeInTheDocument();
+  });
+
+  it('should collapse the diff when the toggle is clicked again', async () => {
+    renderRow(EDIT_ENTRY);
+
+    const toggle = () => screen.getByRole('button', { name: /(expand|collapse) diff/i });
+    await userEvent.click(toggle());
+    expect(screen.getAllByText(/itzg\/minecraft-server/, { selector: 'pre' })).toHaveLength(2);
+
+    await userEvent.click(toggle());
+    expect(screen.queryByText(/itzg\/minecraft-server/, { selector: 'pre' })).not.toBeInTheDocument();
+  });
+});

--- a/app/packages/web/src/components/audit-entry-row.component.tsx
+++ b/app/packages/web/src/components/audit-entry-row.component.tsx
@@ -26,9 +26,9 @@ function formatDiffValue(value: unknown): string {
 
 /**
  * One row in the `/audit` table. Always shows the summary columns
- * (timestamp, actor, action, game, version id); clicking the row (or its
- * chevron) expands a second row underneath showing the raw `before`/`after`
- * JSON diff in two side-by-side `<pre>` blocks.
+ * (timestamp, actor, action, game, version id); clicking the chevron button
+ * expands a second row underneath showing the raw `before`/`after` JSON
+ * diff in two side-by-side `<pre>` blocks.
  */
 export function AuditEntryRow({ entry }: { entry: AuditEntry }) {
   const [expanded, setExpanded] = useState(false);
@@ -36,29 +36,15 @@ export function AuditEntryRow({ entry }: { entry: AuditEntry }) {
 
   return (
     <>
-      <TableRow
-        role="button"
-        tabIndex={0}
-        aria-expanded={expanded}
-        onClick={toggle}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            toggle();
-          }
-        }}
-        className="cursor-pointer"
-      >
+      <TableRow>
         <TableCell className="w-8">
           <Button
             variant="ghost"
             size="sm"
             className="h-6 w-6 p-0"
+            aria-expanded={expanded}
             aria-label={expanded ? 'Collapse diff' : 'Expand diff'}
-            onClick={(e) => {
-              e.stopPropagation();
-              toggle();
-            }}
+            onClick={toggle}
           >
             {expanded ? (
               <ChevronDown className="size-3.5" aria-hidden="true" />

--- a/app/packages/web/src/components/audit-entry-row.component.tsx
+++ b/app/packages/web/src/components/audit-entry-row.component.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { AuditAction, AuditEntry } from '../api.service.js';
+import { Badge } from '@/components/ui/badge.component';
+import { Button } from '@/components/ui/button.component';
+import { TableCell, TableRow } from '@/components/ui/table.component';
+import { cn } from '@/lib/utils.utils';
+
+/** Maps an {@link AuditAction} to the badge color variant used in the audit log. */
+const ACTION_BADGE_VARIANT: Record<AuditAction, 'success' | 'warning' | 'destructive'> = {
+  add: 'success',
+  edit: 'warning',
+  remove: 'destructive',
+};
+
+/** Format an ISO-8601 timestamp as a locale-aware date+time string, falling back to the raw value if unparseable. */
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+/** Pretty-print a `before`/`after` config for the expanded diff view, or `'null'` when absent. */
+function formatDiffValue(value: unknown): string {
+  return value === null || value === undefined ? 'null' : JSON.stringify(value, null, 2);
+}
+
+/**
+ * One row in the `/audit` table. Always shows the summary columns
+ * (timestamp, actor, action, game, version id); clicking the row (or its
+ * chevron) expands a second row underneath showing the raw `before`/`after`
+ * JSON diff in two side-by-side `<pre>` blocks.
+ */
+export function AuditEntryRow({ entry }: { entry: AuditEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const toggle = () => setExpanded((e) => !e);
+
+  return (
+    <>
+      <TableRow
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        className="cursor-pointer"
+      >
+        <TableCell className="w-8">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 p-0"
+            aria-label={expanded ? 'Collapse diff' : 'Expand diff'}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggle();
+            }}
+          >
+            {expanded ? (
+              <ChevronDown className="size-3.5" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="size-3.5" aria-hidden="true" />
+            )}
+          </Button>
+        </TableCell>
+        <TableCell className="font-[var(--font-mono)] text-xs whitespace-nowrap">
+          {formatTimestamp(entry.timestamp)}
+        </TableCell>
+        <TableCell>{entry.actor}</TableCell>
+        <TableCell>
+          <Badge variant={ACTION_BADGE_VARIANT[entry.action]} className="capitalize">
+            {entry.action}
+          </Badge>
+        </TableCell>
+        <TableCell className="capitalize">{entry.game}</TableCell>
+        <TableCell className="font-[var(--font-mono)] text-xs text-[var(--color-muted-foreground)]">
+          {entry.versionId ?? '—'}
+        </TableCell>
+      </TableRow>
+      {expanded && (
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={6} className="bg-[var(--color-surface-2)]/50">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div>
+                <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+                  Before
+                </div>
+                <pre
+                  className={cn(
+                    'overflow-x-auto rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-xs',
+                  )}
+                >
+                  {formatDiffValue(entry.before)}
+                </pre>
+              </div>
+              <div>
+                <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-[var(--color-muted-foreground)]">
+                  After
+                </div>
+                <pre
+                  className={cn(
+                    'overflow-x-auto rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-xs',
+                  )}
+                >
+                  {formatDiffValue(entry.after)}
+                </pre>
+              </div>
+            </div>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}

--- a/app/packages/web/src/pages/audit.page.test.tsx
+++ b/app/packages/web/src/pages/audit.page.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AuditEntry, AuditPageResult } from '../api.service.js';
+
+const apiMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  costsEstimate: vi.fn(),
+  audit: vi.fn(),
+}));
+vi.mock('../api.service.js', () => ({ api: apiMock }));
+
+import { AuditPage } from './audit.page.js';
+import { renderPage } from '../test-utils/render-page.utils.js';
+
+/** First page of two audit entries, with a cursor to an older page. */
+const PAGE_ONE: AuditPageResult = {
+  entries: [
+    {
+      sk: '2026-07-02T00:00:00.000Z#01J001',
+      timestamp: '2026-07-02T00:00:00.000Z',
+      actor: 'alice',
+      action: 'edit',
+      game: 'minecraft',
+      before: { name: 'minecraft', image: 'itzg/minecraft-server:1', cpu: 1024, memory: 2048, ports: [], volumes: [] },
+      after: { name: 'minecraft', image: 'itzg/minecraft-server:2', cpu: 1024, memory: 2048, ports: [], volumes: [] },
+      versionId: 'v-2',
+    },
+    {
+      sk: '2026-07-01T00:00:00.000Z#01J000',
+      timestamp: '2026-07-01T00:00:00.000Z',
+      actor: 'bob',
+      action: 'add',
+      game: 'valheim',
+      before: null,
+      after: { name: 'valheim', image: 'lloesche/valheim-server', cpu: 512, memory: 1024, ports: [], volumes: [] },
+      versionId: 'v-1',
+    },
+  ],
+  nextBefore: '2026-07-01T00:00:00.000Z#01J000',
+};
+
+/** Second, older page — no `nextBefore`, so "Load more" disappears after it's fetched. */
+const PAGE_TWO: AuditPageResult = {
+  entries: [
+    {
+      sk: '2026-06-30T00:00:00.000Z#01J-1',
+      timestamp: '2026-06-30T00:00:00.000Z',
+      actor: 'carol',
+      action: 'remove',
+      game: 'terraria',
+      before: { name: 'terraria', image: 'ryshe/terraria', cpu: 512, memory: 1024, ports: [], volumes: [] },
+      after: null,
+    },
+  ],
+};
+
+function entryFixture(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    sk: '2026-07-01T00:00:00.000Z#01J000',
+    timestamp: '2026-07-01T00:00:00.000Z',
+    actor: 'bob',
+    action: 'add',
+    game: 'valheim',
+    before: null,
+    after: { name: 'valheim', image: 'lloesche/valheim-server', cpu: 512, memory: 1024, ports: [], volumes: [] },
+    ...overrides,
+  };
+}
+
+describe('AuditPage', () => {
+  beforeEach(() => {
+    apiMock.status.mockResolvedValue([]);
+    apiMock.costsEstimate.mockResolvedValue({ games: {}, totalPerHourIfAllOn: 0 });
+    apiMock.audit.mockReset();
+  });
+
+  it('should fetch api.audit({ limit: 25 }) on mount', async () => {
+    apiMock.audit.mockResolvedValue({ entries: [] });
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    await waitFor(() => expect(apiMock.audit).toHaveBeenCalledWith({ limit: 25 }));
+  });
+
+  it('should render a loading state before the audit fetch resolves', () => {
+    apiMock.audit.mockReturnValue(new Promise(() => {}));
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('should render an empty state when there are no audit entries', async () => {
+    apiMock.audit.mockResolvedValue({ entries: [] });
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    expect(await screen.findByText('No audit entries yet.')).toBeInTheDocument();
+  });
+
+  it('should render an error state when the audit fetch fails', async () => {
+    apiMock.audit.mockRejectedValue(new Error('boom'));
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    expect(await screen.findByText('Could not load the audit log.')).toBeInTheDocument();
+  });
+
+  it('should render rows showing the timestamp, actor, action, game, and versionId for each entry', async () => {
+    apiMock.audit.mockResolvedValue(PAGE_ONE);
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('edit')).toBeInTheDocument();
+    expect(screen.getByText('minecraft')).toBeInTheDocument();
+    expect(screen.getByText('v-2')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByText('add')).toBeInTheDocument();
+    expect(screen.getByText('valheim')).toBeInTheDocument();
+    expect(screen.getByText('v-1')).toBeInTheDocument();
+  });
+
+  it('should expand a row to show the before/after JSON diff and collapse it again on a second click', async () => {
+    apiMock.audit.mockResolvedValue({ entries: [entryFixture()] });
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    await screen.findByText('bob');
+    expect(screen.queryByText(/lloesche\/valheim-server/, { selector: 'pre' })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /expand diff/i }));
+    expect(screen.getByText(/lloesche\/valheim-server/, { selector: 'pre' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse diff/i }));
+    expect(screen.queryByText(/lloesche\/valheim-server/, { selector: 'pre' })).not.toBeInTheDocument();
+  });
+
+  it('should show a "Load more" button when nextBefore is present, and hide it once the last page loads', async () => {
+    apiMock.audit.mockResolvedValue(PAGE_ONE);
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    await screen.findByText('alice');
+    expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument();
+  });
+
+  it('should not show a "Load more" button when the page has no nextBefore', async () => {
+    apiMock.audit.mockResolvedValue({ entries: [entryFixture()] });
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    await screen.findByText('bob');
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it('should pass nextBefore as before and append the next page of entries when "Load more" is clicked', async () => {
+    apiMock.audit.mockResolvedValueOnce(PAGE_ONE).mockResolvedValueOnce(PAGE_TWO);
+
+    renderPage(<AuditPage />, { initialEntries: ['/audit'] });
+
+    await screen.findByText('alice');
+    await userEvent.click(screen.getByRole('button', { name: /load more/i }));
+
+    await waitFor(() =>
+      expect(apiMock.audit).toHaveBeenCalledWith({ limit: 25, before: PAGE_ONE.nextBefore }),
+    );
+
+    // Both the original page's rows and the newly appended page's row are present.
+    expect(await screen.findByText('carol')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+
+    // The last page has no nextBefore, so "Load more" is gone.
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
+  });
+});

--- a/app/packages/web/src/pages/audit.page.tsx
+++ b/app/packages/web/src/pages/audit.page.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { api, type AuditEntry } from '../api.service.js';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.component';
+import { Button } from '@/components/ui/button.component';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table.component';
+import { AuditEntryRow } from '../components/audit-entry-row.component.js';
+import { PollingIndicator } from '../polling/polling-indicator.component.js';
+
+/** Number of audit entries fetched per page (initial load and each "Load more"). */
+const PAGE_SIZE = 25;
+
+/**
+ * Audit log route (`/audit`). Fetches the newest {@link PAGE_SIZE} entries on
+ * mount, renders them as expandable rows (see {@link AuditEntryRow}) showing
+ * the before/after `terraform.tfvars` diff for each mutation, and paginates
+ * older entries via a "Load more" button that passes the previous page's
+ * `nextBefore` cursor back to `api.audit()`.
+ */
+export function AuditPage() {
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [nextBefore, setNextBefore] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .audit({ limit: PAGE_SIZE })
+      .then((page) => {
+        if (cancelled) return;
+        setEntries(page.entries);
+        setNextBefore(page.nextBefore);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load the audit log.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loadMore = useCallback(() => {
+    if (!nextBefore) return;
+    setLoadingMore(true);
+    setError(null);
+    api
+      .audit({ limit: PAGE_SIZE, before: nextBefore })
+      .then((page) => {
+        setEntries((prev) => [...prev, ...page.entries]);
+        setNextBefore(page.nextBefore);
+      })
+      .catch(() => {
+        setError('Could not load more audit entries.');
+      })
+      .finally(() => {
+        setLoadingMore(false);
+      });
+  }, [nextBefore]);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-[var(--color-foreground)]">Audit Log</h2>
+          <p className="mt-1 text-sm text-[var(--color-muted-foreground)]">
+            Who changed which game&apos;s configuration, and what changed.
+          </p>
+        </div>
+        <PollingIndicator />
+      </header>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xs uppercase tracking-wider text-[var(--color-muted-foreground)]">
+            Recent changes
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex h-32 items-center justify-center gap-2 text-sm text-[var(--color-muted-foreground)]">
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              Loading…
+            </div>
+          ) : error && entries.length === 0 ? (
+            <div className="flex h-32 items-center justify-center text-sm text-[var(--color-red)]">
+              {error}
+            </div>
+          ) : entries.length === 0 ? (
+            <div className="flex h-32 items-center justify-center text-sm text-[var(--color-muted-foreground)]">
+              No audit entries yet.
+            </div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-8" />
+                    <TableHead>Timestamp</TableHead>
+                    <TableHead>Actor</TableHead>
+                    <TableHead>Action</TableHead>
+                    <TableHead>Game</TableHead>
+                    <TableHead>Version</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {entries.map((entry) => (
+                    <AuditEntryRow key={entry.sk} entry={entry} />
+                  ))}
+                </TableBody>
+              </Table>
+
+              {error && (
+                <p className="mt-3 text-xs text-[var(--color-red)]">{error}</p>
+              )}
+
+              {nextBefore && (
+                <div className="mt-4 flex justify-center">
+                  <Button variant="secondary" size="sm" onClick={loadMore} disabled={loadingMore}>
+                    {loadingMore ? (
+                      <>
+                        <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+                        Loading…
+                      </>
+                    ) : (
+                      'Load more'
+                    )}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -146,7 +146,7 @@ id and etag:
 | `base_allowed_guilds` | `list(string)` | `[]` | Guild IDs written to the `BASE#discord` row on every apply. The management UI shows these as locked; they cannot be removed via the UI. Update in tfvars + re-apply to change. |
 | `base_admin_user_ids` | `list(string)` | `[]` | Discord user IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
 | `base_admin_role_ids` | `list(string)` | `[]` | Discord role IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
-| `audit_table_name` | `string` | `""` → `{project_name}-audit` | Name of the DynamoDB audit log table (`aws/audit_store.tf`) recording who did what and when across the management app and the Discord bot. Empty defaults to `${project_name}-audit`. |
+| `audit_table_name` | `string` | `""` → `{project_name}-audit` | Name of the DynamoDB audit log table (`aws/audit_store.tf`) recording who did what and when for game-server configuration changes (add/edit/remove) made via the management app's UI. Does not cover Discord bot actions, server start/stop, or credential edits. Empty defaults to `${project_name}-audit`. |
 | `tfvars_bucket_name` | `string` | `null` → `{project_name}-tfvars` | Name of the versioned S3 bucket created by the [bootstrap module](#bootstrap-module-terraformbootstrap) to hold `terraform.tfvars` outside the operator's parent repo. Read via a `data "aws_s3_bucket" "tfvars"` source in root `main.tf`; must resolve to a bucket that already exists (see apply-before-main ordering below). |
 | `tags` | `map(string)` | defaults | Merged into `default_tags` for cost allocation (`Project`). |
 

--- a/docs/docs/components/terraform.md
+++ b/docs/docs/components/terraform.md
@@ -146,6 +146,7 @@ id and etag:
 | `base_allowed_guilds` | `list(string)` | `[]` | Guild IDs written to the `BASE#discord` row on every apply. The management UI shows these as locked; they cannot be removed via the UI. Update in tfvars + re-apply to change. |
 | `base_admin_user_ids` | `list(string)` | `[]` | Discord user IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
 | `base_admin_role_ids` | `list(string)` | `[]` | Discord role IDs with permanent server-wide admin rights. Same Terraform-managed floor as above. |
+| `audit_table_name` | `string` | `""` → `{project_name}-audit` | Name of the DynamoDB audit log table (`aws/audit_store.tf`) recording who did what and when across the management app and the Discord bot. Empty defaults to `${project_name}-audit`. |
 | `tfvars_bucket_name` | `string` | `null` → `{project_name}-tfvars` | Name of the versioned S3 bucket created by the [bootstrap module](#bootstrap-module-terraformbootstrap) to hold `terraform.tfvars` outside the operator's parent repo. Read via a `data "aws_s3_bucket" "tfvars"` source in root `main.tf`; must resolve to a bucket that already exists (see apply-before-main ordering below). |
 | `tags` | `map(string)` | defaults | Merged into `default_tags` for cost allocation (`Project`). |
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -558,8 +558,9 @@ CONFIG + PENDING rows), and two Secrets Manager secrets — all created by
 > **A second DynamoDB table, `audit_table_name`, is created unconditionally**
 > in the same `terraform apply` — it is not part of the Discord bot and
 > doesn't require any of the setup below. It records structured audit log
-> entries (who did what and when) for actions across the management app and
-> the Discord bot, e.g. server start/stop and credential edits. See
+> entries (who did what and when) for game-server configuration changes
+> (add/edit/remove) made via the management app's UI. It does not record
+> Discord bot actions, server start/stop, or credential edits. See
 > [`audit_table_name`](/components/terraform#variables) to override its name.
 
 1. **Create a Discord application** at

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -436,9 +436,11 @@ terraform apply
 
 `apply` takes 5–10 minutes end-to-end. It creates the VPC, two public
 subnets, an ECS cluster, one task definition + EFS access point +
-CloudWatch log group **per game**, the four Lambdas, a DynamoDB table, two
-Secrets Manager secrets, the EventBridge rule + schedule, and (if any game
-has `https = true`) an ALB with an ACM certificate.
+CloudWatch log group **per game**, the four Lambdas, two DynamoDB tables
+(Discord config/state and the audit log — see
+[step 7](#7-optional-wire-up-the-discord-bot)), two Secrets Manager secrets,
+the EventBridge rule + schedule, and (if any game has `https = true`) an ALB
+with an ACM certificate.
 
 When it finishes, note two outputs:
 
@@ -549,9 +551,16 @@ into the installer.
 
 ## 7. (Optional) Wire up the Discord bot
 
-The serverless bot is two Lambdas, one DynamoDB table, and two Secrets
-Manager secrets — all created by `terraform apply` in step 5. You now
-connect it to a Discord application.
+The serverless bot is two Lambdas, one DynamoDB table (`discord_table_name`,
+CONFIG + PENDING rows), and two Secrets Manager secrets — all created by
+`terraform apply` in step 5. You now connect it to a Discord application.
+
+> **A second DynamoDB table, `audit_table_name`, is created unconditionally**
+> in the same `terraform apply` — it is not part of the Discord bot and
+> doesn't require any of the setup below. It records structured audit log
+> entries (who did what and when) for actions across the management app and
+> the Discord bot, e.g. server start/stop and credential edits. See
+> [`audit_table_name`](/components/terraform#variables) to override its name.
 
 1. **Create a Discord application** at
    [discord.com/developers/applications](https://discord.com/developers/applications) → **New Application** →

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,10 +52,12 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.600.0",
         "@aws-sdk/client-cost-explorer": "^3.600.0",
+        "@aws-sdk/client-dynamodb": "^3.600.0",
         "@aws-sdk/client-ec2": "^3.600.0",
         "@aws-sdk/client-ecs": "^3.600.0",
         "@aws-sdk/client-s3": "^3.600.0",
         "@aws-sdk/client-secrets-manager": "^3.600.0",
+        "@aws-sdk/lib-dynamodb": "^3.600.0",
         "@hyveon/shared": "*"
       }
     },
@@ -164,6 +166,7 @@
         "@aws-sdk/client-dynamodb": "^3.600.0",
         "@aws-sdk/client-secrets-manager": "^3.600.0",
         "@aws-sdk/lib-dynamodb": "^3.600.0",
+        "ulid": "^3.0.2",
         "zod": "^3.23.8"
       }
     },
@@ -17726,6 +17729,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
+      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "dist/cli.js"
       }
     },
     "node_modules/unbox-primitive": {

--- a/terraform/aws/audit_store.tf
+++ b/terraform/aws/audit_store.tf
@@ -1,11 +1,13 @@
 # ──────────────────────────────────────────────────────────────────────────────
 # Audit log DynamoDB table
 #
-# Pay-per-request table recording who did what and when across the management
-# app and the Discord bot (e.g. server start/stop, credential edits). Items are
-# expected to use a partition key that groups related events (e.g. by date or
-# actor) and a sort key for ordering within the partition — schema details live
-# in the app layer, not here.
+# Pay-per-request table recording game-server config mutations (add/edit/
+# remove) made through the management app. All items live under a single
+# fixed partition (`pk = "AUDIT"`); the sort key is `<ISO timestamp>#<ULID>`
+# (see `buildAuditSk` in `@hyveon/shared/audit.ts`), so a query against that
+# partition with `ScanIndexForward: false` returns entries newest-first. See
+# `AwsAuditLogStore` in `app/packages/cloud-aws/src/AwsAuditLogStore.ts` for
+# the read/write implementation.
 # ──────────────────────────────────────────────────────────────────────────────
 
 resource "aws_dynamodb_table" "audit" {

--- a/terraform/aws/audit_store.tf
+++ b/terraform/aws/audit_store.tf
@@ -1,0 +1,31 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Audit log DynamoDB table
+#
+# Pay-per-request table recording who did what and when across the management
+# app and the Discord bot (e.g. server start/stop, credential edits). Items are
+# expected to use a partition key that groups related events (e.g. by date or
+# actor) and a sort key for ordering within the partition — schema details live
+# in the app layer, not here.
+# ──────────────────────────────────────────────────────────────────────────────
+
+resource "aws_dynamodb_table" "audit" {
+  name         = var.audit_table_name != "" ? var.audit_table_name : "${var.project_name}-audit"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = false
+  }
+
+  tags = { Name = var.audit_table_name != "" ? var.audit_table_name : "${var.project_name}-audit" }
+}

--- a/terraform/aws/audit_store.tf
+++ b/terraform/aws/audit_store.tf
@@ -26,7 +26,7 @@ resource "aws_dynamodb_table" "audit" {
   }
 
   point_in_time_recovery {
-    enabled = false
+    enabled = true
   }
 
   tags = { Name = var.audit_table_name != "" ? var.audit_table_name : "${var.project_name}-audit" }

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -118,3 +118,10 @@ output "watchdog_function_name" {
   description = "Watchdog Lambda function name"
   value       = aws_lambda_function.watchdog.function_name
 }
+
+# ── Audit log outputs ─────────────────────────────────────────────────────────
+
+output "audit_table_name" {
+  description = "DynamoDB table holding audit log entries"
+  value       = aws_dynamodb_table.audit.name
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -151,3 +151,11 @@ variable "discord_public_key" {
   default     = ""
   sensitive   = true
 }
+
+# ── Audit log ────────────────────────────────────────────────────────────────
+
+variable "audit_table_name" {
+  description = "Name of the DynamoDB audit log table. Defaults to \"$${project_name}-audit\" when empty."
+  type        = string
+  default     = ""
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,4 +87,6 @@ module "cloud" {
   discord_application_id = var.discord_application_id
   discord_bot_token      = var.discord_bot_token
   discord_public_key     = var.discord_public_key
+
+  audit_table_name = var.audit_table_name
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -116,6 +116,13 @@ output "watchdog_function_name" {
   value       = module.cloud[0].watchdog_function_name
 }
 
+# ── Audit log outputs ─────────────────────────────────────────────────────────
+
+output "audit_table_name" {
+  description = "DynamoDB table holding audit log entries"
+  value       = module.cloud[0].audit_table_name
+}
+
 # ── Bootstrap-created resources ──────────────────────────────────────────────
 
 output "tfvars_bucket_name" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -38,6 +38,10 @@ watchdog_min_packets      = 100
 # discord_bot_token      = "MTIz...xyz"
 # discord_public_key     = "0123abc..."
 
+# Name of the DynamoDB audit log table. Optional override — defaults to
+# "{project_name}-audit" when unset.
+# audit_table_name = "hyveon-audit"
+
 # Base allowlist / admins (optional — permanent floor managed by Terraform).
 # Guilds and admin user/role IDs listed here are written to a separate
 # BASE#discord DynamoDB row on every `terraform apply`. The management UI

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -163,6 +163,14 @@ variable "discord_public_key" {
   sensitive   = true
 }
 
+# ── Audit log ────────────────────────────────────────────────────────────────
+
+variable "audit_table_name" {
+  description = "Name of the DynamoDB audit log table. Defaults to \"$${project_name}-audit\" when empty."
+  type        = string
+  default     = ""
+}
+
 # ── Bootstrap ─────────────────────────────────────────────────────────────────
 
 variable "tfvars_bucket_name" {


### PR DESCRIPTION
Closes #102

## Summary

- Adds a new `${project_name}-audit` DynamoDB table (Terraform) and `AwsAuditLogStore` implementation, wired through the `AUDIT_LOG_STORE` DI token in `CloudProviderModule` alongside the existing cloud-agnostic contracts.
- Adds a Nest `AuditService` that `GamesWriteService` calls on every add/edit/remove mutation (capturing actor, action, game, before/after JSON, and the S3 `versionId` returned by `TfvarsService.write()`), exposed via `GET /api/audit` (IPC controller + HTTP shim), gated by the existing `ApiTokenGuard`.
- Adds a web `/audit` page (with a preload `gsd.audit.list` bridge and `api.audit()` client method) rendering the last N entries with expandable before/after diffs and cursor-based pagination, plus unit/component/e2e coverage and the four-file Terraform-variable checklist for `audit_table_name`.

## Changes

```
 app/packages/cloud-aws/package.json                |   2 +
 .../cloud-aws/src/AwsAuditLogStore.test.ts         | 178 +++++++++++++++++++++
 app/packages/cloud-aws/src/AwsAuditLogStore.ts     | 151 +++++++++++++++++
 .../cloud-aws/src/AwsRemoteFileStore.test.ts       |  20 +++
 app/packages/cloud-aws/src/AwsRemoteFileStore.ts   |   8 +-
 app/packages/cloud-aws/src/index.ts                |   1 +
 app/packages/desktop-main/src/app.module.ts        |   6 +
 .../src/controllers/audit-http.controller.test.ts  |  83 ++++++++++
 .../src/controllers/audit-http.controller.ts       |  47 ++++++
 .../src/controllers/audit.controller.test.ts       |  75 +++++++++
 .../src/controllers/audit.controller.ts            |  31 ++++
 .../games.controller.integration.test.ts           |  16 +-
 .../src/modules/cloud-provider.module.test.ts      |  52 +++++-
 .../src/modules/cloud-provider.module.ts           |  41 +++--
 .../src/modules/cloud-provider.tokens.ts           |   3 +
 .../desktop-main/src/services/AuditService.test.ts | 162 +++++++++++++++++++
 .../desktop-main/src/services/AuditService.ts      | 140 ++++++++++++++++
 .../src/services/ConfigService.test.ts             |  18 +++
 .../desktop-main/src/services/ConfigService.ts     |   2 +
 .../src/services/GamesWriteService.test.ts         | 149 +++++++++++++----
 .../desktop-main/src/services/GamesWriteService.ts |  68 ++++++--
 .../src/services/TfvarsService.s3.test.ts          |  29 +++-
 .../desktop-main/src/services/TfvarsService.ts     |  58 +++++--
 .../src/services/TfvarsService.write.test.ts       |  40 ++++-
 app/packages/desktop-preload/src/gsd-api.ts        |  62 +++++++
 app/packages/desktop-preload/src/preload.test.ts   |  19 +++
 app/packages/desktop-preload/src/preload.ts        |   4 +
 app/packages/shared/package.json                   |   1 +
 app/packages/shared/src/audit.test.ts              |  44 +++++
 app/packages/shared/src/audit.ts                   |  62 +++++++
 app/packages/shared/src/cloud.ts                   |  38 ++++-
 app/packages/shared/src/index.ts                   |   1 +
 app/packages/web/e2e/fixtures/gsd-http-bridge.ts   |   9 ++
 app/packages/web/e2e/fixtures/index.ts             |  37 ++++-
 app/packages/web/e2e/fixtures/tfstate.fixture.json |   1 +
 app/packages/web/e2e/pages/AuditPage.ts            |  61 +++++++
 app/packages/web/e2e/pages/index.ts                |   1 +
 app/packages/web/e2e/specs/audit.spec.ts           | 153 ++++++++++++++++++
 app/packages/web/src/api.service.test.ts           |  33 ++++
 app/packages/web/src/api.service.ts                |  52 ++++++
 app/packages/web/src/app.component.tsx             |   3 +
 .../src/components/app-layout.component.test.tsx   |  13 ++
 .../web/src/components/app-layout.component.tsx    |   2 +
 .../components/audit-entry-row.component.test.tsx  |  95 +++++++++++
 .../src/components/audit-entry-row.component.tsx   | 118 ++++++++++++++
 app/packages/web/src/pages/audit.page.test.tsx     | 178 +++++++++++++++++++++
 app/packages/web/src/pages/audit.page.tsx          | 149 +++++++++++++++++
 docs/docs/components/terraform.md                  |   1 +
 docs/docs/setup.md                                 |  22 ++-
 package-lock.json                                  |  12 ++
 terraform/aws/audit_store.tf                       |  33 ++++
 terraform/aws/outputs.tf                           |   7 +
 terraform/aws/variables.tf                         |   8 +
 terraform/main.tf                                  |   2 +
 terraform/outputs.tf                               |   7 +
 terraform/terraform.tfvars.example                 |   4 +
 terraform/variables.tf                             |   8 +
 57 files changed, 2532 insertions(+), 88 deletions(-)
```

## Test plan

- [x] CRUD mutation writes one audit row — covered by `GamesWriteService.test.ts` asserting `AuditService.record()` is called on add/edit/remove with actor, action, game, before/after, and versionId.
- [x] Audit page renders the last N entries with timestamps + actors + diffs — covered by `audit.page.test.tsx`, `audit-entry-row.component.test.tsx`, and the `audit.spec.ts` e2e spec (expandable diff assertions).
- [x] Pagination works — `AuditService.test.ts` and `audit.controller.test.ts` cover `limit`/`before` cursor params; `audit.page.test.tsx` and `audit.spec.ts` cover the "load more" flow.
- [x] Four-file Terraform-variable checklist updated for `audit_table_name` — `terraform/variables.tf`, `terraform/aws/variables.tf`, `terraform/main.tf`, `terraform/terraform.tfvars.example`, plus `docs/docs/components/terraform.md` and `docs/docs/setup.md`.
- [x] `npm run app:test` passing for touched workspaces (shared, cloud-aws, desktop-main, desktop-preload, web).
- [x] `npm run app:test:e2e` passing for the new chromium-project `audit.spec.ts`.
