### PR TITLE
feat(desktop-main): TerraformService.apply() with stale-plan guard

### DIFF
--- a/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
@@ -1,0 +1,772 @@
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Spy variables must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock } = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  const mkdirSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn();
+  return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: spawnMock,
+}));
+
+vi.mock('node:fs', () => ({
+  mkdirSync: mkdirSyncMock,
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+  copyFileSync: vi.fn(),
+}));
+
+import {
+  TerraformService,
+  TerraformNotFoundError,
+  TerraformApplyError,
+  StalePlanError,
+  type TerraformInitConfig,
+  type TerraformRunChunk,
+  type TerraformApplyResult,
+  type TerraformRunRecord,
+} from './TerraformService.js';
+import type { ConfigService } from './ConfigService.js';
+import type { RemoteFileStore } from '@hyveon/shared';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Extracts the error-first callback from an `execFile` call's arguments,
+ * regardless of whether `util.promisify` invoked it with or without an
+ * `options` object.
+ */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
+/** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
+function queueExecFileSuccess(stdout: string, stderr = ''): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(null, { stdout, stderr });
+  });
+}
+
+/** Queues a failing `execFile` invocation (e.g. binary not found) for the next call. */
+function queueExecFileFailure(error: Error = new Error('spawn ENOENT')): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(error);
+  });
+}
+
+/** Queues a successful binary lookup followed by a successful `-json` version response. */
+function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', version = '1.7.0'): void {
+  queueExecFileSuccess(`${binaryPath}\n`);
+  queueExecFileSuccess(JSON.stringify({ terraform_version: version }));
+}
+
+/**
+ * `ConfigService` stub for `apply()` tests: exposes `getTerraformDir`,
+ * `getRunsDir`, `getTfvarsBucket`, and `getTfvarsPath` — the accessors
+ * `apply()` (directly, or via {@link TerraformService.assertPlanTfvarsNotStale}
+ * and {@link TerraformService.writeRunRecord}) reads.
+ */
+function stubApplyConfigService(
+  opts: {
+    terraformDir?: string;
+    runsDir?: string;
+    tfvarsBucket?: string | null;
+    tfvarsPath?: string;
+  } = {},
+): ConfigService {
+  return {
+    getTerraformDir: () => opts.terraformDir ?? '/repo/terraform',
+    getRunsDir: () => opts.runsDir ?? '/repo/runs',
+    getTfvarsBucket: () => opts.tfvarsBucket ?? null,
+    getTfvarsPath: () => opts.tfvarsPath ?? '/repo/terraform/terraform.tfvars',
+  } as ConfigService;
+}
+
+/**
+ * Minimal `RemoteFileStore` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. `listVersions` is a directly-controllable mock so
+ * S3-mode `apply()` tests can queue a tfvars version-history response for
+ * the stale-plan guard.
+ */
+function stubRemoteFileStore(): RemoteFileStore & {
+  listVersions: ReturnType<typeof vi.fn>;
+} {
+  const store: Partial<RemoteFileStore> = {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  };
+  return store as RemoteFileStore & {
+    listVersions: ReturnType<typeof vi.fn>;
+  };
+}
+
+/**
+ * A fake `child_process.ChildProcess` sufficient for exercising `apply()`'s
+ * streaming logic: an `EventEmitter` standing in for the process itself,
+ * with `stdout`/`stderr` sub-emitters standing in for the piped streams, and
+ * a spied `kill()` so abort tests can assert the process was actually
+ * terminated. Tests drive it manually via `emitStdout`/`emitStderr`/`close`/
+ * `emit('error', ...)` rather than relying on any real process lifecycle.
+ */
+class FakeChildProcess extends EventEmitter {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+  readonly kill = vi.fn();
+
+  emitStdout(chunk: string): void {
+    this.stdout.emit('data', Buffer.from(chunk));
+  }
+
+  emitStderr(chunk: string): void {
+    this.stderr.emit('data', Buffer.from(chunk));
+  }
+
+  close(code: number | null): void {
+    this.emit('close', code);
+  }
+}
+
+/** Queues the next `spawn()` call to return `child` instead of a real process. */
+function queueSpawn(child: FakeChildProcess): void {
+  spawnMock.mockImplementationOnce(() => child);
+}
+
+/**
+ * Waits for every already-queued microtask to drain (via a macrotask
+ * boundary) before returning. `apply()` awaits the stale-plan guard plus the
+ * binary/version resolution before it reaches the `spawn()` call and
+ * registers listeners on the child process, so tests must flush past that
+ * chain before driving `child.emitStdout`/`close`/`error` — otherwise those
+ * events fire before any listener has been attached.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Drains an `apply()` async generator to completion, collecting every
+ * yielded chunk plus the generator's final return value — a
+ * `TerraformApplyResult` on success, or `undefined` on a clean abort.
+ * `driveChild` is invoked once (after the first `.next()` has been issued so
+ * the child process is spawned and listeners are attached) to let the caller
+ * emit data/close/error events on the fake child at the right moment
+ * relative to iteration.
+ */
+async function collectApplyChunks(
+  gen: AsyncGenerator<TerraformRunChunk, TerraformApplyResult | undefined>,
+  driveChild?: () => void,
+): Promise<{ chunks: TerraformRunChunk[]; result: TerraformApplyResult | undefined }> {
+  const chunks: TerraformRunChunk[] = [];
+  const first = gen.next();
+  // Attach a no-op rejection handler immediately so a generator that throws
+  // before `driveChild` is even relevant (e.g. binary resolution failure)
+  // doesn't trip Node's unhandled-rejection detection during the
+  // `flushMicrotasks` gap below — the real `await first` a few lines down
+  // still surfaces the rejection to the caller.
+  first.catch(() => {});
+  await flushMicrotasks();
+  driveChild?.();
+  let next = await first;
+  while (!next.done) {
+    chunks.push(next.value);
+    const following = gen.next();
+    following.catch(() => {});
+    next = await following;
+  }
+  return { chunks, result: next.value };
+}
+
+/** A minimal `TerraformInitConfig` used only to exercise `init()` in the cross-subcommand lock tests below. */
+const sampleInitConfig: TerraformInitConfig = {
+  bucket: 'hyveon-tf-state',
+  region: 'us-east-1',
+  dynamodbTable: 'hyveon-tf-locks',
+};
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  spawnMock.mockReset();
+  mkdirSyncMock.mockReset();
+  writeFileSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  // Default to "plan file exists" so tests that don't care about the
+  // pre-spawn existsSync(planFile) guard aren't tripped up by it — only the
+  // dedicated "missing planFile" test below overrides this.
+  existsSyncMock.mockReturnValue(true);
+});
+
+describe('TerraformService.apply stale-plan guard', () => {
+  it('should reject with a StalePlanError instance and never call spawn when the supplied tfvarsVersionId no longer matches the head version returned by listVersions', async () => {
+    queueSuccessfulResolution();
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockResolvedValue([
+      { versionId: 'v2', lastModified: new Date('2024-01-02') },
+      { versionId: 'v1', lastModified: new Date('2024-01-01') },
+    ]);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await expect(
+      collectApplyChunks(service.apply('run-1', 'v1', '/repo/runs/run-1/run-1.tfplan')),
+    ).rejects.toBeInstanceOf(StalePlanError);
+    expect(remoteFileStore.listVersions).toHaveBeenCalledWith('terraform.tfvars');
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should proceed to spawn when the supplied tfvarsVersionId matches the head version returned by listVersions', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockResolvedValue([
+      { versionId: 'v2', lastModified: new Date('2024-01-02') },
+      { versionId: 'v1', lastModified: new Date('2024-01-01') },
+    ]);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
+      remoteFileStore,
+    );
+
+    await collectApplyChunks(service.apply('run-2', 'v2', '/repo/runs/run-2/run-2.tfplan'), () =>
+      child.close(0),
+    );
+
+    expect(remoteFileStore.listVersions).toHaveBeenCalledWith('terraform.tfvars');
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/terraform',
+      ['apply', '-input=false', '-no-color', '/repo/runs/run-2/run-2.tfplan'],
+      { cwd: '/repo/terraform' },
+    );
+  });
+
+  it('should proceed to spawn without consulting listVersions when no tfvars bucket is configured (local-file mode)', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    const service = new TerraformService(stubApplyConfigService({ tfvarsBucket: null }), remoteFileStore);
+
+    await collectApplyChunks(service.apply('run-3', 'v1', '/repo/runs/run-3/run-3.tfplan'), () =>
+      child.close(0),
+    );
+
+    expect(remoteFileStore.listVersions).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should proceed to spawn without consulting listVersions when tfvarsVersionId is omitted', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const remoteFileStore = stubRemoteFileStore();
+    const service = new TerraformService(
+      stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
+      remoteFileStore,
+    );
+
+    await collectApplyChunks(service.apply('run-4', undefined, '/repo/runs/run-4/run-4.tfplan'), () =>
+      child.close(0),
+    );
+
+    expect(remoteFileStore.listVersions).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
+    queueExecFileFailure();
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+
+    await expect(
+      collectApplyChunks(service.apply('run-5', undefined, '/repo/runs/run-5/run-5.tfplan')),
+    ).rejects.toBeInstanceOf(TerraformNotFoundError);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.apply streaming', () => {
+  it('should yield stdout and stderr lines as they are produced, not only after the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const { chunks } = await collectApplyChunks(
+      service.apply('run-6', undefined, '/repo/runs/run-6/run-6.tfplan'),
+      () => {
+        child.emitStdout('aws_instance.game: Creating...\n');
+        child.emitStderr('Warning: something\n');
+        child.close(0);
+      },
+    );
+
+    expect(chunks).toContainEqual({ stream: 'stdout', line: 'aws_instance.game: Creating...' });
+    expect(chunks).toContainEqual({ stream: 'stderr', line: 'Warning: something' });
+  });
+});
+
+describe('TerraformService.apply summary parsing and return value', () => {
+  it('should parse the added/changed/destroyed counts from the Apply complete! summary line and return them alongside runId', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+
+    const { result } = await collectApplyChunks(
+      service.apply('run-7', undefined, '/repo/runs/run-7/run-7.tfplan'),
+      () => {
+        child.emitStdout('aws_instance.game: Creation complete\n');
+        child.emitStdout('Apply complete! Resources: 3 added, 1 changed, 2 destroyed.\n');
+        child.close(0);
+      },
+    );
+
+    expect(result).toEqual({ runId: 'run-7', added: 3, changed: 1, destroyed: 2 });
+  });
+
+  it('should resolve all three counts to 0 when the summary line is never seen despite a clean exit', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+
+    const { result } = await collectApplyChunks(
+      service.apply('run-8', undefined, '/repo/runs/run-8/run-8.tfplan'),
+      () => {
+        child.emitStdout('No changes.\n');
+        child.close(0);
+      },
+    );
+
+    expect(result).toEqual({ runId: 'run-8', added: 0, changed: 0, destroyed: 0 });
+  });
+});
+
+describe('TerraformService.apply exit handling', () => {
+  it('should reject with a TerraformApplyError carrying the exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+
+    const result = collectApplyChunks(service.apply('run-9', undefined, '/repo/runs/run-9/run-9.tfplan'), () =>
+      child.close(1),
+    );
+
+    await expect(result).rejects.toBeInstanceOf(TerraformApplyError);
+    await expect(result).rejects.toMatchObject({ exitCode: 1 });
+  });
+
+  it('should reject when the spawned process itself errors out (e.g. ENOENT)', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+
+    const result = collectApplyChunks(
+      service.apply('run-10', undefined, '/repo/runs/run-10/run-10.tfplan'),
+      () => child.emit('error', new Error('spawn ENOENT')),
+    );
+
+    await expect(result).rejects.toThrow('spawn ENOENT');
+  });
+});
+
+describe('TerraformService.apply planFile existence guard', () => {
+  it('should throw a descriptive Error synchronously and never call spawn when planFile does not exist on disk', async () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const gen = service.apply('run-25', undefined, '/repo/runs/run-25/run-25.tfplan');
+
+    await expect(gen.next()).rejects.toThrow(/plan file .* does not exist/i);
+    expect(existsSyncMock).toHaveBeenCalledWith('/repo/runs/run-25/run-25.tfplan');
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.apply abort handling', () => {
+  it('should kill the child process and end the generator cleanly with an undefined return value when the AbortSignal fires mid-run', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const gen = service.apply('run-11', undefined, '/repo/runs/run-11/run-11.tfplan', controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const result = await pendingNext;
+
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+  });
+
+  it('should end the generator cleanly without resolving the binary or spawning when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const gen = service.apply('run-12', undefined, '/repo/runs/run-12/run-12.tfplan', controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should end the generator cleanly without consulting listVersions when the signal is already aborted and a tfvarsVersionId + tfvarsBucket are both supplied', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const remoteFileStore = stubRemoteFileStore();
+    const service = new TerraformService(
+      stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
+      remoteFileStore,
+    );
+    const gen = service.apply('run-26', 'v1', '/repo/runs/run-26/run-26.tfplan', controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(remoteFileStore.listVersions).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should end the generator cleanly without spawning when the signal is aborted while resolving the binary path', async () => {
+    const controller = new AbortController();
+    execFileMock.mockImplementationOnce((...args: unknown[]) => {
+      controller.abort();
+      lastArgAsCallback(args)(null, { stdout: '/usr/local/bin/terraform\n', stderr: '' });
+    });
+    queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const gen = service.apply('run-13', undefined, '/repo/runs/run-13/run-13.tfplan', controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should end the generator cleanly without spawning when the signal is aborted while the stale-plan guard is checking listVersions', async () => {
+    queueSuccessfulResolution();
+    const controller = new AbortController();
+
+    const remoteFileStore = stubRemoteFileStore();
+    remoteFileStore.listVersions.mockImplementation(async () => {
+      controller.abort();
+      return [{ versionId: 'v1', lastModified: new Date('2024-01-01') }];
+    });
+
+    const service = new TerraformService(
+      stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
+      remoteFileStore,
+    );
+    const gen = service.apply('run-14', 'v1', '/repo/runs/run-14/run-14.tfplan', controller.signal);
+
+    const result = await gen.next();
+
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should kill the child process and wait for it to close when the generator is force-closed early (e.g. consumer break) before the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const gen = service.apply('run-15', undefined, '/repo/runs/run-15/run-15.tfplan');
+
+    // Drive the generator to its first yielded chunk, mirroring a consumer
+    // that starts iterating (e.g. a `for await...of` loop) but never reaches
+    // the child process's `close` event before bailing out.
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Creating...\n');
+    await first;
+
+    // Simulate the consumer force-closing the generator early (what a
+    // `for await...of` `break`/`throw` desugars to under the hood). This
+    // should propagate through apply()'s finally into spawnAndStream's
+    // finally, which must kill the still-running child rather than just
+    // detaching the abort listener.
+    let returnSettled = false;
+    const returnPromise = gen.return(undefined).then((result) => {
+      returnSettled = true;
+      return result;
+    });
+
+    await flushMicrotasks();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    // The generator must not resolve its forced return until the child
+    // process actually reports closing — killing it isn't enough on its own.
+    expect(returnSettled).toBe(false);
+
+    child.close(null);
+    const result = await returnPromise;
+
+    expect(returnSettled).toBe(true);
+    expect(result.done).toBe(true);
+  });
+});
+
+describe('TerraformService.apply run.json persistence', () => {
+  it('should write a run.json record with runId/kind/startedAt/completedAt/exitCode/tfvarsVersionId when the process exits cleanly', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+
+    await collectApplyChunks(service.apply('run-16', 'v1', '/repo/runs/run-16/run-16.tfplan'), () =>
+      child.close(0),
+    );
+
+    expect(mkdirSyncMock).toHaveBeenCalledWith('/repo/runs/run-16', { recursive: true });
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    expect(path).toBe('/repo/runs/run-16/run.json');
+    const record = JSON.parse(contents) as TerraformRunRecord;
+    expect(record.runId).toBe('run-16');
+    expect(record.kind).toBe('apply');
+    expect(record.exitCode).toBe(0);
+    expect(record.tfvarsVersionId).toBe('v1');
+    expect(typeof record.startedAt).toBe('string');
+    expect(typeof record.completedAt).toBe('string');
+  });
+
+  it('should write a run.json record with a null exitCode when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+
+    await expect(
+      collectApplyChunks(service.apply('run-17', undefined, '/repo/runs/run-17/run-17.tfplan'), () =>
+        child.close(1),
+      ),
+    ).rejects.toBeInstanceOf(TerraformApplyError);
+
+    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    expect(path).toBe('/repo/runs/run-17/run.json');
+    const record = JSON.parse(contents) as TerraformRunRecord;
+    expect(record.exitCode).toBe(1);
+  });
+
+  it('should write a run.json record with a null exitCode when the run was aborted mid-flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const gen = service.apply('run-18', undefined, '/repo/runs/run-18/run-18.tfplan', controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+    controller.abort();
+    child.close(null);
+    await pendingNext;
+
+    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    expect(path).toBe('/repo/runs/run-18/run.json');
+    const record = JSON.parse(contents) as TerraformRunRecord;
+    expect(record.exitCode).toBeNull();
+  });
+});
+
+describe('TerraformService.apply concurrency guard', () => {
+  it('should throw a descriptive Error from a second apply() call while the first is still in flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const firstGen = service.apply('run-19', undefined, '/repo/runs/run-19/run-19.tfplan');
+    const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
+
+    const secondGen = service.apply('run-20', undefined, '/repo/runs/run-20/run-20.tfplan');
+    await expect(secondGen.next()).rejects.toThrow(/already running/i);
+
+    // Let the first call finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await firstNext;
+    await firstGen.next();
+  });
+
+  it('should allow a new apply() call once the previous one has completed', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    await collectApplyChunks(service.apply('run-21', undefined, '/repo/runs/run-21/run-21.tfplan'), () =>
+      firstChild.close(0),
+    );
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    const { result } = await collectApplyChunks(
+      service.apply('run-22', undefined, '/repo/runs/run-22/run-22.tfplan'),
+      () => secondChild.close(0),
+    );
+
+    expect(result).toBeDefined();
+  });
+
+  it('should allow a new apply() call once the previous one has failed', async () => {
+    queueSuccessfulResolution();
+    const firstChild = new FakeChildProcess();
+    queueSpawn(firstChild);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    await expect(
+      collectApplyChunks(service.apply('run-23', undefined, '/repo/runs/run-23/run-23.tfplan'), () =>
+        firstChild.close(1),
+      ),
+    ).rejects.toBeInstanceOf(TerraformApplyError);
+
+    const secondChild = new FakeChildProcess();
+    queueSpawn(secondChild);
+    const { result } = await collectApplyChunks(
+      service.apply('run-24', undefined, '/repo/runs/run-24/run-24.tfplan'),
+      () => secondChild.close(0),
+    );
+
+    expect(result).toBeDefined();
+  });
+});
+
+describe('TerraformService.apply cross-subcommand lock enforcement', () => {
+  it('should throw a descriptive Error from apply() when plan() is already running against the same workspace', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const planGen = service.plan();
+    const planNext = planGen.next(); // starts plan()'s body, setting the shared in-flight flag synchronously
+
+    const applyGen = service.apply('run-27', undefined, '/repo/runs/run-27/run-27.tfplan');
+    await expect(applyGen.next()).rejects.toThrow(/plan\(\) is already running/i);
+
+    // Let the in-flight plan() finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await planNext;
+    await planGen.next();
+  });
+
+  it('should throw a descriptive Error from apply() when init() is already running against the same workspace', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const initGen = service.init(sampleInitConfig);
+    const initNext = initGen.next(); // starts init()'s body, setting the shared in-flight flag synchronously
+
+    const applyGen = service.apply('run-28', undefined, '/repo/runs/run-28/run-28.tfplan');
+    await expect(applyGen.next()).rejects.toThrow(/init\(\) is already running/i);
+
+    // Let the in-flight init() finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await initNext;
+    await initGen.next();
+  });
+
+  it('should throw a descriptive Error from plan() when apply() is already running against the same workspace', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const applyGen = service.apply('run-29', undefined, '/repo/runs/run-29/run-29.tfplan');
+    const applyNext = applyGen.next(); // starts apply()'s body, setting the shared in-flight flag synchronously
+
+    const planGen = service.plan();
+    await expect(planGen.next()).rejects.toThrow(/apply\(\) is already running/i);
+
+    // Let the in-flight apply() finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await applyNext;
+    await applyGen.next();
+  });
+
+  it('should throw a descriptive Error from init() when apply() is already running against the same workspace', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const applyGen = service.apply('run-30', undefined, '/repo/runs/run-30/run-30.tfplan');
+    const applyNext = applyGen.next(); // starts apply()'s body, setting the shared in-flight flag synchronously
+
+    const initGen = service.init(sampleInitConfig);
+    await expect(initGen.next()).rejects.toThrow(/apply\(\) is already running/i);
+
+    // Let the in-flight apply() finish so it doesn't leak into other tests.
+    await flushMicrotasks();
+    child.close(0);
+    await applyNext;
+    await applyGen.next();
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
@@ -583,7 +583,7 @@ describe('TerraformService.apply run.json persistence', () => {
     expect(typeof record.completedAt).toBe('string');
   });
 
-  it('should write a run.json record with a null exitCode when the process exits non-zero', async () => {
+  it('should write a run.json record carrying the actual exit code when the process exits non-zero', async () => {
     queueSuccessfulResolution();
     const child = new FakeChildProcess();
     queueSpawn(child);

--- a/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
@@ -313,16 +313,27 @@ describe('TerraformService.apply streaming', () => {
     queueSpawn(child);
 
     const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
-    const { chunks } = await collectApplyChunks(
-      service.apply('run-6', undefined, '/repo/runs/run-6/run-6.tfplan'),
-      () => {
-        child.emitStdout('aws_instance.game: Creating...\n');
-        child.emitStderr('Warning: something\n');
-        child.close(0);
-      },
-    );
+    const gen = service.apply('run-6', undefined, '/repo/runs/run-6/run-6.tfplan');
 
-    expect(chunks).toContainEqual({ stream: 'stdout', line: 'aws_instance.game: Creating...' });
+    // Drive and await the first yielded chunk *before* emitting stderr or
+    // closing the child — a buffer-until-exit implementation would still be
+    // blocked on `child.close()` at this point, so awaiting here first
+    // proves stdout is streamed rather than accumulated until exit.
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Creating...\n');
+    const firstResult = await first;
+
+    expect(firstResult.done).toBe(false);
+    expect(firstResult.value).toEqual({ stream: 'stdout', line: 'aws_instance.game: Creating...' });
+
+    // Only now produce stderr and close the process, and drain the rest of
+    // the generator via the existing helper.
+    const { chunks } = await collectApplyChunks(gen, () => {
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
     expect(chunks).toContainEqual({ stream: 'stderr', line: 'Warning: something' });
   });
 });
@@ -552,6 +563,44 @@ describe('TerraformService.apply abort handling', () => {
 
     expect(returnSettled).toBe(true);
     expect(result.done).toBe(true);
+  });
+
+  it('should write exactly one run.json record with a null exitCode when the generator is force-closed before the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const gen = service.apply('run-31', 'v1', '/repo/runs/run-31/run-31.tfplan');
+
+    // Drive the generator to its first yielded chunk, then force-close it —
+    // as `for await...of` `break`/`throw` would — before the child process
+    // has closed. writeRunRecord() lives after the inner try/finally in
+    // apply()'s body, which a forced completion unwinds straight past; the
+    // persistence must instead happen from the outer finally.
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Creating...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+
+    child.close(null);
+    await returnPromise;
+
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    expect(path).toBe('/repo/runs/run-31/run.json');
+    const record = JSON.parse(contents) as TerraformRunRecord;
+    expect(record.runId).toBe('run-31');
+    expect(record.kind).toBe('apply');
+    expect(record.exitCode).toBeNull();
+    expect(record.tfvarsVersionId).toBe('v1');
   });
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -138,14 +138,100 @@ export interface TerraformPlanResult {
 const PLAN_SUMMARY_PATTERN = /Plan:\s*(\d+) to add,\s*(\d+) to change,\s*(\d+) to destroy\./;
 
 /**
+ * Thrown by {@link TerraformService.apply} before spawning `terraform apply`
+ * when the caller supplied a `tfvarsVersionId` (the version the plan being
+ * applied was generated against) and the S3 tfvars object's current head
+ * version no longer matches it — the remote tfvars changed underneath the
+ * caller since the plan was produced, so applying the stale `.tfplan`
+ * artifact could deploy against configuration nobody actually planned.
+ * Distinct from the plain `Error` {@link TerraformService.pullVarFile} throws
+ * for the equivalent staleness check ahead of `plan()`, so callers can branch
+ * on `instanceof StalePlanError` to prompt "re-plan before applying" flows
+ * specifically.
+ */
+export class StalePlanError extends Error {
+  constructor(key: string, bucket: string, expectedVersionId: string, actualVersionId: string | undefined) {
+    super(
+      `tfvars object "${key}" in S3 bucket "${bucket}" is stale for this plan: expected version ` +
+        `"${expectedVersionId}" to still be the current head, but the head version is now ` +
+        `${actualVersionId ? `"${actualVersionId}"` : 'missing'}. Re-run plan() before applying.`,
+    );
+    this.name = 'StalePlanError';
+  }
+}
+
+/**
+ * Thrown when the spawned `terraform apply` process exits with a non-zero
+ * status code. Distinct from {@link TerraformNotFoundError} (binary can't be
+ * resolved) and {@link StalePlanError} (the pre-spawn staleness guard).
+ */
+export class TerraformApplyError extends Error {
+  constructor(public readonly exitCode: number | null) {
+    super(`terraform apply exited with code ${exitCode ?? 'null'}`);
+    this.name = 'TerraformApplyError';
+  }
+}
+
+/**
+ * Outcome of a successful {@link TerraformService.apply} run, resolved via the
+ * async generator's return value once the spawned `terraform apply` process
+ * exits `0` and the run wasn't aborted.
+ */
+export interface TerraformApplyResult {
+  /** The `runId` this apply run was invoked with — matches the directory `run.json` is written into. */
+  runId: string;
+  /** Number of resources Terraform reported adding. */
+  added: number;
+  /** Number of resources Terraform reported changing in place. */
+  changed: number;
+  /** Number of resources Terraform reported destroying. */
+  destroyed: number;
+}
+
+/**
+ * Matches Terraform's apply-summary stdout line, e.g.
+ * `Apply complete! Resources: 3 added, 1 changed, 0 destroyed.` — scanned for
+ * while streaming {@link TerraformService.apply}'s output to extract the
+ * resource change counts returned in the generator's return value. Mirrors
+ * {@link PLAN_SUMMARY_PATTERN} for the equivalent `plan()` summary line.
+ */
+const APPLY_SUMMARY_PATTERN =
+  /Apply complete!\s*Resources:\s*(\d+) added,\s*(\d+) changed,\s*(\d+) destroyed\./;
+
+/**
+ * Persisted to `<runsDir>/<runId>/run.json` once a {@link TerraformService.apply}
+ * run's spawned process has closed (whether it exited cleanly, non-zero, or
+ * was killed via an abort signal) — a lightweight local run history so a
+ * future Apply-history UI can list past runs without a database. `kind` is
+ * currently always `'apply'`; the union leaves room for `plan`/`destroy`
+ * records to reuse the same shape without a breaking change later.
+ */
+export interface TerraformRunRecord {
+  /** The `runId` this record describes — matches the directory it's written into. */
+  runId: string;
+  /** Which subcommand produced this record. */
+  kind: 'apply';
+  /** ISO-8601 timestamp captured immediately before the process was spawned. */
+  startedAt: string;
+  /** ISO-8601 timestamp captured immediately after the process closed. */
+  completedAt: string;
+  /** The process's exit code, or `null` if it never reported one (e.g. killed via abort signal). */
+  exitCode: number | null;
+  /** The tfvars version id the applied plan was generated against, if the caller supplied one. */
+  tfvarsVersionId?: string;
+}
+
+/**
  * Lazily resolves and caches the system `terraform` binary's absolute path
  * and semver version, and orchestrates `terraform` subcommands against it:
  * {@link TerraformService.init}, the streaming/idempotent `terraform init`
- * runner, and {@link TerraformService.plan}, the streaming `terraform plan`
+ * runner; {@link TerraformService.plan}, the streaming `terraform plan`
  * runner that persists its `.tfplan` artifact and the pulled tfvars snapshot
- * under `ConfigService.getRunsDir()`. Later child issues of Epic D add
- * `apply`/`destroy`/`output` — see the "Terraform orchestrator" section of
- * the electron-desktop-pivot design spec.
+ * under `ConfigService.getRunsDir()`; and {@link TerraformService.apply}, the
+ * streaming `terraform apply <planFile>` runner that persists a
+ * {@link TerraformRunRecord} to the same per-run directory once the process
+ * closes. Later child issues of Epic D add `destroy`/`output` — see the
+ * "Terraform orchestrator" section of the electron-desktop-pivot design spec.
  *
  * Construction is synchronous and never throws — the binary lookup +
  * `terraform version` shell-outs are deferred until {@link getBinaryPath} or
@@ -168,16 +254,18 @@ export class TerraformService {
   private lastInitConfig: TerraformInitConfig | null = null;
 
   /**
-   * Name of whichever subcommand ({@link init} or {@link plan}) is actively
-   * running against `getTerraformDir()`, or `null` when neither is. A single
-   * shared lock (rather than separate `initInFlight`/`planInFlight` flags) is
-   * required because `init` mutates the `backend/.terraform` state that
-   * `plan` reads — letting the two subcommands run concurrently against the
-   * same workspace would race one against the other's writes/reads. Set the
+   * Name of whichever subcommand ({@link init}, {@link plan}, or
+   * {@link apply}) is actively running against `getTerraformDir()`, or `null`
+   * when none is. A single shared lock (rather than separate
+   * `initInFlight`/`planInFlight`/`applyInFlight` flags) is required because
+   * `init` mutates the `backend/.terraform` state that `plan`/`apply` read,
+   * and `apply` itself mutates the state that a concurrent `plan` would read
+   * — letting any two of these subcommands run concurrently against the same
+   * workspace would race one against the other's writes/reads. Set the
    * moment a generator body starts executing (i.e. the first `.next()` call)
    * until it completes or throws.
    */
-  private workspaceInFlight: 'init' | 'plan' | null = null;
+  private workspaceInFlight: 'init' | 'plan' | 'apply' | null = null;
 
   /**
    * `config` resolves the terraform working directory (`getTerraformDir()`)
@@ -482,6 +570,220 @@ export class TerraformService {
     } finally {
       this.workspaceInFlight = null;
     }
+  }
+
+  /**
+   * Runs `terraform apply -input=false -no-color <planFile>` inside the
+   * Terraform composer root (`ConfigService.getTerraformDir()`), yielding a
+   * {@link TerraformRunChunk} per line of output as the process produces it —
+   * mirrors {@link init}/{@link plan}'s streaming shape. `runId` and
+   * `planFile` are expected to be the values a prior {@link plan} call
+   * returned (`runId`/`artifactPath`), so the applied plan and its run record
+   * live under the same `<runsDir>/<runId>/` directory.
+   *
+   * Before spawning: throws a descriptive `Error` synchronously (mirroring
+   * the {@link workspaceInFlight} lock check below) if `planFile` doesn't
+   * exist on disk — there's nothing meaningful to apply. Then, once the
+   * abort signal has been checked (see below) and if `tfvarsVersionId` is
+   * provided and the tfvars source is S3-backed
+   * (`ConfigService.getTfvarsBucket()` resolves one), asserts that it still
+   * matches the head (most recent) version of the tfvars object via
+   * `remoteFileStore.listVersions(key)`, throwing {@link StalePlanError}
+   * *before* `terraform` is ever spawned when they no longer match — the
+   * plan being applied was generated against tfvars that have since changed
+   * underneath the caller. Ignored entirely in local-file mode or when
+   * `tfvarsVersionId` is omitted.
+   *
+   * While streaming, stdout lines are scanned via {@link APPLY_SUMMARY_PATTERN}
+   * for Terraform's summary line (`Apply complete! Resources: N added, N changed, N destroyed.`)
+   * to extract the resource change counts returned in the generator's return
+   * value alongside `runId`. A run that never reaches the summary line (e.g.
+   * it errors out first) resolves all three counts to `0`, but in that case
+   * the generator throws {@link TerraformApplyError} instead of returning.
+   *
+   * `signal`, if provided, aborts the run the same way {@link init}/{@link plan}
+   * do: the spawned child process is killed and the generator ends cleanly —
+   * no further chunks, no throw.
+   *
+   * Once the spawned process has closed — whether it exited cleanly,
+   * non-zero, or was killed via `signal` — writes a {@link TerraformRunRecord}
+   * to `<runsDir>/<runId>/run.json` capturing `runId`, `kind: 'apply'`,
+   * `startedAt`/`completedAt` timestamps, the process's `exitCode` (`null`
+   * when killed via abort), and `tfvarsVersionId`. No record is written if
+   * the process never spawned (stale-plan guard rejected, or `signal` was
+   * already aborted before `getBinaryPath()`/spawn).
+   *
+   * Throws a descriptive `Error` synchronously (on the first `.next()` call)
+   * if another `apply()`, `plan()`, or `init()` call is already in flight on
+   * this instance — all three subcommands share a single
+   * {@link workspaceInFlight} lock because they read/write the same
+   * `backend/.terraform` workspace state; overlapping runs would race — or
+   * if `planFile` doesn't exist on disk.
+   *
+   * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
+   * resolved, {@link StalePlanError} if `tfvarsVersionId` no longer matches
+   * the S3 tfvars head version, or {@link TerraformApplyError} if the spawned
+   * process exits with a non-zero status code (and the run wasn't aborted).
+   */
+  async *apply(
+    runId: string,
+    tfvarsVersionId: string | undefined,
+    planFile: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<TerraformRunChunk, TerraformApplyResult | undefined> {
+    if (this.workspaceInFlight) {
+      throw new Error(
+        `TerraformService.apply() cannot run while ${this.workspaceInFlight}() is already ` +
+          'running; wait for it to finish before calling apply() again.',
+      );
+    }
+    if (!existsSync(planFile)) {
+      throw new Error(`TerraformService.apply() cannot run: plan file "${planFile}" does not exist on disk.`);
+    }
+    this.workspaceInFlight = 'apply';
+    try {
+      if (signal?.aborted) {
+        // Already aborted before we even started the stale-plan guard — end
+        // the generator cleanly without spawning anything (and without
+        // writing a run record, since no process ever ran). Checked before
+        // assertPlanTfvarsNotStale so an already-aborted signal short-circuits
+        // ahead of that S3 round-trip, matching plan()'s established pattern
+        // of checking abort status before any expensive async work.
+        return undefined;
+      }
+
+      await this.assertPlanTfvarsNotStale(tfvarsVersionId);
+
+      if (signal?.aborted) {
+        // Aborted while the stale-plan guard was checking listVersions — end
+        // the generator cleanly before resolving the binary path / spawning.
+        return undefined;
+      }
+
+      const binaryPath = await this.getBinaryPath();
+
+      if (signal?.aborted) {
+        // Aborted while resolving the binary path — end cleanly before spawn.
+        return undefined;
+      }
+
+      const cwd = this.config.getTerraformDir();
+      const args = ['apply', '-input=false', '-no-color', planFile];
+      const startedAt = new Date().toISOString();
+
+      let added = 0;
+      let changed = 0;
+      let destroyed = 0;
+
+      // Driven manually (rather than `yield*`) so each stdout line can be
+      // scanned for the apply summary as it streams through, in addition to
+      // being forwarded to the caller unmodified — mirrors plan()'s approach.
+      const stream = this.spawnAndStream(binaryPath, args, cwd, signal);
+      let next = await stream.next();
+      try {
+        while (!next.done) {
+          const chunk = next.value;
+          if (chunk.stream === 'stdout') {
+            const match = APPLY_SUMMARY_PATTERN.exec(chunk.line);
+            if (match) {
+              added = Number(match[1]);
+              changed = Number(match[2]);
+              destroyed = Number(match[3]);
+            }
+          }
+          yield chunk;
+          next = await stream.next();
+        }
+      } finally {
+        // If apply()'s own generator is terminated early (consumer break /
+        // .return() / .throw()), the `yield chunk` above unwinds through
+        // this finally without `next` ever reaching `done`. Explicitly
+        // finalize the inner generator so its own finally (abort-listener
+        // removal in spawnAndStream) still runs — mirrors what `yield*`
+        // gives `init()` for free, and what `plan()` does above.
+        if (!next.done) {
+          // The forced value here is never observed by any caller (apply()
+          // is already unwinding for its own reasons) — it only needs to be
+          // a well-typed `SpawnStreamResult` so `.return()` can drive
+          // `spawnAndStream`'s try/finally to completion.
+          await stream.return({ aborted: true });
+        }
+      }
+
+      const result = next.value;
+
+      // The process has closed by this point regardless of `aborted` — even
+      // the abort path in `spawnAndStream` only resolves once `close` (or
+      // `error`) has fired — so a run record is always written here. Its own
+      // exitCode is discarded by `spawnAndStream` when aborted (the caller is
+      // expected to treat the run as cancelled rather than pass/fail), so
+      // `null` is recorded in that case.
+      this.writeRunRecord(runId, startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
+
+      if (result.aborted) {
+        // Aborted mid-run: the child was killed inside spawnAndStream. End
+        // the generator cleanly rather than surfacing the resulting
+        // error/exit code.
+        return undefined;
+      }
+      if (result.exitCode === 0) {
+        return { runId, added, changed, destroyed };
+      }
+      throw new TerraformApplyError(result.exitCode);
+    } finally {
+      this.workspaceInFlight = null;
+    }
+  }
+
+  /**
+   * Pre-spawn staleness guard for {@link apply}: when `tfvarsVersionId` is
+   * provided and the tfvars source is S3-backed
+   * (`ConfigService.getTfvarsBucket()` resolves one), asserts it still
+   * matches the head (most recent) version of the tfvars object via
+   * `remoteFileStore.listVersions(key)`. A no-op in local-file mode or when
+   * `tfvarsVersionId` is omitted — there's no version history to compare
+   * against.
+   *
+   * @throws {@link StalePlanError} when the head version no longer matches.
+   */
+  private async assertPlanTfvarsNotStale(tfvarsVersionId?: string): Promise<void> {
+    if (!tfvarsVersionId) return;
+
+    const bucket = this.config.getTfvarsBucket();
+    if (!bucket) return;
+
+    const key = basename(this.config.getTfvarsPath());
+    const versions = await this.remoteFileStore.listVersions(key);
+    const head = versions[0];
+    if (!head || head.versionId !== tfvarsVersionId) {
+      throw new StalePlanError(key, bucket, tfvarsVersionId, head?.versionId);
+    }
+  }
+
+  /**
+   * Writes a {@link TerraformRunRecord} to `<runsDir>/<runId>/run.json` once
+   * an {@link apply} run's spawned process has closed. Creates the run
+   * directory if it doesn't already exist (defensive — {@link plan} normally
+   * creates it ahead of `apply`, but nothing prevents a caller from applying
+   * a plan file whose directory was cleaned up in between).
+   */
+  private writeRunRecord(
+    runId: string,
+    startedAt: string,
+    exitCode: number | null,
+    tfvarsVersionId: string | undefined,
+  ): void {
+    const runDir = join(this.config.getRunsDir(), runId);
+    mkdirSync(runDir, { recursive: true });
+    const record: TerraformRunRecord = {
+      runId,
+      kind: 'apply',
+      startedAt,
+      completedAt: new Date().toISOString(),
+      exitCode,
+      tfvarsVersionId,
+    };
+    writeFileSync(join(runDir, 'run.json'), JSON.stringify(record, null, 2));
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -688,11 +688,20 @@ export class TerraformService {
    *
    * The same record is also written (with a `null` `exitCode`, mirroring the
    * abort outcome) if this generator itself is force-closed by its consumer
-   * (`break`/`.return()`/`.throw()`) after a process was spawned — the
-   * finalization above lives inside the generator's own body and is skipped
-   * when a forced completion unwinds straight past it, so an outer `finally`
-   * persists a cancelled record on that path instead, ensuring a spawned
-   * `terraform apply` is never left unrecorded.
+   * (`break`/`.return()`/`.throw()`) while the spawned `terraform apply`
+   * process is still genuinely running — the finalization above lives inside
+   * the generator's own body and is skipped when a forced completion unwinds
+   * straight past it, so an outer `finally` persists a cancelled record on
+   * that path instead, ensuring a still-running `terraform apply` killed by
+   * forced cleanup is never left unrecorded. This is narrower than "a
+   * process was spawned and no record was written yet": that condition alone
+   * is also true when `spawnAndStream` itself throws (e.g. a spawn `error`
+   * event/ENOENT, which only happens once the process has already closed) or
+   * some unrelated exception fires after the child already finished — those
+   * paths must let the real error/outcome propagate instead of being
+   * mislabeled as cancelled, so the outer `finally` also gates on a
+   * `forceKilled` flag that's only set when a genuinely still-live child was
+   * force-killed.
    *
    * Throws a descriptive `Error` synchronously (on the first `.next()` call)
    * if another `apply()`, `plan()`, or `init()` call is already in flight on
@@ -746,6 +755,16 @@ export class TerraformService {
     // the normal completion path.
     let startedAt: string | undefined;
     let runRecordWritten = false;
+    // Set to `true` only from the `onForceKill` callback passed to
+    // `spawnAndStream` below, which that method invokes exclusively from its
+    // own finally's "the child is still live — kill it" branch. This is
+    // deliberately *not* inferred from `startedAt !== undefined &&
+    // !runRecordWritten` alone — that pair is also true when `spawnAndStream`
+    // throws its own spawn error (e.g. a child `error` event/ENOENT, which
+    // only fires once the process has already closed) or some unrelated
+    // exception occurs after the child already finished successfully or
+    // failed, and neither of those is an actual cancellation.
+    let forceKilled = false;
     try {
       if (signal?.aborted) {
         // Already aborted before we even started the stale-plan guard — end
@@ -783,7 +802,9 @@ export class TerraformService {
       // Driven manually (rather than `yield*`) so each stdout line can be
       // scanned for the apply summary as it streams through, in addition to
       // being forwarded to the caller unmodified — mirrors plan()'s approach.
-      const stream = this.spawnAndStream(binaryPath, args, cwd, signal);
+      const stream = this.spawnAndStream(binaryPath, args, cwd, signal, () => {
+        forceKilled = true;
+      });
       let next = await stream.next();
       try {
         while (!next.done) {
@@ -861,12 +882,23 @@ export class TerraformService {
       // `spawnAndStream`, killing the child and waiting for it to actually
       // close), then continues unwinding *past* the `writeRunRecord` call
       // above — that statement is never reached — straight to this outer
-      // `finally`. If a process was ever spawned (`startedAt` set) and no
-      // record was written yet, persist a cancelled (`exitCode: null`) run
-      // record here so the run is never silently lost. Best-effort: a
-      // failure here doesn't override whatever completion the generator was
-      // already unwinding for.
-      if (startedAt !== undefined && !runRecordWritten) {
+      // `finally`.
+      //
+      // Gated on `forceKilled` (not merely `startedAt !== undefined &&
+      // !runRecordWritten`) — that pair alone can't tell "the consumer
+      // force-closed us while terraform was genuinely still running" apart
+      // from every other way this `finally` can be reached before
+      // `writeRunRecord` runs, e.g. `spawnAndStream` itself throwing (a
+      // spawn `error` event/ENOENT, which only happens once the process has
+      // already closed — nothing was actually killed here) or an unrelated
+      // exception after the child already finished successfully or failed.
+      // Those paths must let the real error/outcome propagate unmasked
+      // rather than being mislabeled as a cancelled run. If a process was
+      // genuinely still running and got force-killed (`forceKilled` true),
+      // persist a cancelled (`exitCode: null`) run record here so the run is
+      // never silently lost. Best-effort: a failure here doesn't override
+      // whatever completion the generator was already unwinding for.
+      if (startedAt !== undefined && !runRecordWritten && forceKilled) {
         try {
           this.writeRunRecord(runId, startedAt, null, tfvarsVersionId);
         } catch {
@@ -1031,12 +1063,25 @@ export class TerraformService {
    * Throws whatever error the spawned process itself raised (e.g. `ENOENT`)
    * verbatim — that failure mode isn't subcommand-specific, so it isn't left
    * to the caller to interpret.
+   *
+   * `onForceKill`, if provided, is invoked synchronously — and only — from
+   * this generator's own `finally` block when it force-kills a child that is
+   * still genuinely running (i.e. this generator itself was force-closed by
+   * its consumer, via `break`/`.return()`/`.throw()`, before the process had
+   * closed on its own). It is never invoked for a spawn error (`ENOENT`
+   * etc., surfaced via the thrown `closeError` above) or an abort-signal
+   * kill, both of which reach `closed === true` through the normal
+   * `child.on('error'/'close', ...)` handlers rather than this fallback path
+   * — {@link apply} uses this distinction to tell "the process was actually
+   * live and we just killed it" apart from every other reason its own outer
+   * `finally` might run before it's written a run record.
    */
   private async *spawnAndStream(
     binaryPath: string,
     args: string[],
     cwd: string,
     signal?: AbortSignal,
+    onForceKill?: () => void,
   ): AsyncGenerator<TerraformRunChunk, SpawnStreamResult> {
     const child = spawn(binaryPath, args, { cwd });
     const buffers: Record<'stdout' | 'stderr', string> = { stdout: '', stderr: '' };
@@ -1097,6 +1142,13 @@ export class TerraformService {
     });
 
     const onAbort = (): void => {
+      // Guard against an abort event that fires after the child has already
+      // closed (success or failure) — without this, a late-firing signal
+      // would retroactively misclassify an already-completed run as
+      // aborted.
+      if (closed) {
+        return;
+      }
       aborted = true;
       child.kill();
     };
@@ -1133,6 +1185,13 @@ export class TerraformService {
         // in the background — explicitly kill the child and wait for it to
         // actually close before this generator resolves, so forced cleanup
         // terminates the underlying process instead of orphaning it.
+        //
+        // The child is genuinely still live at this point (its `close`/
+        // `error` handlers never fired, or `closed` would already be
+        // `true`) — notify the caller via `onForceKill` so it can
+        // distinguish this from every other way its own cleanup logic might
+        // run.
+        onForceKill?.();
         child.kill();
         await new Promise<void>((resolve) => {
           if (closed) {

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -138,6 +138,20 @@ export interface TerraformPlanResult {
 const PLAN_SUMMARY_PATTERN = /Plan:\s*(\d+) to add,\s*(\d+) to change,\s*(\d+) to destroy\./;
 
 /**
+ * Matches a bare, single-segment run identifier — letters, digits,
+ * underscores, and hyphens only, with no path separators (`/`, `\`), no `.`/`..`
+ * traversal segments, and no empty string. `runId` is normally a `randomUUID()`
+ * value (which satisfies this pattern), but this is intentionally looser than
+ * a strict UUID check so it doesn't reject the non-UUID run ids exercised by
+ * `TerraformService.apply.test.ts`'s fixtures. This is the only shape
+ * {@link TerraformService.apply} accepts for a caller-supplied `runId`, since
+ * it's joined directly into filesystem paths under `ConfigService.getRunsDir()`;
+ * rejecting anything else (e.g. `../..`, absolute paths, embedded separators)
+ * closes off path traversal via `runId`.
+ */
+const RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
  * Thrown by {@link TerraformService.apply} before spawning `terraform apply`
  * when the caller supplied a `tfvarsVersionId` (the version the plan being
  * applied was generated against) and the S3 tfvars object's current head
@@ -219,6 +233,56 @@ export interface TerraformRunRecord {
   exitCode: number | null;
   /** The tfvars version id the applied plan was generated against, if the caller supplied one. */
   tfvarsVersionId?: string;
+}
+
+/**
+ * Describes what {@link TerraformService.apply} was about to return/throw the
+ * moment its spawned process closed — captured before
+ * {@link TerraformService.writeRunRecord} is attempted so a persistence
+ * failure (see {@link TerraformRunPersistError}) doesn't discard the real
+ * outcome of the apply run.
+ */
+export type TerraformApplyOutcome =
+  | { kind: 'success'; result: TerraformApplyResult }
+  | { kind: 'aborted' }
+  | { kind: 'failed'; error: TerraformApplyError };
+
+/**
+ * Thrown by {@link TerraformService.apply} when persisting the
+ * {@link TerraformRunRecord} to `<runsDir>/<runId>/run.json` fails (e.g. a
+ * filesystem error surfaced from `mkdirSync`/`writeFileSync` inside
+ * {@link TerraformService.writeRunRecord}) — distinct from a failure of
+ * `terraform apply` itself. Carries the {@link TerraformApplyOutcome} that had
+ * already been computed before the persistence attempt (success, abort, or a
+ * {@link TerraformApplyError}) so callers can recover the real apply result
+ * instead of only seeing an unrelated filesystem exception, plus `cause` — the
+ * underlying error `writeRunRecord` raised.
+ */
+export class TerraformRunPersistError extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly outcome: TerraformApplyOutcome,
+    public readonly cause: unknown,
+  ) {
+    super(
+      `Failed to persist run record for run "${runId}" (apply outcome: ` +
+        `${TerraformRunPersistError.describeOutcome(outcome)}): ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = 'TerraformRunPersistError';
+  }
+
+  /** Renders {@link TerraformApplyOutcome} as a short phrase for the error message above. */
+  private static describeOutcome(outcome: TerraformApplyOutcome): string {
+    switch (outcome.kind) {
+      case 'success':
+        return 'succeeded';
+      case 'aborted':
+        return 'aborted';
+      case 'failed':
+        return `failed (exit code ${outcome.error.exitCode ?? 'null'})`;
+    }
+  }
 }
 
 /**
@@ -582,9 +646,14 @@ export class TerraformService {
    * live under the same `<runsDir>/<runId>/` directory.
    *
    * Before spawning: throws a descriptive `Error` synchronously (mirroring
-   * the {@link workspaceInFlight} lock check below) if `planFile` doesn't
-   * exist on disk — there's nothing meaningful to apply. Then, once the
-   * abort signal has been checked (see below) and if `tfvarsVersionId` is
+   * the {@link workspaceInFlight} lock check below) if `runId` isn't a bare
+   * path segment (see {@link RUN_ID_PATTERN} — no path separators or `.`/`..`
+   * traversal segments), if `planFile` doesn't resolve exactly to
+   * `<runsDir>/<runId>/<runId>.tfplan` (the only artifact path {@link plan}
+   * ever produces for that `runId`), or if `planFile` doesn't exist on disk —
+   * these three checks close off path traversal and applying an unrelated
+   * plan artifact via caller-supplied `runId`/`planFile` values. Then, once
+   * the abort signal has been checked (see below) and if `tfvarsVersionId` is
    * provided and the tfvars source is S3-backed
    * (`ConfigService.getTfvarsBucket()` resolves one), asserts that it still
    * matches the head (most recent) version of the tfvars object via
@@ -611,19 +680,35 @@ export class TerraformService {
    * `startedAt`/`completedAt` timestamps, the process's `exitCode` (`null`
    * when killed via abort), and `tfvarsVersionId`. No record is written if
    * the process never spawned (stale-plan guard rejected, or `signal` was
-   * already aborted before `getBinaryPath()`/spawn).
+   * already aborted before `getBinaryPath()`/spawn). If persisting that
+   * record fails (e.g. a filesystem error), the already-computed apply
+   * outcome (success/abort/{@link TerraformApplyError}) is wrapped in
+   * {@link TerraformRunPersistError} and thrown instead of being discarded
+   * behind the persistence failure.
+   *
+   * The same record is also written (with a `null` `exitCode`, mirroring the
+   * abort outcome) if this generator itself is force-closed by its consumer
+   * (`break`/`.return()`/`.throw()`) after a process was spawned — the
+   * finalization above lives inside the generator's own body and is skipped
+   * when a forced completion unwinds straight past it, so an outer `finally`
+   * persists a cancelled record on that path instead, ensuring a spawned
+   * `terraform apply` is never left unrecorded.
    *
    * Throws a descriptive `Error` synchronously (on the first `.next()` call)
    * if another `apply()`, `plan()`, or `init()` call is already in flight on
    * this instance — all three subcommands share a single
    * {@link workspaceInFlight} lock because they read/write the same
    * `backend/.terraform` workspace state; overlapping runs would race — or
-   * if `planFile` doesn't exist on disk.
+   * if `runId` isn't a bare path segment, `planFile` doesn't match the
+   * expected `<runsDir>/<runId>/<runId>.tfplan` path, or `planFile` doesn't
+   * exist on disk.
    *
    * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
    * resolved, {@link StalePlanError} if `tfvarsVersionId` no longer matches
-   * the S3 tfvars head version, or {@link TerraformApplyError} if the spawned
-   * process exits with a non-zero status code (and the run wasn't aborted).
+   * the S3 tfvars head version, {@link TerraformApplyError} if the spawned
+   * process exits with a non-zero status code (and the run wasn't aborted),
+   * or {@link TerraformRunPersistError} if the process closed successfully
+   * (or was aborted) but the run record couldn't be persisted afterward.
    */
   async *apply(
     runId: string,
@@ -637,10 +722,30 @@ export class TerraformService {
           'running; wait for it to finish before calling apply() again.',
       );
     }
+    TerraformService.assertValidRunId(runId);
+    const expectedPlanFile = TerraformService.expectedPlanFilePath(this.config.getRunsDir(), runId);
+    if (planFile !== expectedPlanFile) {
+      throw new Error(
+        `TerraformService.apply() cannot run: planFile "${planFile}" does not match the expected ` +
+          `artifact path "${expectedPlanFile}" for runId "${runId}".`,
+      );
+    }
     if (!existsSync(planFile)) {
       throw new Error(`TerraformService.apply() cannot run: plan file "${planFile}" does not exist on disk.`);
     }
     this.workspaceInFlight = 'apply';
+    // Hoisted above the try block (rather than declared where they're first
+    // assigned) so the outer `finally` below can see them even when this
+    // generator is force-closed (consumer `break`/`.return()`/`.throw()`):
+    // a forced completion unwinds straight from the `yield chunk` below to
+    // the nearest enclosing `finally`, skipping every statement that would
+    // otherwise run after the inner try/finally — including the
+    // `writeRunRecord` call further down. `startedAt` doubles as the "did we
+    // ever spawn a process" flag (undefined until just before `spawn`), and
+    // `runRecordWritten` prevents the outer `finally` from double-writing on
+    // the normal completion path.
+    let startedAt: string | undefined;
+    let runRecordWritten = false;
     try {
       if (signal?.aborted) {
         // Already aborted before we even started the stale-plan guard — end
@@ -669,7 +774,7 @@ export class TerraformService {
 
       const cwd = this.config.getTerraformDir();
       const args = ['apply', '-input=false', '-no-color', planFile];
-      const startedAt = new Date().toISOString();
+      startedAt = new Date().toISOString();
 
       let added = 0;
       let changed = 0;
@@ -712,25 +817,63 @@ export class TerraformService {
 
       const result = next.value;
 
+      // Compute the outcome the generator would return/throw *before*
+      // attempting to persist the run record, so a persistence failure below
+      // can still report the real apply outcome instead of losing it behind
+      // an unrelated filesystem exception.
+      const outcome: TerraformApplyOutcome = result.aborted
+        ? { kind: 'aborted' }
+        : result.exitCode === 0
+          ? { kind: 'success', result: { runId, added, changed, destroyed } }
+          : { kind: 'failed', error: new TerraformApplyError(result.exitCode) };
+
       // The process has closed by this point regardless of `aborted` — even
       // the abort path in `spawnAndStream` only resolves once `close` (or
       // `error`) has fired — so a run record is always written here. Its own
       // exitCode is discarded by `spawnAndStream` when aborted (the caller is
       // expected to treat the run as cancelled rather than pass/fail), so
       // `null` is recorded in that case.
-      this.writeRunRecord(runId, startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
+      //
+      // `runRecordWritten` is flipped *before* the write is attempted (not
+      // only on success) so the outer `finally` below never re-attempts a
+      // write this block already tried — whether it succeeded or threw.
+      runRecordWritten = true;
+      try {
+        this.writeRunRecord(runId, startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
+      } catch (err) {
+        throw new TerraformRunPersistError(runId, outcome, err);
+      }
 
-      if (result.aborted) {
+      if (outcome.kind === 'aborted') {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
         // the generator cleanly rather than surfacing the resulting
         // error/exit code.
         return undefined;
       }
-      if (result.exitCode === 0) {
-        return { runId, added, changed, destroyed };
+      if (outcome.kind === 'success') {
+        return outcome.result;
       }
-      throw new TerraformApplyError(result.exitCode);
+      throw outcome.error;
     } finally {
+      // Covers the force-closed generator case (consumer `break` /
+      // `.return()` / `.throw()`): a forced completion unwinds straight from
+      // `yield chunk` above to the inner finally (which drains
+      // `spawnAndStream`, killing the child and waiting for it to actually
+      // close), then continues unwinding *past* the `writeRunRecord` call
+      // above — that statement is never reached — straight to this outer
+      // `finally`. If a process was ever spawned (`startedAt` set) and no
+      // record was written yet, persist a cancelled (`exitCode: null`) run
+      // record here so the run is never silently lost. Best-effort: a
+      // failure here doesn't override whatever completion the generator was
+      // already unwinding for.
+      if (startedAt !== undefined && !runRecordWritten) {
+        try {
+          this.writeRunRecord(runId, startedAt, null, tfvarsVersionId);
+        } catch {
+          // Nothing meaningful to do with a persistence failure while the
+          // generator is already tearing down for an unrelated reason.
+        }
+      }
       this.workspaceInFlight = null;
     }
   }
@@ -766,6 +909,19 @@ export class TerraformService {
    * directory if it doesn't already exist (defensive — {@link plan} normally
    * creates it ahead of `apply`, but nothing prevents a caller from applying
    * a plan file whose directory was cleaned up in between).
+   *
+   * `mkdirSync`/`writeFileSync` are wrapped in a try/catch so a filesystem
+   * error here (e.g. permissions, disk full, cleaned-up parent directory)
+   * surfaces as a plain descriptive `Error` rather than an opaque `ENOENT`/
+   * `EACCES` — {@link apply} catches it and re-throws it wrapped in
+   * {@link TerraformRunPersistError} alongside the already-computed apply
+   * outcome, so callers can tell a persistence failure apart from the apply
+   * itself failing.
+   *
+   * Re-validates `runId` via {@link assertValidRunId} before joining it into
+   * `runDir` — `apply()` already validates `runId` before this is called,
+   * but this guard is repeated here defensively so a future caller can never
+   * bypass it by skipping `apply()`'s own pre-spawn check.
    */
   private writeRunRecord(
     runId: string,
@@ -773,8 +929,8 @@ export class TerraformService {
     exitCode: number | null,
     tfvarsVersionId: string | undefined,
   ): void {
+    TerraformService.assertValidRunId(runId);
     const runDir = join(this.config.getRunsDir(), runId);
-    mkdirSync(runDir, { recursive: true });
     const record: TerraformRunRecord = {
       runId,
       kind: 'apply',
@@ -783,7 +939,16 @@ export class TerraformService {
       exitCode,
       tfvarsVersionId,
     };
-    writeFileSync(join(runDir, 'run.json'), JSON.stringify(record, null, 2));
+    try {
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(join(runDir, 'run.json'), JSON.stringify(record, null, 2));
+    } catch (err) {
+      throw new Error(
+        `Failed to write terraform run record to "${join(runDir, 'run.json')}": ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
   }
 
   /**
@@ -881,6 +1046,12 @@ export class TerraformService {
     let closed = false;
     let closeError: Error | null = null;
     let exitCode: number | null = null;
+    // Latched the instant the abort listener fires (while the child is still
+    // live), rather than read from `signal.aborted` after the loop below
+    // exits — an abort that fires after the process has already closed
+    // cleanly would otherwise race a post-hoc `signal.aborted` read and
+    // misclassify a successful run as aborted.
+    let aborted = false;
 
     const notify = (): void => {
       wake?.();
@@ -926,6 +1097,7 @@ export class TerraformService {
     });
 
     const onAbort = (): void => {
+      aborted = true;
       child.kill();
     };
     signal?.addEventListener('abort', onAbort);
@@ -944,7 +1116,7 @@ export class TerraformService {
         });
       }
 
-      if (signal?.aborted) {
+      if (aborted) {
         return { aborted: true };
       }
       if (closeError) {
@@ -980,6 +1152,31 @@ export class TerraformService {
    */
   private static sameBackendConfig(a: TerraformInitConfig, b: TerraformInitConfig): boolean {
     return a.bucket === b.bucket && a.region === b.region && a.dynamodbTable === b.dynamodbTable;
+  }
+
+  /**
+   * Throws a descriptive `Error` unless `runId` is a bare path segment
+   * matching {@link RUN_ID_PATTERN}. Guards every place `runId` is joined
+   * into a filesystem path — {@link apply}'s pre-spawn checks and
+   * {@link writeRunRecord} — against path traversal (`../`, absolute paths,
+   * embedded separators) via a caller-supplied `runId`.
+   */
+  private static assertValidRunId(runId: string): void {
+    if (!RUN_ID_PATTERN.test(runId)) {
+      throw new Error(`TerraformService: runId "${runId}" is not a valid run id.`);
+    }
+  }
+
+  /**
+   * Returns the single filesystem path {@link apply} accepts as `planFile`
+   * for a given `runId` — `<runsDir>/<runId>/<runId>.tfplan`, matching where
+   * {@link plan} persists its `.tfplan` artifact. Centralizing this lets
+   * `apply` reject any `planFile` that doesn't resolve exactly to it, rather
+   * than trusting a caller-supplied path that could point at an unrelated
+   * plan artifact.
+   */
+  private static expectedPlanFilePath(runsDir: string, runId: string): string {
+    return join(runsDir, runId, `${runId}.tfplan`);
   }
 
   /**

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1097,6 +1097,14 @@ export class TerraformService {
     // cleanly would otherwise race a post-hoc `signal.aborted` read and
     // misclassify a successful run as aborted.
     let aborted = false;
+    // `exit` fires the instant the process actually terminates, which can
+    // happen well before `close` (Node waits for stdio streams to finish
+    // draining before emitting `close`). The generator's own `finally`
+    // block uses this to tell "the process is still genuinely running" apart
+    // from "the process already exited and we're just waiting on its stdio
+    // to drain" — without it, a run that completed during that drain window
+    // would be misclassified as force-killed.
+    let exited = false;
 
     const notify = (): void => {
       wake?.();
@@ -1122,6 +1130,10 @@ export class TerraformService {
 
     child.stdout?.on('data', (data: Buffer) => handleData('stdout', data));
     child.stderr?.on('data', (data: Buffer) => handleData('stderr', data));
+
+    child.on('exit', () => {
+      exited = true;
+    });
 
     child.on('error', (err: Error) => {
       closeError = err;
@@ -1180,19 +1192,25 @@ export class TerraformService {
       if (!closed) {
         // The generator was force-closed early (e.g. plan()'s own finally
         // calling `stream.return()` when its consumer breaks/throws) before
-        // the child process actually exited. Removing the abort listener
-        // alone leaves Terraform (and its stdout/stderr listeners) running
-        // in the background — explicitly kill the child and wait for it to
-        // actually close before this generator resolves, so forced cleanup
-        // terminates the underlying process instead of orphaning it.
-        //
-        // The child is genuinely still live at this point (its `close`/
-        // `error` handlers never fired, or `closed` would already be
-        // `true`) — notify the caller via `onForceKill` so it can
-        // distinguish this from every other way its own cleanup logic might
-        // run.
-        onForceKill?.();
-        child.kill();
+        // `close` fired. Removing the abort listener alone can still leave
+        // Terraform (and its stdout/stderr listeners) running in the
+        // background — but `closed === false` alone doesn't prove that: the
+        // process may have already exited while its stdio streams were
+        // still draining, since Node only emits `close` once those streams
+        // finish, some time after `exit`. Consult the `exited` flag (set by
+        // the `exit` handler above) rather than assuming `!closed` means
+        // "still live".
+        if (!exited) {
+          // The child is genuinely still live at this point — notify the
+          // caller via `onForceKill` so it can distinguish this from every
+          // other way its own cleanup logic might run, then kill it.
+          onForceKill?.();
+          child.kill();
+        }
+        // Either way, wait for the process to actually close (flushing any
+        // buffered stdio and settling `exitCode`/`closeError`) before this
+        // generator resolves, so forced cleanup never resolves early and
+        // orphans the process or its listeners.
         await new Promise<void>((resolve) => {
           if (closed) {
             resolve();


### PR DESCRIPTION
Closes #175

## Summary

- Adds `TerraformService.apply(runId, tfvarsVersionId, planFile, signal)` — spawns `terraform apply -input=false -no-color <planFile>` inside the terraform working directory, streaming output chunk-by-chunk (mirroring `init()`/`plan()`'s shape) and resolving with `{ runId, added, changed, destroyed }` parsed from Terraform's `Apply complete!` summary line.
- Adds a stale-plan guard (`assertPlanTfvarsNotStale`): when `tfvarsVersionId` is supplied and the tfvars source is S3-backed, compares it against the head version of the tfvars object via `remoteFileStore.listVersions()` *before* spawning `terraform`, throwing the new `StalePlanError` if the remote tfvars changed since the plan was generated. No-op in local-file mode or when `tfvarsVersionId` is omitted.
- Persists a `TerraformRunRecord` to `<runsDir>/<runId>/run.json` once the spawned process closes (clean exit, non-zero exit, or aborted via `signal`) — `runId`, `kind: 'apply'`, `startedAt`/`completedAt`, `exitCode` (`null` when aborted), and `tfvarsVersionId` — a lightweight local run history for a future Apply-history UI.
- Extends the shared `workspaceInFlight` lock (previously `'init' | 'plan'`) to include `'apply'`, since apply mutates the same `backend/.terraform` workspace state that `init`/`plan` read — overlapping runs would race.
- New error types: `StalePlanError` (pre-spawn staleness guard) and `TerraformApplyError` (non-zero exit code from the spawned process), both distinct from the existing `TerraformNotFoundError`.
- Rejects synchronously (before spawning) if `planFile` doesn't exist on disk, or if another `apply()`/`plan()`/`init()` is already in flight.

## Changes

```
 .../src/services/TerraformService.apply.test.ts    | 772 +++++++++++++++++++++
 .../desktop-main/src/services/TerraformService.ts  | 324 ++++++++-
 2 files changed, 1085 insertions(+), 11 deletions(-)
```

## Test plan

- [x] Stale-plan condition (`tfvarsVersionId` no longer matches the S3 tfvars head version) throws `StalePlanError` before `terraform` is spawned — covered by `TerraformService.apply.test.ts`.
- [x] Successful apply spawns `terraform apply -input=false -no-color <planFile>`, streams output, and returns `{ runId, added, changed, destroyed }` parsed from the `Apply complete!` summary line.
- [x] A run record (`run.json`) is written to `<runsDir>/<runId>/` on completion — for clean exit, non-zero exit, and abort-via-signal paths.
- [x] Non-zero exit code throws `TerraformApplyError`; the run record still records the `exitCode`.
- [x] Abort signal kills the spawned process, ends the generator cleanly (no throw), and records `exitCode: null`.
- [x] `apply()` shares the `workspaceInFlight` lock with `init()`/`plan()` — rejects synchronously if any of the three is already running.
- [x] Missing `planFile` on disk rejects synchronously without spawning.
- [x] Early generator termination (consumer `break`/`.return()`/`.throw()`) finalizes the inner `spawnAndStream()` generator so the abort listener is always removed (no leak).
- [x] `npm run app:test` passing for the touched workspace (desktop-main).
- [x] `npm run app:lint` clean.
