### PR TITLE
feat(desktop-main): TerraformService.output() exposing tf outputs

### DIFF
--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -301,9 +301,9 @@ describe('TerraformController', () => {
 
   describe('output', () => {
     /** A minimal resolved outputs payload shared across the "output" cases. */
-    const OUTPUTS: TfOutputs = {
-      cluster_name: 'hyveon-cluster',
-    } as unknown as TfOutputs;
+    const OUTPUTS = {
+      ecs_cluster_name: 'hyveon-cluster',
+    } as Partial<TfOutputs> as TfOutputs;
 
     it('should resolve with whatever TerraformService.output resolves with', async () => {
       const terraform = makeTerraform();

--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -1,7 +1,12 @@
 import 'reflect-metadata';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TerraformController } from './terraform.controller.js';
-import { TerraformInitError, type TerraformInitConfig, type TerraformRunChunk } from '../services/TerraformService.js';
+import {
+  TerraformInitError,
+  type TerraformInitConfig,
+  type TerraformRunChunk,
+} from '../services/TerraformService.js';
+import type { TfOutputs } from '../services/ConfigService.js';
 import type { TerraformService } from '../services/TerraformService.js';
 
 // ---------------------------------------------------------------------------
@@ -40,10 +45,14 @@ const CONFIG: TerraformInitConfig = {
   dynamodbTable: 'hyveon-tf-locks',
 };
 
-/** Build a TerraformService stub whose `init` yields nothing by default. */
+/**
+ * Build a TerraformService stub whose `init` yields nothing by default and
+ * whose `output` resolves `null` by default.
+ */
 function makeTerraform(): TerraformService {
   const stub: Partial<TerraformService> = {
     init: vi.fn().mockImplementation(async function* () { /* empty */ }),
+    output: vi.fn().mockResolvedValue(null),
   };
   return stub as TerraformService;
 }
@@ -97,6 +106,11 @@ describe('TerraformController', () => {
     it('should register init on the "terraform.init" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.init);
       expect(pattern).toEqual(['terraform.init']);
+    });
+
+    it('should register output on the "terraform.output" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.output);
+      expect(pattern).toEqual(['terraform.output']);
     });
   });
 
@@ -278,6 +292,58 @@ describe('TerraformController', () => {
       expect(typeof result.error).toBe('string');
       expect(terraform.init).not.toHaveBeenCalled();
       expect(sender.send).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // output
+  // -------------------------------------------------------------------------
+
+  describe('output', () => {
+    /** A minimal resolved outputs payload shared across the "output" cases. */
+    const OUTPUTS: TfOutputs = {
+      cluster_name: 'hyveon-cluster',
+    } as unknown as TfOutputs;
+
+    it('should resolve with whatever TerraformService.output resolves with', async () => {
+      const terraform = makeTerraform();
+      vi.mocked(terraform.output).mockResolvedValue(OUTPUTS);
+
+      const result = await new TerraformController(terraform).output({});
+
+      expect(result).toBe(OUTPUTS);
+    });
+
+    it('should pass force: true through to TerraformService.output when the payload sets it', async () => {
+      const terraform = makeTerraform();
+
+      await new TerraformController(terraform).output({ force: true });
+
+      expect(terraform.output).toHaveBeenCalledWith(true);
+    });
+
+    it('should default force to false when the payload omits it', async () => {
+      const terraform = makeTerraform();
+
+      await new TerraformController(terraform).output({});
+
+      expect(terraform.output).toHaveBeenCalledWith(false);
+    });
+
+    it('should default force to false when no payload is provided at all', async () => {
+      const terraform = makeTerraform();
+
+      await new TerraformController(terraform).output(undefined);
+
+      expect(terraform.output).toHaveBeenCalledWith(false);
+    });
+
+    it('should propagate whatever error TerraformService.output rejects with', async () => {
+      const terraform = makeTerraform();
+      const error = new Error('terraform output -json exited with code 1');
+      vi.mocked(terraform.output).mockRejectedValue(error);
+
+      await expect(new TerraformController(terraform).output({})).rejects.toThrow(error);
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/terraform.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.ts
@@ -8,6 +8,7 @@ import {
   type TerraformInitConfig,
   type TerraformRunChunk,
 } from '../services/TerraformService.js';
+import type { TfOutputs } from '../services/ConfigService.js';
 import { logger } from '../logger.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -55,6 +56,15 @@ interface TerraformInitAck {
   started: boolean;
   streamId?: string;
   error?: string;
+}
+
+/**
+ * Payload accepted by {@link TerraformController.output}. `force` is
+ * optional and defaults to `false`, mirroring `TerraformService.output`'s
+ * own default parameter.
+ */
+interface TerraformOutputPayload {
+  force?: boolean;
 }
 
 /**
@@ -202,6 +212,30 @@ export class TerraformController implements OnModuleInit {
     })();
 
     return { started: true, streamId };
+  }
+
+  /**
+   * Returns the current Terraform outputs by delegating to
+   * `TerraformService.output`. Unlike {@link init}, this channel needs no
+   * manual bridging — it resolves a single value rather than streaming
+   * progress, so the generic `ipcMain.handle` bridge in
+   * `../ipc-main-bridge.ts` wires `ipcRenderer.invoke('terraform.output', ...)`
+   * to this handler automatically (it isn't listed in
+   * `SELF_BRIDGED_PATTERNS`).
+   *
+   * `payload.force` defaults to `false` when the payload is omitted or
+   * `force` isn't set, matching `TerraformService.output`'s own default —
+   * pass `force: true` to bypass its in-memory cache and re-spawn
+   * `terraform output -json` regardless of how recently the last call
+   * resolved. Any error `TerraformService.output` throws (e.g.
+   * `TerraformNotFoundError`, a non-zero `terraform output` exit) propagates
+   * to the caller unchanged, causing `ipcRenderer.invoke` to reject.
+   *
+   * Reachable via the Electron IPC transport (`terraform.output`).
+   */
+  @MessagePattern('terraform.output')
+  async output(@Payload() payload: TerraformOutputPayload = {}): Promise<TfOutputs | null> {
+    return this.terraform.output(payload?.force ?? false);
   }
 
   /**

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -136,7 +136,11 @@ describe('ConfigService', () => {
 
     it('should apply the fallback aws_region when outputs omit it', () => {
       mockExists.mockReturnValue(true);
-      mockRead.mockReturnValue(makeState({}));
+      // A non-empty outputs map that simply doesn't include `aws_region` —
+      // distinct from an *empty* `{}` map, which is now treated as "infra
+      // not yet deployed" and short-circuits to `null` before defaults are
+      // ever filled in.
+      mockRead.mockReturnValue(makeState({ ecs_cluster_name: { value: 'my-cluster' } }));
       expect(service.getTfOutputs()!.aws_region).toBe('us-east-1');
     });
 

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -55,6 +55,60 @@ export interface TfOutputs {
 }
 
 /**
+ * Shape of the raw `terraform.tfstate` JSON as parsed off disk, restricted to
+ * the `outputs` map that {@link projectTfOutputs} reads from.
+ */
+export type RawTfState = { outputs?: Record<string, { value: unknown }> };
+
+/**
+ * Project the subset of Terraform outputs the app cares about (see
+ * {@link TfOutputs}) out of a parsed `terraform.tfstate` payload, filling in
+ * defaults for any keys the state doesn't have (e.g. because a Terraform
+ * apply hasn't run since a given output was added). Returns `null` when the
+ * state has no `outputs` map at all — treated by callers as "infra not yet
+ * deployed".
+ *
+ * Extracted from {@link ConfigService.getTfOutputs} as a pure function so the
+ * projection logic can be exercised (and reused) independently of the
+ * instance's file-reading/caching concerns.
+ */
+export function projectTfOutputs(raw: RawTfState): TfOutputs | null {
+  if (!raw.outputs) {
+    logger.warn('Terraform state has no outputs — infra not yet deployed');
+    return null;
+  }
+
+  const out = raw.outputs;
+  const get = <T>(key: string, fallback: T): T =>
+    key in out ? (out[key]!.value as T) : fallback;
+
+  const projected: TfOutputs = {
+    aws_region: get('aws_region', 'us-east-1'),
+    ecs_cluster_name: get('ecs_cluster_name', ''),
+    ecs_cluster_arn: get('ecs_cluster_arn', ''),
+    subnet_ids: get('subnet_ids', ''),
+    security_group_id: get('security_group_id', ''),
+    file_manager_security_group_id: get('file_manager_security_group_id', ''),
+    efs_file_system_id: get('efs_file_system_id', ''),
+    efs_access_points: get('efs_access_points', {}),
+    domain_name: get('domain_name', ''),
+    game_names: get('game_names', []),
+    alb_dns_name: get('alb_dns_name', null),
+    acm_certificate_arn: get('acm_certificate_arn', null),
+    discord_table_name: get('discord_table_name', ''),
+    audit_table_name: get('audit_table_name', ''),
+    discord_bot_token_secret_arn: get('discord_bot_token_secret_arn', ''),
+    discord_public_key_secret_arn: get('discord_public_key_secret_arn', ''),
+    interactions_invoke_url: get('interactions_invoke_url', null),
+    discord_interactions_url: get('discord_interactions_url', null),
+    applied_game_servers: get('applied_game_servers', null),
+  };
+
+  logger.debug('Loaded Terraform outputs', { games: projected.game_names });
+  return projected;
+}
+
+/**
  * User-editable watchdog tuning knobs persisted to `server_config.json`.
  * Consumed by the watchdog Lambda via Terraform variables; the UI only
  * displays/edits them — changes require `terraform apply` to take effect.
@@ -130,13 +184,12 @@ export class ConfigService {
   getTfOutputs(): TfOutputs | null {
     if (this.tfCache !== undefined) return this.tfCache;
 
-    type RawState = { outputs?: Record<string, { value: unknown }> };
-    let raw: RawState;
+    let raw: RawTfState;
 
     const tfStatePath = this.getTfStatePath();
     if (existsSync(tfStatePath)) {
       try {
-        raw = JSON.parse(readFileSync(tfStatePath, 'utf-8')) as RawState;
+        raw = JSON.parse(readFileSync(tfStatePath, 'utf-8')) as RawTfState;
       } catch (err) {
         logger.error('Failed to parse Terraform state', { err, path: tfStatePath });
         return (this.tfCache = null);
@@ -151,39 +204,7 @@ export class ConfigService {
     }
 
     try {
-      if (!raw.outputs) {
-        logger.warn('Terraform state has no outputs — infra not yet deployed', { path: tfStatePath });
-        return (this.tfCache = null);
-      }
-
-      const out = raw.outputs;
-      const get = <T>(key: string, fallback: T): T =>
-        key in out ? (out[key]!.value as T) : fallback;
-
-      this.tfCache = {
-        aws_region: get('aws_region', 'us-east-1'),
-        ecs_cluster_name: get('ecs_cluster_name', ''),
-        ecs_cluster_arn: get('ecs_cluster_arn', ''),
-        subnet_ids: get('subnet_ids', ''),
-        security_group_id: get('security_group_id', ''),
-        file_manager_security_group_id: get('file_manager_security_group_id', ''),
-        efs_file_system_id: get('efs_file_system_id', ''),
-        efs_access_points: get('efs_access_points', {}),
-        domain_name: get('domain_name', ''),
-        game_names: get('game_names', []),
-        alb_dns_name: get('alb_dns_name', null),
-        acm_certificate_arn: get('acm_certificate_arn', null),
-        discord_table_name: get('discord_table_name', ''),
-        audit_table_name: get('audit_table_name', ''),
-        discord_bot_token_secret_arn: get('discord_bot_token_secret_arn', ''),
-        discord_public_key_secret_arn: get('discord_public_key_secret_arn', ''),
-        interactions_invoke_url: get('interactions_invoke_url', null),
-        discord_interactions_url: get('discord_interactions_url', null),
-        applied_game_servers: get('applied_game_servers', null),
-      };
-
-      logger.debug('Loaded Terraform outputs', { games: this.tfCache.game_names });
-      return this.tfCache;
+      return (this.tfCache = projectTfOutputs(raw));
     } catch (err) {
       logger.error('Failed to parse Terraform state', { err });
       return (this.tfCache = null);

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -65,15 +65,17 @@ export type RawTfState = { outputs?: Record<string, { value: unknown }> };
  * {@link TfOutputs}) out of a parsed `terraform.tfstate` payload, filling in
  * defaults for any keys the state doesn't have (e.g. because a Terraform
  * apply hasn't run since a given output was added). Returns `null` when the
- * state has no `outputs` map at all — treated by callers as "infra not yet
- * deployed".
+ * state has no `outputs` map at all, or when that map is empty — both cases
+ * mean nothing has been deployed yet (an empty map is what `terraform output -json`
+ * reports before the first apply) — and both are treated by callers as
+ * "infra not yet deployed".
  *
  * Extracted from {@link ConfigService.getTfOutputs} as a pure function so the
  * projection logic can be exercised (and reused) independently of the
  * instance's file-reading/caching concerns.
  */
 export function projectTfOutputs(raw: RawTfState): TfOutputs | null {
-  if (!raw.outputs) {
+  if (!raw.outputs || Object.keys(raw.outputs).length === 0) {
     logger.warn('Terraform state has no outputs — infra not yet deployed');
     return null;
   }

--- a/app/packages/desktop-main/src/services/TerraformService.output.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.output.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/*
+ * Spy variables must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const { execFileMock } = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  return { execFileMock };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: vi.fn(),
+}));
+
+import { TerraformService } from './TerraformService.js';
+import { projectTfOutputs, type ConfigService, type RawTfState, type TfOutputs } from './ConfigService.js';
+import type { RemoteFileStore } from '@hyveon/shared';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Extracts the error-first callback from an `execFile` call's arguments,
+ * regardless of whether `util.promisify` invoked it with or without an
+ * `options` object.
+ */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
+/** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
+function queueExecFileSuccess(stdout: string, stderr = ''): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(null, { stdout, stderr });
+  });
+}
+
+/** Queues a failing `execFile` invocation (e.g. a non-zero `terraform output` exit). */
+function queueExecFileFailure(error: Error = new Error('exit status 1')): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(error);
+  });
+}
+
+/** Queues a successful binary lookup followed by a successful `-json` version response. */
+function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', version = '1.7.0'): void {
+  queueExecFileSuccess(`${binaryPath}\n`);
+  queueExecFileSuccess(JSON.stringify({ terraform_version: version }));
+}
+
+/**
+ * Minimal `ConfigService` stub sufficient for `output()`: only
+ * `getTerraformDir()` is read (as the spawned process's `cwd`).
+ */
+function stubOutputConfigService(terraformDir = '/repo/terraform'): ConfigService {
+  return { getTerraformDir: () => terraformDir } as ConfigService;
+}
+
+/**
+ * Minimal `RemoteFileStore` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency — `output()` never touches it.
+ */
+function stubRemoteFileStore(): RemoteFileStore {
+  return {} as RemoteFileStore;
+}
+
+/** A minimal, well-formed `terraform output -json` payload for one output key. */
+const SAMPLE_STDOUT = JSON.stringify({
+  aws_region: { value: 'us-east-1' },
+  ecs_cluster_name: { value: 'hyveon-cluster' },
+  game_names: { value: ['minecraft'] },
+});
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TerraformService.output first call', () => {
+  it('should spawn terraform output -json and resolve to the exact TfOutputs shape projectTfOutputs produces', async () => {
+    queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
+    queueExecFileSuccess(SAMPLE_STDOUT);
+
+    const service = new TerraformService(stubOutputConfigService('/repo/terraform'), stubRemoteFileStore());
+
+    const result = await service.output();
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      '/usr/local/bin/terraform',
+      ['output', '-json'],
+      { cwd: '/repo/terraform' },
+      expect.any(Function),
+    );
+    const expected: TfOutputs | null = projectTfOutputs({
+      outputs: JSON.parse(SAMPLE_STDOUT) as RawTfState['outputs'],
+    });
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('TerraformService.output caching', () => {
+  it('should serve a second non-force call within the 60s TTL window from cache without spawning again', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    queueSuccessfulResolution();
+    queueExecFileSuccess(SAMPLE_STDOUT);
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+
+    const first = await service.output();
+    expect(execFileMock).toHaveBeenCalledTimes(3); // lookup + version + output
+
+    // Still within the 60s TTL window.
+    dateNowSpy.mockReturnValue(1_000_000 + 59_000);
+
+    const second = await service.output();
+
+    expect(execFileMock).toHaveBeenCalledTimes(3); // no additional spawn
+    expect(second).toEqual(first);
+  });
+
+  it('should re-spawn a non-force call once the 60s TTL has elapsed', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    queueSuccessfulResolution();
+    queueExecFileSuccess(SAMPLE_STDOUT);
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+    await service.output();
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+
+    // Past the 60s TTL window.
+    dateNowSpy.mockReturnValue(1_000_000 + 60_001);
+    const otherStdout = JSON.stringify({ aws_region: { value: 'eu-west-1' } });
+    queueExecFileSuccess(otherStdout);
+
+    const result = await service.output();
+
+    // Binary/version resolution is memoized on the instance regardless of the
+    // output cache, so only one additional execFile call (the re-spawned
+    // `output -json`) is expected here.
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+    expect(result).toEqual(
+      projectTfOutputs({ outputs: JSON.parse(otherStdout) as RawTfState['outputs'] }),
+    );
+  });
+
+  it('should bypass a still-fresh cache and unconditionally re-spawn when force is true', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    queueSuccessfulResolution();
+    queueExecFileSuccess(SAMPLE_STDOUT);
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+    await service.output();
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+
+    // Still well within the 60s TTL window — a non-force call would be served
+    // from cache, but force=true must bypass that.
+    dateNowSpy.mockReturnValue(1_000_000 + 1_000);
+    const otherStdout = JSON.stringify({ aws_region: { value: 'ap-southeast-2' } });
+    queueExecFileSuccess(otherStdout);
+
+    const result = await service.output(true);
+
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+    expect(result).toEqual(
+      projectTfOutputs({ outputs: JSON.parse(otherStdout) as RawTfState['outputs'] }),
+    );
+  });
+});
+
+describe('TerraformService.output failure handling', () => {
+  it('should leave outputCache untouched and retry on the next call when the spawned process fails', async () => {
+    queueSuccessfulResolution();
+    queueExecFileFailure(new Error('terraform output exited with code 1'));
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+
+    await expect(service.output()).rejects.toThrow('terraform output exited with code 1');
+
+    // The failed attempt must not have poisoned the cache — the next call
+    // (non-force, since there was never a successful cache entry) retries
+    // rather than throwing again or serving a broken value.
+    queueExecFileSuccess(SAMPLE_STDOUT);
+    const result = await service.output();
+
+    expect(result).toEqual(
+      projectTfOutputs({ outputs: JSON.parse(SAMPLE_STDOUT) as RawTfState['outputs'] }),
+    );
+  });
+
+  it('should leave outputCache untouched and retry on the next call when the stdout is not valid JSON', async () => {
+    queueSuccessfulResolution();
+    queueExecFileSuccess('not valid json');
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+
+    await expect(service.output()).rejects.toThrow();
+
+    queueExecFileSuccess(SAMPLE_STDOUT);
+    const result = await service.output();
+
+    expect(result).toEqual(
+      projectTfOutputs({ outputs: JSON.parse(SAMPLE_STDOUT) as RawTfState['outputs'] }),
+    );
+  });
+
+  it('should leave a prior successful cache entry intact when a later force call fails', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    queueSuccessfulResolution();
+    queueExecFileSuccess(SAMPLE_STDOUT);
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+    const first = await service.output();
+
+    dateNowSpy.mockReturnValue(1_000_000 + 1_000);
+    queueExecFileFailure(new Error('terraform output exited with code 1'));
+    await expect(service.output(true)).rejects.toThrow('terraform output exited with code 1');
+
+    // A subsequent non-force call, still within the TTL window measured from
+    // the original successful resolution, is served from the untouched cache
+    // rather than the failed attempt having cleared/corrupted it.
+    dateNowSpy.mockReturnValue(1_000_000 + 2_000);
+    const second = await service.output();
+
+    expect(second).toEqual(first);
+    expect(execFileMock).toHaveBeenCalledTimes(4); // resolution(2) + first output(1) + failed force call(1)
+  });
+});
+
+describe('TerraformService.output null-outputs case', () => {
+  it('should cache and return null when terraform output -json reports no outputs', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    queueSuccessfulResolution();
+    // JSON.parse('null') resolves to `null`, so `projectTfOutputs({ outputs: null })`
+    // hits its "no outputs map at all" branch and returns `null`.
+    queueExecFileSuccess('null');
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+
+    const first = await service.output();
+    expect(first).toBeNull();
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+
+    // A second non-force call within the TTL must be served from cache
+    // (proving `null` itself is a valid cached value, not treated the same
+    // as "no cache entry yet").
+    dateNowSpy.mockReturnValue(1_000_000 + 1_000);
+    const second = await service.output();
+
+    expect(second).toBeNull();
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.output.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.output.test.ts
@@ -266,3 +266,19 @@ describe('TerraformService.output null-outputs case', () => {
     expect(execFileMock).toHaveBeenCalledTimes(3);
   });
 });
+
+describe('TerraformService.output empty-outputs case', () => {
+  it('should resolve to null when terraform output -json reports an empty outputs map', async () => {
+    queueSuccessfulResolution();
+    // `terraform output -json` reports `{}` when nothing has been deployed
+    // yet — `projectTfOutputs({ outputs: {} })` must hit the same "no
+    // outputs" branch as the `null` case above, not fall through to a
+    // default-filled TfOutputs object.
+    queueExecFileSuccess('{}');
+
+    const service = new TerraformService(stubOutputConfigService(), stubRemoteFileStore());
+
+    const result = await service.output();
+    expect(result).toBeNull();
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 import { Inject, Injectable } from '@nestjs/common';
 import type { RemoteFileStore } from '@hyveon/shared';
 import { logger } from '../logger.js';
-import { ConfigService } from './ConfigService.js';
+import { ConfigService, projectTfOutputs, type TfOutputs } from './ConfigService.js';
 import { REMOTE_FILE_STORE } from '../modules/cloud-provider.tokens.js';
 
 const execFileAsync = promisify(execFile);
@@ -357,6 +357,15 @@ export interface TerraformDestroyResult {
 const DESTROY_SUMMARY_PATTERN = /Destroy complete!\s*Resources:\s*(\d+) destroyed\./;
 
 /**
+ * How long a successful {@link TerraformService.output} call's resolved
+ * {@link TfOutputs} stays cached before a subsequent non-`force` call
+ * re-spawns `terraform output -json` — outputs only change after a
+ * successful `apply`/`destroy`, so a caller polling `output()` repeatedly
+ * doesn't shell out to `terraform` on every request.
+ */
+const OUTPUT_CACHE_TTL_MS = 60 * 1000;
+
+/**
  * Describes what {@link TerraformService.destroy} was about to return/throw
  * the moment its spawned process closed — captured before
  * {@link TerraformService.writeRunRecord} is attempted so a persistence
@@ -377,11 +386,13 @@ export type TerraformDestroyOutcome =
  * under `ConfigService.getRunsDir()`; {@link TerraformService.apply}, the
  * streaming `terraform apply <planFile>` runner that persists a
  * {@link TerraformRunRecord} to the same per-run directory once the process
- * closes; and {@link TerraformService.destroy}, the streaming
+ * closes; {@link TerraformService.destroy}, the streaming
  * `terraform destroy -auto-approve` runner gated behind a short-lived
- * confirmation token minted via {@link TerraformService.mintDestroyConfirmationToken}.
- * A later child issue of Epic D adds `output` — see the "Terraform
- * orchestrator" section of the electron-desktop-pivot design spec.
+ * confirmation token minted via {@link TerraformService.mintDestroyConfirmationToken};
+ * and {@link TerraformService.output}, which runs `terraform output -json`
+ * and projects the result through the same {@link projectTfOutputs} helper
+ * `ConfigService.getTfOutputs()` uses, caching the resolved value for 60s
+ * (bypassable via `force: true`).
  *
  * Construction is synchronous and never throws — the binary lookup +
  * `terraform version` shell-outs are deferred until {@link getBinaryPath} or
@@ -426,6 +437,17 @@ export class TerraformService {
    * superseded by a newer one.
    */
   private pendingDestroyConfirmation: { token: string; expiresAt: number } | null = null;
+
+  /**
+   * Memoized result of the most recent successful {@link output} call,
+   * alongside the timestamp (`Date.now()`) it resolved at. `value` mirrors
+   * `output()`'s own return type — `null` when `terraform output -json`
+   * reported no outputs. `null` (the whole field, not just `value`) until
+   * the first successful `output()` call. Consulted by {@link output} to
+   * decide whether a non-`force` call can be served from cache instead of
+   * re-spawning `terraform`; see {@link OUTPUT_CACHE_TTL_MS}.
+   */
+  private outputCache: { value: TfOutputs | null; resolvedAt: number } | null = null;
 
   /**
    * `config` resolves the terraform working directory (`getTerraformDir()`)
@@ -1231,6 +1253,54 @@ export class TerraformService {
       }
       this.workspaceInFlight = null;
     }
+  }
+
+  /**
+   * Runs `terraform output -json` inside the Terraform composer root
+   * (`ConfigService.getTerraformDir()`) and projects the result through the
+   * same {@link projectTfOutputs} helper `ConfigService.getTfOutputs()` uses
+   * against `terraform.tfstate` — so a caller reading outputs via
+   * `TerraformService` sees the identical {@link TfOutputs} shape as one
+   * reading the state file directly. Returns `null` when
+   * `terraform output -json` reports no outputs (mirrors
+   * `projectTfOutputs`'s "infra not yet deployed" case).
+   *
+   * Unlike {@link init}/{@link plan}/{@link apply}/{@link destroy}, this is a
+   * plain buffered call (`execFile`, like {@link resolveVersion}) rather than
+   * a streaming generator — `terraform output` is a fast, read-only query
+   * with no line-by-line progress worth surfacing to a caller, and it
+   * doesn't mutate `backend/.terraform` workspace state, so it isn't gated
+   * behind {@link workspaceInFlight}.
+   *
+   * The resolved value is cached in-memory for {@link OUTPUT_CACHE_TTL_MS}
+   * (60s): outputs only change after a successful `apply`/`destroy`, so a
+   * caller polling `output()` repeatedly (e.g. a future outputs panel)
+   * doesn't spawn a fresh `terraform` process on every call. Pass
+   * `force: true` to bypass the cache and re-spawn regardless of how
+   * recently the last call resolved — e.g. immediately after `apply()`/
+   * `destroy()` complete, where the caller knows the outputs may have
+   * changed.
+   *
+   * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
+   * resolved, or whatever error the spawned `terraform output -json` process
+   * itself raised (e.g. a non-zero exit before any state has ever been
+   * applied). Neither failure updates {@link outputCache}, so the next call
+   * (force or not) retries rather than being stuck serving a stale/expired
+   * cache entry.
+   */
+  async output(force = false): Promise<TfOutputs | null> {
+    if (!force && this.outputCache && Date.now() - this.outputCache.resolvedAt < OUTPUT_CACHE_TTL_MS) {
+      return this.outputCache.value;
+    }
+
+    const binaryPath = await this.getBinaryPath();
+    const cwd = this.config.getTerraformDir();
+    const { stdout } = await execFileAsync(binaryPath, ['output', '-json'], { cwd });
+    const outputs = JSON.parse(stdout) as Record<string, { value: unknown }>;
+    const value = projectTfOutputs({ outputs });
+
+    this.outputCache = { value, resolvedAt: Date.now() };
+    return value;
   }
 
   /**

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -517,6 +517,40 @@ export interface TerraformInitConfig {
   dynamodbTable: string;
 }
 
+/**
+ * Shape of the subset of Terraform root outputs the management app consumes.
+ *
+ * Mirrors `TfOutputs` in `@hyveon/desktop-main/src/services/ConfigService.ts`
+ * — that file is the source of truth; keep this copy in sync with it.
+ */
+export interface TfOutputs {
+  aws_region: string;
+  ecs_cluster_name: string;
+  ecs_cluster_arn: string;
+  subnet_ids: string;
+  security_group_id: string;
+  file_manager_security_group_id: string;
+  efs_file_system_id: string;
+  efs_access_points: Record<string, string>;
+  domain_name: string;
+  game_names: string[];
+  alb_dns_name: string | null;
+  acm_certificate_arn: string | null;
+  discord_table_name: string;
+  audit_table_name: string;
+  discord_bot_token_secret_arn: string;
+  discord_public_key_secret_arn: string;
+  interactions_invoke_url: string | null;
+  discord_interactions_url: string | null;
+  /**
+   * Full per-game `game_servers` configuration as last applied by Terraform
+   * (the `applied_game_servers` sensitive output — see `terraform/aws/outputs.tf`),
+   * keyed by game name. `null` when the output is absent (e.g. state predates
+   * this output, or `terraform apply` hasn't run since it was added).
+   */
+  applied_game_servers: Record<string, Omit<GameServer, 'name'>> | null;
+}
+
 // ---------------------------------------------------------------------------
 // Per-namespace sub-interfaces
 // ---------------------------------------------------------------------------
@@ -683,6 +717,14 @@ export interface GsdTerraformApi {
    * `terraform init` process was ever spawned.
    */
   init: (config: TerraformInitConfig, signal?: AbortSignal) => AsyncIterable<TerraformRunChunk>;
+  /**
+   * Returns the current Terraform outputs by invoking the `terraform.output`
+   * IPC channel with `{ force }`. `force` defaults to `false`, matching
+   * `TerraformService.output`'s own default; pass `true` to bypass its
+   * in-memory cache and re-spawn `terraform output -json`. Resolves `null`
+   * when Terraform reports no outputs (infra not yet deployed).
+   */
+  output: (force?: boolean) => Promise<TfOutputs | null>;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -966,4 +966,99 @@ describe('preload dispatcher', () => {
       }, 10_000);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // terraform.output
+  // -------------------------------------------------------------------------
+
+  describe('terraform.output', () => {
+    /** Minimal `TfOutputs`-shaped fixture used across these tests. */
+    const OUTPUTS = {
+      aws_region: 'us-east-1',
+      ecs_cluster_name: 'hyveon-cluster',
+      ecs_cluster_arn: 'arn:aws:ecs:us-east-1:123456789012:cluster/hyveon-cluster',
+      subnet_ids: 'subnet-1,subnet-2',
+      security_group_id: 'sg-1',
+      file_manager_security_group_id: 'sg-2',
+      efs_file_system_id: 'fs-1',
+      efs_access_points: { minecraft: 'fsap-1' },
+      domain_name: 'example.com',
+      game_names: ['minecraft'],
+      alb_dns_name: null,
+      acm_certificate_arn: null,
+      discord_table_name: 'hyveon-discord',
+      audit_table_name: 'hyveon-audit',
+      discord_bot_token_secret_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:bot-token',
+      discord_public_key_secret_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:public-key',
+      interactions_invoke_url: null,
+      discord_interactions_url: null,
+      applied_game_servers: null,
+    };
+
+    describe('real-IPC fallthrough', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should invoke the terraform.output channel with { force: true } and resolve with the typed outputs object', async () => {
+        ipcInvoke.mockResolvedValue(OUTPUTS);
+        const terraform = bridge['terraform'] as { output: (force?: boolean) => Promise<unknown> };
+
+        const result = await terraform.output(true);
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.output', { force: true });
+        expect(result).toEqual(OUTPUTS);
+      });
+
+      it('should invoke the terraform.output channel with { force: false } when force is explicitly false', async () => {
+        ipcInvoke.mockResolvedValue(OUTPUTS);
+        const terraform = bridge['terraform'] as { output: (force?: boolean) => Promise<unknown> };
+
+        await terraform.output(false);
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.output', { force: false });
+      });
+
+      it('should invoke the terraform.output channel with { force: undefined } when no argument is supplied', async () => {
+        ipcInvoke.mockResolvedValue(OUTPUTS);
+        const terraform = bridge['terraform'] as { output: (force?: boolean) => Promise<unknown> };
+
+        await terraform.output();
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.output', { force: undefined });
+      });
+
+      it('should resolve with null when terraform.output reports no outputs', async () => {
+        ipcInvoke.mockResolvedValue(null);
+        const terraform = bridge['terraform'] as { output: (force?: boolean) => Promise<unknown> };
+
+        const result = await terraform.output();
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('mock-override', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should call the registered mock instead of ipcRenderer.invoke when terraform.output is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+        const mockHandler = vi.fn().mockResolvedValue(OUTPUTS);
+        testApi.mock('terraform.output', mockHandler);
+
+        const terraform = bridge['terraform'] as { output: (force?: boolean) => Promise<unknown> };
+        const result = await terraform.output(true);
+
+        expect(mockHandler).toHaveBeenCalledWith({ force: true });
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(result).toEqual(OUTPUTS);
+      });
+    });
+  });
 });

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -37,6 +37,7 @@ import type {
   LogChunk,
   TerraformInitConfig,
   TerraformRunChunk,
+  TfOutputs,
   UpdateGamePayload,
 } from './gsd-api.js';
 
@@ -415,6 +416,7 @@ const api: GsdApi = {
 
   terraform: {
     init: streamTerraformInit,
+    output: (force?: boolean) => invoke<TfOutputs | null>('terraform.output', { force }),
   },
 };
 


### PR DESCRIPTION
Closes #178

## Summary

- Adds `TerraformService.output(force?)` — spawns `terraform output -json`, parses stdout into the same `TfOutputs` shape `ConfigService.getTfOutputs()` derives from the state file, and caches the result for 60s; passing `force: true` bypasses the cache and re-spawns.
- Extracts `projectTfOutputs()` out of `ConfigService.getTfOutputs()` as a standalone helper so `TerraformService.output()` can reuse the exact same projection logic against live `terraform output -json` data instead of the cached state file, keeping the two code paths in sync.
- Adds a `terraform.output` IPC handler in `TerraformController` (and the corresponding preload bridge method `gsd.terraform.output()`) so the dashboard, Discord page, and file manager can request fresh outputs after an apply without re-reading `terraform.tfstate`.
- Unit tests for the cache-hit/cache-miss/force-bypass behavior of `TerraformService.output()`, the new IPC handler, and the preload bridge method.

## Changes

```
 .../src/controllers/terraform.controller.test.ts   |  70 +++++-
 .../src/controllers/terraform.controller.ts        |  34 +++
 .../desktop-main/src/services/ConfigService.ts     |  93 ++++---
 .../src/services/TerraformService.output.test.ts   | 268 +++++++++++++++++++++
 .../desktop-main/src/services/TerraformService.ts  |  80 +++++-
 app/packages/desktop-preload/src/gsd-api.ts        |  42 ++++
 app/packages/desktop-preload/src/preload.test.ts   |  95 ++++++++
 app/packages/desktop-preload/src/preload.ts        |   2 +
 8 files changed, 641 insertions(+), 43 deletions(-)
```

## Test plan

- [x] `TerraformService.output()` returns the same shape `ConfigService.getTfOutputs()` parses from the state file — covered by `TerraformService.output.test.ts`.
- [x] A second call within 60s of the first returns the cached result without re-spawning `terraform`.
- [x] A call with `force: true` bypasses the cache and re-spawns `terraform output -json` regardless of cache age.
- [x] A call after the 60s cache window re-spawns automatically.
- [x] `TerraformController`'s `terraform.output` IPC handler forwards to `TerraformService.output()` and returns the parsed outputs — covered by `terraform.controller.test.ts`.
- [x] `gsd.terraform.output()` is exposed on the preload bridge and invokes the `terraform.output` channel — covered by `preload.test.ts`.
- [x] `npm run app:test` passing for the touched workspaces (desktop-main, desktop-preload).
- [x] `npm run app:lint` clean.
