### PR TITLE
feat(desktop-main): TerraformService.init() with backend-config args

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -5,6 +5,7 @@ import { Module } from '@nestjs/common';
 import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
 import { TfvarsModule } from './modules/tfvars.module.js';
+import { TerraformModule } from './modules/terraform.module.js';
 import { GamesController } from './controllers/games.controller.js';
 import { GamesHttpController } from './controllers/games-http.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
@@ -24,6 +25,7 @@ import { DriftController } from './controllers/drift.controller.js';
 import { DriftHttpController } from './controllers/drift-http.controller.js';
 import { AuditController } from './controllers/audit.controller.js';
 import { AuditHttpController } from './controllers/audit-http.controller.js';
+import { TerraformController } from './controllers/terraform.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
 import { DriftService } from './services/DriftService.js';
 import { GamesWriteService } from './services/GamesWriteService.js';
@@ -33,10 +35,10 @@ import { AuditService } from './services/AuditService.js';
 
 /**
  * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`,
- * `TfvarsModule`) to the IPC controllers.
+ * `TfvarsModule`, `TerraformModule`) to the IPC controllers.
  */
 @Module({
-  imports: [AwsModule, DiscordModule, TfvarsModule],
+  imports: [AwsModule, DiscordModule, TfvarsModule, TerraformModule],
   controllers: [
     GamesController,
     GamesHttpController,
@@ -57,6 +59,7 @@ import { AuditService } from './services/AuditService.js';
     DriftHttpController,
     AuditController,
     AuditHttpController,
+    TerraformController,
   ],
   providers: [
     {

--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -42,9 +42,10 @@ const CONFIG: TerraformInitConfig = {
 
 /** Build a TerraformService stub whose `init` yields nothing by default. */
 function makeTerraform(): TerraformService {
-  return {
+  const stub: Partial<TerraformService> = {
     init: vi.fn().mockImplementation(async function* () { /* empty */ }),
-  } as unknown as TerraformService;
+  };
+  return stub as TerraformService;
 }
 
 /**
@@ -56,11 +57,15 @@ function makeCtx(isDestroyed = false) {
   const sender = {
     send: vi.fn(),
     isDestroyed: vi.fn().mockReturnValue(isDestroyed),
+    // `TerraformController.init` registers a `'destroyed'` listener (and
+    // removes it once the run settles) so it can abort immediately when the
+    // WebContents goes away instead of only checking `isDestroyed()` between
+    // chunks.
+    once: vi.fn(),
+    removeListener: vi.fn(),
   };
-  return {
-    ctx: { evt: { sender } } as unknown as { evt: { sender: typeof sender } },
-    sender,
-  };
+  const ctx: { evt: { sender: typeof sender } } = { evt: { sender } };
+  return { ctx, sender };
 }
 
 /** Flush the microtask queue so async fire-and-forget loops fully settle. */
@@ -159,7 +164,7 @@ describe('TerraformController', () => {
 
       const result = await new TerraformController(terraform).init(CONFIG, ctx);
 
-      expect(result).toEqual({ started: true });
+      expect(result).toEqual({ started: true, streamId: expect.any(String) });
     });
 
     it('should send each yielded chunk to the renderer via sender.send, in order', async () => {
@@ -179,7 +184,12 @@ describe('TerraformController', () => {
       await flushPromises();
 
       const chunkCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.init.chunk');
-      expect(chunkCalls.map(([, payload]) => payload)).toEqual(chunks);
+      // Every chunk payload is tagged with the same per-call streamId so the
+      // renderer (and a rejected concurrent call) can tell which run it
+      // belongs to.
+      const streamIds = new Set(chunkCalls.map(([, payload]) => (payload as { streamId: string }).streamId));
+      expect(streamIds.size).toBe(1);
+      expect(chunkCalls.map(([, payload]) => (payload as { chunk: TerraformRunChunk }).chunk)).toEqual(chunks);
     });
 
     it('should forward the config payload and an AbortSignal to TerraformService.init', async () => {
@@ -201,7 +211,7 @@ describe('TerraformController', () => {
       await new TerraformController(terraform).init(CONFIG, ctx);
       await flushPromises();
 
-      expect(sender.send).toHaveBeenCalledWith('terraform.init.end', { exitCode: 0 });
+      expect(sender.send).toHaveBeenCalledWith('terraform.init.end', { streamId: expect.any(String), exitCode: 0 });
       const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.init.end');
       expect(endCall?.[1]).not.toHaveProperty('error');
     });

--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -1,0 +1,273 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TerraformController } from './terraform.controller.js';
+import { TerraformInitError, type TerraformInitConfig, type TerraformRunChunk } from '../services/TerraformService.js';
+import type { TerraformService } from '../services/TerraformService.js';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state — must be declared before any vi.mock() factory runs.
+// ---------------------------------------------------------------------------
+
+/**
+ * Captures every `ipcMain.handle`/`ipcMain.removeHandler` call so tests can
+ * assert on routing registration without a real Electron main process.
+ */
+const { mockIpcMainHandle, mockIpcMainRemoveHandler } = vi.hoisted(() => {
+  const mockIpcMainHandle = vi.fn();
+  const mockIpcMainRemoveHandler = vi.fn();
+  return { mockIpcMainHandle, mockIpcMainRemoveHandler };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mockIpcMainHandle,
+    removeHandler: mockIpcMainRemoveHandler,
+  },
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** A minimal backend config payload shared across test cases. */
+const CONFIG: TerraformInitConfig = {
+  bucket: 'hyveon-tf-state',
+  region: 'us-east-1',
+  dynamodbTable: 'hyveon-tf-locks',
+};
+
+/** Build a TerraformService stub whose `init` yields nothing by default. */
+function makeTerraform(): TerraformService {
+  return {
+    init: vi.fn().mockImplementation(async function* () { /* empty */ }),
+  } as unknown as TerraformService;
+}
+
+/**
+ * Build a minimal `IpcMainInvokeEvent` stub with a controlled `sender`
+ * (WebContents). Tests can inspect calls on `sender.send` and control the
+ * return value of `sender.isDestroyed()`.
+ */
+function makeCtx(isDestroyed = false) {
+  const sender = {
+    send: vi.fn(),
+    isDestroyed: vi.fn().mockReturnValue(isDestroyed),
+  };
+  return {
+    ctx: { evt: { sender } } as unknown as { evt: { sender: typeof sender } },
+    sender,
+  };
+}
+
+/** Flush the microtask queue so async fire-and-forget loops fully settle. */
+function flushPromises(): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * The metadata key NestJS stores on each method decorated with
+ * `@MessagePattern`. Asserting this value guards against typos in the
+ * channel name that would silently break IPC routing.
+ */
+const PATTERN_METADATA_KEY = 'microservices:pattern';
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('TerraformController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // @MessagePattern channel name registration
+  // -------------------------------------------------------------------------
+
+  describe('@MessagePattern channel names', () => {
+    it('should register init on the "terraform.init" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.init);
+      expect(pattern).toEqual(['terraform.init']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // onModuleInit — ipcMain.handle bridge for terraform.init
+  // -------------------------------------------------------------------------
+
+  describe('onModuleInit', () => {
+    // onModuleInit only wires the bridge when running inside a real Electron
+    // main process, detected via `process.versions.electron`. Vitest runs under
+    // plain Node where it's undefined, so fake it for the "is Electron" cases
+    // and restore afterwards.
+    const realElectronVersion = process.versions.electron;
+    const setElectron = (value: string | undefined): void => {
+      if (value === undefined) {
+        delete (process.versions as { electron?: string }).electron;
+      } else {
+        Object.defineProperty(process.versions, 'electron', { value, configurable: true });
+      }
+    };
+    beforeEach(() => setElectron('30.0.0'));
+    afterEach(() => setElectron(realElectronVersion));
+
+    it('should skip the ipcMain bridge when not running inside an Electron main process', async () => {
+      // Plain-Node runtimes (integration test server, Docker, CI) have no
+      // `process.versions.electron`; importing electron there would throw, so
+      // the bridge must be skipped without touching ipcMain at all.
+      setElectron(undefined);
+      await new TerraformController(makeTerraform()).onModuleInit();
+      expect(mockIpcMainHandle).not.toHaveBeenCalled();
+      expect(mockIpcMainRemoveHandler).not.toHaveBeenCalled();
+    });
+
+    it('should register ipcMain.handle for "terraform.init" so ipcRenderer.invoke can resolve', async () => {
+      await new TerraformController(makeTerraform()).onModuleInit();
+      expect(mockIpcMainHandle).toHaveBeenCalledWith('terraform.init', expect.any(Function));
+    });
+
+    it('should remove any existing "terraform.init" handler before registering so hot-reload re-bootstrap does not throw', async () => {
+      // A second bootstrap (hot-reload / dev restart) would otherwise hit
+      // "Attempted to register a second handler for 'terraform.init'".
+      // Clearing the handler first keeps re-registration idempotent.
+      await new TerraformController(makeTerraform()).onModuleInit();
+      expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith('terraform.init');
+      expect(mockIpcMainRemoveHandler.mock.invocationCallOrder[0]).toBeLessThan(
+        mockIpcMainHandle.mock.invocationCallOrder[0],
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // init
+  // -------------------------------------------------------------------------
+
+  describe('init', () => {
+    it('should return { started: true } immediately without waiting for the run to settle', async () => {
+      // TerraformService.init never yields/returns on its own here, so if
+      // init() awaited the whole loop synchronously this call would hang.
+      const terraform = makeTerraform();
+      // eslint-disable-next-line require-yield -- generator intentionally never yields/returns to prove init() doesn't await it
+      vi.mocked(terraform.init).mockImplementation(async function* () {
+        await new Promise<void>(() => { /* never resolves */ });
+      });
+      const { ctx } = makeCtx();
+
+      const result = await new TerraformController(terraform).init(CONFIG, ctx);
+
+      expect(result).toEqual({ started: true });
+    });
+
+    it('should send each yielded chunk to the renderer via sender.send, in order', async () => {
+      const chunks: TerraformRunChunk[] = [
+        { stream: 'stdout', line: 'Initializing the backend...' },
+        { stream: 'stdout', line: 'Initializing provider plugins...' },
+        { stream: 'stdout', line: 'Terraform has been successfully initialized!' },
+      ];
+      async function* yieldChunks() {
+        for (const chunk of chunks) yield chunk;
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.init).mockImplementation(yieldChunks);
+      const { ctx, sender } = makeCtx();
+
+      await new TerraformController(terraform).init(CONFIG, ctx);
+      await flushPromises();
+
+      const chunkCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.init.chunk');
+      expect(chunkCalls.map(([, payload]) => payload)).toEqual(chunks);
+    });
+
+    it('should forward the config payload and an AbortSignal to TerraformService.init', async () => {
+      const terraform = makeTerraform();
+      const { ctx } = makeCtx();
+
+      await new TerraformController(terraform).init(CONFIG, ctx);
+      await flushPromises();
+
+      expect(terraform.init).toHaveBeenCalledWith(CONFIG, expect.any(AbortSignal));
+    });
+
+    it('should send an end message with exitCode 0 and no error when the run succeeds', async () => {
+      async function* empty() { /* no chunks, generator returns normally */ }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.init).mockImplementation(empty);
+      const { ctx, sender } = makeCtx();
+
+      await new TerraformController(terraform).init(CONFIG, ctx);
+      await flushPromises();
+
+      expect(sender.send).toHaveBeenCalledWith('terraform.init.end', { exitCode: 0 });
+      const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.init.end');
+      expect(endCall?.[1]).not.toHaveProperty('error');
+    });
+
+    it('should send an end message with the process exit code and a stringified error on TerraformInitError', async () => {
+      async function* failsWithExitCode(): AsyncGenerator<TerraformRunChunk> {
+        yield { stream: 'stderr', line: 'Error configuring backend "s3"' };
+        throw new TerraformInitError(1);
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.init).mockImplementation(failsWithExitCode);
+      const { ctx, sender } = makeCtx();
+
+      await new TerraformController(terraform).init(CONFIG, ctx);
+      await flushPromises();
+
+      const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.init.end');
+      expect(endCall?.[1]).toMatchObject({ exitCode: 1 });
+      expect(String(endCall?.[1]?.error)).toContain('terraform init exited with code 1');
+    });
+
+    it('should send an end message with a null exitCode for a non-process failure (e.g. binary not found)', async () => {
+      // eslint-disable-next-line require-yield -- generator must throw before yielding to simulate a pre-spawn failure
+      async function* failsWithoutExitCode(): AsyncGenerator<TerraformRunChunk> {
+        throw new Error('terraform binary not found on PATH');
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.init).mockImplementation(failsWithoutExitCode);
+      const { ctx, sender } = makeCtx();
+
+      await new TerraformController(terraform).init(CONFIG, ctx);
+      await flushPromises();
+
+      const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.init.end');
+      expect(endCall?.[1]).toMatchObject({ exitCode: null });
+      expect(String(endCall?.[1]?.error)).toContain('terraform binary not found on PATH');
+    });
+
+    it('should not send further chunks or an end message once the WebContents is destroyed', async () => {
+      async function* twoLines(): AsyncGenerator<TerraformRunChunk> {
+        yield { stream: 'stdout', line: 'first' };
+        yield { stream: 'stdout', line: 'second' };
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.init).mockImplementation(twoLines);
+      // Simulate WebContents already destroyed before the loop runs.
+      const { ctx, sender } = makeCtx(true);
+
+      await new TerraformController(terraform).init(CONFIG, ctx);
+      await flushPromises();
+
+      expect(sender.send).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } and never call TerraformService.init when the payload fails validation', async () => {
+      const terraform = makeTerraform();
+      const { ctx, sender } = makeCtx();
+      const invalidConfig = { bucket: '', region: 'us-east-1', dynamodbTable: 'hyveon-tf-locks' };
+
+      const result = await new TerraformController(terraform).init(invalidConfig, ctx);
+      await flushPromises();
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.init).not.toHaveBeenCalled();
+      expect(sender.send).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/terraform.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.ts
@@ -1,7 +1,13 @@
+import { randomUUID } from 'node:crypto';
 import { Controller, OnModuleInit } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
-import { TerraformService, TerraformInitError, type TerraformInitConfig } from '../services/TerraformService.js';
+import {
+  TerraformService,
+  TerraformInitError,
+  type TerraformInitConfig,
+  type TerraformRunChunk,
+} from '../services/TerraformService.js';
 import { logger } from '../logger.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -11,13 +17,29 @@ const CHUNK_CHANNEL = 'terraform.init.chunk';
 const END_CHANNEL = 'terraform.init.end';
 
 /**
+ * Message payload sent, in order, on {@link CHUNK_CHANNEL} for every chunk
+ * `TerraformService.init` yields. `streamId` ties the chunk back to the
+ * `init()` call that produced it (see {@link TerraformInitAck.streamId}) so
+ * the renderer — and a second, rejected concurrent call — can never mix up
+ * output from two overlapping runs.
+ */
+interface TerraformInitChunkMessage {
+  streamId: string;
+  chunk: TerraformRunChunk;
+}
+
+/**
  * Message payload sent once on {@link END_CHANNEL} when a `terraform.init`
- * run finishes. `exitCode` is `0` on success. On failure it carries whatever
- * exit code the spawned process reported (or `null` when the run failed
+ * run finishes. `streamId` identifies which `init()` call this terminates
+ * (see {@link TerraformInitAck.streamId}) so a rejected/second concurrent
+ * call can't broadcast an end event that the first caller mistakes for its
+ * own. `exitCode` is `0` on success. On failure it carries whatever exit
+ * code the spawned process reported (or `null` when the run failed
  * before/without an exit code, e.g. the binary couldn't be resolved or a
  * second `init` was already in flight), plus a stringified `error`.
  */
 interface TerraformInitEndMessage {
+  streamId: string;
   exitCode: number | null;
   error?: string;
 }
@@ -25,12 +47,13 @@ interface TerraformInitEndMessage {
 /**
  * Immediate acknowledgement `init()` resolves with. `started: true` means the
  * streaming loop was kicked off in the background (chunk/end messages will
- * follow on the side channels). `started: false` means `config` failed
- * validation and no `TerraformService.init` run was attempted — `error`
- * describes why.
+ * follow on the side channels, tagged with `streamId`). `started: false`
+ * means `config` failed validation and no `TerraformService.init` run was
+ * attempted — `error` describes why and `streamId` is omitted.
  */
 interface TerraformInitAck {
   started: boolean;
+  streamId?: string;
   error?: string;
 }
 
@@ -45,6 +68,15 @@ interface TerraformInitAck {
 @Controller()
 export class TerraformController implements OnModuleInit {
   constructor(private readonly terraform: TerraformService) {}
+
+  /**
+   * Per-call `AbortController`s keyed by the `streamId` minted in
+   * {@link init}. Lets a future `terraform.init.cancel` channel reach the
+   * right in-flight run, and lets the `WebContents` `'destroyed'` listener in
+   * {@link init} abort immediately without racing the chunk loop's own
+   * `isDestroyed()` check.
+   */
+  private readonly activeInits = new Map<string, AbortController>();
 
   /**
    * Registers an `ipcMain.handle` bridge for the `terraform.init` channel
@@ -90,24 +122,33 @@ export class TerraformController implements OnModuleInit {
    * run is attempted and the method resolves immediately with
    * `{ started: false, error }` — no chunk/end messages are sent.
    *
-   * Otherwise the streaming loop is fired and forgotten (mirroring
-   * `LogsController.streamLogs`'s `void (async () => { ... })()` pattern) and
-   * the method resolves immediately with `{ started: true }`, well before the
-   * `terraform init` run itself settles. Each chunk `TerraformService.init`
-   * yields is forwarded, in order, to the renderer via `sender.send` on
-   * {@link CHUNK_CHANNEL}. Once the run settles a single terminal message is
-   * sent on {@link END_CHANNEL}: `{ exitCode: 0 }` on success, or
-   * `{ exitCode, error }` on failure — `exitCode` comes from
+   * Otherwise a per-call `streamId` (`randomUUID()`) is minted and returned
+   * in the ack, and the streaming loop is fired and forgotten (mirroring
+   * `LogsController.streamLogs`'s `void (async () => { ... })()` pattern);
+   * the method resolves immediately with `{ started: true, streamId }`, well
+   * before the `terraform init` run itself settles. Every chunk/end message
+   * is tagged with that same `streamId` so the renderer — and a second,
+   * rejected concurrent call — can always tell which run a message belongs
+   * to and never cross-terminate another caller's stream. Each chunk
+   * `TerraformService.init` yields is forwarded, in order, to the renderer
+   * via `sender.send` on {@link CHUNK_CHANNEL} as
+   * `{ streamId, chunk }`. Once the run settles a single terminal message is
+   * sent on {@link END_CHANNEL}: `{ streamId, exitCode: 0 }` on success, or
+   * `{ streamId, exitCode, error }` on failure — `exitCode` comes from
    * {@link TerraformInitError} when the spawned process exited non-zero, and
    * is `null` for any other failure (binary not found, a second `init`
    * already in flight, a spawn error, etc).
    *
    * Creates its own `AbortController` per invocation (the same reasoning as
    * `LogsController.streamLogs`: `ElectronIPCTransport` passes `{ evt }` as
-   * the execution context, so there's no `signal` injected by the transport)
-   * and passes its `signal` through to `TerraformService.init` so a future
-   * cancel channel (or WebContents-destroyed cleanup) has something to abort
-   * against.
+   * the execution context, so there's no `signal` injected by the transport),
+   * registers it in {@link activeInits} keyed by `streamId` so a future
+   * cancel channel can reach it, and passes its `signal` through to
+   * `TerraformService.init`. A `'destroyed'` listener on the `WebContents`
+   * aborts the controller the instant the window/webview goes away, rather
+   * than relying solely on the chunk loop's own `isDestroyed()` check (which
+   * only re-evaluates between chunks and never fires at all once
+   * `TerraformService.init` stops yielding).
    *
    * Reachable via the Electron IPC transport (`terraform.init`).
    */
@@ -123,7 +164,16 @@ export class TerraformController implements OnModuleInit {
     }
 
     const sender: WebContents = ctx.evt.sender;
+    const streamId = randomUUID();
     const ac = new AbortController();
+    this.activeInits.set(streamId, ac);
+
+    const onDestroyed = () => ac.abort();
+    sender.once('destroyed', onDestroyed);
+    const cleanup = () => {
+      this.activeInits.delete(streamId);
+      sender.removeListener('destroyed', onDestroyed);
+    };
 
     // Fire-and-forget the streaming loop. Chunks are pushed back to the
     // renderer directly via WebContents.send rather than through the normal
@@ -132,23 +182,26 @@ export class TerraformController implements OnModuleInit {
       try {
         for await (const chunk of this.terraform.init(config, ac.signal)) {
           if (sender.isDestroyed()) { ac.abort(); return; }
-          sender.send(CHUNK_CHANNEL, chunk);
+          const chunkMessage: TerraformInitChunkMessage = { streamId, chunk };
+          sender.send(CHUNK_CHANNEL, chunkMessage);
         }
         if (!sender.isDestroyed()) {
-          const message: TerraformInitEndMessage = { exitCode: 0 };
+          const message: TerraformInitEndMessage = { streamId, exitCode: 0 };
           sender.send(END_CHANNEL, message);
         }
       } catch (err) {
         logger.error('terraform init error', { err });
         if (!sender.isDestroyed()) {
           const exitCode = err instanceof TerraformInitError ? err.exitCode : null;
-          const message: TerraformInitEndMessage = { exitCode, error: String(err) };
+          const message: TerraformInitEndMessage = { streamId, exitCode, error: String(err) };
           sender.send(END_CHANNEL, message);
         }
+      } finally {
+        cleanup();
       }
     })();
 
-    return { started: true };
+    return { started: true, streamId };
   }
 
   /**

--- a/app/packages/desktop-main/src/controllers/terraform.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.ts
@@ -1,0 +1,172 @@
+import { Controller, OnModuleInit } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
+import { TerraformService, TerraformInitError, type TerraformInitConfig } from '../services/TerraformService.js';
+import { logger } from '../logger.js';
+
+/** Fixed side-channel `TerraformController.init` pushes streamed output on. */
+const CHUNK_CHANNEL = 'terraform.init.chunk';
+
+/** Fixed side-channel `TerraformController.init` sends its terminal message on. */
+const END_CHANNEL = 'terraform.init.end';
+
+/**
+ * Message payload sent once on {@link END_CHANNEL} when a `terraform.init`
+ * run finishes. `exitCode` is `0` on success. On failure it carries whatever
+ * exit code the spawned process reported (or `null` when the run failed
+ * before/without an exit code, e.g. the binary couldn't be resolved or a
+ * second `init` was already in flight), plus a stringified `error`.
+ */
+interface TerraformInitEndMessage {
+  exitCode: number | null;
+  error?: string;
+}
+
+/**
+ * Immediate acknowledgement `init()` resolves with. `started: true` means the
+ * streaming loop was kicked off in the background (chunk/end messages will
+ * follow on the side channels). `started: false` means `config` failed
+ * validation and no `TerraformService.init` run was attempted — `error`
+ * describes why.
+ */
+interface TerraformInitAck {
+  started: boolean;
+  error?: string;
+}
+
+/**
+ * IPC-only Terraform controller. Handles Electron main-process messages via
+ * `@MessagePattern` — no HTTP routes are registered here.
+ *
+ * Bridges {@link TerraformService.init}'s async-generator output onto the
+ * fixed `terraform.init.chunk` / `terraform.init.end` side channels so the
+ * renderer's first-run wizard can render `terraform init` output live.
+ */
+@Controller()
+export class TerraformController implements OnModuleInit {
+  constructor(private readonly terraform: TerraformService) {}
+
+  /**
+   * Registers an `ipcMain.handle` bridge for the `terraform.init` channel
+   * after the Nest module initialises, so that
+   * `ipcRenderer.invoke('terraform.init', config)` in the preload actually
+   * resolves.
+   *
+   * `@MessagePattern('terraform.init')` only wires the transport's internal
+   * dispatcher — it does **not** call `ipcMain.handle`, so `ipcRenderer.invoke`
+   * would otherwise hang. This hook bridges the gap, mirroring
+   * `LogsController.onModuleInit`'s handling of `logs.stream` — see
+   * `SELF_BRIDGED_PATTERNS` in `../ipc-main-bridge.ts`, which excludes
+   * `terraform.init` from the generic bridge for the same reason: the handler
+   * pushes follow-up chunk/end messages over side channels for the duration
+   * of a long-running run rather than resolving a single value.
+   *
+   * Only runs inside a real Electron main process. In plain-Node runtimes
+   * (integration test server, Docker, CI) `process.versions.electron` is
+   * undefined and importing `electron` would throw, so the bridge is skipped
+   * entirely rather than guessing which error means "no Electron" from the
+   * message.
+   */
+  async onModuleInit(): Promise<void> {
+    if (!process.versions.electron) {
+      // Not running inside the Electron main process — ipcMain bridge skipped.
+      return;
+    }
+    const { ipcMain } = (await import('electron')) as unknown as { ipcMain: IpcMain };
+    // Remove any existing handler first so hot-reload re-registration does
+    // not throw "IPC channel already registered".
+    ipcMain.removeHandler('terraform.init');
+    ipcMain.handle('terraform.init', (evt, config: TerraformInitConfig) =>
+      this.init(config, { evt: evt as IpcMainInvokeEvent }),
+    );
+  }
+
+  /**
+   * Kicks off `terraform init` against `config` and streams its output back
+   * to the renderer.
+   *
+   * Validates `config` first: `bucket`, `region`, and `dynamodbTable` must
+   * all be non-empty strings. If validation fails, no `TerraformService.init`
+   * run is attempted and the method resolves immediately with
+   * `{ started: false, error }` — no chunk/end messages are sent.
+   *
+   * Otherwise the streaming loop is fired and forgotten (mirroring
+   * `LogsController.streamLogs`'s `void (async () => { ... })()` pattern) and
+   * the method resolves immediately with `{ started: true }`, well before the
+   * `terraform init` run itself settles. Each chunk `TerraformService.init`
+   * yields is forwarded, in order, to the renderer via `sender.send` on
+   * {@link CHUNK_CHANNEL}. Once the run settles a single terminal message is
+   * sent on {@link END_CHANNEL}: `{ exitCode: 0 }` on success, or
+   * `{ exitCode, error }` on failure — `exitCode` comes from
+   * {@link TerraformInitError} when the spawned process exited non-zero, and
+   * is `null` for any other failure (binary not found, a second `init`
+   * already in flight, a spawn error, etc).
+   *
+   * Creates its own `AbortController` per invocation (the same reasoning as
+   * `LogsController.streamLogs`: `ElectronIPCTransport` passes `{ evt }` as
+   * the execution context, so there's no `signal` injected by the transport)
+   * and passes its `signal` through to `TerraformService.init` so a future
+   * cancel channel (or WebContents-destroyed cleanup) has something to abort
+   * against.
+   *
+   * Reachable via the Electron IPC transport (`terraform.init`).
+   */
+  @MessagePattern('terraform.init')
+  async init(
+    @Payload() config: TerraformInitConfig,
+    ctx: { evt: IpcMainInvokeEvent },
+  ): Promise<TerraformInitAck> {
+    const validationError = TerraformController.validateConfig(config);
+    if (validationError) {
+      logger.error('terraform init rejected: invalid config', { error: validationError });
+      return { started: false, error: validationError };
+    }
+
+    const sender: WebContents = ctx.evt.sender;
+    const ac = new AbortController();
+
+    // Fire-and-forget the streaming loop. Chunks are pushed back to the
+    // renderer directly via WebContents.send rather than through the normal
+    // invoke reply mechanism, which only supports a single return value.
+    void (async () => {
+      try {
+        for await (const chunk of this.terraform.init(config, ac.signal)) {
+          if (sender.isDestroyed()) { ac.abort(); return; }
+          sender.send(CHUNK_CHANNEL, chunk);
+        }
+        if (!sender.isDestroyed()) {
+          const message: TerraformInitEndMessage = { exitCode: 0 };
+          sender.send(END_CHANNEL, message);
+        }
+      } catch (err) {
+        logger.error('terraform init error', { err });
+        if (!sender.isDestroyed()) {
+          const exitCode = err instanceof TerraformInitError ? err.exitCode : null;
+          const message: TerraformInitEndMessage = { exitCode, error: String(err) };
+          sender.send(END_CHANNEL, message);
+        }
+      }
+    })();
+
+    return { started: true };
+  }
+
+  /**
+   * Validates that `config.bucket`, `config.region`, and
+   * `config.dynamodbTable` are all non-empty strings. Returns a descriptive
+   * error message when validation fails, or `null` when `config` is valid.
+   */
+  private static validateConfig(config: TerraformInitConfig): string | null {
+    const isNonEmptyString = (value: unknown): value is string =>
+      typeof value === 'string' && value.length > 0;
+
+    if (
+      !isNonEmptyString(config?.bucket) ||
+      !isNonEmptyString(config?.region) ||
+      !isNonEmptyString(config?.dynamodbTable)
+    ) {
+      return 'terraform.init requires non-empty bucket, region, and dynamodbTable strings';
+    }
+    return null;
+  }
+}

--- a/app/packages/desktop-main/src/ipc-main-bridge.test.ts
+++ b/app/packages/desktop-main/src/ipc-main-bridge.test.ts
@@ -134,6 +134,20 @@ describe('registerIpcMainBridges', () => {
     expect(mockIpcMainHandle).toHaveBeenCalledWith('logs.get', expect.any(Function));
   });
 
+  it('should skip "terraform.init" entirely, leaving it to bridge itself', async () => {
+    expect(SELF_BRIDGED_PATTERNS.has('terraform.init')).toBe(true);
+
+    const { transport } = makeTransport(['terraform.init', 'games.list']);
+
+    await registerIpcMainBridges(transport);
+
+    expect(mockIpcMainRemoveHandler).not.toHaveBeenCalledWith('terraform.init');
+    expect(mockIpcMainHandle).not.toHaveBeenCalledWith('terraform.init', expect.any(Function));
+    // The sibling pattern on the same map is still bridged normally.
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith('games.list');
+    expect(mockIpcMainHandle).toHaveBeenCalledWith('games.list', expect.any(Function));
+  });
+
   it('should be a no-op when the transport has no registered handlers', async () => {
     const { transport } = makeTransport([]);
 

--- a/app/packages/desktop-main/src/ipc-main-bridge.ts
+++ b/app/packages/desktop-main/src/ipc-main-bridge.ts
@@ -6,12 +6,16 @@ import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
  * IPC channels that manage their own `ipcMain.handle` registration and must
  * be skipped by the generic bridge to avoid a double registration.
  *
- * `logs.stream` is the only such channel today: `LogsController.onModuleInit`
- * bridges it manually because the handler needs to push follow-up chunk/end
- * messages over side channels derived from a `streamId` it mints itself —
- * see `app/packages/desktop-main/src/controllers/logs.controller.ts`.
+ * - `logs.stream`: `LogsController.onModuleInit` bridges it manually because
+ *   the handler needs to push follow-up chunk/end messages over side channels
+ *   derived from a `streamId` it mints itself — see
+ *   `app/packages/desktop-main/src/controllers/logs.controller.ts`.
+ * - `terraform.init`: bridged manually by its own controller because the
+ *   handler streams progress events over a side channel for the duration of
+ *   a long-running `terraform init` invocation, the same self-bridging
+ *   pattern `logs.stream` uses.
  */
-export const SELF_BRIDGED_PATTERNS: ReadonlySet<string> = new Set(['logs.stream']);
+export const SELF_BRIDGED_PATTERNS: ReadonlySet<string> = new Set(['logs.stream', 'terraform.init']);
 
 /**
  * `ElectronIPCTransport` (from `nestjs-electron-ipc-transport`) only exposes

--- a/app/packages/desktop-main/src/modules/terraform.module.ts
+++ b/app/packages/desktop-main/src/modules/terraform.module.ts
@@ -16,9 +16,8 @@ import { TerraformService } from '../services/TerraformService.js';
  * will use to resolve the working directory) — plain Nest DI, no factory
  * needed since neither service does async work at construction time.
  *
- * Not yet imported by `AppModule` — this is scaffolding only. A later child
- * issue of Epic D (local terraform orchestration) will import this module
- * once IPC-driven plan/apply/destroy/output handlers exist to consume it.
+ * Imported by `AppModule` alongside `TerraformController`, which bridges
+ * `TerraformService.init`'s async-generator output onto Electron IPC.
  */
 @Module({
   imports: [ConfigModule],

--- a/app/packages/desktop-main/src/modules/terraform.module.ts
+++ b/app/packages/desktop-main/src/modules/terraform.module.ts
@@ -1,24 +1,28 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from './config.module.js';
 import { TerraformService } from '../services/TerraformService.js';
 
 /**
  * Feature module for `TerraformService`, the local `terraform` CLI
  * detection/orchestration seam (see `TerraformService`'s file-level doc
- * comment). Construction is asynchronous (binary lookup + `terraform version`),
- * so the provider is wired via a `useFactory` that delegates to the static
- * `TerraformService.create()` rather than `useClass`.
+ * comment). Construction is synchronous and never throws — binary lookup and
+ * version resolution are deferred to first use of `getBinaryPath()` /
+ * `getVersion()` — so the provider is wired as a plain class provider rather
+ * than an async `useFactory`, and `AppModule` can import this module safely
+ * even on machines without `terraform` on PATH.
+ *
+ * Imports `ConfigModule` because `TerraformService` takes `ConfigService` as
+ * a constructor dependency (the seam later terraform orchestration methods
+ * will use to resolve the working directory) — plain Nest DI, no factory
+ * needed since neither service does async work at construction time.
  *
  * Not yet imported by `AppModule` — this is scaffolding only. A later child
  * issue of Epic D (local terraform orchestration) will import this module
  * once IPC-driven plan/apply/destroy/output handlers exist to consume it.
  */
 @Module({
-  providers: [
-    {
-      provide: TerraformService,
-      useFactory: () => TerraformService.create(),
-    },
-  ],
+  imports: [ConfigModule],
+  providers: [TerraformService],
   exports: [TerraformService],
 })
 export class TerraformModule {}

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -338,6 +338,7 @@ describe('ConfigService', () => {
       delete process.env['SERVER_CONFIG_PATH'];
       delete process.env['TFVARS_PATH'];
       delete process.env['GSD_TFVARS_BUCKET'];
+      delete process.env['TF_DIR'];
     });
 
     it('should return packaged tfstate path when readIsPackaged returns true', () => {
@@ -439,6 +440,25 @@ describe('ConfigService', () => {
         throw new Error('EACCES');
       });
       expect(service.getTfvarsBucket()).toBeNull();
+    });
+
+    it('should return the TF_DIR env var value when set', () => {
+      process.env['TF_DIR'] = '/custom/terraform';
+      expect(service.getTerraformDir()).toBe('/custom/terraform');
+    });
+
+    it('should return the packaged resourcesPath terraform dir when readIsPackaged returns true', () => {
+      type Internals = { readIsPackaged: () => boolean; readResourcesPath: () => string | undefined };
+      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(service as unknown as Internals, 'readResourcesPath').mockReturnValue('/fake/resources');
+      expect(service.getTerraformDir()).toBe(path.join('/fake/resources', 'terraform'));
+    });
+
+    it('should return the repo-root terraform dir fallback when readIsPackaged returns false', () => {
+      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
+      const result = service.getTerraformDir();
+      expect(result).toMatch(/terraform$/);
+      expect(path.isAbsolute(result)).toBe(true);
     });
   });
 });

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -491,7 +491,7 @@ describe('ConfigService', () => {
       expect(mockCp).toHaveBeenCalledTimes(1);
       const [cpFrom, cpTo] = mockCp.mock.calls[0];
       expect(cpFrom).toBe(path.join('/fake/resources', 'terraform'));
-      expect(cpTo).toMatch(new RegExp(`^${writableDir}\\.staging-`));
+      expect(String(cpTo).startsWith(`${writableDir}.staging-`)).toBe(true);
       expect(mockRename).toHaveBeenCalledWith(cpTo, writableDir);
     });
 
@@ -514,7 +514,7 @@ describe('ConfigService', () => {
       expect(mockRename).not.toHaveBeenCalled();
       expect(mockRm).toHaveBeenCalledTimes(1);
       const [rmPath] = mockRm.mock.calls[0];
-      expect(rmPath).toMatch(new RegExp(`^${writableDir}\\.staging-`));
+      expect(String(rmPath).startsWith(`${writableDir}.staging-`)).toBe(true);
 
       // A subsequent call must retry seeding rather than treating the failed
       // attempt as "already seeded" — `writableDir` was never created.

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -7,6 +7,8 @@ vi.mock('fs', () => ({
   writeFileSync: vi.fn(),
   existsSync: vi.fn(),
   cpSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
 }));
 
 vi.mock('../logger.js', () => ({
@@ -18,7 +20,7 @@ vi.mock('../logger.js', () => ({
   },
 }));
 
-import { readFileSync, writeFileSync, existsSync, cpSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, cpSync, renameSync, rmSync } from 'fs';
 import { ConfigService } from './ConfigService.js';
 
 /** Strongly-typed mock handles for the `fs` module. */
@@ -26,6 +28,8 @@ const mockExists = vi.mocked(existsSync);
 const mockRead = vi.mocked(readFileSync);
 const mockWrite = vi.mocked(writeFileSync);
 const mockCp = vi.mocked(cpSync);
+const mockRename = vi.mocked(renameSync);
+const mockRm = vi.mocked(rmSync);
 
 /**
  * Test-only subclass that re-exposes `ConfigService`'s protected
@@ -479,13 +483,44 @@ describe('ConfigService', () => {
       mockExists.mockReturnValue(false);
 
       const result = testableService.getTerraformDir();
+      const writableDir = path.join('/fake/userData', 'terraform');
 
-      expect(result).toBe(path.join('/fake/userData', 'terraform'));
-      expect(mockCp).toHaveBeenCalledWith(
-        path.join('/fake/resources', 'terraform'),
-        path.join('/fake/userData', 'terraform'),
-        { recursive: true },
-      );
+      expect(result).toBe(writableDir);
+      // Seeding stages the copy into a sibling directory and renames it into
+      // place, so `writableDir` never exists in a partially-copied state.
+      expect(mockCp).toHaveBeenCalledTimes(1);
+      const [cpFrom, cpTo] = mockCp.mock.calls[0];
+      expect(cpFrom).toBe(path.join('/fake/resources', 'terraform'));
+      expect(cpTo).toMatch(new RegExp(`^${writableDir}\\.staging-`));
+      expect(mockRename).toHaveBeenCalledWith(cpTo, writableDir);
+    });
+
+    it('should fall back to the packaged resourcesPath terraform dir and not treat writableDir as seeded when cpSync fails', () => {
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readResourcesPath').mockReturnValue('/fake/resources');
+      vi.spyOn(testableService, 'readUserDataPath').mockReturnValue('/fake/userData');
+      const writableDir = path.join('/fake/userData', 'terraform');
+      // Only the final writableDir check should report "exists" as false —
+      // the staging dir cleanup check runs after the throw, so report it as
+      // present so we can assert the cleanup path (rmSync) runs too.
+      mockExists.mockImplementation((p) => p !== writableDir);
+      mockCp.mockImplementation(() => {
+        throw new Error('ENOSPC: no space left on device');
+      });
+
+      const result = testableService.getTerraformDir();
+
+      expect(result).toBe(path.join('/fake/resources', 'terraform'));
+      expect(mockRename).not.toHaveBeenCalled();
+      expect(mockRm).toHaveBeenCalledTimes(1);
+      const [rmPath] = mockRm.mock.calls[0];
+      expect(rmPath).toMatch(new RegExp(`^${writableDir}\\.staging-`));
+
+      // A subsequent call must retry seeding rather than treating the failed
+      // attempt as "already seeded" — `writableDir` was never created.
+      mockCp.mockClear();
+      testableService.getTerraformDir();
+      expect(mockCp).toHaveBeenCalledTimes(1);
     });
 
     it('should not re-seed the writable userData terraform dir when it already exists', () => {

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -6,6 +6,7 @@ vi.mock('fs', () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   existsSync: vi.fn(),
+  cpSync: vi.fn(),
 }));
 
 vi.mock('../logger.js', () => ({
@@ -17,13 +18,33 @@ vi.mock('../logger.js', () => ({
   },
 }));
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, cpSync } from 'fs';
 import { ConfigService } from './ConfigService.js';
 
 /** Strongly-typed mock handles for the `fs` module. */
 const mockExists = vi.mocked(existsSync);
 const mockRead = vi.mocked(readFileSync);
 const mockWrite = vi.mocked(writeFileSync);
+const mockCp = vi.mocked(cpSync);
+
+/**
+ * Test-only subclass that re-exposes `ConfigService`'s protected
+ * environment-probing methods as public members so `vi.spyOn` can target
+ * them directly, without resorting to `as unknown as` double assertions.
+ */
+class TestableConfigService extends ConfigService {
+  public override readIsPackaged(): boolean {
+    return super.readIsPackaged();
+  }
+
+  public override readResourcesPath(): string | undefined {
+    return super.readResourcesPath();
+  }
+
+  public override readUserDataPath(): string | null {
+    return super.readUserDataPath();
+  }
+}
 
 /**
  * Build a Terraform state file payload from an `outputs` map.
@@ -332,6 +353,13 @@ describe('ConfigService', () => {
   });
 
   describe('path resolution', () => {
+    /** Subclass instance exposing protected internals for direct `vi.spyOn` stubbing. */
+    let testableService: TestableConfigService;
+
+    beforeEach(() => {
+      testableService = new TestableConfigService();
+    });
+
     afterEach(() => {
       vi.restoreAllMocks();
       delete process.env['TF_STATE_PATH'];
@@ -342,17 +370,16 @@ describe('ConfigService', () => {
     });
 
     it('should return packaged tfstate path when readIsPackaged returns true', () => {
-      type Internals = { readIsPackaged: () => boolean; readResourcesPath: () => string | undefined };
-      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
-      vi.spyOn(service as unknown as Internals, 'readResourcesPath').mockReturnValue('/fake/resources');
-      expect(service.getTfStatePath()).toBe(
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readResourcesPath').mockReturnValue('/fake/resources');
+      expect(testableService.getTfStatePath()).toBe(
         path.join('/fake/resources', 'terraform', 'aws', 'terraform.tfstate'),
       );
     });
 
     it('should return the repo-relative fallback when readIsPackaged returns false', () => {
-      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
-      const result = service.getTfStatePath();
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(false);
+      const result = testableService.getTfStatePath();
       expect(result).toMatch(/terraform[/\\]terraform\.tfstate$/);
       expect(path.isAbsolute(result)).toBe(true);
     });
@@ -363,17 +390,16 @@ describe('ConfigService', () => {
     });
 
     it('should return packaged server_config path when readIsPackaged returns true', () => {
-      type Internals = { readIsPackaged: () => boolean; readUserDataPath: () => string | null };
-      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
-      vi.spyOn(service as unknown as Internals, 'readUserDataPath').mockReturnValue('/fake/userData');
-      expect(service.getServerConfigPath()).toBe(
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readUserDataPath').mockReturnValue('/fake/userData');
+      expect(testableService.getServerConfigPath()).toBe(
         path.join('/fake/userData', 'server_config.json'),
       );
     });
 
     it('should return the repo-relative fallback when readIsPackaged returns false', () => {
-      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
-      const result = service.getServerConfigPath();
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(false);
+      const result = testableService.getServerConfigPath();
       expect(result).toMatch(/server_config\.json$/);
       expect(path.isAbsolute(result)).toBe(true);
     });
@@ -384,17 +410,16 @@ describe('ConfigService', () => {
     });
 
     it('should return packaged tfvars path when readIsPackaged returns true', () => {
-      type Internals = { readIsPackaged: () => boolean; readResourcesPath: () => string | undefined };
-      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
-      vi.spyOn(service as unknown as Internals, 'readResourcesPath').mockReturnValue('/fake/resources');
-      expect(service.getTfvarsPath()).toBe(
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readResourcesPath').mockReturnValue('/fake/resources');
+      expect(testableService.getTfvarsPath()).toBe(
         path.join('/fake/resources', 'terraform', 'terraform.tfvars'),
       );
     });
 
     it('should return the repo-relative tfvars fallback when readIsPackaged returns false', () => {
-      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
-      const result = service.getTfvarsPath();
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(false);
+      const result = testableService.getTfvarsPath();
       expect(result).toMatch(/terraform[/\\]terraform\.tfvars$/);
       expect(path.isAbsolute(result)).toBe(true);
     });
@@ -447,16 +472,46 @@ describe('ConfigService', () => {
       expect(service.getTerraformDir()).toBe('/custom/terraform');
     });
 
-    it('should return the packaged resourcesPath terraform dir when readIsPackaged returns true', () => {
-      type Internals = { readIsPackaged: () => boolean; readResourcesPath: () => string | undefined };
-      vi.spyOn(service as unknown as Internals, 'readIsPackaged').mockReturnValue(true);
-      vi.spyOn(service as unknown as Internals, 'readResourcesPath').mockReturnValue('/fake/resources');
-      expect(service.getTerraformDir()).toBe(path.join('/fake/resources', 'terraform'));
+    it('should seed and return the writable userData terraform dir when packaged and userData is available', () => {
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readResourcesPath').mockReturnValue('/fake/resources');
+      vi.spyOn(testableService, 'readUserDataPath').mockReturnValue('/fake/userData');
+      mockExists.mockReturnValue(false);
+
+      const result = testableService.getTerraformDir();
+
+      expect(result).toBe(path.join('/fake/userData', 'terraform'));
+      expect(mockCp).toHaveBeenCalledWith(
+        path.join('/fake/resources', 'terraform'),
+        path.join('/fake/userData', 'terraform'),
+        { recursive: true },
+      );
+    });
+
+    it('should not re-seed the writable userData terraform dir when it already exists', () => {
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readResourcesPath').mockReturnValue('/fake/resources');
+      vi.spyOn(testableService, 'readUserDataPath').mockReturnValue('/fake/userData');
+      mockExists.mockReturnValue(true);
+
+      const result = testableService.getTerraformDir();
+
+      expect(result).toBe(path.join('/fake/userData', 'terraform'));
+      expect(mockCp).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the packaged resourcesPath terraform dir when userData is unavailable', () => {
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(true);
+      vi.spyOn(testableService, 'readResourcesPath').mockReturnValue('/fake/resources');
+      vi.spyOn(testableService, 'readUserDataPath').mockReturnValue(null);
+
+      expect(testableService.getTerraformDir()).toBe(path.join('/fake/resources', 'terraform'));
+      expect(mockCp).not.toHaveBeenCalled();
     });
 
     it('should return the repo-root terraform dir fallback when readIsPackaged returns false', () => {
-      vi.spyOn(service as unknown as { readIsPackaged: () => boolean }, 'readIsPackaged').mockReturnValue(false);
-      const result = service.getTerraformDir();
+      vi.spyOn(testableService, 'readIsPackaged').mockReturnValue(false);
+      const result = testableService.getTerraformDir();
       expect(result).toMatch(/terraform$/);
       expect(path.isAbsolute(result)).toBe(true);
     });

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { readFileSync, writeFileSync, existsSync, cpSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, cpSync, renameSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { randomUUID } from 'crypto';
 import type { GameServer } from '@hyveon/shared';
 import { logger } from '../logger.js';
 
@@ -203,6 +204,14 @@ export class ConfigService {
   }
 
   /**
+   * Read the Terraform composer root override from `TF_DIR`. Extracted for
+   * test-stubbing, mirroring {@link readEnvRegion} / {@link readEnvApiToken}.
+   */
+  readEnvTerraformDir(): string | undefined {
+    return process.env['TF_DIR'];
+  }
+
+  /**
    * Read the tfvars in-memory cache TTL override (milliseconds) from
    * `TFVARS_CACHE_TTL_MS`. Extracted for test-stubbing, mirroring
    * {@link readEnvRegion} / {@link readEnvApiToken}.
@@ -306,12 +315,13 @@ export class ConfigService {
    *     `.terraform/`, lock files, and plan artifacts. So the bundled composer
    *     is seeded (once, on first use) into `<userData>/terraform` — a
    *     writable per-user directory — via {@link seedTerraformWorkspace}, and
-   *     that writable copy is returned instead. Falls back to the read-only
-   *     `<resourcesPath>/terraform` if `userData` can't be resolved.
+   *     that writable copy is returned instead. If seeding fails, the
+   *     read-only `<resourcesPath>/terraform` is returned instead of a
+   *     partially-copied `writableDir` — see {@link seedTerraformWorkspace}.
    *  3. Dev/test fallback — repo root `terraform/`.
    */
   getTerraformDir(): string {
-    const envOverride = process.env['TF_DIR'];
+    const envOverride = this.readEnvTerraformDir();
     if (envOverride) return envOverride;
 
     if (this.readIsPackaged()) {
@@ -320,8 +330,13 @@ export class ConfigService {
       const userData = this.readUserDataPath();
       if (userData) {
         const writableDir = join(userData, 'terraform');
-        this.seedTerraformWorkspace(bundledDir, writableDir);
-        return writableDir;
+        if (this.seedTerraformWorkspace(bundledDir, writableDir)) {
+          return writableDir;
+        }
+        logger.warn('Falling back to read-only bundled Terraform dir after seed failure', {
+          bundledDir,
+        });
+        return bundledDir;
       }
       return bundledDir;
     }
@@ -333,22 +348,44 @@ export class ConfigService {
   /**
    * Copy the bundled read-only Terraform composer (`<resourcesPath>/terraform`)
    * into the writable `<userData>/terraform` workspace on first use. No-ops
-   * when the writable directory already exists, so subsequent runs reuse the
-   * previously-seeded copy (and its `.terraform/` init state) instead of
-   * clobbering it on every launch.
+   * (returns `true`) when the writable directory already exists, so
+   * subsequent runs reuse the previously-seeded copy (and its `.terraform/`
+   * init state) instead of clobbering it on every launch.
+   *
+   * Copies into a sibling staging directory first, then atomically renames it
+   * into place with {@link renameSync}. This guarantees `writableDir` only
+   * ever exists in a fully-seeded state — a `cpSync` failure never leaves a
+   * partially-copied `writableDir` behind, so a future call won't mistake an
+   * incomplete copy for "already seeded" via the `existsSync` check above.
+   *
+   * @returns `true` if `writableDir` is present and fully seeded after this
+   *   call, `false` if seeding failed (caller must not treat `writableDir` as
+   *   usable in that case).
    */
-  private seedTerraformWorkspace(bundledDir: string, writableDir: string): void {
-    if (existsSync(writableDir)) return;
+  private seedTerraformWorkspace(bundledDir: string, writableDir: string): boolean {
+    if (existsSync(writableDir)) return true;
 
+    const stagingDir = `${writableDir}.staging-${randomUUID()}`;
     try {
-      cpSync(bundledDir, writableDir, { recursive: true });
+      cpSync(bundledDir, stagingDir, { recursive: true });
+      renameSync(stagingDir, writableDir);
       logger.info('Seeded Terraform workspace into userData', { from: bundledDir, to: writableDir });
+      return true;
     } catch (err) {
       logger.error('Failed to seed Terraform workspace into userData', {
         err,
         from: bundledDir,
         to: writableDir,
       });
+      try {
+        if (existsSync(stagingDir)) rmSync(stagingDir, { recursive: true, force: true });
+      } catch (cleanupErr) {
+        logger.error('Failed to clean up Terraform workspace staging directory', {
+          err: cleanupErr,
+          stagingDir,
+        });
+      }
+      return false;
     }
   }
 

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -291,6 +291,32 @@ export class ConfigService {
   }
 
   /**
+   * Resolve the absolute path to the Terraform *composer root* — the
+   * directory `TerraformService` spawns the `terraform` binary in for
+   * `init`/`plan`/`apply`/`destroy`/`output`. This is `terraform/`, which
+   * holds the thin backend/provider composer (`terraform/main.tf`) that
+   * wires in `module "cloud"` — **not** `terraform/aws/`, where the actual
+   * AWS resources live.
+   *
+   * Resolution order (identical in structure to {@link getTfStatePath}):
+   *  1. `TF_DIR` env var — wins when set.
+   *  2. Electron packaged app (`app.isPackaged`) — `<resourcesPath>/terraform`.
+   *  3. Dev/test fallback — repo root `terraform/`.
+   */
+  getTerraformDir(): string {
+    const envOverride = process.env['TF_DIR'];
+    if (envOverride) return envOverride;
+
+    if (this.readIsPackaged()) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return join(this.readResourcesPath()!, 'terraform');
+    }
+
+    // Dev fallback: repo root is one level above _APP_ROOT (app/)
+    return join(_APP_ROOT, '..', 'terraform');
+  }
+
+  /**
    * Resolve the absolute path to `server_config.json`.
    *
    * Resolution order:

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, cpSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
@@ -300,7 +300,14 @@ export class ConfigService {
    *
    * Resolution order (identical in structure to {@link getTfStatePath}):
    *  1. `TF_DIR` env var — wins when set.
-   *  2. Electron packaged app (`app.isPackaged`) — `<resourcesPath>/terraform`.
+   *  2. Electron packaged app (`app.isPackaged`) — `<resourcesPath>/terraform` is
+   *     read-only in most installed-app layouts (macOS code-signing, Windows
+   *     `Program Files` ACLs), and `terraform init`/`apply` need to write
+   *     `.terraform/`, lock files, and plan artifacts. So the bundled composer
+   *     is seeded (once, on first use) into `<userData>/terraform` — a
+   *     writable per-user directory — via {@link seedTerraformWorkspace}, and
+   *     that writable copy is returned instead. Falls back to the read-only
+   *     `<resourcesPath>/terraform` if `userData` can't be resolved.
    *  3. Dev/test fallback — repo root `terraform/`.
    */
   getTerraformDir(): string {
@@ -309,11 +316,40 @@ export class ConfigService {
 
     if (this.readIsPackaged()) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return join(this.readResourcesPath()!, 'terraform');
+      const bundledDir = join(this.readResourcesPath()!, 'terraform');
+      const userData = this.readUserDataPath();
+      if (userData) {
+        const writableDir = join(userData, 'terraform');
+        this.seedTerraformWorkspace(bundledDir, writableDir);
+        return writableDir;
+      }
+      return bundledDir;
     }
 
     // Dev fallback: repo root is one level above _APP_ROOT (app/)
     return join(_APP_ROOT, '..', 'terraform');
+  }
+
+  /**
+   * Copy the bundled read-only Terraform composer (`<resourcesPath>/terraform`)
+   * into the writable `<userData>/terraform` workspace on first use. No-ops
+   * when the writable directory already exists, so subsequent runs reuse the
+   * previously-seeded copy (and its `.terraform/` init state) instead of
+   * clobbering it on every launch.
+   */
+  private seedTerraformWorkspace(bundledDir: string, writableDir: string): void {
+    if (existsSync(writableDir)) return;
+
+    try {
+      cpSync(bundledDir, writableDir, { recursive: true });
+      logger.info('Seeded Terraform workspace into userData', { from: bundledDir, to: writableDir });
+    } catch (err) {
+      logger.error('Failed to seed Terraform workspace into userData', {
+        err,
+        from: bundledDir,
+        to: writableDir,
+      });
+    }
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TerraformService.init.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.init.test.ts
@@ -1,0 +1,480 @@
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Spy variables must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const { execFileMock, spawnMock } = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  return { execFileMock, spawnMock };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: spawnMock,
+}));
+
+import {
+  TerraformService,
+  TerraformNotFoundError,
+  TerraformInitError,
+  type TerraformInitConfig,
+  type TerraformRunChunk,
+} from './TerraformService.js';
+import type { ConfigService } from './ConfigService.js';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Extracts the error-first callback from an `execFile` call's arguments,
+ * regardless of whether `util.promisify` invoked it with or without an
+ * `options` object.
+ */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
+/** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
+function queueExecFileSuccess(stdout: string, stderr = ''): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(null, { stdout, stderr });
+  });
+}
+
+/** Queues a failing `execFile` invocation (e.g. binary not found) for the next call. */
+function queueExecFileFailure(error: Error = new Error('spawn ENOENT')): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(error);
+  });
+}
+
+/** Queues a successful binary lookup followed by a successful `-json` version response. */
+function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', version = '1.7.0'): void {
+  queueExecFileSuccess(`${binaryPath}\n`);
+  queueExecFileSuccess(JSON.stringify({ terraform_version: version }));
+}
+
+/**
+ * Minimal `ConfigService` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency and its `getTerraformDir()` call from `init()`.
+ */
+function stubConfigService(terraformDir = '/repo/terraform'): ConfigService {
+  return { getTerraformDir: () => terraformDir } as ConfigService;
+}
+
+/**
+ * A fake `child_process.ChildProcess` sufficient for exercising `init()`'s
+ * streaming logic: an `EventEmitter` standing in for the process itself,
+ * with `stdout`/`stderr` sub-emitters standing in for the piped streams, and
+ * a spied `kill()` so abort tests can assert the process was actually
+ * terminated. Tests drive it manually via `emitStdout`/`emitStderr`/`close`/
+ * `emit('error', ...)` rather than relying on any real process lifecycle.
+ */
+class FakeChildProcess extends EventEmitter {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+  readonly kill = vi.fn();
+
+  emitStdout(chunk: string): void {
+    this.stdout.emit('data', Buffer.from(chunk));
+  }
+
+  emitStderr(chunk: string): void {
+    this.stderr.emit('data', Buffer.from(chunk));
+  }
+
+  close(code: number | null): void {
+    this.emit('close', code);
+  }
+}
+
+/** Queues the next `spawn()` call to return `child` instead of a real process. */
+function queueSpawn(child: FakeChildProcess): void {
+  spawnMock.mockImplementationOnce(() => child);
+}
+
+/**
+ * Waits for every already-queued microtask to drain (via a macrotask
+ * boundary) before returning. `init()` awaits the binary/version resolution
+ * (itself a chain of `execFileAsync` promises) before it reaches the
+ * `spawn()` call and registers listeners on the child process, so tests must
+ * flush past that chain before driving `child.emitStdout`/`close`/`error` —
+ * otherwise those events fire before any listener has been attached.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Drains an `init()` async generator to completion, collecting every yielded
+ * chunk. `driveChild` is invoked once (after the first `.next()` has been
+ * issued so the child process is spawned and listeners are attached) to let
+ * the caller emit data/close/error events on the fake child at the right
+ * moment relative to iteration.
+ */
+async function collectAllChunks(
+  gen: AsyncGenerator<TerraformRunChunk, void>,
+  driveChild?: () => void,
+): Promise<TerraformRunChunk[]> {
+  const chunks: TerraformRunChunk[] = [];
+  const first = gen.next();
+  // Attach a no-op rejection handler immediately so a generator that throws
+  // before `driveChild` is even relevant (e.g. binary resolution failure)
+  // doesn't trip Node's unhandled-rejection detection during the
+  // `flushMicrotasks` gap below — the real `await first` a few lines down
+  // still surfaces the rejection to the caller.
+  first.catch(() => {});
+  await flushMicrotasks();
+  driveChild?.();
+  let result = await first;
+  while (!result.done) {
+    chunks.push(result.value);
+    const next = gen.next();
+    next.catch(() => {});
+    result = await next;
+  }
+  return chunks;
+}
+
+const sampleConfig: TerraformInitConfig = {
+  bucket: 'hyveon-tf-state',
+  region: 'us-east-1',
+  dynamodbTable: 'hyveon-tf-locks',
+};
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  spawnMock.mockReset();
+});
+
+describe('TerraformService.init spawning', () => {
+  it('should spawn terraform init with backend-config args derived from the resolved binary path and terraform dir', async () => {
+    queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService('/repo/terraform'));
+
+    await collectAllChunks(service.init(sampleConfig), () => child.close(0));
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/terraform',
+      [
+        'init',
+        '-input=false',
+        '-no-color',
+        '-backend-config=bucket=hyveon-tf-state',
+        '-backend-config=region=us-east-1',
+        '-backend-config=dynamodb_table=hyveon-tf-locks',
+      ],
+      { cwd: '/repo/terraform' },
+    );
+  });
+
+  it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
+    queueExecFileFailure();
+
+    const service = new TerraformService(stubConfigService());
+
+    await expect(collectAllChunks(service.init(sampleConfig))).rejects.toBeInstanceOf(
+      TerraformNotFoundError,
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.init streaming', () => {
+  it('should yield each stdout line as it is produced, not only after the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    const gen = service.init(sampleConfig);
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('Initializing the backend...\n');
+    const firstResult = await first;
+    expect(firstResult).toEqual({
+      value: { stream: 'stdout', line: 'Initializing the backend...' },
+      done: false,
+    });
+
+    const second = gen.next();
+    child.emitStdout('Terraform has been successfully initialized!\n');
+    child.close(0);
+    const secondResult = await second;
+
+    expect(secondResult).toEqual({
+      value: { stream: 'stdout', line: 'Terraform has been successfully initialized!' },
+      done: false,
+    });
+
+    const finalResult = await gen.next();
+    expect(finalResult.done).toBe(true);
+  });
+
+  it('should yield stderr lines tagged as the stderr stream', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    const chunks = await collectAllChunks(service.init(sampleConfig), () => {
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
+    expect(chunks).toContainEqual({ stream: 'stderr', line: 'Warning: something' });
+  });
+
+  it('should split a single data event containing multiple lines into one chunk per line', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    const chunks = await collectAllChunks(service.init(sampleConfig), () => {
+      child.emitStdout('line one\nline two\nline three\n');
+      child.close(0);
+    });
+
+    expect(chunks).toEqual([
+      { stream: 'stdout', line: 'line one' },
+      { stream: 'stdout', line: 'line two' },
+      { stream: 'stdout', line: 'line three' },
+    ]);
+  });
+
+  it('should flush a trailing partial line without a terminating newline once the process closes', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    const chunks = await collectAllChunks(service.init(sampleConfig), () => {
+      child.emitStdout('no trailing newline');
+      child.close(0);
+    });
+
+    expect(chunks).toContainEqual({ stream: 'stdout', line: 'no trailing newline' });
+  });
+
+  it('should complete with no chunks when the process produces no output', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    const chunks = await collectAllChunks(service.init(sampleConfig), () => child.close(0));
+
+    expect(chunks).toEqual([]);
+  });
+});
+
+describe('TerraformService.init exit handling', () => {
+  it('should complete normally when the spawned process exits with code 0', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+
+    await expect(collectAllChunks(service.init(sampleConfig), () => child.close(0))).resolves.toEqual(
+      [],
+    );
+  });
+
+  it('should reject with a TerraformInitError carrying the exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+
+    const result = collectAllChunks(service.init(sampleConfig), () => child.close(1));
+
+    await expect(result).rejects.toBeInstanceOf(TerraformInitError);
+    await expect(result).rejects.toMatchObject({ exitCode: 1 });
+  });
+
+  it('should reject when the spawned process itself errors out (e.g. ENOENT)', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+
+    const result = collectAllChunks(service.init(sampleConfig), () =>
+      child.emit('error', new Error('spawn ENOENT')),
+    );
+
+    await expect(result).rejects.toThrow('spawn ENOENT');
+  });
+});
+
+describe('TerraformService.init idempotency', () => {
+  it('should complete a second init() call with an identical config without calling spawn again', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    await collectAllChunks(service.init(sampleConfig), () => child.close(0));
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    await collectAllChunks(service.init({ ...sampleConfig }));
+
+    // The second call must be a genuine no-op: spawn is not invoked again.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should yield exactly one informational stdout chunk and return without spawning when the config is unchanged', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    await collectAllChunks(service.init(sampleConfig), () => child.close(0));
+
+    spawnMock.mockClear();
+
+    const secondChunks = await collectAllChunks(service.init({ ...sampleConfig }));
+
+    expect(secondChunks).toHaveLength(1);
+    expect(secondChunks[0]?.stream).toBe('stdout');
+    expect(secondChunks[0]?.line).toContain('backend config unchanged');
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should spawn again when a subsequent init() call uses a different backend config', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubConfigService());
+    await collectAllChunks(service.init(sampleConfig), () => firstChild.close(0));
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    await collectAllChunks(service.init({ ...sampleConfig, bucket: 'a-different-bucket' }), () =>
+      secondChild.close(0),
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not memoize a failed init() call, so a retry with the same config spawns again', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubConfigService());
+    await expect(
+      collectAllChunks(service.init(sampleConfig), () => firstChild.close(1)),
+    ).rejects.toBeInstanceOf(TerraformInitError);
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    await expect(
+      collectAllChunks(service.init(sampleConfig), () => secondChild.close(0)),
+    ).resolves.toEqual([]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('TerraformService.init abort handling', () => {
+  it('should kill the child process and end the generator cleanly when the AbortSignal fires mid-run', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(stubConfigService());
+    const gen = service.init(sampleConfig, controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const result = await pendingNext;
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(result.done).toBe(true);
+
+    // Iterating further keeps returning done, never throwing.
+    await expect(gen.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it('should not update the memoized config when a run is aborted, so a later identical config still spawns', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(stubConfigService());
+
+    const pendingNext = service.init(sampleConfig, controller.signal).next();
+    await flushMicrotasks();
+    controller.abort();
+    child.close(null);
+    await pendingNext;
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    await collectAllChunks(service.init({ ...sampleConfig }), () => secondChild.close(0));
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('TerraformService.init concurrency guard', () => {
+  it('should throw a descriptive Error from a second init() call while the first is still in flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubConfigService());
+    const firstGen = service.init(sampleConfig);
+    const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
+
+    const secondGen = service.init(sampleConfig);
+    await expect(secondGen.next()).rejects.toThrow(/already running/i);
+
+    // Let the first call finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await firstNext;
+    await firstGen.next();
+  });
+
+  it('should allow a new init() call once the previous one has completed', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubConfigService());
+    await collectAllChunks(service.init(sampleConfig), () => firstChild.close(0));
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    await expect(
+      collectAllChunks(service.init({ ...sampleConfig, bucket: 'another-bucket' }), () =>
+        secondChild.close(0),
+      ),
+    ).resolves.toEqual([]);
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.init.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.init.test.ts
@@ -419,6 +419,20 @@ describe('TerraformService.init abort handling', () => {
     await expect(gen.next()).resolves.toMatchObject({ done: true });
   });
 
+  it('should end the generator cleanly without resolving the binary or spawning when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const service = new TerraformService(stubConfigService());
+    const gen = service.init(sampleConfig, controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it('should not update the memoized config when a run is aborted, so a later identical config still spawns', async () => {
     queueSuccessfulResolution();
     const child = new FakeChildProcess();

--- a/app/packages/desktop-main/src/services/TerraformService.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.test.ts
@@ -15,6 +15,17 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { TerraformService, TerraformNotFoundError, lookupCommandFor } from './TerraformService.js';
+import type { ConfigService } from './ConfigService.js';
+
+/**
+ * Minimal `ConfigService` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. `TerraformService` doesn't call any `ConfigService`
+ * methods yet, so an empty object cast is enough — this keeps the stub
+ * trivially in sync as `ConfigService`'s surface grows.
+ */
+function stubConfigService(): ConfigService {
+  return {} as ConfigService;
+}
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
@@ -42,6 +53,12 @@ function queueExecFileFailure(error: Error = new Error('spawn ENOENT')): void {
   execFileMock.mockImplementationOnce((...args: unknown[]) => {
     lastArgAsCallback(args)(error);
   });
+}
+
+/** Queues a successful binary lookup followed by a successful `-json` version response. */
+function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', version = '1.7.0'): void {
+  queueExecFileSuccess(`${binaryPath}\n`);
+  queueExecFileSuccess(JSON.stringify({ terraform_version: version }));
 }
 
 beforeEach(() => {
@@ -79,52 +96,76 @@ describe('TerraformNotFoundError', () => {
   });
 });
 
-describe('TerraformService.create binary detection', () => {
+describe('TerraformService construction', () => {
+  it('should never throw when constructing the service, even without any execFile mocks queued', () => {
+    expect(() => new TerraformService(stubConfigService())).not.toThrow();
+  });
+
+  it('should not shell out to resolve the binary until an accessor is called', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const service = new TerraformService(stubConfigService());
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService binary detection', () => {
   it('should resolve the binary path from the which/where.exe output', async () => {
-    queueExecFileSuccess('/usr/local/bin/terraform\n');
-    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
+    queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getBinaryPath()).toBe('/usr/local/bin/terraform');
+    await expect(service.getBinaryPath()).resolves.toBe('/usr/local/bin/terraform');
   });
 
   it('should use the first non-empty trimmed line when the lookup command returns multiple lines', async () => {
     queueExecFileSuccess('\n  /opt/homebrew/bin/terraform  \nsome-other-line\n');
     queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getBinaryPath()).toBe('/opt/homebrew/bin/terraform');
+    await expect(service.getBinaryPath()).resolves.toBe('/opt/homebrew/bin/terraform');
   });
 
-  it('should reject with a TerraformNotFoundError instance when the lookup command fails', async () => {
+  it('should reject getBinaryPath with a TerraformNotFoundError instance on first use when the lookup command fails', async () => {
     queueExecFileFailure();
 
-    await expect(TerraformService.create()).rejects.toBeInstanceOf(TerraformNotFoundError);
+    const service = new TerraformService(stubConfigService());
+
+    await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
+  });
+
+  it('should reject getVersion with a TerraformNotFoundError instance on first use when the lookup command fails', async () => {
+    queueExecFileFailure();
+
+    const service = new TerraformService(stubConfigService());
+
+    await expect(service.getVersion()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
 
   it('should reject with a TerraformNotFoundError instance when the lookup command produces no output', async () => {
     queueExecFileSuccess('');
 
-    await expect(TerraformService.create()).rejects.toBeInstanceOf(TerraformNotFoundError);
+    const service = new TerraformService(stubConfigService());
+
+    await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
 
   it('should reject with a TerraformNotFoundError instance when the lookup command output is only whitespace', async () => {
     queueExecFileSuccess('   \n  \n');
 
-    await expect(TerraformService.create()).rejects.toBeInstanceOf(TerraformNotFoundError);
+    const service = new TerraformService(stubConfigService());
+
+    await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
 });
 
-describe('TerraformService.create version parsing', () => {
+describe('TerraformService version parsing', () => {
   it('should parse the terraform_version field from terraform version -json output', async () => {
-    queueExecFileSuccess('/usr/local/bin/terraform\n');
-    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.5' }));
+    queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.5');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getVersion()).toBe('1.7.5');
+    await expect(service.getVersion()).resolves.toBe('1.7.5');
   });
 
   it('should fall back to parsing plain-text output when the -json output is not valid JSON', async () => {
@@ -132,9 +173,9 @@ describe('TerraformService.create version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('Terraform v1.6.2\non linux_amd64\n');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getVersion()).toBe('1.6.2');
+    await expect(service.getVersion()).resolves.toBe('1.6.2');
   });
 
   it('should fall back to parsing plain-text output when terraform_version is missing from the json output', async () => {
@@ -142,9 +183,9 @@ describe('TerraformService.create version parsing', () => {
     queueExecFileSuccess(JSON.stringify({ some_other_field: true }));
     queueExecFileSuccess('Terraform v1.5.0\n');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getVersion()).toBe('1.5.0');
+    await expect(service.getVersion()).resolves.toBe('1.5.0');
   });
 
   it('should parse a pre-release version suffix from the plain-text fallback output', async () => {
@@ -152,9 +193,9 @@ describe('TerraformService.create version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('Terraform v1.9.0-beta1\n');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getVersion()).toBe('1.9.0-beta1');
+    await expect(service.getVersion()).resolves.toBe('1.9.0-beta1');
   });
 
   it('should throw a plain Error, not a TerraformNotFoundError, when the plain-text output cannot be parsed', async () => {
@@ -162,7 +203,8 @@ describe('TerraformService.create version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('garbage output with no version');
 
-    const result = TerraformService.create();
+    const service = new TerraformService(stubConfigService());
+    const result = service.getVersion();
 
     await expect(result).rejects.toThrow('Unable to parse terraform version');
     await expect(result).rejects.not.toBeInstanceOf(TerraformNotFoundError);
@@ -171,20 +213,65 @@ describe('TerraformService.create version parsing', () => {
 
 describe('TerraformService instance accessors', () => {
   it('should expose the resolved binary path via getBinaryPath', async () => {
-    queueExecFileSuccess('/usr/bin/terraform\n');
-    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.8.1' }));
+    queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getBinaryPath()).toBe('/usr/bin/terraform');
+    await expect(service.getBinaryPath()).resolves.toBe('/usr/bin/terraform');
   });
 
   it('should expose the resolved version via getVersion', async () => {
-    queueExecFileSuccess('/usr/bin/terraform\n');
-    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.8.1' }));
+    queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = await TerraformService.create();
+    const service = new TerraformService(stubConfigService());
 
-    expect(service.getVersion()).toBe('1.8.1');
+    await expect(service.getVersion()).resolves.toBe('1.8.1');
+  });
+});
+
+describe('TerraformService resolution memoization', () => {
+  it('should only shell out once across multiple getBinaryPath calls', async () => {
+    queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
+
+    const service = new TerraformService(stubConfigService());
+
+    await service.getBinaryPath();
+    await service.getBinaryPath();
+
+    expect(execFileMock).toHaveBeenCalledTimes(2); // one lookup call + one version call
+  });
+
+  it('should reuse the memoized resolution between getBinaryPath and getVersion', async () => {
+    queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
+
+    const service = new TerraformService(stubConfigService());
+
+    await service.getBinaryPath();
+    await service.getVersion();
+
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should resolve concurrent getBinaryPath calls to the same memoized result with a single lookup', async () => {
+    queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
+
+    const service = new TerraformService(stubConfigService());
+
+    const [first, second] = await Promise.all([service.getBinaryPath(), service.getBinaryPath()]);
+
+    expect(first).toBe('/usr/bin/terraform');
+    expect(second).toBe('/usr/bin/terraform');
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should memoize a TerraformNotFoundError rejection so a second call does not re-invoke execFile', async () => {
+    queueExecFileFailure();
+
+    const service = new TerraformService(stubConfigService());
+
+    await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
+    await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from './ConfigService.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -30,45 +31,78 @@ export class TerraformNotFoundError extends Error {
   }
 }
 
+/** Binary path + semver version resolved on first use and memoized thereafter. */
+interface TerraformResolution {
+  binaryPath: string;
+  version: string;
+}
+
 /**
- * Resolves and caches the system `terraform` binary's absolute path and
- * semver version at construction time. This is the seam every later
+ * Lazily resolves and caches the system `terraform` binary's absolute path
+ * and semver version. This is the seam every later
  * `init`/`plan`/`apply`/`destroy`/`output` orchestration method (added in
  * later child issues of Epic D) will spawn against — see the "Terraform
  * orchestrator" section of the electron-desktop-pivot design spec.
  *
- * Construction is asynchronous (binary lookup + `terraform version` both
- * shell out), so instances are built via the static {@link create} factory
- * rather than a public constructor. `TerraformModule` wires this factory
- * into Nest DI via a `useFactory` provider.
+ * Construction is synchronous and never throws — the binary lookup +
+ * `terraform version` shell-outs are deferred until {@link getBinaryPath} or
+ * {@link getVersion} is first called, so `TerraformModule` can be imported by
+ * `AppModule` unconditionally even on machines without `terraform` on PATH.
+ * The resolution (or its rejection) is memoized on the instance, so the
+ * lookup/version commands only ever run once per instance regardless of how
+ * many times the accessors are called.
  */
 @Injectable()
 export class TerraformService {
-  private constructor(
-    private readonly binaryPath: string,
-    private readonly version: string,
-  ) {}
+  private resolution: Promise<TerraformResolution> | null = null;
+
+  /**
+   * `config` isn't consumed yet — it's the seam a later child issue of Epic D
+   * will use to resolve the terraform working directory for
+   * `init`/`plan`/`apply`/`destroy`/`output`. The `void` below is a
+   * deliberate no-op read so `noUnusedLocals` doesn't flag the property
+   * before that consumer exists; remove it once `this.config` is used for
+   * real.
+   */
+  constructor(private readonly config: ConfigService) {
+    void this.config;
+  }
 
   /**
    * Resolves the system `terraform` binary via `which` (POSIX) / `where.exe`
    * (Windows), then queries `terraform version` for the semver string,
-   * caching both on the returned instance. Rejects with
-   * {@link TerraformNotFoundError} when the lookup fails.
+   * memoizing the result (or rejection) so subsequent calls don't re-run the
+   * shell-outs. Rejects with {@link TerraformNotFoundError} when the lookup
+   * fails.
    */
-  static async create(): Promise<TerraformService> {
-    const binaryPath = await TerraformService.resolveBinaryPath();
-    const version = await TerraformService.resolveVersion(binaryPath);
-    return new TerraformService(binaryPath, version);
+  private resolve(): Promise<TerraformResolution> {
+    if (!this.resolution) {
+      this.resolution = TerraformService.resolveBinaryPath().then(async (binaryPath) => {
+        const version = await TerraformService.resolveVersion(binaryPath);
+        return { binaryPath, version };
+      });
+    }
+    return this.resolution;
   }
 
-  /** Returns the cached absolute path to the resolved `terraform` binary. */
-  getBinaryPath(): string {
-    return this.binaryPath;
+  /**
+   * Returns the absolute path to the resolved `terraform` binary, resolving
+   * (and memoizing) it on first call. Rejects with
+   * {@link TerraformNotFoundError} when the binary can't be found on PATH.
+   */
+  async getBinaryPath(): Promise<string> {
+    const { binaryPath } = await this.resolve();
+    return binaryPath;
   }
 
-  /** Returns the cached semver version string parsed from `terraform version`. */
-  getVersion(): string {
-    return this.version;
+  /**
+   * Returns the semver version string parsed from `terraform version`,
+   * resolving (and memoizing) it on first call. Rejects with
+   * {@link TerraformNotFoundError} when the binary can't be found on PATH.
+   */
+  async getVersion(): Promise<string> {
+    const { version } = await this.resolve();
+    return version;
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -208,7 +208,19 @@ export class TerraformService {
         return;
       }
 
+      if (signal?.aborted) {
+        // Already aborted before we even started resolving the binary path —
+        // end the generator cleanly without spawning anything.
+        return;
+      }
+
       const binaryPath = await this.getBinaryPath();
+
+      if (signal?.aborted) {
+        // Aborted while resolving the binary path — end cleanly before spawn.
+        return;
+      }
+
       const cwd = this.config.getTerraformDir();
       const args = [
         'init',

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from './ConfigService.js';
@@ -38,11 +38,52 @@ interface TerraformResolution {
 }
 
 /**
+ * Backend configuration values passed to `terraform init -backend-config=...`
+ * for the S3 remote state backend bootstrapped by the First-Run Wizard (see
+ * the "Terraform orchestrator" section of the electron-desktop-pivot design
+ * spec). Maps 1:1 onto the `-backend-config=bucket=...` /
+ * `-backend-config=region=...` / `-backend-config=dynamodb_table=...` CLI
+ * flags {@link TerraformService.init} passes to `terraform init`.
+ */
+export interface TerraformInitConfig {
+  bucket: string;
+  region: string;
+  dynamodbTable: string;
+}
+
+/**
+ * A single line of output from a streamed `terraform` subcommand run, tagged
+ * with the stream it came from. Yielded by {@link TerraformService.init} (and,
+ * later, `plan`/`apply`/`destroy`/`output`) as the spawned process produces
+ * output, rather than being buffered until the process exits — this is the
+ * shape the future `terraform.init.chunk` / `terraform.init.end` IPC bridge
+ * consumes directly from the async generator.
+ */
+export interface TerraformRunChunk {
+  stream: 'stdout' | 'stderr';
+  line: string;
+}
+
+/**
+ * Thrown when the spawned `terraform init` process exits with a non-zero
+ * status code. Distinct from {@link TerraformNotFoundError}, which is thrown
+ * when the binary itself can't be located before the process is even
+ * spawned.
+ */
+export class TerraformInitError extends Error {
+  constructor(public readonly exitCode: number | null) {
+    super(`terraform init exited with code ${exitCode ?? 'null'}`);
+    this.name = 'TerraformInitError';
+  }
+}
+
+/**
  * Lazily resolves and caches the system `terraform` binary's absolute path
- * and semver version. This is the seam every later
- * `init`/`plan`/`apply`/`destroy`/`output` orchestration method (added in
- * later child issues of Epic D) will spawn against — see the "Terraform
- * orchestrator" section of the electron-desktop-pivot design spec.
+ * and semver version, and orchestrates `terraform` subcommands against it —
+ * starting with {@link TerraformService.init}, the streaming/idempotent
+ * `terraform init` runner. Later child issues of Epic D add
+ * `plan`/`apply`/`destroy`/`output` — see the "Terraform orchestrator"
+ * section of the electron-desktop-pivot design spec.
  *
  * Construction is synchronous and never throws — the binary lookup +
  * `terraform version` shell-outs are deferred until {@link getBinaryPath} or
@@ -57,16 +98,23 @@ export class TerraformService {
   private resolution: Promise<TerraformResolution> | null = null;
 
   /**
-   * `config` isn't consumed yet — it's the seam a later child issue of Epic D
-   * will use to resolve the terraform working directory for
-   * `init`/`plan`/`apply`/`destroy`/`output`. The `void` below is a
-   * deliberate no-op read so `noUnusedLocals` doesn't flag the property
-   * before that consumer exists; remove it once `this.config` is used for
-   * real.
+   * Backend config the most recent successful {@link init} call completed
+   * with. Compared field-by-field against the `config` of a subsequent
+   * `init()` call to make repeat calls with an identical backend a no-op —
+   * see {@link init}'s TSDoc.
    */
-  constructor(private readonly config: ConfigService) {
-    void this.config;
-  }
+  private lastInitConfig: TerraformInitConfig | null = null;
+
+  /**
+   * `true` while an {@link init} call is actively running (from the moment
+   * its generator body starts executing, i.e. the first `.next()` call, until
+   * it completes or throws). Guards against a second concurrent `init()` call
+   * racing the first against the same `terraform` working directory.
+   */
+  private initInFlight = false;
+
+  /** `config` resolves the terraform working directory (`getTerraformDir()`) for `init`/`plan`/`apply`/`destroy`/`output`. */
+  constructor(private readonly config: ConfigService) {}
 
   /**
    * Resolves the system `terraform` binary via `which` (POSIX) / `where.exe`
@@ -103,6 +151,172 @@ export class TerraformService {
   async getVersion(): Promise<string> {
     const { version } = await this.resolve();
     return version;
+  }
+
+  /**
+   * Runs `terraform init` with `-backend-config=bucket=<bucket>`,
+   * `-backend-config=region=<region>`, and
+   * `-backend-config=dynamodb_table=<dynamodbTable>` flags derived from
+   * `config`, inside the Terraform composer root
+   * (`ConfigService.getTerraformDir()`), yielding a {@link TerraformRunChunk}
+   * per line of output as the process produces it.
+   *
+   * Uses `child_process.spawn` (rather than the buffered `execFile` helper
+   * used for binary/version detection above) so stdout/stderr can be
+   * streamed line-by-line as the process produces them, instead of only
+   * becoming available once the whole command finishes. The async-generator
+   * shape is the seam the `terraform.init.chunk` / `terraform.init.end` IPC
+   * bridge (a later child issue of Epic D) consumes directly to forward
+   * chunks to the renderer.
+   *
+   * Idempotent: if the last successful `init()` call completed with a
+   * field-identical `config`, this yields a single informational stdout
+   * chunk and returns without spawning a second `terraform init` process —
+   * the First-Run Wizard's "Reconfigure" flow (and any accidental
+   * double-invoke) can safely call `init` again with the same backend
+   * without doing redundant work.
+   *
+   * `signal`, if provided, aborts the run: the spawned child process is
+   * killed and the generator ends cleanly (no further chunks, no throw)
+   * rather than rejecting with {@link TerraformInitError}.
+   *
+   * Throws a descriptive `Error` synchronously (on the first `.next()` call)
+   * if another `init()` call is already in flight on this instance — overlapping
+   * `terraform init` runs against the same working directory would race.
+   *
+   * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
+   * resolved, or {@link TerraformInitError} if the spawned process exits with
+   * a non-zero status code (and the run wasn't aborted). Neither failure is
+   * memoized, so a subsequent call (even with the same `config`) retries.
+   */
+  async *init(
+    config: TerraformInitConfig,
+    signal?: AbortSignal,
+  ): AsyncGenerator<TerraformRunChunk, void> {
+    if (this.initInFlight) {
+      throw new Error(
+        'TerraformService.init() is already running; wait for it to finish before calling init() again.',
+      );
+    }
+    this.initInFlight = true;
+    try {
+      if (this.lastInitConfig && TerraformService.sameBackendConfig(this.lastInitConfig, config)) {
+        yield {
+          stream: 'stdout',
+          line: 'terraform init skipped: backend config unchanged since the last successful init',
+        };
+        return;
+      }
+
+      const binaryPath = await this.getBinaryPath();
+      const cwd = this.config.getTerraformDir();
+      const args = [
+        'init',
+        '-input=false',
+        '-no-color',
+        `-backend-config=bucket=${config.bucket}`,
+        `-backend-config=region=${config.region}`,
+        `-backend-config=dynamodb_table=${config.dynamodbTable}`,
+      ];
+
+      const child = spawn(binaryPath, args, { cwd });
+      const buffers: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' };
+
+      const queue: TerraformRunChunk[] = [];
+      let wake: (() => void) | null = null;
+      let closed = false;
+      let closeError: Error | null = null;
+      let exitCode: number | null = null;
+
+      const notify = (): void => {
+        wake?.();
+        wake = null;
+      };
+
+      const push = (chunk: TerraformRunChunk): void => {
+        queue.push(chunk);
+        notify();
+      };
+
+      const handleData = (stream: 'stdout' | 'stderr', data: Buffer | string): void => {
+        buffers[stream] += data.toString();
+        const lines = buffers[stream].split(/\r?\n/);
+        // The last element is either an empty string (data ended on a
+        // newline) or an incomplete trailing line — hold it back until more
+        // data (or `close`) completes it.
+        buffers[stream] = lines.pop() ?? '';
+        for (const line of lines) {
+          push({ stream, line });
+        }
+      };
+
+      child.stdout?.on('data', (data: Buffer) => handleData('stdout', data));
+      child.stderr?.on('data', (data: Buffer) => handleData('stderr', data));
+
+      child.on('error', (err: Error) => {
+        closeError = err;
+        closed = true;
+        notify();
+      });
+
+      child.on('close', (code: number | null) => {
+        for (const stream of ['stdout', 'stderr'] as const) {
+          if (buffers[stream].length > 0) {
+            push({ stream, line: buffers[stream] });
+            buffers[stream] = '';
+          }
+        }
+        exitCode = code;
+        closed = true;
+        notify();
+      });
+
+      const onAbort = (): void => {
+        child.kill();
+      };
+      signal?.addEventListener('abort', onAbort);
+
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            yield queue.shift()!;
+            continue;
+          }
+          if (closed) {
+            break;
+          }
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+          });
+        }
+
+        if (signal?.aborted) {
+          // Aborted mid-run: the child was killed above. End the generator
+          // cleanly rather than surfacing the resulting error/exit code.
+          return;
+        }
+        if (closeError) {
+          throw closeError;
+        }
+        if (exitCode === 0) {
+          this.lastInitConfig = config;
+          return;
+        }
+        throw new TerraformInitError(exitCode);
+      } finally {
+        signal?.removeEventListener('abort', onAbort);
+      }
+    } finally {
+      this.initInFlight = false;
+    }
+  }
+
+  /**
+   * Field-by-field equality check between two {@link TerraformInitConfig}
+   * values, used by {@link init} to decide whether a repeat call is a no-op.
+   */
+  private static sameBackendConfig(a: TerraformInitConfig, b: TerraformInitConfig): boolean {
+    return a.bucket === b.bucket && a.region === b.region && a.dynamodbTable === b.dynamodbTable;
   }
 
   /**

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -492,6 +492,31 @@ export interface AuditPageResult {
   nextBefore?: string;
 }
 
+/**
+ * A single line of output from a streamed `terraform` subcommand run, tagged
+ * with the stream it came from.
+ *
+ * Mirrors `TerraformRunChunk` in `@hyveon/desktop-main/src/services/TerraformService.ts`
+ * — that file is the source of truth; keep this copy in sync with it.
+ */
+export interface TerraformRunChunk {
+  stream: 'stdout' | 'stderr';
+  line: string;
+}
+
+/**
+ * Backend configuration values passed to `terraform init -backend-config=...`
+ * for the S3 remote state backend bootstrapped by the First-Run Wizard.
+ *
+ * Mirrors `TerraformInitConfig` in `@hyveon/desktop-main/src/services/TerraformService.ts`
+ * — that file is the source of truth; keep this copy in sync with it.
+ */
+export interface TerraformInitConfig {
+  bucket: string;
+  region: string;
+  dynamodbTable: string;
+}
+
 // ---------------------------------------------------------------------------
 // Per-namespace sub-interfaces
 // ---------------------------------------------------------------------------
@@ -632,6 +657,34 @@ export interface GsdAuditApi {
   list: (opts?: { limit?: number; before?: string }) => Promise<AuditPageResult>;
 }
 
+/**
+ * Terraform orchestration: streams `terraform init` output live as the
+ * process runs.
+ */
+export interface GsdTerraformApi {
+  /**
+   * Runs `terraform init` against `config` (backend bucket/region/DynamoDB
+   * lock table) and returns its output as an async iterable of
+   * {@link TerraformRunChunk}. Consume it with
+   * `for await (const chunk of terraform.init(config, signal))`.
+   *
+   * Internally this wraps the fixed `terraform.init.chunk` / `terraform.init.end`
+   * side-channel IPC messages `TerraformController.init` sends in an async
+   * generator — unlike `logs.stream`, there is no per-call `streamId` because
+   * `TerraformService.init` only ever allows one run in flight at a time.
+   *
+   * Pass an `AbortSignal` to cancel the stream: aborting (or breaking out of
+   * the `for await` loop) stops consuming the run early, mirroring
+   * `logs.stream`'s cancellation semantics.
+   *
+   * The iterator completes normally once the run finishes successfully, and
+   * throws (using the `terraform.init.end` payload's `error` field) if the
+   * run failed — including if the initial `config` failed validation and no
+   * `terraform init` process was ever spawned.
+   */
+  init: (config: TerraformInitConfig, signal?: AbortSignal) => AsyncIterable<TerraformRunChunk>;
+}
+
 // ---------------------------------------------------------------------------
 // Test-only injection surface
 // ---------------------------------------------------------------------------
@@ -734,6 +787,8 @@ export interface GsdApi {
   diagnostics: GsdDiagnosticsApi;
   /** Audit log: paginated history of `game_servers` mutations from DynamoDB. */
   audit: GsdAuditApi;
+  /** Terraform orchestration: streams `terraform init` output live as the process runs. */
+  terraform: GsdTerraformApi;
   /**
    * Test-only injection surface; `undefined` in production.
    *

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -627,4 +627,305 @@ describe('preload dispatcher', () => {
       }, 10_000);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // terraform.init
+  // -------------------------------------------------------------------------
+
+  describe('terraform.init', () => {
+    /**
+     * Helper to collect all chunks from the `terraform.init` async iterable
+     * into an array.
+     */
+    async function collectChunks(
+      iterable: AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>,
+    ): Promise<{ stream: 'stdout' | 'stderr'; line: string }[]> {
+      const chunks: { stream: 'stdout' | 'stderr'; line: string }[] = [];
+      for await (const chunk of iterable) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    }
+
+    const CONFIG = { bucket: 'my-bucket', region: 'us-east-1', dynamodbTable: 'my-lock-table' };
+
+    // -----------------------------------------------------------------------
+    // Mocked-delegation branch
+    // -----------------------------------------------------------------------
+
+    describe('mocked-delegation branch', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should delegate to the registered mock iterable instead of ipcRenderer when terraform.init is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* fakeStream() {
+          yield { stream: 'stdout' as const, line: 'Initializing backend...' };
+          yield { stream: 'stdout' as const, line: 'Terraform has been successfully initialized!' };
+        }
+
+        const mockHandler = vi.fn().mockReturnValue(fakeStream());
+        testApi.mock('terraform.init', mockHandler);
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown, signal?: AbortSignal) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        const chunks = await collectChunks(terraform.init(CONFIG));
+
+        expect(mockHandler).toHaveBeenCalledWith(CONFIG, undefined);
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(ipcSend).not.toHaveBeenCalled();
+        expect(chunks).toEqual([
+          { stream: 'stdout', line: 'Initializing backend...' },
+          { stream: 'stdout', line: 'Terraform has been successfully initialized!' },
+        ]);
+      });
+
+      it('should forward the AbortSignal to the mock handler when one is provided', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* emptyStream() {}
+        const mockHandler = vi.fn().mockReturnValue(emptyStream());
+        testApi.mock('terraform.init', mockHandler);
+
+        const controller = new AbortController();
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown, signal?: AbortSignal) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        await collectChunks(terraform.init(CONFIG, controller.signal));
+
+        expect(mockHandler).toHaveBeenCalledWith(CONFIG, controller.signal);
+      });
+
+      it('should not attach any ipcRenderer listeners when the mock handles the stream', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* emptyStream() {}
+        testApi.mock('terraform.init', vi.fn().mockReturnValue(emptyStream()));
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        await collectChunks(terraform.init(CONFIG));
+
+        expect(ipcOn).not.toHaveBeenCalled();
+        expect(ipcOnce).not.toHaveBeenCalled();
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Unmocked passthrough branch
+    // -----------------------------------------------------------------------
+
+    describe('unmocked passthrough branch', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        // Load with test-mode OFF so no mock registry is active — the real IPC
+        // path is always exercised.
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should attach the chunk/end listeners before calling ipcRenderer.invoke so no early chunk is dropped', async () => {
+        ipcInvoke.mockResolvedValue({ started: true });
+
+        // Simulate the main process sending an end event synchronously after the
+        // invoke so the generator completes without hanging.
+        ipcOnce.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.init.end') {
+            Promise.resolve().then(() => listener({} as unknown, { exitCode: 0 }));
+          }
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        await collectChunks(terraform.init(CONFIG));
+
+        // Registration must happen strictly before the invoke call resolves —
+        // otherwise a chunk sent immediately after the main process
+        // acknowledges the call could be dropped.
+        const onCallOrder = ipcOn.mock.invocationCallOrder[0];
+        const onceCallOrder = ipcOnce.mock.invocationCallOrder[0];
+        const invokeCallOrder = ipcInvoke.mock.invocationCallOrder[0];
+
+        expect(onCallOrder).toBeLessThan(invokeCallOrder);
+        expect(onceCallOrder).toBeLessThan(invokeCallOrder);
+      });
+
+      it('should invoke terraform.init on ipcRenderer with the config and attach chunk/end listeners', async () => {
+        ipcInvoke.mockResolvedValue({ started: true });
+
+        // Simulate the main process sending an end event synchronously after the
+        // invoke so the generator completes without hanging.
+        ipcOnce.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.init.end') {
+            Promise.resolve().then(() => listener({} as unknown, { exitCode: 0 }));
+          }
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        const chunks = await collectChunks(terraform.init(CONFIG));
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.init', CONFIG);
+        expect(chunks).toEqual([]);
+      });
+
+      it('should yield chunks received over the terraform.init.chunk IPC channel in order', async () => {
+        ipcInvoke.mockResolvedValue({ started: true });
+
+        // Capture the chunk listener so we can fire chunks after setup.
+        let capturedChunkListener: ((_evt: unknown, chunk: { stream: string; line: string }) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (_evt: unknown, chunk: { stream: string; line: string }) => void) => {
+          if (channel === 'terraform.init.chunk') {
+            capturedChunkListener = listener;
+          }
+        });
+
+        // Fire two chunks then end the stream.
+        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
+          if (channel === 'terraform.init.end') {
+            Promise.resolve()
+              .then(() => {
+                capturedChunkListener?.({}, { stream: 'stdout', line: 'Initializing backend...' });
+                capturedChunkListener?.({}, { stream: 'stdout', line: 'Terraform has been successfully initialized!' });
+              })
+              .then(() => listener({} as unknown, { exitCode: 0 }));
+          }
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        const chunks = await collectChunks(terraform.init(CONFIG));
+
+        expect(chunks).toEqual([
+          { stream: 'stdout', line: 'Initializing backend...' },
+          { stream: 'stdout', line: 'Terraform has been successfully initialized!' },
+        ]);
+      });
+
+      it('should throw when the terraform.init.end event carries an error field', async () => {
+        ipcInvoke.mockResolvedValue({ started: true });
+
+        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
+          if (channel === 'terraform.init.end') {
+            Promise.resolve().then(() => listener({} as unknown, { exitCode: 1, error: 'terraform init exited with code 1' }));
+          }
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+
+        await expect(collectChunks(terraform.init(CONFIG))).rejects.toThrow('terraform init exited with code 1');
+      });
+
+      it('should throw using the ack error, after cleaning up the listeners, when the invoke resolves with started: false', async () => {
+        ipcInvoke.mockResolvedValue({
+          started: false,
+          error: 'terraform.init requires non-empty bucket, region, and dynamodbTable strings',
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+
+        await expect(collectChunks(terraform.init(CONFIG))).rejects.toThrow(
+          'terraform.init requires non-empty bucket, region, and dynamodbTable strings',
+        );
+
+        // Listeners are attached before invoke (so no early chunk is dropped),
+        // but must be torn down once the ack reports the run never started.
+        expect(ipcOn).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
+        expect(ipcOnce).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
+      });
+
+      it('should remove chunk/end listeners once the stream completes', async () => {
+        ipcInvoke.mockResolvedValue({ started: true });
+
+        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
+          if (channel === 'terraform.init.end') {
+            Promise.resolve().then(() => listener({} as unknown, { exitCode: 0 }));
+          }
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        await collectChunks(terraform.init(CONFIG));
+
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
+      });
+
+      // -----------------------------------------------------------------------
+      // AbortSignal cancellation
+      // -----------------------------------------------------------------------
+
+      it('should stop yielding and clean up listeners without calling invoke when the signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown, signal?: AbortSignal) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        const chunks = await collectChunks(terraform.init(CONFIG, controller.signal));
+
+        expect(chunks).toEqual([]);
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
+      });
+
+      it('should stop the async iterable and clean up listeners when the signal aborts mid-stream', async () => {
+        ipcInvoke.mockResolvedValue({ started: true });
+
+        // Keep the stream alive — never fire the end event — so the consumer
+        // must be interrupted by the abort instead.
+        let capturedChunkListener: ((_evt: unknown, chunk: { stream: string; line: string }) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (_evt: unknown, chunk: { stream: string; line: string }) => void) => {
+          if (channel === 'terraform.init.chunk') capturedChunkListener = listener;
+        });
+        ipcOnce.mockImplementation(
+          (_channel: string, _listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
+            // Never fires — stream stays open until the signal aborts.
+          },
+        );
+
+        const controller = new AbortController();
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown, signal?: AbortSignal) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        const gen = terraform.init(CONFIG, controller.signal)[Symbol.asyncIterator]();
+
+        // Start the generator — it suspends at the inner `await new Promise`
+        // once the ack resolves and no chunk has arrived yet.
+        const nextPromise = gen.next();
+        await Promise.resolve();
+        await Promise.resolve();
+        // Deliver one chunk to prove the stream was flowing before the abort.
+        capturedChunkListener?.({}, { stream: 'stdout', line: 'Initializing backend...' });
+        const first = await nextPromise;
+        expect(first).toEqual({ done: false, value: { stream: 'stdout', line: 'Initializing backend...' } });
+
+        // Now abort — the generator should stop waiting for further chunks and
+        // complete on its own without the consumer having to call return().
+        controller.abort();
+        const second = await gen.next();
+
+        expect(second).toEqual({ done: true, value: undefined });
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
+      }, 10_000);
+    });
+  });
 });

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -724,6 +724,14 @@ describe('preload dispatcher', () => {
     describe('unmocked passthrough branch', () => {
       let bridge: Record<string, unknown>;
 
+      /**
+       * `TerraformController.init` mints a per-call `streamId` and tags every
+       * chunk/end payload with it (returning the same id in the invoke ack) so
+       * a second, rejected concurrent call can't cross-terminate this call's
+       * stream. Tests below default to this id when simulating the ack/events.
+       */
+      const STREAM_ID = 'sid-terraform-1';
+
       beforeEach(async () => {
         // Load with test-mode OFF so no mock registry is active — the real IPC
         // path is always exercised.
@@ -731,13 +739,16 @@ describe('preload dispatcher', () => {
       });
 
       it('should attach the chunk/end listeners before calling ipcRenderer.invoke so no early chunk is dropped', async () => {
-        ipcInvoke.mockResolvedValue({ started: true });
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
 
         // Simulate the main process sending an end event synchronously after the
-        // invoke so the generator completes without hanging.
-        ipcOnce.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+        // invoke so the generator completes without hanging. `terraform.init.end`
+        // is registered via `ipcRenderer.on` (not `.once`), since a foreign
+        // (rejected concurrent call's) end event could otherwise arrive first
+        // on the same fixed channel and be consumed by a `once` listener.
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
           if (channel === 'terraform.init.end') {
-            Promise.resolve().then(() => listener({} as unknown, { exitCode: 0 }));
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID, exitCode: 0 }));
           }
         });
 
@@ -749,22 +760,22 @@ describe('preload dispatcher', () => {
         // Registration must happen strictly before the invoke call resolves —
         // otherwise a chunk sent immediately after the main process
         // acknowledges the call could be dropped.
-        const onCallOrder = ipcOn.mock.invocationCallOrder[0];
-        const onceCallOrder = ipcOnce.mock.invocationCallOrder[0];
+        const firstOnCallOrder = ipcOn.mock.invocationCallOrder[0];
+        const secondOnCallOrder = ipcOn.mock.invocationCallOrder[1];
         const invokeCallOrder = ipcInvoke.mock.invocationCallOrder[0];
 
-        expect(onCallOrder).toBeLessThan(invokeCallOrder);
-        expect(onceCallOrder).toBeLessThan(invokeCallOrder);
+        expect(firstOnCallOrder).toBeLessThan(invokeCallOrder);
+        expect(secondOnCallOrder).toBeLessThan(invokeCallOrder);
       });
 
       it('should invoke terraform.init on ipcRenderer with the config and attach chunk/end listeners', async () => {
-        ipcInvoke.mockResolvedValue({ started: true });
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
 
         // Simulate the main process sending an end event synchronously after the
         // invoke so the generator completes without hanging.
-        ipcOnce.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
           if (channel === 'terraform.init.end') {
-            Promise.resolve().then(() => listener({} as unknown, { exitCode: 0 }));
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID, exitCode: 0 }));
           }
         });
 
@@ -778,32 +789,29 @@ describe('preload dispatcher', () => {
       });
 
       it('should yield chunks received over the terraform.init.chunk IPC channel in order', async () => {
-        ipcInvoke.mockResolvedValue({ started: true });
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
 
-        // Capture the chunk listener so we can fire chunks after setup.
-        let capturedChunkListener: ((_evt: unknown, chunk: { stream: string; line: string }) => void) | null = null;
-        ipcOn.mockImplementation((channel: string, listener: (_evt: unknown, chunk: { stream: string; line: string }) => void) => {
-          if (channel === 'terraform.init.chunk') {
-            capturedChunkListener = listener;
-          }
-        });
-
-        // Fire two chunks then end the stream.
-        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
-          if (channel === 'terraform.init.end') {
-            Promise.resolve()
-              .then(() => {
-                capturedChunkListener?.({}, { stream: 'stdout', line: 'Initializing backend...' });
-                capturedChunkListener?.({}, { stream: 'stdout', line: 'Terraform has been successfully initialized!' });
-              })
-              .then(() => listener({} as unknown, { exitCode: 0 }));
-          }
+        // Capture the chunk/end listeners so we can fire events after setup.
+        let capturedChunkListener: ((_evt: unknown, data: { streamId: string; chunk: { stream: string; line: string } }) => void) | null = null;
+        let capturedEndListener: ((_evt: unknown, data: { streamId: string; exitCode: number | null; error?: string }) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.init.chunk') capturedChunkListener = listener as typeof capturedChunkListener;
+          if (channel === 'terraform.init.end') capturedEndListener = listener as typeof capturedEndListener;
         });
 
         const terraform = bridge['terraform'] as {
           init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
         };
-        const chunks = await collectChunks(terraform.init(CONFIG));
+        const collected = collectChunks(terraform.init(CONFIG));
+
+        // Fire two chunks then end the stream, all tagged with this call's streamId.
+        await Promise.resolve();
+        await Promise.resolve();
+        capturedChunkListener?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Initializing backend...' } });
+        capturedChunkListener?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Terraform has been successfully initialized!' } });
+        capturedEndListener?.({}, { streamId: STREAM_ID, exitCode: 0 });
+
+        const chunks = await collected;
 
         expect(chunks).toEqual([
           { stream: 'stdout', line: 'Initializing backend...' },
@@ -811,12 +819,45 @@ describe('preload dispatcher', () => {
         ]);
       });
 
-      it('should throw when the terraform.init.end event carries an error field', async () => {
-        ipcInvoke.mockResolvedValue({ started: true });
+      it('should ignore chunk/end events tagged with a foreign streamId so a rejected concurrent call cannot cross-terminate this stream', async () => {
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
 
-        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
+        let capturedChunkListener: ((_evt: unknown, data: { streamId: string; chunk: { stream: string; line: string } }) => void) | null = null;
+        let capturedEndListener: ((_evt: unknown, data: { streamId: string; exitCode: number | null; error?: string }) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.init.chunk') capturedChunkListener = listener as typeof capturedChunkListener;
+          if (channel === 'terraform.init.end') capturedEndListener = listener as typeof capturedEndListener;
+        });
+
+        const terraform = bridge['terraform'] as {
+          init: (config: unknown) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+        };
+        const collected = collectChunks(terraform.init(CONFIG));
+
+        await Promise.resolve();
+        await Promise.resolve();
+        // A rejected, overlapping call's end event fires first, tagged with a
+        // different streamId — must not terminate this stream.
+        capturedEndListener?.({}, { streamId: 'sid-other-rejected-call', exitCode: null, error: 'boom' });
+        // Nor should a foreign chunk be yielded into this stream.
+        capturedChunkListener?.({}, { streamId: 'sid-other-rejected-call', chunk: { stream: 'stdout', line: 'not mine' } });
+        // This call's own chunk/end events still resolve the generator normally.
+        capturedChunkListener?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Initializing backend...' } });
+        capturedEndListener?.({}, { streamId: STREAM_ID, exitCode: 0 });
+
+        const chunks = await collected;
+
+        expect(chunks).toEqual([{ stream: 'stdout', line: 'Initializing backend...' }]);
+      });
+
+      it('should throw when the terraform.init.end event carries an error field', async () => {
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
+
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
           if (channel === 'terraform.init.end') {
-            Promise.resolve().then(() => listener({} as unknown, { exitCode: 1, error: 'terraform init exited with code 1' }));
+            Promise.resolve().then(() =>
+              listener({} as unknown, { streamId: STREAM_ID, exitCode: 1, error: 'terraform init exited with code 1' }),
+            );
           }
         });
 
@@ -844,17 +885,17 @@ describe('preload dispatcher', () => {
         // Listeners are attached before invoke (so no early chunk is dropped),
         // but must be torn down once the ack reports the run never started.
         expect(ipcOn).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
-        expect(ipcOnce).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
+        expect(ipcOn).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
         expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.chunk', expect.any(Function));
         expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.init.end', expect.any(Function));
       });
 
       it('should remove chunk/end listeners once the stream completes', async () => {
-        ipcInvoke.mockResolvedValue({ started: true });
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
 
-        ipcOnce.mockImplementation((channel: string, listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
           if (channel === 'terraform.init.end') {
-            Promise.resolve().then(() => listener({} as unknown, { exitCode: 0 }));
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID, exitCode: 0 }));
           }
         });
 
@@ -887,19 +928,16 @@ describe('preload dispatcher', () => {
       });
 
       it('should stop the async iterable and clean up listeners when the signal aborts mid-stream', async () => {
-        ipcInvoke.mockResolvedValue({ started: true });
+        ipcInvoke.mockResolvedValue({ started: true, streamId: STREAM_ID });
 
         // Keep the stream alive — never fire the end event — so the consumer
         // must be interrupted by the abort instead.
-        let capturedChunkListener: ((_evt: unknown, chunk: { stream: string; line: string }) => void) | null = null;
-        ipcOn.mockImplementation((channel: string, listener: (_evt: unknown, chunk: { stream: string; line: string }) => void) => {
-          if (channel === 'terraform.init.chunk') capturedChunkListener = listener;
+        let capturedChunkListener: ((_evt: unknown, data: { streamId: string; chunk: { stream: string; line: string } }) => void) | null = null;
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.init.chunk') capturedChunkListener = listener as typeof capturedChunkListener;
+          // 'terraform.init.end' listener is captured but intentionally never
+          // invoked — the stream stays open until the signal aborts.
         });
-        ipcOnce.mockImplementation(
-          (_channel: string, _listener: (_evt: unknown, data: { exitCode: number | null; error?: string }) => void) => {
-            // Never fires — stream stays open until the signal aborts.
-          },
-        );
 
         const controller = new AbortController();
         const terraform = bridge['terraform'] as {
@@ -913,7 +951,7 @@ describe('preload dispatcher', () => {
         await Promise.resolve();
         await Promise.resolve();
         // Deliver one chunk to prove the stream was flowing before the abort.
-        capturedChunkListener?.({}, { stream: 'stdout', line: 'Initializing backend...' });
+        capturedChunkListener?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Initializing backend...' } });
         const first = await nextPromise;
         expect(first).toEqual({ done: false, value: { stream: 'stdout', line: 'Initializing backend...' } });
 

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -14,13 +14,17 @@
  * generator. Aborting the supplied `AbortSignal` — or breaking out of the
  * `for await` loop — sends `logs.stream.<id>.cancel` to stop the main loop.
  *
- * `terraform.init(config, signal)` streams similarly, but since only one
- * `terraform init` run is ever in flight at a time, it wraps the fixed
- * `terraform.init.chunk` / `terraform.init.end` side channels directly rather
- * than minting a per-call stream id. There is no dedicated cancel channel —
- * aborting simply stops the generator from consuming further chunks, since
- * `TerraformService.init` only ever allows one run in flight at a time and the
- * main process has nothing to tear down early.
+ * `terraform.init(config, signal)` streams similarly, but `TerraformController.init`
+ * pushes chunks/end messages on fixed `terraform.init.chunk` / `terraform.init.end`
+ * side channels shared by every call rather than per-call channel names.
+ * `invoke('terraform.init', config)` resolves with a `streamId` minted by the
+ * controller for this call, and every chunk/end message on those shared
+ * channels is tagged with the `streamId` of the call that produced it — the
+ * generator ignores any message whose `streamId` doesn't match its own, so a
+ * rejected concurrent call or a late message from an abandoned stream can
+ * never resolve/terminate a different call's generator. There is no dedicated
+ * cancel channel — aborting simply stops the generator from consuming further
+ * chunks, since the main process has nothing to tear down early.
  */
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
@@ -176,10 +180,15 @@ async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<Lo
  * `terraform.init.end` side channels into an {@link AsyncIterable} of
  * {@link TerraformRunChunk}.
  *
- * Unlike `streamLogs`, `TerraformService.init` only ever allows a single run
- * in flight at a time, so `TerraformController.init` always pushes chunks on
- * the same fixed channel names rather than minting a per-call `streamId` —
- * there is nothing to key listeners on beyond the two constants above.
+ * `TerraformController.init` pushes chunk/end events on these two fixed
+ * channel names for *every* call (rather than minting per-call channel
+ * names the way `streamLogs` does), but tags each payload with the
+ * `streamId` it minted for this call and returned in the invoke ack
+ * (`{ started, streamId, error? }`). Events whose `streamId` doesn't match
+ * this call's own `streamId` are ignored — this is what stops a second,
+ * rejected concurrent `terraform.init` call (e.g. `TerraformService.init`'s
+ * single-flight guard rejecting an overlapping run) from broadcasting an end
+ * event that would otherwise prematurely terminate this caller's stream.
  *
  * When a mock is registered for the `'terraform.init'` channel (test mode
  * only), the mock handler is called with `(config)` and its return value is
@@ -190,14 +199,18 @@ async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<Lo
  * `terraform.init.end` listeners are attached **before**
  * `ipcRenderer.invoke('terraform.init', config)` is called, so no chunk sent
  * immediately after the main process acknowledges the call can ever be
- * dropped. The invoke call resolves with `{ started, error? }`: a `false`
+ * dropped. Since this call's own `streamId` isn't known until the invoke
+ * resolves, events observed before then are held in a raw buffer and
+ * replayed (filtered by the now-known `streamId`) once the ack arrives. The
+ * invoke call resolves with `{ started, streamId?, error? }`: a `false`
  * `started` value means `config` failed validation and no `terraform init`
  * process was ever spawned — no chunk/end messages will ever arrive, so the
  * generator throws right away using `error` (and cleans up the now-unused
- * listeners in `finally`). When `started` is `true`, chunks are buffered as
- * they arrive on `terraform.init.chunk` and yielded in order; the generator
- * completes when `terraform.init.end` fires with no `error`, or throws using
- * its `error` field otherwise.
+ * listeners in `finally`). When `started` is `true`, chunks tagged with this
+ * call's `streamId` are buffered as they arrive on `terraform.init.chunk`
+ * and yielded in order; the generator completes when a `terraform.init.end`
+ * event tagged with this call's `streamId` fires with no `error`, or throws
+ * using its `error` field otherwise.
  *
  * Following the `logs.stream` pattern, an optional `signal` may be supplied to
  * cancel consumption early: aborting (or breaking out of the `for await`
@@ -219,6 +232,16 @@ async function* streamTerraformInit(config: TerraformInitConfig, signal?: AbortS
   let ended = false;
   let endError: string | undefined;
   let aborted = false;
+  /**
+   * This call's own `streamId`, known only once the `terraform.init` invoke
+   * resolves. `null` until then, at which point every raw chunk/end event
+   * buffered so far is replayed through the `streamId` filter below.
+   */
+  let ownStreamId: string | null = null;
+  /** Chunk events observed before `ownStreamId` is known. */
+  const rawChunkBuffer: Array<{ streamId: string; chunk: TerraformRunChunk }> = [];
+  /** End events observed before `ownStreamId` is known. */
+  const rawEndBuffer: Array<{ streamId: string; exitCode: number | null; error?: string }> = [];
   /** Resolves the pending `await` when a chunk arrives, the stream ends, or the signal aborts. */
   let wake: (() => void) | null = null;
   const signalWake = () => {
@@ -229,26 +252,49 @@ async function* streamTerraformInit(config: TerraformInitConfig, signal?: AbortS
     }
   };
 
-  const onChunk = (_evt: IpcRendererEvent, chunk: TerraformRunChunk) => {
-    buffer.push(chunk);
+  /** Applies a chunk event, discarding it if it belongs to a different `terraform.init` call. */
+  const applyChunk = (data: { streamId: string; chunk: TerraformRunChunk }) => {
+    if (data.streamId !== ownStreamId) return;
+    buffer.push(data.chunk);
     signalWake();
   };
-  const onEnd = (_evt: IpcRendererEvent, data: { exitCode: number | null; error?: string }) => {
+  /** Applies an end event, discarding it if it belongs to a different `terraform.init` call. */
+  const applyEnd = (data: { streamId: string; exitCode: number | null; error?: string }) => {
+    if (data.streamId !== ownStreamId) return;
     ended = true;
-    endError = data?.error;
+    endError = data.error;
     signalWake();
+  };
+
+  const onChunk = (_evt: IpcRendererEvent, data: { streamId: string; chunk: TerraformRunChunk }) => {
+    if (ownStreamId === null) {
+      rawChunkBuffer.push(data);
+      return;
+    }
+    applyChunk(data);
+  };
+  const onEnd = (_evt: IpcRendererEvent, data: { streamId: string; exitCode: number | null; error?: string }) => {
+    if (ownStreamId === null) {
+      rawEndBuffer.push(data);
+      return;
+    }
+    applyEnd(data);
   };
   const onAbort = () => {
     aborted = true;
     signalWake();
   };
 
-  // Attach both listeners before invoking so no early chunk sent right after
+  // Attach both listeners before invoking so no early event sent right after
   // the main process acknowledges the call is ever dropped — unlike
   // `streamLogs`, the channel names here are fixed constants known up front,
-  // so there is no need to wait for the invoke response first.
+  // so there is no need to wait for the invoke response first. `onEnd` can no
+  // longer use `ipcRenderer.once`: a rejected concurrent call's end event
+  // (tagged with a foreign `streamId`) could arrive on this same fixed
+  // channel before our own, and a `once` listener would consume and discard
+  // it, missing our own end event entirely.
   ipcRenderer.on(TERRAFORM_INIT_CHUNK_CHANNEL, onChunk);
-  ipcRenderer.once(TERRAFORM_INIT_END_CHANNEL, onEnd);
+  ipcRenderer.on(TERRAFORM_INIT_END_CHANNEL, onEnd);
   if (signal) {
     if (signal.aborted) aborted = true;
     else signal.addEventListener('abort', onAbort, { once: true });
@@ -257,13 +303,22 @@ async function* streamTerraformInit(config: TerraformInitConfig, signal?: AbortS
   try {
     if (aborted) return;
 
-    const ack = (await invoke('terraform.init', config)) as { started: boolean; error?: string };
-    if (!ack.started) {
+    const ack = (await invoke('terraform.init', config)) as { started: boolean; streamId?: string; error?: string };
+    if (!ack.started || !ack.streamId) {
       throw new Error(ack.error ?? 'terraform.init failed to start');
     }
+    ownStreamId = ack.streamId;
+
+    // Replay anything observed before we knew our own streamId, filtering
+    // out events tagged with a different (foreign, overlapping) run.
+    for (const data of rawChunkBuffer) applyChunk(data);
+    rawChunkBuffer.length = 0;
+    for (const data of rawEndBuffer) applyEnd(data);
+    rawEndBuffer.length = 0;
 
     while (true) {
       while (buffer.length > 0) {
+        if (aborted) return;
         yield buffer.shift()!;
       }
       if (aborted) return;

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -13,6 +13,14 @@
  * the per-stream `logs.stream.<id>.chunk` / `.end` IPC events in an async
  * generator. Aborting the supplied `AbortSignal` — or breaking out of the
  * `for await` loop — sends `logs.stream.<id>.cancel` to stop the main loop.
+ *
+ * `terraform.init(config, signal)` streams similarly, but since only one
+ * `terraform init` run is ever in flight at a time, it wraps the fixed
+ * `terraform.init.chunk` / `terraform.init.end` side channels directly rather
+ * than minting a per-call stream id. There is no dedicated cancel channel —
+ * aborting simply stops the generator from consuming further chunks, since
+ * `TerraformService.init` only ever allows one run in flight at a time and the
+ * main process has nothing to tear down early.
  */
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
@@ -23,8 +31,16 @@ import type {
   GsdApi,
   GsdTestApi,
   LogChunk,
+  TerraformInitConfig,
+  TerraformRunChunk,
   UpdateGamePayload,
 } from './gsd-api.js';
+
+/** Fixed side-channel `TerraformController.init` pushes streamed output on. */
+const TERRAFORM_INIT_CHUNK_CHANNEL = 'terraform.init.chunk';
+
+/** Fixed side-channel `TerraformController.init` sends its terminal message on. */
+const TERRAFORM_INIT_END_CHANNEL = 'terraform.init.end';
 
 /**
  * Per-channel mock registry populated by tests via `window.gsd.__test.mock(channel, handler)`.
@@ -155,6 +171,117 @@ async function* streamLogs(game: string, signal?: AbortSignal): AsyncIterable<Lo
   }
 }
 
+/**
+ * Bridges `TerraformController.init`'s fixed `terraform.init.chunk` /
+ * `terraform.init.end` side channels into an {@link AsyncIterable} of
+ * {@link TerraformRunChunk}.
+ *
+ * Unlike `streamLogs`, `TerraformService.init` only ever allows a single run
+ * in flight at a time, so `TerraformController.init` always pushes chunks on
+ * the same fixed channel names rather than minting a per-call `streamId` —
+ * there is nothing to key listeners on beyond the two constants above.
+ *
+ * When a mock is registered for the `'terraform.init'` channel (test mode
+ * only), the mock handler is called with `(config)` and its return value is
+ * treated as an `AsyncIterable<TerraformRunChunk>` — the real IPC listener
+ * path is never touched.
+ *
+ * In production (no mock registered), the `terraform.init.chunk` /
+ * `terraform.init.end` listeners are attached **before**
+ * `ipcRenderer.invoke('terraform.init', config)` is called, so no chunk sent
+ * immediately after the main process acknowledges the call can ever be
+ * dropped. The invoke call resolves with `{ started, error? }`: a `false`
+ * `started` value means `config` failed validation and no `terraform init`
+ * process was ever spawned — no chunk/end messages will ever arrive, so the
+ * generator throws right away using `error` (and cleans up the now-unused
+ * listeners in `finally`). When `started` is `true`, chunks are buffered as
+ * they arrive on `terraform.init.chunk` and yielded in order; the generator
+ * completes when `terraform.init.end` fires with no `error`, or throws using
+ * its `error` field otherwise.
+ *
+ * Following the `logs.stream` pattern, an optional `signal` may be supplied to
+ * cancel consumption early: aborting (or breaking out of the `for await`
+ * loop) stops the wait loop and the `finally` block detaches the listeners.
+ * There is no per-run cancel side channel to notify the main process — the
+ * `terraform init` run itself keeps running to completion in the background,
+ * but the generator stops yielding further chunks to the caller.
+ */
+async function* streamTerraformInit(config: TerraformInitConfig, signal?: AbortSignal): AsyncIterable<TerraformRunChunk> {
+  const initMock = mockRegistry.get('terraform.init');
+  if (initMock !== undefined) {
+    const mockIterable = initMock(config, signal) as AsyncIterable<TerraformRunChunk>;
+    yield* mockIterable;
+    return;
+  }
+
+  /** Chunks received but not yet yielded. */
+  const buffer: TerraformRunChunk[] = [];
+  let ended = false;
+  let endError: string | undefined;
+  let aborted = false;
+  /** Resolves the pending `await` when a chunk arrives, the stream ends, or the signal aborts. */
+  let wake: (() => void) | null = null;
+  const signalWake = () => {
+    if (wake) {
+      const fn = wake;
+      wake = null;
+      fn();
+    }
+  };
+
+  const onChunk = (_evt: IpcRendererEvent, chunk: TerraformRunChunk) => {
+    buffer.push(chunk);
+    signalWake();
+  };
+  const onEnd = (_evt: IpcRendererEvent, data: { exitCode: number | null; error?: string }) => {
+    ended = true;
+    endError = data?.error;
+    signalWake();
+  };
+  const onAbort = () => {
+    aborted = true;
+    signalWake();
+  };
+
+  // Attach both listeners before invoking so no early chunk sent right after
+  // the main process acknowledges the call is ever dropped — unlike
+  // `streamLogs`, the channel names here are fixed constants known up front,
+  // so there is no need to wait for the invoke response first.
+  ipcRenderer.on(TERRAFORM_INIT_CHUNK_CHANNEL, onChunk);
+  ipcRenderer.once(TERRAFORM_INIT_END_CHANNEL, onEnd);
+  if (signal) {
+    if (signal.aborted) aborted = true;
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
+
+  try {
+    if (aborted) return;
+
+    const ack = (await invoke('terraform.init', config)) as { started: boolean; error?: string };
+    if (!ack.started) {
+      throw new Error(ack.error ?? 'terraform.init failed to start');
+    }
+
+    while (true) {
+      while (buffer.length > 0) {
+        yield buffer.shift()!;
+      }
+      if (aborted) return;
+      if (ended) {
+        if (endError) throw new Error(endError);
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  } finally {
+    ipcRenderer.removeListener(TERRAFORM_INIT_CHUNK_CHANNEL, onChunk);
+    ipcRenderer.removeListener(TERRAFORM_INIT_END_CHANNEL, onEnd);
+    signal?.removeEventListener('abort', onAbort);
+  }
+}
+
 const api: GsdApi = {
   games: {
     list: () => invoke('games.list'),
@@ -229,6 +356,10 @@ const api: GsdApi = {
 
   audit: {
     list: (opts?: { limit?: number; before?: string }) => invoke('audit.list', opts),
+  },
+
+  terraform: {
+    init: streamTerraformInit,
   },
 };
 


### PR DESCRIPTION
Closes #171

## Summary

- Adds `TerraformService.init({ bucket, region, dynamodbTable })` — spawns `terraform init -backend-config="bucket=..." -backend-config="region=..." -backend-config="dynamodb_table=..."` in the terraform working directory, streaming stdout/stderr chunks and resolving with the exit status. Refactors binary resolution to lazy (resolved on first use, not at construction) so `AppModule` can import `TerraformModule` safely without an async factory blocking app boot.
- Adds `ConfigService.getTerraformDir()` to resolve the terraform working directory, wires a `TerraformController` that exposes `terraform.init` as a self-bridged, streaming IPC pattern (`terraform.init.chunk` / `.end` channels) registered in `ipc-main-bridge.ts`, and adds `gsd.terraform.init()` to the preload bridge so the renderer can subscribe to live output.
- Idempotency: a completed `terraform init` for the same backend config is a no-op on re-run (state tracked in `TerraformService`), matching the First-Run Wizard step 5 requirement.

## Changes

```
 app/packages/desktop-main/src/app.module.ts        |   7 +-
 .../src/controllers/terraform.controller.test.ts   | 273 ++++++++++++
 .../src/controllers/terraform.controller.ts        | 172 ++++++++
 .../desktop-main/src/ipc-main-bridge.test.ts       |  14 +
 app/packages/desktop-main/src/ipc-main-bridge.ts   |  14 +-
 .../desktop-main/src/modules/terraform.module.ts   |  27 +-
 .../src/services/ConfigService.test.ts             |  20 +
 .../desktop-main/src/services/ConfigService.ts     |  26 ++
 .../src/services/TerraformService.init.test.ts     | 480 +++++++++++++++++++++
 .../src/services/TerraformService.test.ts          | 149 +++++--
 .../desktop-main/src/services/TerraformService.ts  | 300 +++++++++++--
 app/packages/desktop-preload/src/gsd-api.ts        |  55 +++
 app/packages/desktop-preload/src/preload.test.ts   | 301 +++++++++++++
 app/packages/desktop-preload/src/preload.ts        | 131 ++++++
 14 files changed, 1893 insertions(+), 76 deletions(-)
```

## Test plan

- [x] `TerraformService.init()` spawns `terraform init` with the three `-backend-config` args derived from `{ bucket, region, dynamodbTable }` — covered by `TerraformService.init.test.ts`.
- [x] Output is streamed chunk-by-chunk over IPC (`terraform.init.chunk`) with a terminal `.end` event carrying exit status — covered by `TerraformController.test.ts` and `preload.test.ts`.
- [x] Re-running `init` with the same config is a no-op (idempotent) — covered by `TerraformService.init.test.ts`.
- [x] Lazy binary resolution keeps `TerraformModule` safe to import eagerly from `AppModule` — covered by `TerraformService.test.ts` updates and `app.module.ts` wiring.
- [x] `gsd.terraform.init()` preload bridge exposes the streaming API for the First-Run Wizard step 5 to consume.
- [x] `npm run app:test` passing for the touched workspace (desktop-main, desktop-preload).
- [x] `npm run app:lint` clean.
