### PR TITLE
feat(desktop-main): TerraformService.plan() producing tfplan artifact

### DIFF
--- a/app/packages/desktop-main/src/modules/terraform.module.ts
+++ b/app/packages/desktop-main/src/modules/terraform.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from './config.module.js';
+import { CloudProviderModule } from './cloud-provider.module.js';
 import { TerraformService } from '../services/TerraformService.js';
 
 /**
@@ -12,16 +13,21 @@ import { TerraformService } from '../services/TerraformService.js';
  * even on machines without `terraform` on PATH.
  *
  * Imports `ConfigModule` because `TerraformService` takes `ConfigService` as
- * a constructor dependency (the seam later terraform orchestration methods
- * will use to resolve the working directory) — plain Nest DI, no factory
- * needed since neither service does async work at construction time.
+ * a constructor dependency (used to resolve the working directory and the
+ * per-run artifacts directory) and `CloudProviderModule` for the
+ * `REMOTE_FILE_STORE` token — `TerraformService.plan()` pulls the current
+ * tfvars snapshot from it in S3 mode, mirroring `TfvarsModule`'s wiring —
+ * both re-exported alongside `TerraformService` so any consumer that only
+ * needs `TerraformModule` gets the full dependency chain without also
+ * importing `AwsModule`. Plain Nest DI, no async factory needed since none of
+ * these providers do async work at construction time.
  *
  * Imported by `AppModule` alongside `TerraformController`, which bridges
  * `TerraformService.init`'s async-generator output onto Electron IPC.
  */
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, CloudProviderModule],
   providers: [TerraformService],
-  exports: [TerraformService],
+  exports: [ConfigModule, CloudProviderModule, TerraformService],
 })
 export class TerraformModule {}

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
+import os from 'os';
 
 vi.mock('fs', () => ({
   readFileSync: vi.fn(),
@@ -371,6 +372,7 @@ describe('ConfigService', () => {
       delete process.env['TFVARS_PATH'];
       delete process.env['GSD_TFVARS_BUCKET'];
       delete process.env['TF_DIR'];
+      delete process.env['RUNS_DIR_PATH'];
     });
 
     it('should return packaged tfstate path when readIsPackaged returns true', () => {
@@ -549,6 +551,25 @@ describe('ConfigService', () => {
       const result = testableService.getTerraformDir();
       expect(result).toMatch(/terraform$/);
       expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    describe('getRunsDir', () => {
+      it('should return the RUNS_DIR_PATH env var value when set', () => {
+        process.env['RUNS_DIR_PATH'] = '/custom/runs';
+        expect(service.getRunsDir()).toBe('/custom/runs');
+      });
+
+      it('should return <userData>/runs when the env var is unset and userData is available', () => {
+        vi.spyOn(testableService, 'readUserDataPath').mockReturnValue('/fake/userData');
+        expect(testableService.getRunsDir()).toBe(path.join('/fake/userData', 'runs'));
+      });
+
+      it('should return the OS tmpdir fallback when the env var is unset and userData is unavailable', () => {
+        vi.spyOn(testableService, 'readUserDataPath').mockReturnValue(null);
+        const result = testableService.getRunsDir();
+        expect(result).toBe(path.join(os.tmpdir(), 'hyveon-runs'));
+        expect(path.isAbsolute(result)).toBe(true);
+      });
     });
   });
 });

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -559,6 +559,13 @@ describe('ConfigService', () => {
         expect(service.getRunsDir()).toBe('/custom/runs');
       });
 
+      it('should resolve a relative RUNS_DIR_PATH env var against process.cwd() rather than getTerraformDir()', () => {
+        process.env['RUNS_DIR_PATH'] = 'relative/runs';
+        const result = service.getRunsDir();
+        expect(result).toBe(path.resolve('relative/runs'));
+        expect(path.isAbsolute(result)).toBe(true);
+      });
+
       it('should return <userData>/runs when the env var is unset and userData is available', () => {
         vi.spyOn(testableService, 'readUserDataPath').mockReturnValue('/fake/userData');
         expect(testableService.getRunsDir()).toBe(path.join('/fake/userData', 'runs'));

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { readFileSync, writeFileSync, existsSync, cpSync, renameSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { randomUUID } from 'crypto';
@@ -233,6 +234,14 @@ export class ConfigService {
   }
 
   /**
+   * Read the Terraform run-artifacts directory override from `RUNS_DIR_PATH`.
+   * Extracted for test-stubbing, mirroring {@link readEnvTerraformDir}.
+   */
+  readEnvRunsDir(): string | undefined {
+    return process.env['RUNS_DIR_PATH'];
+  }
+
+  /**
    * Return `process.resourcesPath` when running inside an Electron packaged app,
    * or `undefined` otherwise. Extracted as a protected method so tests can stub
    * it via `vi.spyOn` without touching `process.resourcesPath` directly.
@@ -387,6 +396,33 @@ export class ConfigService {
       }
       return false;
     }
+  }
+
+  /**
+   * Resolve the absolute path to the directory `TerraformService.plan()`
+   * (and future `apply`/`destroy`) writes per-run artifacts into — the
+   * pulled tfvars snapshot, the `.tfplan` file, and partial logs, one
+   * subdirectory per `runId` (`<runsDir>/<runId>/...`). See the "Terraform
+   * run cache" row in `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md`.
+   *
+   * Resolution order:
+   *  1. `RUNS_DIR_PATH` env var — wins when set.
+   *  2. Electron `userData` directory (`<userData>/runs`) — a writable
+   *     per-user location that survives app updates, available whenever this
+   *     process is running inside Electron (see {@link readUserDataPath}).
+   *  3. OS temp directory (`<os.tmpdir()>/hyveon-runs`) fallback — used in
+   *     plain-Node/test contexts where no Electron `userData` path exists.
+   */
+  getRunsDir(): string {
+    const envOverride = this.readEnvRunsDir();
+    if (envOverride) return envOverride;
+
+    const userData = this.readUserDataPath();
+    if (userData) {
+      return join(userData, 'runs');
+    }
+
+    return join(tmpdir(), 'hyveon-runs');
   }
 
   /**

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { readFileSync, writeFileSync, existsSync, cpSync, renameSync, rmSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
@@ -406,7 +406,11 @@ export class ConfigService {
    * run cache" row in `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md`.
    *
    * Resolution order:
-   *  1. `RUNS_DIR_PATH` env var — wins when set.
+   *  1. `RUNS_DIR_PATH` env var — wins when set. Resolved with `resolve()`
+   *     against `process.cwd()` so a relative override doesn't silently
+   *     resolve against `getTerraformDir()`'s cwd (the directory
+   *     `TerraformService` spawns `terraform` from) instead of the
+   *     directory the app was launched from.
    *  2. Electron `userData` directory (`<userData>/runs`) — a writable
    *     per-user location that survives app updates, available whenever this
    *     process is running inside Electron (see {@link readUserDataPath}).
@@ -415,7 +419,7 @@ export class ConfigService {
    */
   getRunsDir(): string {
     const envOverride = this.readEnvRunsDir();
-    if (envOverride) return envOverride;
+    if (envOverride) return resolve(envOverride);
 
     const userData = this.readUserDataPath();
     if (userData) {

--- a/app/packages/desktop-main/src/services/TerraformService.init.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.init.test.ts
@@ -6,25 +6,53 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * vi.mock() calls are lifted to the top of the compiled output above regular
  * declarations.
  */
-const { execFileMock, spawnMock } = vi.hoisted(() => {
-  const execFileMock = vi.fn();
-  const spawnMock = vi.fn();
-  return { execFileMock, spawnMock };
-});
+const { execFileMock, spawnMock, mkdirSyncMock, existsSyncMock, writeFileSyncMock, copyFileSyncMock, randomUUIDMock } =
+  vi.hoisted(() => {
+    const execFileMock = vi.fn();
+    const spawnMock = vi.fn();
+    const mkdirSyncMock = vi.fn();
+    const existsSyncMock = vi.fn();
+    const writeFileSyncMock = vi.fn();
+    const copyFileSyncMock = vi.fn();
+    const randomUUIDMock = vi.fn();
+    return {
+      execFileMock,
+      spawnMock,
+      mkdirSyncMock,
+      existsSyncMock,
+      writeFileSyncMock,
+      copyFileSyncMock,
+      randomUUIDMock,
+    };
+  });
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
   spawn: spawnMock,
 }));
 
+vi.mock('node:fs', () => ({
+  mkdirSync: mkdirSyncMock,
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+  copyFileSync: copyFileSyncMock,
+}));
+
+vi.mock('node:crypto', () => ({
+  randomUUID: randomUUIDMock,
+}));
+
 import {
   TerraformService,
   TerraformNotFoundError,
   TerraformInitError,
+  TerraformPlanError,
   type TerraformInitConfig,
   type TerraformRunChunk,
+  type TerraformPlanResult,
 } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RemoteFileStore } from '@hyveon/shared';
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
@@ -64,6 +92,47 @@ function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', vers
  */
 function stubConfigService(terraformDir = '/repo/terraform'): ConfigService {
   return { getTerraformDir: () => terraformDir } as ConfigService;
+}
+
+/**
+ * `ConfigService` stub for `plan()` tests: exposes `getTerraformDir`,
+ * `getRunsDir`, `getTfvarsBucket`, and `getTfvarsPath` — the accessors
+ * `plan()` reads, beyond the narrower `getTerraformDir()`-only stub above
+ * that's sufficient for `init()`.
+ */
+function stubPlanConfigService(
+  opts: {
+    terraformDir?: string;
+    runsDir?: string;
+    tfvarsBucket?: string | null;
+    tfvarsPath?: string;
+  } = {},
+): ConfigService {
+  return {
+    getTerraformDir: () => opts.terraformDir ?? '/repo/terraform',
+    getRunsDir: () => opts.runsDir ?? '/repo/runs',
+    getTfvarsBucket: () => opts.tfvarsBucket ?? null,
+    getTfvarsPath: () => opts.tfvarsPath ?? '/repo/terraform/terraform.tfvars',
+  } as ConfigService;
+}
+
+/**
+ * Minimal `RemoteFileStore` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. `get`/`put`/`listVersions` are directly-controllable
+ * mocks so S3-mode `plan()` tests can queue a tfvars object response.
+ */
+function stubRemoteFileStore(): RemoteFileStore & {
+  get: ReturnType<typeof vi.fn>;
+  listVersions: ReturnType<typeof vi.fn>;
+} {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  } as unknown as RemoteFileStore & {
+    get: ReturnType<typeof vi.fn>;
+    listVersions: ReturnType<typeof vi.fn>;
+  };
 }
 
 /**
@@ -140,6 +209,32 @@ async function collectAllChunks(
   return chunks;
 }
 
+/**
+ * Drains a `plan()` async generator to completion, collecting every yielded
+ * chunk plus the generator's final return value — a `TerraformPlanResult` on
+ * success, or `undefined` on a clean abort. Mirrors {@link collectAllChunks}
+ * but also captures the return value, which `plan()` (unlike `init()`)
+ * resolves with on success.
+ */
+async function collectPlanChunks(
+  gen: AsyncGenerator<TerraformRunChunk, TerraformPlanResult | undefined>,
+  driveChild?: () => void,
+): Promise<{ chunks: TerraformRunChunk[]; result: TerraformPlanResult | undefined }> {
+  const chunks: TerraformRunChunk[] = [];
+  const first = gen.next();
+  first.catch(() => {});
+  await flushMicrotasks();
+  driveChild?.();
+  let next = await first;
+  while (!next.done) {
+    chunks.push(next.value);
+    const following = gen.next();
+    following.catch(() => {});
+    next = await following;
+  }
+  return { chunks, result: next.value };
+}
+
 const sampleConfig: TerraformInitConfig = {
   bucket: 'hyveon-tf-state',
   region: 'us-east-1',
@@ -149,6 +244,13 @@ const sampleConfig: TerraformInitConfig = {
 beforeEach(() => {
   execFileMock.mockReset();
   spawnMock.mockReset();
+  mkdirSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(true);
+  writeFileSyncMock.mockReset();
+  copyFileSyncMock.mockReset();
+  randomUUIDMock.mockReset();
+  randomUUIDMock.mockReturnValue('run-123');
 });
 
 describe('TerraformService.init spawning', () => {
@@ -157,7 +259,7 @@ describe('TerraformService.init spawning', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService('/repo/terraform'));
+    const service = new TerraformService(stubConfigService('/repo/terraform'), stubRemoteFileStore());
 
     await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
@@ -178,7 +280,7 @@ describe('TerraformService.init spawning', () => {
   it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(collectAllChunks(service.init(sampleConfig))).rejects.toBeInstanceOf(
       TerraformNotFoundError,
@@ -193,7 +295,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const gen = service.init(sampleConfig);
 
     const first = gen.next();
@@ -224,7 +326,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => {
       child.emitStderr('Warning: something\n');
       child.close(0);
@@ -238,7 +340,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => {
       child.emitStdout('line one\nline two\nline three\n');
       child.close(0);
@@ -256,7 +358,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => {
       child.emitStdout('no trailing newline');
       child.close(0);
@@ -270,7 +372,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
     expect(chunks).toEqual([]);
@@ -283,7 +385,7 @@ describe('TerraformService.init exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(collectAllChunks(service.init(sampleConfig), () => child.close(0))).resolves.toEqual(
       [],
@@ -295,7 +397,7 @@ describe('TerraformService.init exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     const result = collectAllChunks(service.init(sampleConfig), () => child.close(1));
 
@@ -308,7 +410,7 @@ describe('TerraformService.init exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     const result = collectAllChunks(service.init(sampleConfig), () =>
       child.emit('error', new Error('spawn ENOENT')),
@@ -324,7 +426,7 @@ describe('TerraformService.init idempotency', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -340,7 +442,7 @@ describe('TerraformService.init idempotency', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
     spawnMock.mockClear();
@@ -358,7 +460,7 @@ describe('TerraformService.init idempotency', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     await collectAllChunks(service.init(sampleConfig), () => firstChild.close(0));
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -377,7 +479,7 @@ describe('TerraformService.init idempotency', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     await expect(
       collectAllChunks(service.init(sampleConfig), () => firstChild.close(1)),
     ).rejects.toBeInstanceOf(TerraformInitError);
@@ -399,7 +501,7 @@ describe('TerraformService.init abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const gen = service.init(sampleConfig, controller.signal);
 
     const pendingNext = gen.next();
@@ -423,7 +525,7 @@ describe('TerraformService.init abort handling', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const gen = service.init(sampleConfig, controller.signal);
 
     const result = await gen.next();
@@ -439,7 +541,7 @@ describe('TerraformService.init abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     const pendingNext = service.init(sampleConfig, controller.signal).next();
     await flushMicrotasks();
@@ -461,7 +563,7 @@ describe('TerraformService.init concurrency guard', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const firstGen = service.init(sampleConfig);
     const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
 
@@ -480,7 +582,7 @@ describe('TerraformService.init concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     await collectAllChunks(service.init(sampleConfig), () => firstChild.close(0));
 
     const secondChild = new FakeChildProcess();
@@ -490,5 +592,291 @@ describe('TerraformService.init concurrency guard', () => {
         secondChild.close(0),
       ),
     ).resolves.toEqual([]);
+  });
+});
+
+describe('TerraformService.plan spawning and artifact persistence', () => {
+  it('should mint a runId, create its runs-dir, pull the local tfvars snapshot, and spawn terraform plan with -out/-var-file derived from them', async () => {
+    queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
+    randomUUIDMock.mockReturnValue('run-123');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({
+        terraformDir: '/repo/terraform',
+        runsDir: '/repo/runs',
+        tfvarsBucket: null,
+        tfvarsPath: '/repo/terraform/terraform.tfvars',
+      }),
+      stubRemoteFileStore(),
+    );
+
+    await collectPlanChunks(service.plan(), () => child.close(0));
+
+    expect(mkdirSyncMock).toHaveBeenCalledWith('/repo/runs/run-123', { recursive: true });
+    expect(copyFileSyncMock).toHaveBeenCalledWith(
+      '/repo/terraform/terraform.tfvars',
+      '/repo/runs/run-123/terraform.tfvars',
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/terraform',
+      [
+        'plan',
+        '-input=false',
+        '-no-color',
+        '-out=/repo/runs/run-123/run-123.tfplan',
+        '-var-file=/repo/runs/run-123/terraform.tfvars',
+      ],
+      { cwd: '/repo/terraform' },
+    );
+  });
+
+  it('should pull the tfvars snapshot from the RemoteFileStore instead of the local filesystem when a tfvars bucket is configured', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-456');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.get.mockResolvedValue({
+      body: new TextEncoder().encode('game_servers = {}'),
+      etag: 'etag-1',
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await collectPlanChunks(service.plan(), () => child.close(0));
+
+    expect(remoteFileStore.get).toHaveBeenCalledWith('terraform.tfvars');
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      '/repo/runs/run-456/terraform.tfvars',
+      expect.any(Uint8Array),
+    );
+    expect(copyFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should proceed to spawn when the supplied tfvarsVersionId matches the head version returned by listVersions', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-999');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockResolvedValue([
+      { versionId: 'v2', lastModified: new Date('2024-01-02') },
+      { versionId: 'v1', lastModified: new Date('2024-01-01') },
+    ]);
+    remoteFileStore.get.mockResolvedValue({
+      body: new TextEncoder().encode('game_servers = {}'),
+      etag: 'etag-1',
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await collectPlanChunks(service.plan('v2'), () => child.close(0));
+
+    expect(remoteFileStore.listVersions).toHaveBeenCalledWith('terraform.tfvars');
+    expect(remoteFileStore.get).toHaveBeenCalledWith('terraform.tfvars');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject and never call spawn when the supplied tfvarsVersionId no longer matches the head version returned by listVersions', async () => {
+    queueSuccessfulResolution();
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockResolvedValue([
+      { versionId: 'v2', lastModified: new Date('2024-01-02') },
+      { versionId: 'v1', lastModified: new Date('2024-01-01') },
+    ]);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await expect(collectPlanChunks(service.plan('v1'))).rejects.toThrow(/stale/i);
+    expect(remoteFileStore.listVersions).toHaveBeenCalledWith('terraform.tfvars');
+    expect(remoteFileStore.get).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject and never call spawn when the local tfvars source does not exist', async () => {
+    queueSuccessfulResolution();
+    existsSyncMock.mockReturnValue(false);
+
+    const service = new TerraformService(stubPlanConfigService({ tfvarsBucket: null }), stubRemoteFileStore());
+
+    await expect(collectPlanChunks(service.plan())).rejects.toThrow(/tfvars file not found/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
+    queueExecFileFailure();
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    await expect(collectPlanChunks(service.plan())).rejects.toBeInstanceOf(TerraformNotFoundError);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.plan streaming', () => {
+  it('should yield stdout and stderr lines as they are produced, not only after the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const { chunks } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Refreshing state...\n');
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
+    expect(chunks).toContainEqual({ stream: 'stdout', line: 'Refreshing state...' });
+    expect(chunks).toContainEqual({ stream: 'stderr', line: 'Warning: something' });
+  });
+});
+
+describe('TerraformService.plan summary parsing and return value', () => {
+  it('should parse the add/change/destroy counts from the Plan: summary line and return them alongside the artifact/var-file paths', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-789');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+
+    const { result } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Terraform will perform the following actions:\n');
+      child.emitStdout('Plan: 3 to add, 1 to change, 2 to destroy.\n');
+      child.close(0);
+    });
+
+    expect(result).toEqual({
+      runId: 'run-789',
+      artifactPath: '/repo/runs/run-789/run-789.tfplan',
+      varFilePath: '/repo/runs/run-789/terraform.tfvars',
+      add: 3,
+      change: 1,
+      destroy: 2,
+    });
+  });
+
+  it('should resolve all three counts to 0 when the plan has no changes', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    const { result } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('No changes. Your infrastructure matches the configuration.\n');
+      child.close(0);
+    });
+
+    expect(result).toMatchObject({ add: 0, change: 0, destroy: 0 });
+  });
+});
+
+describe('TerraformService.plan exit handling', () => {
+  it('should reject with a TerraformPlanError carrying the exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    const result = collectPlanChunks(service.plan(), () => child.close(1));
+
+    await expect(result).rejects.toBeInstanceOf(TerraformPlanError);
+    await expect(result).rejects.toMatchObject({ exitCode: 1 });
+  });
+});
+
+describe('TerraformService.plan abort handling', () => {
+  it('should kill the child process and end the generator cleanly with an undefined return value when the AbortSignal fires mid-run', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const gen = service.plan(undefined, controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const result = await pendingNext;
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it('should end the generator cleanly without resolving the binary or spawning when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const gen = service.plan(undefined, controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.plan concurrency guard', () => {
+  it('should throw a descriptive Error from a second plan() call while the first is still in flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const firstGen = service.plan();
+    const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
+
+    const secondGen = service.plan();
+    await expect(secondGen.next()).rejects.toThrow(/already running/i);
+
+    // Let the first call finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await firstNext;
+    await firstGen.next();
+  });
+
+  it('should allow a new plan() call once the previous one has completed', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    await collectPlanChunks(service.plan(), () => firstChild.close(0));
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    const { result } = await collectPlanChunks(service.plan(), () => secondChild.close(0));
+
+    expect(result).toBeDefined();
   });
 });

--- a/app/packages/desktop-main/src/services/TerraformService.init.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.init.test.ts
@@ -125,11 +125,12 @@ function stubRemoteFileStore(): RemoteFileStore & {
   get: ReturnType<typeof vi.fn>;
   listVersions: ReturnType<typeof vi.fn>;
 } {
-  return {
+  const store: Partial<RemoteFileStore> = {
     get: vi.fn(),
     put: vi.fn(),
     listVersions: vi.fn(),
-  } as unknown as RemoteFileStore & {
+  };
+  return store as RemoteFileStore & {
     get: ReturnType<typeof vi.fn>;
     listVersions: ReturnType<typeof vi.fn>;
   };

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -1,0 +1,608 @@
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Spy variables must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const {
+  execFileMock,
+  spawnMock,
+  mkdirSyncMock,
+  existsSyncMock,
+  writeFileSyncMock,
+  copyFileSyncMock,
+  randomUUIDMock,
+} = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  const mkdirSyncMock = vi.fn();
+  const existsSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  const copyFileSyncMock = vi.fn();
+  const randomUUIDMock = vi.fn();
+  return {
+    execFileMock,
+    spawnMock,
+    mkdirSyncMock,
+    existsSyncMock,
+    writeFileSyncMock,
+    copyFileSyncMock,
+    randomUUIDMock,
+  };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: spawnMock,
+}));
+
+vi.mock('node:fs', () => ({
+  mkdirSync: mkdirSyncMock,
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+  copyFileSync: copyFileSyncMock,
+}));
+
+vi.mock('node:crypto', () => ({
+  randomUUID: randomUUIDMock,
+}));
+
+import {
+  TerraformService,
+  TerraformNotFoundError,
+  TerraformPlanError,
+  type TerraformRunChunk,
+  type TerraformPlanResult,
+} from './TerraformService.js';
+import type { ConfigService } from './ConfigService.js';
+import type { RemoteFileStore } from '@hyveon/shared';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Extracts the error-first callback from an `execFile` call's arguments,
+ * regardless of whether `util.promisify` invoked it with or without an
+ * `options` object.
+ */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
+/** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
+function queueExecFileSuccess(stdout: string, stderr = ''): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(null, { stdout, stderr });
+  });
+}
+
+/** Queues a failing `execFile` invocation (e.g. binary not found) for the next call. */
+function queueExecFileFailure(error: Error = new Error('spawn ENOENT')): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(error);
+  });
+}
+
+/** Queues a successful binary lookup followed by a successful `-json` version response. */
+function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', version = '1.7.0'): void {
+  queueExecFileSuccess(`${binaryPath}\n`);
+  queueExecFileSuccess(JSON.stringify({ terraform_version: version }));
+}
+
+/**
+ * `ConfigService` stub for `plan()` tests: exposes `getTerraformDir`,
+ * `getRunsDir`, `getTfvarsBucket`, and `getTfvarsPath` — the accessors
+ * `plan()` reads.
+ */
+function stubPlanConfigService(
+  opts: {
+    terraformDir?: string;
+    runsDir?: string;
+    tfvarsBucket?: string | null;
+    tfvarsPath?: string;
+  } = {},
+): ConfigService {
+  return {
+    getTerraformDir: () => opts.terraformDir ?? '/repo/terraform',
+    getRunsDir: () => opts.runsDir ?? '/repo/runs',
+    getTfvarsBucket: () => opts.tfvarsBucket ?? null,
+    getTfvarsPath: () => opts.tfvarsPath ?? '/repo/terraform/terraform.tfvars',
+  } as ConfigService;
+}
+
+/**
+ * Minimal `RemoteFileStore` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. `get`/`put`/`listVersions` are directly-controllable
+ * mocks so S3-mode `plan()` tests can queue a tfvars object response.
+ */
+function stubRemoteFileStore(): RemoteFileStore & {
+  get: ReturnType<typeof vi.fn>;
+  listVersions: ReturnType<typeof vi.fn>;
+} {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  } as unknown as RemoteFileStore & {
+    get: ReturnType<typeof vi.fn>;
+    listVersions: ReturnType<typeof vi.fn>;
+  };
+}
+
+/**
+ * A fake `child_process.ChildProcess` sufficient for exercising `plan()`'s
+ * streaming logic: an `EventEmitter` standing in for the process itself,
+ * with `stdout`/`stderr` sub-emitters standing in for the piped streams, and
+ * a spied `kill()` so abort tests can assert the process was actually
+ * terminated. Tests drive it manually via `emitStdout`/`emitStderr`/`close`/
+ * `emit('error', ...)` rather than relying on any real process lifecycle.
+ */
+class FakeChildProcess extends EventEmitter {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+  readonly kill = vi.fn();
+
+  emitStdout(chunk: string): void {
+    this.stdout.emit('data', Buffer.from(chunk));
+  }
+
+  emitStderr(chunk: string): void {
+    this.stderr.emit('data', Buffer.from(chunk));
+  }
+
+  close(code: number | null): void {
+    this.emit('close', code);
+  }
+}
+
+/** Queues the next `spawn()` call to return `child` instead of a real process. */
+function queueSpawn(child: FakeChildProcess): void {
+  spawnMock.mockImplementationOnce(() => child);
+}
+
+/**
+ * Waits for every already-queued microtask to drain (via a macrotask
+ * boundary) before returning. `plan()` awaits the binary/version resolution
+ * plus the tfvars pull (itself a chain of promises) before it reaches the
+ * `spawn()` call and registers listeners on the child process, so tests must
+ * flush past that chain before driving `child.emitStdout`/`close`/`error` —
+ * otherwise those events fire before any listener has been attached.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Drains a `plan()` async generator to completion, collecting every yielded
+ * chunk plus the generator's final return value — a `TerraformPlanResult` on
+ * success, or `undefined` on a clean abort. `driveChild` is invoked once
+ * (after the first `.next()` has been issued so the child process is spawned
+ * and listeners are attached) to let the caller emit data/close/error events
+ * on the fake child at the right moment relative to iteration.
+ */
+async function collectPlanChunks(
+  gen: AsyncGenerator<TerraformRunChunk, TerraformPlanResult | undefined>,
+  driveChild?: () => void,
+): Promise<{ chunks: TerraformRunChunk[]; result: TerraformPlanResult | undefined }> {
+  const chunks: TerraformRunChunk[] = [];
+  const first = gen.next();
+  // Attach a no-op rejection handler immediately so a generator that throws
+  // before `driveChild` is even relevant (e.g. binary resolution failure)
+  // doesn't trip Node's unhandled-rejection detection during the
+  // `flushMicrotasks` gap below — the real `await first` a few lines down
+  // still surfaces the rejection to the caller.
+  first.catch(() => {});
+  await flushMicrotasks();
+  driveChild?.();
+  let next = await first;
+  while (!next.done) {
+    chunks.push(next.value);
+    const following = gen.next();
+    following.catch(() => {});
+    next = await following;
+  }
+  return { chunks, result: next.value };
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  spawnMock.mockReset();
+  mkdirSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(true);
+  writeFileSyncMock.mockReset();
+  copyFileSyncMock.mockReset();
+  randomUUIDMock.mockReset();
+  randomUUIDMock.mockReturnValue('run-123');
+});
+
+describe('TerraformService.plan spawning and artifact persistence', () => {
+  it('should mint a runId, create its runs-dir, pull the local tfvars snapshot, and spawn terraform plan with -out/-var-file derived from them', async () => {
+    queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
+    randomUUIDMock.mockReturnValue('run-123');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({
+        terraformDir: '/repo/terraform',
+        runsDir: '/repo/runs',
+        tfvarsBucket: null,
+        tfvarsPath: '/repo/terraform/terraform.tfvars',
+      }),
+      stubRemoteFileStore(),
+    );
+
+    await collectPlanChunks(service.plan(), () => child.close(0));
+
+    expect(mkdirSyncMock).toHaveBeenCalledWith('/repo/runs/run-123', { recursive: true });
+    expect(copyFileSyncMock).toHaveBeenCalledWith(
+      '/repo/terraform/terraform.tfvars',
+      '/repo/runs/run-123/terraform.tfvars',
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/terraform',
+      [
+        'plan',
+        '-input=false',
+        '-no-color',
+        '-out=/repo/runs/run-123/run-123.tfplan',
+        '-var-file=/repo/runs/run-123/terraform.tfvars',
+      ],
+      { cwd: '/repo/terraform' },
+    );
+  });
+
+  it('should pull the tfvars snapshot from the RemoteFileStore instead of the local filesystem when a tfvars bucket is configured', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-456');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.get.mockResolvedValue({
+      body: new TextEncoder().encode('game_servers = {}'),
+      etag: 'etag-1',
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await collectPlanChunks(service.plan(), () => child.close(0));
+
+    expect(remoteFileStore.get).toHaveBeenCalledWith('terraform.tfvars');
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      '/repo/runs/run-456/terraform.tfvars',
+      expect.any(Uint8Array),
+    );
+    expect(copyFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should proceed to spawn when the supplied tfvarsVersionId matches the head version returned by listVersions', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-999');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockResolvedValue([
+      { versionId: 'v2', lastModified: new Date('2024-01-02') },
+      { versionId: 'v1', lastModified: new Date('2024-01-01') },
+    ]);
+    remoteFileStore.get.mockResolvedValue({
+      body: new TextEncoder().encode('game_servers = {}'),
+      etag: 'etag-1',
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await collectPlanChunks(service.plan('v2'), () => child.close(0));
+
+    expect(remoteFileStore.listVersions).toHaveBeenCalledWith('terraform.tfvars');
+    expect(remoteFileStore.get).toHaveBeenCalledWith('terraform.tfvars');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject and never call spawn when the supplied tfvarsVersionId no longer matches the head version returned by listVersions', async () => {
+    queueSuccessfulResolution();
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockResolvedValue([
+      { versionId: 'v2', lastModified: new Date('2024-01-02') },
+      { versionId: 'v1', lastModified: new Date('2024-01-01') },
+    ]);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await expect(collectPlanChunks(service.plan('v1'))).rejects.toThrow(/stale/i);
+    expect(remoteFileStore.listVersions).toHaveBeenCalledWith('terraform.tfvars');
+    expect(remoteFileStore.get).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject and never call spawn when the S3 tfvars object is missing from the bucket', async () => {
+    queueSuccessfulResolution();
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.get.mockResolvedValue(null);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await expect(collectPlanChunks(service.plan())).rejects.toThrow(/not found in S3 bucket/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject and never call spawn when the local tfvars source does not exist', async () => {
+    queueSuccessfulResolution();
+    existsSyncMock.mockReturnValue(false);
+
+    const service = new TerraformService(stubPlanConfigService({ tfvarsBucket: null }), stubRemoteFileStore());
+
+    await expect(collectPlanChunks(service.plan())).rejects.toThrow(/tfvars file not found/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
+    queueExecFileFailure();
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    await expect(collectPlanChunks(service.plan())).rejects.toBeInstanceOf(TerraformNotFoundError);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.plan streaming', () => {
+  it('should yield stdout and stderr lines as they are produced, not only after the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const { chunks } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Refreshing state...\n');
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
+    expect(chunks).toContainEqual({ stream: 'stdout', line: 'Refreshing state...' });
+    expect(chunks).toContainEqual({ stream: 'stderr', line: 'Warning: something' });
+  });
+
+  it('should split a single data event containing multiple lines into one chunk per line', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const { chunks } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('line one\nline two\nline three\n');
+      child.close(0);
+    });
+
+    expect(chunks).toEqual([
+      { stream: 'stdout', line: 'line one' },
+      { stream: 'stdout', line: 'line two' },
+      { stream: 'stdout', line: 'line three' },
+    ]);
+  });
+});
+
+describe('TerraformService.plan summary parsing and return value', () => {
+  it('should parse the add/change/destroy counts from the Plan: summary line and return them alongside the artifact/var-file paths', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-789');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+
+    const { result } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Terraform will perform the following actions:\n');
+      child.emitStdout('Plan: 3 to add, 1 to change, 2 to destroy.\n');
+      child.close(0);
+    });
+
+    expect(result).toEqual({
+      runId: 'run-789',
+      artifactPath: '/repo/runs/run-789/run-789.tfplan',
+      varFilePath: '/repo/runs/run-789/terraform.tfvars',
+      add: 3,
+      change: 1,
+      destroy: 2,
+    });
+  });
+
+  it('should resolve all three counts to 0 when the plan has no changes', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    const { result } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('No changes. Your infrastructure matches the configuration.\n');
+      child.close(0);
+    });
+
+    expect(result).toMatchObject({ add: 0, change: 0, destroy: 0 });
+  });
+});
+
+describe('TerraformService.plan exit handling', () => {
+  it('should reject with a TerraformPlanError carrying the exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    const result = collectPlanChunks(service.plan(), () => child.close(1));
+
+    await expect(result).rejects.toBeInstanceOf(TerraformPlanError);
+    await expect(result).rejects.toMatchObject({ exitCode: 1 });
+  });
+
+  it('should reject when the spawned process itself errors out (e.g. ENOENT)', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+
+    const result = collectPlanChunks(service.plan(), () => child.emit('error', new Error('spawn ENOENT')));
+
+    await expect(result).rejects.toThrow('spawn ENOENT');
+  });
+});
+
+describe('TerraformService.plan abort handling', () => {
+  it('should kill the child process and end the generator cleanly with an undefined return value when the AbortSignal fires mid-run', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const gen = service.plan(undefined, controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const result = await pendingNext;
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it('should end the generator cleanly without resolving the binary or spawning when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const gen = service.plan(undefined, controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should end the generator cleanly without spawning when the signal is aborted while resolving the binary path', async () => {
+    const controller = new AbortController();
+    execFileMock.mockImplementationOnce((...args: unknown[]) => {
+      controller.abort();
+      lastArgAsCallback(args)(null, { stdout: '/usr/local/bin/terraform\n', stderr: '' });
+    });
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const gen = service.plan(undefined, controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should end the generator cleanly without spawning when the signal is aborted while pulling the tfvars snapshot', async () => {
+    queueSuccessfulResolution();
+    const controller = new AbortController();
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.get.mockImplementation(async () => {
+      controller.abort();
+      return { body: new TextEncoder().encode('game_servers = {}'), etag: 'etag-1' };
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
+      remoteFileStore,
+    );
+    const gen = service.plan(undefined, controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.plan concurrency guard', () => {
+  it('should throw a descriptive Error from a second plan() call while the first is still in flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const firstGen = service.plan();
+    const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
+
+    const secondGen = service.plan();
+    await expect(secondGen.next()).rejects.toThrow(/already running/i);
+
+    // Let the first call finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await firstNext;
+    await firstGen.next();
+  });
+
+  it('should allow a new plan() call once the previous one has completed', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    await collectPlanChunks(service.plan(), () => firstChild.close(0));
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    const { result } = await collectPlanChunks(service.plan(), () => secondChild.close(0));
+
+    expect(result).toBeDefined();
+  });
+
+  it('should allow a new plan() call once the previous one has failed', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    await expect(
+      collectPlanChunks(service.plan(), () => firstChild.close(1)),
+    ).rejects.toBeInstanceOf(TerraformPlanError);
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    const { result } = await collectPlanChunks(service.plan(), () => secondChild.close(0));
+
+    expect(result).toBeDefined();
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -121,11 +121,12 @@ function stubRemoteFileStore(): RemoteFileStore & {
   get: ReturnType<typeof vi.fn>;
   listVersions: ReturnType<typeof vi.fn>;
 } {
-  return {
+  const store: Partial<RemoteFileStore> = {
     get: vi.fn(),
     put: vi.fn(),
     listVersions: vi.fn(),
-  } as unknown as RemoteFileStore & {
+  };
+  return store as RemoteFileStore & {
     get: ReturnType<typeof vi.fn>;
     listVersions: ReturnType<typeof vi.fn>;
   };
@@ -551,6 +552,46 @@ describe('TerraformService.plan abort handling', () => {
     expect(result.done).toBe(true);
     expect(result.value).toBeUndefined();
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should kill the child process and wait for it to close when the generator is force-closed early (e.g. consumer break) before the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const gen = service.plan();
+
+    // Drive the generator to its first yielded chunk, mirroring a consumer
+    // that starts iterating (e.g. a `for await...of` loop) but never reaches
+    // the child process's `close` event before bailing out.
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('Refreshing state...\n');
+    await first;
+
+    // Simulate the consumer force-closing the generator early (what a
+    // `for await...of` `break`/`throw` desugars to under the hood). This
+    // should propagate through plan()'s finally into spawnAndStream's
+    // finally, which must kill the still-running child rather than just
+    // detaching the abort listener.
+    let returnSettled = false;
+    const returnPromise = gen.return(undefined).then((result) => {
+      returnSettled = true;
+      return result;
+    });
+
+    await flushMicrotasks();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    // The generator must not resolve its forced return until the child
+    // process actually reports closing — killing it isn't enough on its own.
+    expect(returnSettled).toBe(false);
+
+    child.close(null);
+    const result = await returnPromise;
+
+    expect(returnSettled).toBe(true);
+    expect(result.done).toBe(true);
   });
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.test.ts
@@ -16,6 +16,7 @@ vi.mock('node:child_process', () => ({
 
 import { TerraformService, TerraformNotFoundError, lookupCommandFor } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RemoteFileStore } from '@hyveon/shared';
 
 /**
  * Minimal `ConfigService` stub sufficient to satisfy `TerraformService`'s
@@ -25,6 +26,15 @@ import type { ConfigService } from './ConfigService.js';
  */
 function stubConfigService(): ConfigService {
   return {} as ConfigService;
+}
+
+/**
+ * Minimal `RemoteFileStore` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. None of the tests in this file exercise `plan()`
+ * (the only method that reads from it), so an empty object cast is enough.
+ */
+function stubRemoteFileStore(): RemoteFileStore {
+  return {} as RemoteFileStore;
 }
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
@@ -98,12 +108,12 @@ describe('TerraformNotFoundError', () => {
 
 describe('TerraformService construction', () => {
   it('should never throw when constructing the service, even without any execFile mocks queued', () => {
-    expect(() => new TerraformService(stubConfigService())).not.toThrow();
+    expect(() => new TerraformService(stubConfigService(), stubRemoteFileStore())).not.toThrow();
   });
 
   it('should not shell out to resolve the binary until an accessor is called', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     expect(execFileMock).not.toHaveBeenCalled();
   });
 });
@@ -112,7 +122,7 @@ describe('TerraformService binary detection', () => {
   it('should resolve the binary path from the which/where.exe output', async () => {
     queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).resolves.toBe('/usr/local/bin/terraform');
   });
@@ -121,7 +131,7 @@ describe('TerraformService binary detection', () => {
     queueExecFileSuccess('\n  /opt/homebrew/bin/terraform  \nsome-other-line\n');
     queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).resolves.toBe('/opt/homebrew/bin/terraform');
   });
@@ -129,7 +139,7 @@ describe('TerraformService binary detection', () => {
   it('should reject getBinaryPath with a TerraformNotFoundError instance on first use when the lookup command fails', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -137,7 +147,7 @@ describe('TerraformService binary detection', () => {
   it('should reject getVersion with a TerraformNotFoundError instance on first use when the lookup command fails', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getVersion()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -145,7 +155,7 @@ describe('TerraformService binary detection', () => {
   it('should reject with a TerraformNotFoundError instance when the lookup command produces no output', async () => {
     queueExecFileSuccess('');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -153,7 +163,7 @@ describe('TerraformService binary detection', () => {
   it('should reject with a TerraformNotFoundError instance when the lookup command output is only whitespace', async () => {
     queueExecFileSuccess('   \n  \n');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -163,7 +173,7 @@ describe('TerraformService version parsing', () => {
   it('should parse the terraform_version field from terraform version -json output', async () => {
     queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.5');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getVersion()).resolves.toBe('1.7.5');
   });
@@ -173,7 +183,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('Terraform v1.6.2\non linux_amd64\n');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getVersion()).resolves.toBe('1.6.2');
   });
@@ -183,7 +193,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess(JSON.stringify({ some_other_field: true }));
     queueExecFileSuccess('Terraform v1.5.0\n');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getVersion()).resolves.toBe('1.5.0');
   });
@@ -193,7 +203,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('Terraform v1.9.0-beta1\n');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getVersion()).resolves.toBe('1.9.0-beta1');
   });
@@ -203,7 +213,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('garbage output with no version');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
     const result = service.getVersion();
 
     await expect(result).rejects.toThrow('Unable to parse terraform version');
@@ -215,7 +225,7 @@ describe('TerraformService instance accessors', () => {
   it('should expose the resolved binary path via getBinaryPath', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).resolves.toBe('/usr/bin/terraform');
   });
@@ -223,7 +233,7 @@ describe('TerraformService instance accessors', () => {
   it('should expose the resolved version via getVersion', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getVersion()).resolves.toBe('1.8.1');
   });
@@ -233,7 +243,7 @@ describe('TerraformService resolution memoization', () => {
   it('should only shell out once across multiple getBinaryPath calls', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await service.getBinaryPath();
     await service.getBinaryPath();
@@ -244,7 +254,7 @@ describe('TerraformService resolution memoization', () => {
   it('should reuse the memoized resolution between getBinaryPath and getVersion', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await service.getBinaryPath();
     await service.getVersion();
@@ -255,7 +265,7 @@ describe('TerraformService resolution memoization', () => {
   it('should resolve concurrent getBinaryPath calls to the same memoized result with a single lookup', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     const [first, second] = await Promise.all([service.getBinaryPath(), service.getBinaryPath()]);
 
@@ -267,7 +277,7 @@ describe('TerraformService resolution memoization', () => {
   it('should memoize a TerraformNotFoundError rejection so a second call does not re-invoke execFile', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -78,6 +78,20 @@ export class TerraformInitError extends Error {
 }
 
 /**
+ * Outcome of {@link TerraformService.spawnAndStream} once the spawned process
+ * has closed (or been aborted). Consumed via `yield*` delegation from
+ * subcommand runners like {@link TerraformService.init}, which decide what a
+ * given exit code means for their own subcommand — `spawnAndStream` itself
+ * has no opinion on success/failure beyond surfacing the raw exit code.
+ */
+type SpawnStreamResult =
+  | { aborted: true }
+  | {
+      aborted: false;
+      exitCode: number | null;
+    };
+
+/**
  * Lazily resolves and caches the system `terraform` binary's absolute path
  * and semver version, and orchestrates `terraform` subcommands against it —
  * starting with {@link TerraformService.init}, the streaming/idempotent
@@ -231,95 +245,131 @@ export class TerraformService {
         `-backend-config=dynamodb_table=${config.dynamodbTable}`,
       ];
 
-      const child = spawn(binaryPath, args, { cwd });
-      const buffers: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' };
+      const result = yield* this.spawnAndStream(binaryPath, args, cwd, signal);
 
-      const queue: TerraformRunChunk[] = [];
-      let wake: (() => void) | null = null;
-      let closed = false;
-      let closeError: Error | null = null;
-      let exitCode: number | null = null;
-
-      const notify = (): void => {
-        wake?.();
-        wake = null;
-      };
-
-      const push = (chunk: TerraformRunChunk): void => {
-        queue.push(chunk);
-        notify();
-      };
-
-      const handleData = (stream: 'stdout' | 'stderr', data: Buffer | string): void => {
-        buffers[stream] += data.toString();
-        const lines = buffers[stream].split(/\r?\n/);
-        // The last element is either an empty string (data ended on a
-        // newline) or an incomplete trailing line — hold it back until more
-        // data (or `close`) completes it.
-        buffers[stream] = lines.pop() ?? '';
-        for (const line of lines) {
-          push({ stream, line });
-        }
-      };
-
-      child.stdout?.on('data', (data: Buffer) => handleData('stdout', data));
-      child.stderr?.on('data', (data: Buffer) => handleData('stderr', data));
-
-      child.on('error', (err: Error) => {
-        closeError = err;
-        closed = true;
-        notify();
-      });
-
-      child.on('close', (code: number | null) => {
-        for (const stream of ['stdout', 'stderr'] as const) {
-          if (buffers[stream].length > 0) {
-            push({ stream, line: buffers[stream] });
-            buffers[stream] = '';
-          }
-        }
-        exitCode = code;
-        closed = true;
-        notify();
-      });
-
-      const onAbort = (): void => {
-        child.kill();
-      };
-      signal?.addEventListener('abort', onAbort);
-
-      try {
-        while (true) {
-          if (queue.length > 0) {
-            yield queue.shift()!;
-            continue;
-          }
-          if (closed) {
-            break;
-          }
-          await new Promise<void>((resolve) => {
-            wake = resolve;
-          });
-        }
-
-        if (signal?.aborted) {
-          // Aborted mid-run: the child was killed above. End the generator
-          // cleanly rather than surfacing the resulting error/exit code.
-          return;
-        }
-        if (closeError) {
-          throw closeError;
-        }
-        if (exitCode === 0) {
-          this.lastInitConfig = config;
-          return;
-        }
-        throw new TerraformInitError(exitCode);
-      } finally {
-        signal?.removeEventListener('abort', onAbort);
+      if (result.aborted) {
+        // Aborted mid-run: the child was killed inside spawnAndStream. End
+        // the generator cleanly rather than surfacing the resulting
+        // error/exit code.
+        return;
       }
+      if (result.exitCode === 0) {
+        this.lastInitConfig = config;
+        return;
+      }
+      throw new TerraformInitError(result.exitCode);
     } finally {
       this.initInFlight = false;
+    }
+  }
+
+  /**
+   * Spawns `binaryPath` with `args` inside `cwd` and streams its stdout/stderr
+   * as {@link TerraformRunChunk} values line-by-line as the process produces
+   * them, rather than buffering until it exits. Shared by every streaming
+   * subcommand runner — currently just {@link init}, with `plan`/`apply`/
+   * `destroy`/`output` expected to reuse it as they're added — so the
+   * buffering/queue/wake plumbing lives in exactly one place.
+   *
+   * If `signal` fires while the process is still running, the child is
+   * killed and the generator's return value resolves to `{ aborted: true }`
+   * once the process actually closes, rather than surfacing the resulting
+   * error/exit code — callers should end their own generator cleanly in that
+   * case instead of throwing. Otherwise resolves to
+   * `{ aborted: false, exitCode }`; callers decide what a given exit code
+   * means for their own subcommand (e.g. {@link init} maps non-zero to
+   * {@link TerraformInitError}).
+   *
+   * Throws whatever error the spawned process itself raised (e.g. `ENOENT`)
+   * verbatim — that failure mode isn't subcommand-specific, so it isn't left
+   * to the caller to interpret.
+   */
+  private async *spawnAndStream(
+    binaryPath: string,
+    args: string[],
+    cwd: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<TerraformRunChunk, SpawnStreamResult> {
+    const child = spawn(binaryPath, args, { cwd });
+    const buffers: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' };
+
+    const queue: TerraformRunChunk[] = [];
+    let wake: (() => void) | null = null;
+    let closed = false;
+    let closeError: Error | null = null;
+    let exitCode: number | null = null;
+
+    const notify = (): void => {
+      wake?.();
+      wake = null;
+    };
+
+    const push = (chunk: TerraformRunChunk): void => {
+      queue.push(chunk);
+      notify();
+    };
+
+    const handleData = (stream: 'stdout' | 'stderr', data: Buffer | string): void => {
+      buffers[stream] += data.toString();
+      const lines = buffers[stream].split(/\r?\n/);
+      // The last element is either an empty string (data ended on a
+      // newline) or an incomplete trailing line — hold it back until more
+      // data (or `close`) completes it.
+      buffers[stream] = lines.pop() ?? '';
+      for (const line of lines) {
+        push({ stream, line });
+      }
+    };
+
+    child.stdout?.on('data', (data: Buffer) => handleData('stdout', data));
+    child.stderr?.on('data', (data: Buffer) => handleData('stderr', data));
+
+    child.on('error', (err: Error) => {
+      closeError = err;
+      closed = true;
+      notify();
+    });
+
+    child.on('close', (code: number | null) => {
+      for (const stream of ['stdout', 'stderr'] as const) {
+        if (buffers[stream].length > 0) {
+          push({ stream, line: buffers[stream] });
+          buffers[stream] = '';
+        }
+      }
+      exitCode = code;
+      closed = true;
+      notify();
+    });
+
+    const onAbort = (): void => {
+      child.kill();
+    };
+    signal?.addEventListener('abort', onAbort);
+
+    try {
+      while (true) {
+        if (queue.length > 0) {
+          yield queue.shift()!;
+          continue;
+        }
+        if (closed) {
+          break;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+
+      if (signal?.aborted) {
+        return { aborted: true };
+      }
+      if (closeError) {
+        throw closeError;
+      }
+      return { aborted: false, exitCode };
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
     }
   }
 

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1,7 +1,12 @@
 import { execFile, spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import { promisify } from 'node:util';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import type { RemoteFileStore } from '@hyveon/shared';
 import { ConfigService } from './ConfigService.js';
+import { REMOTE_FILE_STORE } from '../modules/cloud-provider.tokens.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -92,12 +97,55 @@ type SpawnStreamResult =
     };
 
 /**
+ * Thrown when the spawned `terraform plan` process exits with a non-zero
+ * status code. Distinct from {@link TerraformNotFoundError} (binary can't be
+ * resolved) and {@link TerraformInitError} (an `init` run's own failure).
+ */
+export class TerraformPlanError extends Error {
+  constructor(public readonly exitCode: number | null) {
+    super(`terraform plan exited with code ${exitCode ?? 'null'}`);
+    this.name = 'TerraformPlanError';
+  }
+}
+
+/**
+ * Outcome of a successful {@link TerraformService.plan} run, resolved via the
+ * async generator's return value once the spawned `terraform plan` process
+ * exits `0` and the run wasn't aborted.
+ */
+export interface TerraformPlanResult {
+  /** The `runId` minted for this run — the parent directory (`<runsDir>/<runId>/`) of both {@link artifactPath} and {@link varFilePath}. */
+  runId: string;
+  /** Absolute path to the persisted `.tfplan` binary artifact — what a future `apply()` passes to `terraform apply <artifactPath>`. */
+  artifactPath: string;
+  /** Absolute path to the pulled tfvars snapshot this plan was run against. */
+  varFilePath: string;
+  /** Number of resources Terraform plans to add. */
+  add: number;
+  /** Number of resources Terraform plans to change in place. */
+  change: number;
+  /** Number of resources Terraform plans to destroy. */
+  destroy: number;
+}
+
+/**
+ * Matches Terraform's plan-summary stdout line, e.g.
+ * `Plan: 3 to add, 1 to change, 0 to destroy.` — scanned for while streaming
+ * {@link TerraformService.plan}'s output to extract the resource change
+ * counts returned in the generator's return value. A "no changes" plan (this
+ * pattern never matches) resolves all three counts to `0`.
+ */
+const PLAN_SUMMARY_PATTERN = /Plan:\s*(\d+) to add,\s*(\d+) to change,\s*(\d+) to destroy\./;
+
+/**
  * Lazily resolves and caches the system `terraform` binary's absolute path
- * and semver version, and orchestrates `terraform` subcommands against it —
- * starting with {@link TerraformService.init}, the streaming/idempotent
- * `terraform init` runner. Later child issues of Epic D add
- * `plan`/`apply`/`destroy`/`output` — see the "Terraform orchestrator"
- * section of the electron-desktop-pivot design spec.
+ * and semver version, and orchestrates `terraform` subcommands against it:
+ * {@link TerraformService.init}, the streaming/idempotent `terraform init`
+ * runner, and {@link TerraformService.plan}, the streaming `terraform plan`
+ * runner that persists its `.tfplan` artifact and the pulled tfvars snapshot
+ * under `ConfigService.getRunsDir()`. Later child issues of Epic D add
+ * `apply`/`destroy`/`output` — see the "Terraform orchestrator" section of
+ * the electron-desktop-pivot design spec.
  *
  * Construction is synchronous and never throws — the binary lookup +
  * `terraform version` shell-outs are deferred until {@link getBinaryPath} or
@@ -127,8 +175,30 @@ export class TerraformService {
    */
   private initInFlight = false;
 
-  /** `config` resolves the terraform working directory (`getTerraformDir()`) for `init`/`plan`/`apply`/`destroy`/`output`. */
-  constructor(private readonly config: ConfigService) {}
+  /**
+   * `true` while a {@link plan} call is actively running (from the moment its
+   * generator body starts executing until it completes or throws). Guards
+   * against a second concurrent `plan()` call racing the first against the
+   * same working directory/runs directory. Tracked separately from
+   * {@link initInFlight} since `init` and `plan` are distinct subcommands.
+   */
+  private planInFlight = false;
+
+  /**
+   * `config` resolves the terraform working directory (`getTerraformDir()`)
+   * and the per-run artifacts directory (`getRunsDir()`) for
+   * `init`/`plan`/`apply`/`destroy`/`output`. `remoteFileStore` is typed
+   * against the cloud-agnostic `RemoteFileStore` contract (not a concrete AWS
+   * class) so this service depends only on the interface; `@Inject(REMOTE_FILE_STORE)`
+   * tells Nest which concrete provider (bound by `CloudProviderModule` for
+   * whichever cloud is active) to resolve for that parameter. Used by
+   * {@link plan} to pull the current tfvars snapshot when S3 tfvars sync is
+   * configured (mirrors `TfvarsService`'s local-vs-S3 read).
+   */
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(REMOTE_FILE_STORE) private readonly remoteFileStore: RemoteFileStore,
+  ) {}
 
   /**
    * Resolves the system `terraform` binary via `which` (POSIX) / `where.exe`
@@ -264,11 +334,204 @@ export class TerraformService {
   }
 
   /**
+   * Runs `terraform plan` with `-input=false`, `-no-color`,
+   * `-out=<runDir>/<runId>.tfplan`, and `-var-file=<pulled tfvars>` flags
+   * inside the Terraform composer root (`ConfigService.getTerraformDir()`),
+   * yielding a {@link TerraformRunChunk} per line of output as the process
+   * produces it — mirrors {@link init}'s streaming shape.
+   *
+   * Before spawning: mints a fresh `runId` (`randomUUID()`), creates its
+   * per-run directory `<runsDir>/<runId>/` (`ConfigService.getRunsDir()`),
+   * and pulls a snapshot of the current tfvars into that directory via
+   * {@link pullVarFile} — so the persisted plan artifact and the exact tfvars
+   * it was planned against are captured together for a later `apply()` to
+   * consume (see the "Terraform run cache" row of the electron-desktop-pivot
+   * design spec).
+   *
+   * `tfvarsVersionId`, when provided and the tfvars source is S3-backed
+   * (`ConfigService.getTfvarsBucket()` resolves one), is enforced as a
+   * pre-spawn staleness assertion: {@link pullVarFile} calls
+   * `remoteFileStore.listVersions(key)` and compares `tfvarsVersionId`
+   * against the head (most recent) entry, throwing a descriptive `Error`
+   * before `terraform` is ever spawned when they no longer match — i.e. the
+   * remote tfvars changed underneath the caller since they last read a
+   * version id (e.g. from `TfvarsService`). `RemoteFileStore` has no
+   * version-specific `get`, so this is a staleness check rather than a
+   * pinned/versioned download; the plan is always run against the current
+   * head object once the check passes. Ignored entirely in local-file mode
+   * or when omitted.
+   *
+   * While streaming, stdout lines are scanned via {@link PLAN_SUMMARY_PATTERN}
+   * for Terraform's summary line (`Plan: N to add, N to change, N to destroy.`)
+   * to extract the resource change counts returned in the generator's return
+   * value alongside `runId`, `artifactPath`, and `varFilePath`. A "no changes"
+   * plan (no summary line present) resolves all three counts to `0`.
+   *
+   * `signal`, if provided, aborts the run the same way {@link init} does: the
+   * spawned child process is killed and the generator ends cleanly — no
+   * further chunks, no throw, and the generator resolves to `undefined`
+   * rather than a {@link TerraformPlanResult} or a thrown
+   * {@link TerraformPlanError}.
+   *
+   * Throws a descriptive `Error` synchronously (on the first `.next()` call)
+   * if another `plan()` call is already in flight on this instance.
+   *
+   * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
+   * resolved, a plain `Error` if the configured tfvars source can't be read
+   * or `tfvarsVersionId` is stale (see {@link pullVarFile}), or
+   * {@link TerraformPlanError} if the spawned process exits with a non-zero
+   * status code (and the run wasn't aborted).
+   */
+  async *plan(
+    tfvarsVersionId?: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<TerraformRunChunk, TerraformPlanResult | undefined> {
+    if (this.planInFlight) {
+      throw new Error(
+        'TerraformService.plan() is already running; wait for it to finish before calling plan() again.',
+      );
+    }
+    this.planInFlight = true;
+    try {
+      if (signal?.aborted) {
+        // Already aborted before we even started resolving the binary path —
+        // end the generator cleanly without spawning anything.
+        return undefined;
+      }
+
+      const binaryPath = await this.getBinaryPath();
+
+      if (signal?.aborted) {
+        // Aborted while resolving the binary path — end cleanly before spawn.
+        return undefined;
+      }
+
+      const runId = randomUUID();
+      const runDir = join(this.config.getRunsDir(), runId);
+      mkdirSync(runDir, { recursive: true });
+
+      const varFilePath = await this.pullVarFile(runDir, tfvarsVersionId);
+
+      if (signal?.aborted) {
+        // Aborted while pulling the tfvars snapshot — end cleanly before spawn.
+        return undefined;
+      }
+
+      const artifactPath = join(runDir, `${runId}.tfplan`);
+      const cwd = this.config.getTerraformDir();
+      const args = [
+        'plan',
+        '-input=false',
+        '-no-color',
+        `-out=${artifactPath}`,
+        `-var-file=${varFilePath}`,
+      ];
+
+      let add = 0;
+      let change = 0;
+      let destroy = 0;
+
+      // Driven manually (rather than `yield*`) so each stdout line can be
+      // scanned for the plan summary as it streams through, in addition to
+      // being forwarded to the caller unmodified.
+      const stream = this.spawnAndStream(binaryPath, args, cwd, signal);
+      let next = await stream.next();
+      while (!next.done) {
+        const chunk = next.value;
+        if (chunk.stream === 'stdout') {
+          const match = PLAN_SUMMARY_PATTERN.exec(chunk.line);
+          if (match) {
+            add = Number(match[1]);
+            change = Number(match[2]);
+            destroy = Number(match[3]);
+          }
+        }
+        yield chunk;
+        next = await stream.next();
+      }
+
+      const result = next.value;
+      if (result.aborted) {
+        // Aborted mid-run: the child was killed inside spawnAndStream. End
+        // the generator cleanly rather than surfacing the resulting
+        // error/exit code.
+        return undefined;
+      }
+      if (result.exitCode === 0) {
+        return { runId, artifactPath, varFilePath, add, change, destroy };
+      }
+      throw new TerraformPlanError(result.exitCode);
+    } finally {
+      this.planInFlight = false;
+    }
+  }
+
+  /**
+   * Pulls the current `terraform.tfvars` — from the S3 tfvars bucket via the
+   * injected `RemoteFileStore` when `ConfigService.getTfvarsBucket()`
+   * resolves one (mirrors `TfvarsService.fetchRawTfvars`'s S3-mode read),
+   * otherwise from the local file at `ConfigService.getTfvarsPath()` — and
+   * writes a snapshot copy into `runDir` under the source file's own
+   * basename, so {@link plan} runs against the exact bytes captured for this
+   * run regardless of concurrent edits to the canonical source afterward.
+   *
+   * In S3 mode, when `tfvarsVersionId` is provided, this first calls
+   * `remoteFileStore.listVersions(key)` and asserts that `tfvarsVersionId`
+   * matches the head (most recent) entry *before* reading the object —
+   * `RemoteFileStore.get` has no version-specific overload, so this is a
+   * staleness assertion rather than a pinned/versioned read: it guards
+   * against planning against tfvars that changed underneath the caller since
+   * they last observed a version id, without actually downloading that
+   * specific historical version.
+   *
+   * @returns The absolute path to the written snapshot, which {@link plan}
+   *   passes to `terraform plan` as `-var-file=<path>`.
+   * @throws A descriptive `Error` when the configured source (S3 object or
+   *   local file) doesn't exist, or when `tfvarsVersionId` no longer matches
+   *   the head version of the S3 object — a `plan()` run with no tfvars to
+   *   plan against, or against tfvars known to be stale, isn't meaningful.
+   */
+  private async pullVarFile(runDir: string, tfvarsVersionId?: string): Promise<string> {
+    const bucket = this.config.getTfvarsBucket();
+    const sourcePath = this.config.getTfvarsPath();
+    const destPath = join(runDir, basename(sourcePath));
+
+    if (bucket) {
+      const key = basename(sourcePath);
+
+      if (tfvarsVersionId) {
+        const versions = await this.remoteFileStore.listVersions(key);
+        const head = versions[0];
+        if (!head || head.versionId !== tfvarsVersionId) {
+          throw new Error(
+            `tfvars object "${key}" in S3 bucket "${bucket}" is stale: expected version ` +
+              `"${tfvarsVersionId}" to be the current head, but the head version is ` +
+              `${head ? `"${head.versionId}"` : 'missing'}. Refresh the tfvars before planning.`,
+          );
+        }
+      }
+
+      const obj = await this.remoteFileStore.get(key);
+      if (!obj) {
+        throw new Error(`tfvars object "${key}" not found in S3 bucket "${bucket}".`);
+      }
+      writeFileSync(destPath, obj.body);
+      return destPath;
+    }
+
+    if (!existsSync(sourcePath)) {
+      throw new Error(`tfvars file not found at "${sourcePath}".`);
+    }
+    copyFileSync(sourcePath, destPath);
+    return destPath;
+  }
+
+  /**
    * Spawns `binaryPath` with `args` inside `cwd` and streams its stdout/stderr
    * as {@link TerraformRunChunk} values line-by-line as the process produces
    * them, rather than buffering until it exits. Shared by every streaming
-   * subcommand runner — currently just {@link init}, with `plan`/`apply`/
-   * `destroy`/`output` expected to reuse it as they're added — so the
+   * subcommand runner — currently {@link init} and {@link plan}, with
+   * `apply`/`destroy`/`output` expected to reuse it as they're added — so the
    * buffering/queue/wake plumbing lives in exactly one place.
    *
    * If `signal` fires while the process is still running, the child is

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -168,21 +168,16 @@ export class TerraformService {
   private lastInitConfig: TerraformInitConfig | null = null;
 
   /**
-   * `true` while an {@link init} call is actively running (from the moment
-   * its generator body starts executing, i.e. the first `.next()` call, until
-   * it completes or throws). Guards against a second concurrent `init()` call
-   * racing the first against the same `terraform` working directory.
+   * Name of whichever subcommand ({@link init} or {@link plan}) is actively
+   * running against `getTerraformDir()`, or `null` when neither is. A single
+   * shared lock (rather than separate `initInFlight`/`planInFlight` flags) is
+   * required because `init` mutates the `backend/.terraform` state that
+   * `plan` reads — letting the two subcommands run concurrently against the
+   * same workspace would race one against the other's writes/reads. Set the
+   * moment a generator body starts executing (i.e. the first `.next()` call)
+   * until it completes or throws.
    */
-  private initInFlight = false;
-
-  /**
-   * `true` while a {@link plan} call is actively running (from the moment its
-   * generator body starts executing until it completes or throws). Guards
-   * against a second concurrent `plan()` call racing the first against the
-   * same working directory/runs directory. Tracked separately from
-   * {@link initInFlight} since `init` and `plan` are distinct subcommands.
-   */
-  private planInFlight = false;
+  private workspaceInFlight: 'init' | 'plan' | null = null;
 
   /**
    * `config` resolves the terraform working directory (`getTerraformDir()`)
@@ -265,8 +260,10 @@ export class TerraformService {
    * rather than rejecting with {@link TerraformInitError}.
    *
    * Throws a descriptive `Error` synchronously (on the first `.next()` call)
-   * if another `init()` call is already in flight on this instance — overlapping
-   * `terraform init` runs against the same working directory would race.
+   * if another `init()` *or* `plan()` call is already in flight on this
+   * instance — both subcommands share a single {@link workspaceInFlight} lock
+   * because `init` mutates the `backend/.terraform` state that `plan` reads;
+   * overlapping runs against the same working directory would race.
    *
    * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
    * resolved, or {@link TerraformInitError} if the spawned process exits with
@@ -277,12 +274,13 @@ export class TerraformService {
     config: TerraformInitConfig,
     signal?: AbortSignal,
   ): AsyncGenerator<TerraformRunChunk, void> {
-    if (this.initInFlight) {
+    if (this.workspaceInFlight) {
       throw new Error(
-        'TerraformService.init() is already running; wait for it to finish before calling init() again.',
+        `TerraformService.init() cannot run while ${this.workspaceInFlight}() is already ` +
+          'running; wait for it to finish before calling init() again.',
       );
     }
-    this.initInFlight = true;
+    this.workspaceInFlight = 'init';
     try {
       if (this.lastInitConfig && TerraformService.sameBackendConfig(this.lastInitConfig, config)) {
         yield {
@@ -329,7 +327,7 @@ export class TerraformService {
       }
       throw new TerraformInitError(result.exitCode);
     } finally {
-      this.initInFlight = false;
+      this.workspaceInFlight = null;
     }
   }
 
@@ -374,7 +372,10 @@ export class TerraformService {
    * {@link TerraformPlanError}.
    *
    * Throws a descriptive `Error` synchronously (on the first `.next()` call)
-   * if another `plan()` call is already in flight on this instance.
+   * if another `plan()` *or* `init()` call is already in flight on this
+   * instance — both subcommands share a single {@link workspaceInFlight} lock
+   * because `plan` reads the `backend/.terraform` state that `init` mutates;
+   * overlapping runs against the same working directory would race.
    *
    * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
    * resolved, a plain `Error` if the configured tfvars source can't be read
@@ -386,12 +387,13 @@ export class TerraformService {
     tfvarsVersionId?: string,
     signal?: AbortSignal,
   ): AsyncGenerator<TerraformRunChunk, TerraformPlanResult | undefined> {
-    if (this.planInFlight) {
+    if (this.workspaceInFlight) {
       throw new Error(
-        'TerraformService.plan() is already running; wait for it to finish before calling plan() again.',
+        `TerraformService.plan() cannot run while ${this.workspaceInFlight}() is already ` +
+          'running; wait for it to finish before calling plan() again.',
       );
     }
-    this.planInFlight = true;
+    this.workspaceInFlight = 'plan';
     try {
       if (signal?.aborted) {
         // Already aborted before we even started resolving the binary path —
@@ -478,7 +480,7 @@ export class TerraformService {
       }
       throw new TerraformPlanError(result.exitCode);
     } finally {
-      this.planInFlight = false;
+      this.workspaceInFlight = null;
     }
   }
 
@@ -649,6 +651,24 @@ export class TerraformService {
       return { aborted: false, exitCode };
     } finally {
       signal?.removeEventListener('abort', onAbort);
+      if (!closed) {
+        // The generator was force-closed early (e.g. plan()'s own finally
+        // calling `stream.return()` when its consumer breaks/throws) before
+        // the child process actually exited. Removing the abort listener
+        // alone leaves Terraform (and its stdout/stderr listeners) running
+        // in the background — explicitly kill the child and wait for it to
+        // actually close before this generator resolves, so forced cleanup
+        // terminates the underlying process instead of orphaning it.
+        child.kill();
+        await new Promise<void>((resolve) => {
+          if (closed) {
+            resolve();
+            return;
+          }
+          child.once('close', () => resolve());
+          child.once('error', () => resolve());
+        });
+      }
     }
   }
 

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -436,18 +436,34 @@ export class TerraformService {
       // being forwarded to the caller unmodified.
       const stream = this.spawnAndStream(binaryPath, args, cwd, signal);
       let next = await stream.next();
-      while (!next.done) {
-        const chunk = next.value;
-        if (chunk.stream === 'stdout') {
-          const match = PLAN_SUMMARY_PATTERN.exec(chunk.line);
-          if (match) {
-            add = Number(match[1]);
-            change = Number(match[2]);
-            destroy = Number(match[3]);
+      try {
+        while (!next.done) {
+          const chunk = next.value;
+          if (chunk.stream === 'stdout') {
+            const match = PLAN_SUMMARY_PATTERN.exec(chunk.line);
+            if (match) {
+              add = Number(match[1]);
+              change = Number(match[2]);
+              destroy = Number(match[3]);
+            }
           }
+          yield chunk;
+          next = await stream.next();
         }
-        yield chunk;
-        next = await stream.next();
+      } finally {
+        // If plan()'s own generator is terminated early (consumer break /
+        // .return() / .throw()), the `yield chunk` above unwinds through
+        // this finally without `next` ever reaching `done`. Explicitly
+        // finalize the inner generator so its own finally (abort-listener
+        // removal in spawnAndStream) still runs — mirrors what `yield*`
+        // gives `init()` for free.
+        if (!next.done) {
+          // The forced value here is never observed by any caller (plan()
+          // is already unwinding for its own reasons) — it only needs to be
+          // a well-typed `SpawnStreamResult` so `.return()` can drive
+          // `spawnAndStream`'s try/finally to completion.
+          await stream.return({ aborted: true });
+        }
       }
 
       const result = next.value;


### PR DESCRIPTION
Closes #173

## Summary

- Adds `ConfigService.getRunsDir()` to resolve `userData/runs` (creating it on demand), matching the existing pattern for `getTerraformDir()`.
- Extracts the streaming spawn pump previously inlined in `init()` into a shared private `spawnAndStream()` generator helper on `TerraformService`, so `plan()` can reuse the same abort-signal handling and chunked stdout/stderr streaming.
- Implements `TerraformService.plan(runId, tfvarsVersionId)` — pulls tfvars from the `RemoteFileStore`, writes it to `userData/runs/<runId>/terraform.tfvars.json`, and spawns `terraform plan -var-file=... -out=<runId>.tfplan`, scanning stdout for the plan summary line (add/change/destroy counts) while streaming raw output via the shared generator.
- Fixes an abort-listener leak: when `plan()`'s generator is terminated early (consumer `break`/`.return()`/`.throw()`), it now explicitly finalizes the inner `spawnAndStream()` generator via `.return()` so its `finally` block (which removes the abort listener) always runs.

## Changes

```
 .../desktop-main/src/modules/terraform.module.ts   |  16 +-
 .../src/services/ConfigService.test.ts             |  21 +
 .../desktop-main/src/services/ConfigService.ts     |  36 ++
 .../src/services/TerraformService.init.test.ts     | 436 ++++++++++++++-
 .../src/services/TerraformService.plan.test.ts     | 608 +++++++++++++++++++++
 .../src/services/TerraformService.test.ts          |  48 +-
 .../desktop-main/src/services/TerraformService.ts  | 495 ++++++++++++++---
 7 files changed, 1529 insertions(+), 131 deletions(-)
```

## Test plan

- [x] `plan()` writes the pulled tfvars to `userData/runs/<runId>/terraform.tfvars.json` before spawning — covered by `TerraformService.plan.test.ts`.
- [x] `plan()` spawns `terraform plan -var-file=... -out=<runId>.tfplan`, persisting the tfplan artifact under `userData/runs/<runId>/` — covered by `TerraformService.plan.test.ts`.
- [x] Plan summary (add/change/destroy counts) is parsed from stdout and returned alongside the artifact path — covered by `TerraformService.plan.test.ts`.
- [x] Output streams chunk-by-chunk via the shared `spawnAndStream()` generator, matching `init()`'s streaming contract — covered by `TerraformService.plan.test.ts` and updated `TerraformService.init.test.ts`.
- [x] Early consumer termination of `plan()`'s generator finalizes the inner generator so the abort listener is always removed (no leak) — covered by `TerraformService.plan.test.ts`.
- [x] `ConfigService.getRunsDir()` resolves and creates `userData/runs` — covered by `ConfigService.test.ts`.
- [x] `npm run app:test` passing for the touched workspace (desktop-main).
- [x] `npm run app:lint` clean.
