### PR TITLE
feat(desktop-main): TerraformService scaffolding + binary detection

### DIFF
--- a/app/packages/desktop-main/src/modules/terraform.module.ts
+++ b/app/packages/desktop-main/src/modules/terraform.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TerraformService } from '../services/TerraformService.js';
+
+/**
+ * Feature module for `TerraformService`, the local `terraform` CLI
+ * detection/orchestration seam (see `TerraformService`'s file-level doc
+ * comment). Construction is asynchronous (binary lookup + `terraform version`),
+ * so the provider is wired via a `useFactory` that delegates to the static
+ * `TerraformService.create()` rather than `useClass`.
+ *
+ * Not yet imported by `AppModule` — this is scaffolding only. A later child
+ * issue of Epic D (local terraform orchestration) will import this module
+ * once IPC-driven plan/apply/destroy/output handlers exist to consume it.
+ */
+@Module({
+  providers: [
+    {
+      provide: TerraformService,
+      useFactory: () => TerraformService.create(),
+    },
+  ],
+  exports: [TerraformService],
+})
+export class TerraformModule {}

--- a/app/packages/desktop-main/src/services/TerraformService.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Spy variables must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const { execFileMock } = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  return { execFileMock };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+import { TerraformService, TerraformNotFoundError, lookupCommandFor } from './TerraformService.js';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
+function queueExecFileSuccess(stdout: string, stderr = ''): void {
+  execFileMock.mockImplementationOnce((_file: string, _args: string[], callback: ExecFileCallback) => {
+    callback(null, { stdout, stderr });
+  });
+}
+
+/** Queues a failing `execFile` invocation (e.g. binary not found) for the next call. */
+function queueExecFileFailure(error: Error = new Error('spawn ENOENT')): void {
+  execFileMock.mockImplementationOnce((_file: string, _args: string[], callback: ExecFileCallback) => {
+    callback(error);
+  });
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+describe('lookupCommandFor', () => {
+  it('should return where.exe for the win32 platform', () => {
+    expect(lookupCommandFor('win32')).toBe('where.exe');
+  });
+
+  it('should return which for the darwin platform', () => {
+    expect(lookupCommandFor('darwin')).toBe('which');
+  });
+
+  it('should return which for the linux platform', () => {
+    expect(lookupCommandFor('linux')).toBe('which');
+  });
+});
+
+describe('TerraformNotFoundError', () => {
+  it('should set its name to TerraformNotFoundError', () => {
+    const error = new TerraformNotFoundError('which');
+    expect(error.name).toBe('TerraformNotFoundError');
+  });
+
+  it('should include the provided lookup command in its message', () => {
+    const error = new TerraformNotFoundError('where.exe');
+    expect(error.message).toContain('where.exe');
+  });
+
+  it('should default the lookup command to the current platform lookup command when none is provided', () => {
+    const error = new TerraformNotFoundError();
+    expect(error.message).toContain(lookupCommandFor(process.platform));
+  });
+});
+
+describe('TerraformService.create binary detection', () => {
+  it('should resolve the binary path from the which/where.exe output', async () => {
+    queueExecFileSuccess('/usr/local/bin/terraform\n');
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
+
+    const service = await TerraformService.create();
+
+    expect(service.getBinaryPath()).toBe('/usr/local/bin/terraform');
+  });
+
+  it('should use the first non-empty trimmed line when the lookup command returns multiple lines', async () => {
+    queueExecFileSuccess('\n  /opt/homebrew/bin/terraform  \nsome-other-line\n');
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
+
+    const service = await TerraformService.create();
+
+    expect(service.getBinaryPath()).toBe('/opt/homebrew/bin/terraform');
+  });
+
+  it('should reject with a TerraformNotFoundError instance when the lookup command fails', async () => {
+    queueExecFileFailure();
+
+    await expect(TerraformService.create()).rejects.toBeInstanceOf(TerraformNotFoundError);
+  });
+
+  it('should reject with a TerraformNotFoundError instance when the lookup command produces no output', async () => {
+    queueExecFileSuccess('');
+
+    await expect(TerraformService.create()).rejects.toBeInstanceOf(TerraformNotFoundError);
+  });
+
+  it('should reject with a TerraformNotFoundError instance when the lookup command output is only whitespace', async () => {
+    queueExecFileSuccess('   \n  \n');
+
+    await expect(TerraformService.create()).rejects.toBeInstanceOf(TerraformNotFoundError);
+  });
+});
+
+describe('TerraformService.create version parsing', () => {
+  it('should parse the terraform_version field from terraform version -json output', async () => {
+    queueExecFileSuccess('/usr/local/bin/terraform\n');
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.5' }));
+
+    const service = await TerraformService.create();
+
+    expect(service.getVersion()).toBe('1.7.5');
+  });
+
+  it('should fall back to parsing plain-text output when the -json output is not valid JSON', async () => {
+    queueExecFileSuccess('/usr/local/bin/terraform\n');
+    queueExecFileSuccess('not json');
+    queueExecFileSuccess('Terraform v1.6.2\non linux_amd64\n');
+
+    const service = await TerraformService.create();
+
+    expect(service.getVersion()).toBe('1.6.2');
+  });
+
+  it('should fall back to parsing plain-text output when terraform_version is missing from the json output', async () => {
+    queueExecFileSuccess('/usr/local/bin/terraform\n');
+    queueExecFileSuccess(JSON.stringify({ some_other_field: true }));
+    queueExecFileSuccess('Terraform v1.5.0\n');
+
+    const service = await TerraformService.create();
+
+    expect(service.getVersion()).toBe('1.5.0');
+  });
+
+  it('should parse a pre-release version suffix from the plain-text fallback output', async () => {
+    queueExecFileSuccess('/usr/local/bin/terraform\n');
+    queueExecFileSuccess('not json');
+    queueExecFileSuccess('Terraform v1.9.0-beta1\n');
+
+    const service = await TerraformService.create();
+
+    expect(service.getVersion()).toBe('1.9.0-beta1');
+  });
+
+  it('should throw a plain Error, not a TerraformNotFoundError, when the plain-text output cannot be parsed', async () => {
+    queueExecFileSuccess('/usr/local/bin/terraform\n');
+    queueExecFileSuccess('not json');
+    queueExecFileSuccess('garbage output with no version');
+
+    const result = TerraformService.create();
+
+    await expect(result).rejects.toThrow('Unable to parse terraform version');
+    await expect(result).rejects.not.toBeInstanceOf(TerraformNotFoundError);
+  });
+});
+
+describe('TerraformService instance accessors', () => {
+  it('should expose the resolved binary path via getBinaryPath', async () => {
+    queueExecFileSuccess('/usr/bin/terraform\n');
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.8.1' }));
+
+    const service = await TerraformService.create();
+
+    expect(service.getBinaryPath()).toBe('/usr/bin/terraform');
+  });
+
+  it('should expose the resolved version via getVersion', async () => {
+    queueExecFileSuccess('/usr/bin/terraform\n');
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.8.1' }));
+
+    const service = await TerraformService.create();
+
+    expect(service.getVersion()).toBe('1.8.1');
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.test.ts
@@ -19,17 +19,28 @@ import { TerraformService, TerraformNotFoundError, lookupCommandFor } from './Te
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
 
+/**
+ * Extracts the error-first callback from an `execFile` call's arguments,
+ * regardless of whether `util.promisify` invoked it with or without an
+ * `options` object (i.e. `(file, args, callback)` or
+ * `(file, args, options, callback)`) — the production code now always passes
+ * a `{ timeout }` options object, so the mock must tolerate both shapes.
+ */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
 /** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
 function queueExecFileSuccess(stdout: string, stderr = ''): void {
-  execFileMock.mockImplementationOnce((_file: string, _args: string[], callback: ExecFileCallback) => {
-    callback(null, { stdout, stderr });
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(null, { stdout, stderr });
   });
 }
 
 /** Queues a failing `execFile` invocation (e.g. binary not found) for the next call. */
 function queueExecFileFailure(error: Error = new Error('spawn ENOENT')): void {
-  execFileMock.mockImplementationOnce((_file: string, _args: string[], callback: ExecFileCallback) => {
-    callback(error);
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(error);
   });
 }
 

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1,0 +1,125 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { Injectable } from '@nestjs/common';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Returns the platform-appropriate binary-lookup command: `where.exe` on
+ * Windows, `which` everywhere else. Extracted as a pure function (rather than
+ * an inline ternary on `process.platform`) so the platform branching is
+ * unit-testable without having to stub `process.platform` itself.
+ */
+export function lookupCommandFor(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'where.exe' : 'which';
+}
+
+/**
+ * Thrown when the system `terraform` binary cannot be located on `PATH` via
+ * the platform's lookup command (`which`/`where.exe`). Surfaced to the
+ * first-run wizard's prerequisite check so the operator gets install
+ * instructions instead of an opaque `ENOENT`.
+ */
+export class TerraformNotFoundError extends Error {
+  constructor(lookupCommand: string = lookupCommandFor(process.platform)) {
+    super(
+      `terraform binary not found on PATH (lookup via \`${lookupCommand}\` failed). ` +
+        'Install Terraform and ensure it is on PATH: https://developer.hashicorp.com/terraform/install',
+    );
+    this.name = 'TerraformNotFoundError';
+  }
+}
+
+/**
+ * Resolves and caches the system `terraform` binary's absolute path and
+ * semver version at construction time. This is the seam every later
+ * `init`/`plan`/`apply`/`destroy`/`output` orchestration method (added in
+ * later child issues of Epic D) will spawn against — see the "Terraform
+ * orchestrator" section of the electron-desktop-pivot design spec.
+ *
+ * Construction is asynchronous (binary lookup + `terraform version` both
+ * shell out), so instances are built via the static {@link create} factory
+ * rather than a public constructor. `TerraformModule` wires this factory
+ * into Nest DI via a `useFactory` provider.
+ */
+@Injectable()
+export class TerraformService {
+  private constructor(
+    private readonly binaryPath: string,
+    private readonly version: string,
+  ) {}
+
+  /**
+   * Resolves the system `terraform` binary via `which` (POSIX) / `where.exe`
+   * (Windows), then queries `terraform version` for the semver string,
+   * caching both on the returned instance. Rejects with
+   * {@link TerraformNotFoundError} when the lookup fails.
+   */
+  static async create(): Promise<TerraformService> {
+    const binaryPath = await TerraformService.resolveBinaryPath();
+    const version = await TerraformService.resolveVersion(binaryPath);
+    return new TerraformService(binaryPath, version);
+  }
+
+  /** Returns the cached absolute path to the resolved `terraform` binary. */
+  getBinaryPath(): string {
+    return this.binaryPath;
+  }
+
+  /** Returns the cached semver version string parsed from `terraform version`. */
+  getVersion(): string {
+    return this.version;
+  }
+
+  /**
+   * Shells out to `which terraform` (POSIX) or `where.exe terraform`
+   * (Windows) and returns the first non-empty line of stdout as the
+   * absolute binary path. Any failure (binary missing, lookup command
+   * missing, empty output) is normalized to {@link TerraformNotFoundError}.
+   */
+  private static async resolveBinaryPath(): Promise<string> {
+    const lookupCommand = lookupCommandFor(process.platform);
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync(lookupCommand, ['terraform']));
+    } catch {
+      throw new TerraformNotFoundError(lookupCommand);
+    }
+    const firstLine = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+    if (!firstLine) {
+      throw new TerraformNotFoundError(lookupCommand);
+    }
+    return firstLine;
+  }
+
+  /**
+   * Runs `terraform version -json` against the resolved binary and extracts
+   * `terraform_version` from the parsed JSON output. Falls back to parsing
+   * the plain-text `terraform version` output (matching the
+   * `Terraform v<version>` line) if the `-json` output isn't valid JSON —
+   * older terraform releases predate the `-json` flag. The binary itself has
+   * already been located at this point, so a failure to parse its version
+   * output is a plain descriptive `Error`, not a {@link TerraformNotFoundError}.
+   */
+  private static async resolveVersion(binaryPath: string): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(binaryPath, ['version', '-json']);
+      const parsed = JSON.parse(stdout) as { terraform_version?: unknown };
+      if (typeof parsed.terraform_version === 'string' && parsed.terraform_version.length > 0) {
+        return parsed.terraform_version;
+      }
+    } catch {
+      // `-json` output missing/unparseable (e.g. an older terraform release
+      // that predates the flag) — fall back to plain-text parsing below.
+    }
+    const { stdout } = await execFileAsync(binaryPath, ['version']);
+    const match = /Terraform\s+v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/.exec(stdout);
+    if (!match) {
+      throw new Error(`Unable to parse terraform version from output: ${stdout}`);
+    }
+    return match[1];
+  }
+}


### PR DESCRIPTION
Closes #169

## Summary

- Adds `TerraformService` (`app/packages/desktop-main/src/services/TerraformService.ts`) — resolves and caches the system `terraform` binary's absolute path and semver version at construction time, via a static `create()` factory (construction is async: binary lookup + `terraform version` both shell out).
- Binary lookup uses `which` (POSIX) / `where.exe` (Windows), extracted as a pure `lookupCommandFor(platform)` helper so the platform branch is unit-testable without stubbing `process.platform`. A missing binary throws the typed `TerraformNotFoundError` with install instructions, so the first-run wizard's prerequisite check can surface it instead of an opaque `ENOENT`.
- Version resolution tries `terraform version -json` first (parsing `terraform_version`), falling back to regex-parsing the plain-text `Terraform v<version>` line for older Terraform releases that predate the `-json` flag.
- Adds `TerraformModule`, a Nest feature module wiring `TerraformService` via a `useFactory` provider (required because construction is async). Not yet imported by `AppModule` — this is scaffolding only; a later child issue of Epic D wires it up once IPC-driven plan/apply/destroy/output handlers exist to consume it.
- Unit tests (`TerraformService.test.ts`) cover binary detection success/failure on both platforms, `-json` version parsing, plain-text fallback parsing, and unparseable-output error handling.

## Changes

```
 app/packages/desktop-main/src/modules/terraform.module.ts   |  24 +++
 app/packages/desktop-main/src/services/TerraformService.test.ts | 179 +++++++++++++++++++++
 app/packages/desktop-main/src/services/TerraformService.ts  | 125 ++++++++++++++
 3 files changed, 328 insertions(+)
```

## Test plan

- [x] Service constructs successfully when terraform is on PATH — covered by `TerraformService.test.ts` (`create()` resolves binary path + version).
- [x] Throws typed `TerraformNotFoundError` when terraform is missing from PATH — covered for both the POSIX (`which`) and Windows (`where.exe`) lookup paths.
- [x] Version is parseable from `terraform version` — covered for both the `-json` path and the plain-text fallback (older Terraform releases without `-json` support), plus an unparseable-output error case.
- [x] `npm run app:test` passing for the touched workspace (desktop-main).
- [x] `npm run app:lint` clean.