### PR TITLE
feat(desktop-main): run-record persistence to DynamoDB with S3 log offload

### DIFF
--- a/app/packages/cloud-aws/package.json
+++ b/app/packages/cloud-aws/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/client-secrets-manager": "^3.600.0",
     "@aws-sdk/lib-dynamodb": "^3.600.0",
+    "@aws-sdk/s3-request-presigner": "^3.600.0",
     "@hyveon/shared": "*"
   }
 }

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import type { RunRecord } from '@hyveon/shared';
+import { AwsRunRecordStore } from './AwsRunRecordStore.js';
+
+/** Stub replacing `@aws-sdk/s3-request-presigner`'s `getSignedUrl` so tests
+ * never attempt real SigV4 signing (which requires resolvable credentials). */
+const getSignedUrlMock = vi.fn<() => Promise<string>>();
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args: unknown[]) => getSignedUrlMock(...(args as [])),
+}));
+
+/** Typed stand-in for the DynamoDB document client SDK. */
+const ddbMock = mockClient(DynamoDBDocumentClient);
+/** Typed stand-in for the AWS S3 SDK client. */
+const s3Mock = mockClient(S3Client);
+
+/**
+ * Build an {@link AwsRunRecordStore} whose config-resolution callback
+ * returns a fixed table/bucket/region, avoiding any need to read/mutate
+ * `process.env` in tests. Pass `null` to simulate a store constructed with
+ * no `getConfig` callback at all (the zero-arg-constructible case).
+ */
+function makeStore(
+  config: { tableName: string; bucket: string; region?: string } | null = {
+    tableName: 'hyveon-runs',
+    bucket: 'hyveon-runs-logs',
+    region: 'us-east-1',
+  },
+): AwsRunRecordStore {
+  return new AwsRunRecordStore(config === null ? undefined : () => config);
+}
+
+/** Builds a sample {@link RunRecord}, overridable per-test. */
+function makeRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    sk: '2026-07-17T00:00:00.000Z#run-123',
+    runId: 'run-123',
+    kind: 'apply',
+    status: 'success',
+    startedAt: '2026-07-17T00:00:00.000Z',
+    completedAt: '2026-07-17T00:05:00.000Z',
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+describe('AwsRunRecordStore', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    s3Mock.reset();
+    getSignedUrlMock.mockReset();
+  });
+
+  describe('putRecord', () => {
+    it('should send a PutCommand with pk RUN, the record sk, and status on the written item', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const record = makeRecord();
+      await store.putRecord(record);
+
+      const calls = ddbMock.commandCalls(PutCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-runs');
+      expect(input.Item).toEqual({
+        pk: 'RUN',
+        sk: record.sk,
+        runId: record.runId,
+        kind: record.kind,
+        status: record.status,
+        startedAt: record.startedAt,
+        completedAt: record.completedAt,
+        exitCode: record.exitCode,
+      });
+    });
+
+    it('should include tfvarsVersionId and log on the written item when present on the record', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const record = makeRecord({ tfvarsVersionId: 'v-1', log: 'runs/run-123.log' });
+      await store.putRecord(record);
+
+      const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
+      expect(input.Item?.['tfvarsVersionId']).toBe('v-1');
+      expect(input.Item?.['log']).toBe('runs/run-123.log');
+    });
+
+    it('should omit tfvarsVersionId and log from the written item when absent on the record', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      await store.putRecord(makeRecord());
+
+      const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
+      expect(input.Item).not.toHaveProperty('tfvarsVersionId');
+      expect(input.Item).not.toHaveProperty('log');
+    });
+
+    it('should throw a clear error when constructed without a getConfig callback', async () => {
+      const store = makeStore(null);
+      await expect(store.putRecord(makeRecord())).rejects.toThrow(
+        'AwsRunRecordStore: table not configured. Supply a getConfig callback that resolves { tableName }.',
+      );
+    });
+  });
+
+  describe('putLog', () => {
+    it('should write the body to the runs/<runId>.log S3 key and return that key', async () => {
+      s3Mock.on(PutObjectCommand).resolves({});
+
+      const store = makeStore();
+      const body = new Uint8Array([1, 2, 3]);
+      await expect(store.putLog('run-123', body)).resolves.toBe('runs/run-123.log');
+
+      const input = s3Mock.commandCalls(PutObjectCommand)[0]!.args[0].input;
+      expect(input.Bucket).toBe('hyveon-runs-logs');
+      expect(input.Key).toBe('runs/run-123.log');
+      expect(input.Body).toBe(body);
+    });
+
+    it('should throw a clear error when constructed without a getConfig callback', async () => {
+      const store = makeStore(null);
+      await expect(store.putLog('run-123', new Uint8Array([1]))).rejects.toThrow(
+        'AwsRunRecordStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
+      );
+    });
+  });
+
+  describe('getLogUrl', () => {
+    it('should return a presigned URL for a stored log key', async () => {
+      getSignedUrlMock.mockResolvedValue('https://hyveon-runs-logs.s3.amazonaws.com/runs/run-123.log?X-Amz-Signature=abc');
+
+      const store = makeStore();
+      const url = await store.getLogUrl('runs/run-123.log');
+
+      expect(url).toBe('https://hyveon-runs-logs.s3.amazonaws.com/runs/run-123.log?X-Amz-Signature=abc');
+      expect(getSignedUrlMock).toHaveBeenCalledTimes(1);
+      const [, command, options] = getSignedUrlMock.mock.calls[0]!;
+      expect((command as GetObjectCommand).input).toEqual({
+        Bucket: 'hyveon-runs-logs',
+        Key: 'runs/run-123.log',
+      });
+      expect(options).toEqual({ expiresIn: 3600 });
+    });
+
+    it('should pass a custom expiresInSeconds through to the presigner', async () => {
+      getSignedUrlMock.mockResolvedValue('https://example.com/signed');
+
+      const store = makeStore();
+      await store.getLogUrl('runs/run-123.log', 60);
+
+      const [, , options] = getSignedUrlMock.mock.calls[0]!;
+      expect(options).toEqual({ expiresIn: 60 });
+    });
+
+    it('should throw a clear error when constructed without a getConfig callback', async () => {
+      const store = makeStore(null);
+      await expect(store.getLogUrl('runs/run-123.log')).rejects.toThrow(
+        'AwsRunRecordStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
+      );
+    });
+  });
+});

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
@@ -78,19 +78,32 @@ describe('AwsRunRecordStore', () => {
       });
     });
 
-    it('should include tfvarsVersionId and log on the written item when present on the record', async () => {
+    it('should include tfvarsVersionId and logS3Key on the written item when present on the record', async () => {
       ddbMock.on(PutCommand).resolves({});
 
       const store = makeStore();
-      const record = makeRecord({ tfvarsVersionId: 'v-1', log: 'runs/run-123.log' });
+      const record = makeRecord({ tfvarsVersionId: 'v-1', logS3Key: 'runs/run-123.log' });
       await store.putRecord(record);
 
       const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
       expect(input.Item?.['tfvarsVersionId']).toBe('v-1');
-      expect(input.Item?.['log']).toBe('runs/run-123.log');
+      expect(input.Item?.['logS3Key']).toBe('runs/run-123.log');
+      expect(input.Item).not.toHaveProperty('logInline');
     });
 
-    it('should omit tfvarsVersionId and log from the written item when absent on the record', async () => {
+    it('should include logInline (and not logS3Key) on the written item when the log was embedded', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const record = makeRecord({ logInline: 'terraform plan output' });
+      await store.putRecord(record);
+
+      const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
+      expect(input.Item?.['logInline']).toBe('terraform plan output');
+      expect(input.Item).not.toHaveProperty('logS3Key');
+    });
+
+    it('should omit tfvarsVersionId, logInline, and logS3Key from the written item when absent on the record', async () => {
       ddbMock.on(PutCommand).resolves({});
 
       const store = makeStore();
@@ -98,7 +111,8 @@ describe('AwsRunRecordStore', () => {
 
       const input = ddbMock.commandCalls(PutCommand)[0]!.args[0].input;
       expect(input.Item).not.toHaveProperty('tfvarsVersionId');
-      expect(input.Item).not.toHaveProperty('log');
+      expect(input.Item).not.toHaveProperty('logInline');
+      expect(input.Item).not.toHaveProperty('logS3Key');
     });
 
     it('should throw a clear error when constructed without a getConfig callback', async () => {

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.ts
@@ -1,0 +1,190 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import type { RunRecord, RunRecordStore } from '@hyveon/shared';
+import { resolveDefaultAwsRegion } from './awsRegionEnv.js';
+
+/**
+ * The single DynamoDB partition every run record lives under (`pk = RUN`).
+ * The table's sort key (`sk`, see `buildRunSk` in `@hyveon/shared/runs.js`)
+ * is `<ISO startedAt>#<runId>`, matching `terraform/aws/runs_store.tf`.
+ */
+const PARTITION_KEY = 'RUN';
+
+/**
+ * How long a presigned log URL remains valid when the caller doesn't supply
+ * an explicit `expiresInSeconds` to {@link AwsRunRecordStore.getLogUrl}.
+ */
+const DEFAULT_PRESIGNED_URL_EXPIRY_SECONDS = 3600;
+
+/**
+ * Builds the S3 key a run's captured log is stored under, keyed by `runId`
+ * so a run's log is always addressable without consulting the DynamoDB
+ * record first.
+ *
+ * @param runId - Unique identifier of the run the log belongs to.
+ * @returns The `runs/<runId>.log` S3 key.
+ */
+function buildLogKey(runId: string): string {
+  return `runs/${runId}.log`;
+}
+
+/**
+ * AWS implementation of the cloud-agnostic {@link RunRecordStore} contract,
+ * backed by the DynamoDB run-history table provisioned in
+ * `terraform/aws/runs_store.tf` (`pk = RUN`, `sk` = `buildRunSk()`) for
+ * record metadata, and an S3 bucket for offloaded run logs (see
+ * {@link buildLogKey}). No `@aws-sdk/*` shapes appear outside this class's
+ * private fields/method bodies, so callers depend only on
+ * {@link RunRecordStore}.
+ */
+export class AwsRunRecordStore implements RunRecordStore {
+  private dynamoClient: DynamoDBDocumentClient | null = null;
+  private dynamoClientRegion: string | null = null;
+  private s3Client: S3Client | null = null;
+  private s3ClientRegion: string | null = null;
+
+  /**
+   * @param getConfig - Resolves the DynamoDB table and S3 bucket (and
+   *   optional region) this store reads/writes, on every call — so a
+   *   rename picked up between calls (e.g. after a Terraform re-apply)
+   *   isn't stuck targeting a stale table/bucket. Optional so the class
+   *   remains constructible with no arguments, mirroring
+   *   `AwsAuditLogStore`/`AwsRemoteFileStore`'s zero-arg-constructible
+   *   pattern. When omitted (or when it returns no `tableName`/`bucket`),
+   *   the relevant methods throw a clear "not configured" error rather
+   *   than sending a malformed request. When `region` is omitted, it falls
+   *   back to {@link resolveDefaultAwsRegion} — never read from
+   *   `process.env` directly here, per CLAUDE.md's "no raw `process.env`
+   *   in business logic" guideline.
+   */
+  constructor(
+    private readonly getConfig?: () => { tableName: string; bucket: string; region?: string },
+  ) {}
+
+  /**
+   * Resolves the configured table name, throwing a clear error instead of
+   * letting an unconfigured table fall through to a malformed DynamoDB
+   * request.
+   */
+  private getTableName(): string {
+    const tableName = this.getConfig?.()?.tableName;
+    if (!tableName) {
+      throw new Error(
+        'AwsRunRecordStore: table not configured. Supply a getConfig callback that resolves { tableName }.',
+      );
+    }
+    return tableName;
+  }
+
+  /**
+   * Resolves the configured bucket name, throwing a clear error instead of
+   * letting an unconfigured bucket fall through to a malformed S3 request.
+   */
+  private getBucketName(): string {
+    const bucket = this.getConfig?.()?.bucket;
+    if (!bucket) {
+      throw new Error(
+        'AwsRunRecordStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
+      );
+    }
+    return bucket;
+  }
+
+  /**
+   * Resolves the region to build clients with, falling back to
+   * {@link resolveDefaultAwsRegion} when `getConfig` omits one.
+   */
+  private getRegion(): string {
+    return this.getConfig?.()?.region ?? resolveDefaultAwsRegion();
+  }
+
+  /**
+   * Lazily constructs the DynamoDB document client, recreating it whenever
+   * the freshly-resolved region differs from the region the cached client
+   * was built with — mirrors `AwsAuditLogStore.getClient`'s
+   * rebuild-on-region-change pattern.
+   */
+  private getDynamoClient(): DynamoDBDocumentClient {
+    const region = this.getRegion();
+    if (!this.dynamoClient || this.dynamoClientRegion !== region) {
+      this.dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+      this.dynamoClientRegion = region;
+    }
+    return this.dynamoClient;
+  }
+
+  /**
+   * Lazily constructs the S3 client, recreating it whenever the
+   * freshly-resolved region differs from the region the cached client was
+   * built with — same rebuild-on-region-change pattern as
+   * {@link getDynamoClient}.
+   */
+  private getS3Client(): S3Client {
+    const region = this.getRegion();
+    if (!this.s3Client || this.s3ClientRegion !== region) {
+      this.s3Client = new S3Client({ region });
+      this.s3ClientRegion = region;
+    }
+    return this.s3Client;
+  }
+
+  /**
+   * Creates or overwrites a run record, keyed on `pk = RUN` + {@link RunRecord.sk}.
+   *
+   * @param record - The record to persist, including its `sk` (see `buildRunSk`).
+   */
+  async putRecord(record: RunRecord): Promise<void> {
+    await this.getDynamoClient().send(
+      new PutCommand({
+        TableName: this.getTableName(),
+        Item: {
+          pk: PARTITION_KEY,
+          sk: record.sk,
+          runId: record.runId,
+          kind: record.kind,
+          status: record.status,
+          startedAt: record.startedAt,
+          completedAt: record.completedAt,
+          exitCode: record.exitCode,
+          ...(record.tfvarsVersionId !== undefined ? { tfvarsVersionId: record.tfvarsVersionId } : {}),
+          ...(record.log !== undefined ? { log: record.log } : {}),
+        },
+      }),
+    );
+  }
+
+  /**
+   * Writes a run's captured log to S3 under {@link buildLogKey}'s
+   * `runs/<runId>.log` key.
+   *
+   * @param runId - Unique identifier of the run the log belongs to.
+   * @param body  - The raw log contents to store.
+   * @returns The `runs/<runId>.log` key the log was written under.
+   */
+  async putLog(runId: string, body: Uint8Array): Promise<string> {
+    const key = buildLogKey(runId);
+    await this.getS3Client().send(
+      new PutObjectCommand({ Bucket: this.getBucketName(), Key: key, Body: body }),
+    );
+    return key;
+  }
+
+  /**
+   * Resolves a presigned, temporary `GetObject` URL for a previously stored
+   * log.
+   *
+   * @param logKey - The key returned by a prior {@link putLog} call.
+   * @param expiresInSeconds - How long the returned URL should remain
+   *   valid, in seconds. Defaults to {@link DEFAULT_PRESIGNED_URL_EXPIRY_SECONDS}.
+   * @returns A presigned URL the caller can fetch the log from directly.
+   */
+  async getLogUrl(
+    logKey: string,
+    expiresInSeconds: number = DEFAULT_PRESIGNED_URL_EXPIRY_SECONDS,
+  ): Promise<string> {
+    const command = new GetObjectCommand({ Bucket: this.getBucketName(), Key: logKey });
+    return getSignedUrl(this.getS3Client(), command, { expiresIn: expiresInSeconds });
+  }
+}

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.ts
@@ -149,7 +149,8 @@ export class AwsRunRecordStore implements RunRecordStore {
           completedAt: record.completedAt,
           exitCode: record.exitCode,
           ...(record.tfvarsVersionId !== undefined ? { tfvarsVersionId: record.tfvarsVersionId } : {}),
-          ...(record.log !== undefined ? { log: record.log } : {}),
+          ...(record.logInline !== undefined ? { logInline: record.logInline } : {}),
+          ...(record.logS3Key !== undefined ? { logS3Key: record.logS3Key } : {}),
         },
       }),
     );

--- a/app/packages/cloud-aws/src/index.ts
+++ b/app/packages/cloud-aws/src/index.ts
@@ -2,4 +2,5 @@ export * from './AwsAuditLogStore.js';
 export * from './AwsCloudProvider.js';
 export * from './AwsDiscordEventReceiver.js';
 export * from './AwsRemoteFileStore.js';
+export * from './AwsRunRecordStore.js';
 export * from './AwsSecretsStore.js';

--- a/app/packages/desktop-main/src/modules/cloud-provider.module.test.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.module.test.ts
@@ -6,6 +6,7 @@ import {
   AwsDiscordEventReceiver,
   AwsCloudProvider,
   AwsAuditLogStore,
+  AwsRunRecordStore,
 } from '@hyveon/cloud-aws';
 import type {
   CloudProvider,
@@ -13,6 +14,7 @@ import type {
   RemoteFileStore,
   DiscordEventReceiver,
   AuditLogStore,
+  RunRecordStore,
   StartOpts,
   WorkloadHandle,
   WorkloadStatus,
@@ -21,12 +23,14 @@ import type {
   DateRange,
   AuditEntry,
   AuditPageResult,
+  RunRecord,
 } from '@hyveon/shared';
 import {
   CLOUD_BINDINGS,
   resolveCloudBindings,
   resolveTfvarsFileStoreConfig,
   resolveAuditLogStoreConfig,
+  resolveRunRecordStoreConfig,
   type CloudBindings,
 } from './cloud-provider.module.js';
 import type { ConfigService, ActiveCloud, TfOutputs } from '../services/ConfigService.js';
@@ -41,12 +45,13 @@ function makeConfig(
   activeCloud: ActiveCloud,
   tfvarsBucket: string | null = 'test-tfvars-bucket',
   auditTableName = 'test-audit-table',
+  runsTableName = 'test-runs-table',
 ): ConfigService {
   const stub: Partial<ConfigService> = {
     getActiveCloud: () => activeCloud,
     getRegion: () => 'us-east-1',
     getTfvarsBucket: () => tfvarsBucket,
-    getTfOutputs: () => ({ audit_table_name: auditTableName } as TfOutputs),
+    getTfOutputs: () => ({ audit_table_name: auditTableName, runs_table_name: runsTableName } as TfOutputs),
   };
   return stub as ConfigService;
 }
@@ -124,6 +129,19 @@ class FakeAuditLogStore implements AuditLogStore {
   }
 }
 
+/** Hand-rolled fake `RunRecordStore` — see {@link FakeCloudProvider}. */
+class FakeRunRecordStore implements RunRecordStore {
+  putRecord(_record: RunRecord): Promise<void> {
+    throw new Error('not implemented in fake');
+  }
+  putLog(_runId: string, _body: Uint8Array): Promise<string> {
+    throw new Error('not implemented in fake');
+  }
+  getLogUrl(_logKey: string, _expiresInSeconds?: number): Promise<string> {
+    throw new Error('not implemented in fake');
+  }
+}
+
 /** Registered `CLOUD_BINDINGS` key used to exercise the fake-cloud routing case. */
 const FAKE_CLOUD = 'fake-test-cloud';
 
@@ -134,6 +152,7 @@ const FAKE_BINDINGS: CloudBindings = {
   remoteFileStore: () => new FakeRemoteFileStore(),
   discordReceiver: () => new FakeDiscordEventReceiver(),
   auditLogStore: () => new FakeAuditLogStore(),
+  runRecordStore: () => new FakeRunRecordStore(),
 };
 
 describe('resolveCloudBindings', () => {
@@ -199,6 +218,29 @@ describe('resolveCloudBindings', () => {
       } as ConfigService;
       expect(resolveAuditLogStoreConfig(config)).toEqual({ tableName: '', region: 'us-east-1' });
     });
+
+    it('should produce an AwsRunRecordStore from the aws runRecordStore factory', () => {
+      const config = makeConfig('aws');
+      const bindings = resolveCloudBindings(config);
+      expect(bindings.runRecordStore(config)).toBeInstanceOf(AwsRunRecordStore);
+    });
+
+    it('should resolve the run record store table from ConfigService.getTfOutputs().runs_table_name, bucket from getTfvarsBucket(), and region from getRegion()', () => {
+      const config = makeConfig('aws', 'my-tfvars-bucket', 'test-audit-table', 'my-runs-table');
+      expect(resolveRunRecordStoreConfig(config)).toEqual({
+        tableName: 'my-runs-table',
+        bucket: 'my-tfvars-bucket',
+        region: 'us-east-1',
+      });
+    });
+
+    it('should fall back to empty table/bucket names when getTfOutputs() and getTfvarsBucket() report nothing configured', () => {
+      const config: ConfigService = {
+        ...makeConfig('aws', null),
+        getTfOutputs: () => null,
+      } as ConfigService;
+      expect(resolveRunRecordStoreConfig(config)).toEqual({ tableName: '', bucket: '', region: 'us-east-1' });
+    });
   });
 
   describe('fake-impl routing', () => {
@@ -214,6 +256,7 @@ describe('resolveCloudBindings', () => {
       expect(bindings.remoteFileStore(config)).toBeInstanceOf(FakeRemoteFileStore);
       expect(bindings.discordReceiver(config)).toBeInstanceOf(FakeDiscordEventReceiver);
       expect(bindings.auditLogStore(config)).toBeInstanceOf(FakeAuditLogStore);
+      expect(bindings.runRecordStore(config)).toBeInstanceOf(FakeRunRecordStore);
     });
 
     it('should not resolve to the aws bindings once a fake cloud is registered', () => {

--- a/app/packages/desktop-main/src/modules/cloud-provider.module.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.module.ts
@@ -1,6 +1,19 @@
 import { Module } from '@nestjs/common';
-import { AwsSecretsStore, AwsRemoteFileStore, AwsDiscordEventReceiver, AwsAuditLogStore } from '@hyveon/cloud-aws';
-import type { CloudProvider, SecretsStore, RemoteFileStore, DiscordEventReceiver, AuditLogStore } from '@hyveon/shared';
+import {
+  AwsSecretsStore,
+  AwsRemoteFileStore,
+  AwsDiscordEventReceiver,
+  AwsAuditLogStore,
+  AwsRunRecordStore,
+} from '@hyveon/cloud-aws';
+import type {
+  CloudProvider,
+  SecretsStore,
+  RemoteFileStore,
+  DiscordEventReceiver,
+  AuditLogStore,
+  RunRecordStore,
+} from '@hyveon/shared';
 import { ConfigModule } from './config.module.js';
 import { ConfigService } from '../services/ConfigService.js';
 import { createAwsCloudProvider } from '../services/EcsService.js';
@@ -10,16 +23,17 @@ import {
   REMOTE_FILE_STORE,
   DISCORD_RECEIVER,
   AUDIT_LOG_STORE,
+  RUN_RECORD_STORE,
 } from './cloud-provider.tokens.js';
 
 /**
- * Per-cloud factories for the five cloud-agnostic contracts (`CloudProvider`,
- * `SecretsStore`, `RemoteFileStore`, `DiscordEventReceiver`, `AuditLogStore` —
- * all from `@hyveon/shared/cloud.js`). Keyed by the `ActiveCloud` value
- * `ConfigService` reports; each `CloudBindings` entry supplies one factory per
- * token so {@link resolveCloudBindings} (and, in turn, `CloudProviderModule`'s
- * `useFactory` providers) can look up the right implementation without
- * duplicating the cloud switch five times.
+ * Per-cloud factories for the six cloud-agnostic contracts (`CloudProvider`,
+ * `SecretsStore`, `RemoteFileStore`, `DiscordEventReceiver`, `AuditLogStore`,
+ * `RunRecordStore` — all from `@hyveon/shared/cloud.js`). Keyed by the
+ * `ActiveCloud` value `ConfigService` reports; each `CloudBindings` entry
+ * supplies one factory per token so {@link resolveCloudBindings} (and, in
+ * turn, `CloudProviderModule`'s `useFactory` providers) can look up the right
+ * implementation without duplicating the cloud switch six times.
  */
 export interface CloudBindings {
   cloudProvider: (config: ConfigService) => CloudProvider;
@@ -27,6 +41,7 @@ export interface CloudBindings {
   remoteFileStore: (config: ConfigService) => RemoteFileStore;
   discordReceiver: (config: ConfigService) => DiscordEventReceiver;
   auditLogStore: (config: ConfigService) => AuditLogStore;
+  runRecordStore: (config: ConfigService) => RunRecordStore;
 }
 
 /**
@@ -59,6 +74,28 @@ export function resolveAuditLogStoreConfig(config: ConfigService): { tableName: 
 }
 
 /**
+ * Resolves the `{ tableName, bucket, region }` config the AWS `RunRecordStore`'s
+ * `getConfig` callback needs to target the runs DynamoDB table and the tfvars
+ * S3 bucket used for offloaded run logs: the table name comes from
+ * `ConfigService.getTfOutputs()?.runs_table_name` (falling back to `''` when
+ * the tfstate hasn't been applied yet), the bucket from
+ * `ConfigService.getTfvarsBucket()` (falling back to `''` when tfvars sync
+ * isn't configured), and the region from `getRegion()` — so `AwsRunRecordStore`
+ * surfaces its own "not configured" errors rather than this factory silently
+ * defaulting somewhere. Exported as a standalone function — see
+ * {@link resolveTfvarsFileStoreConfig} for why.
+ */
+export function resolveRunRecordStoreConfig(
+  config: ConfigService,
+): { tableName: string; bucket: string; region: string } {
+  return {
+    tableName: config.getTfOutputs()?.runs_table_name ?? '',
+    bucket: config.getTfvarsBucket() ?? '',
+    region: config.getRegion(),
+  };
+}
+
+/**
  * Registry of per-cloud bindings, keyed by `ActiveCloud` (or any future cloud
  * string). Today only `'aws'` is populated; adding a new cloud provider
  * package means adding an entry here rather than touching the module's
@@ -72,6 +109,7 @@ export const CLOUD_BINDINGS: Record<string, CloudBindings> = {
     remoteFileStore: (config) => new AwsRemoteFileStore(() => resolveTfvarsFileStoreConfig(config)),
     discordReceiver: () => new AwsDiscordEventReceiver(),
     auditLogStore: (config) => new AwsAuditLogStore(() => resolveAuditLogStoreConfig(config)),
+    runRecordStore: (config) => new AwsRunRecordStore(() => resolveRunRecordStoreConfig(config)),
   },
 };
 
@@ -91,7 +129,7 @@ export function resolveCloudBindings(config: ConfigService): CloudBindings {
 }
 
 /**
- * Binds the five cloud-agnostic contracts to concrete implementations for
+ * Binds the six cloud-agnostic contracts to concrete implementations for
  * whichever cloud `ConfigService.getActiveCloud()` reports as active, via
  * {@link resolveCloudBindings} and the {@link CLOUD_BINDINGS} registry. Today
  * that's always `'aws'`, so every token resolves to a `@hyveon/cloud-aws`
@@ -131,7 +169,19 @@ export function resolveCloudBindings(config: ConfigService): CloudBindings {
       useFactory: (config: ConfigService) => resolveCloudBindings(config).auditLogStore(config),
       inject: [ConfigService],
     },
+    {
+      provide: RUN_RECORD_STORE,
+      useFactory: (config: ConfigService) => resolveCloudBindings(config).runRecordStore(config),
+      inject: [ConfigService],
+    },
   ],
-  exports: [CLOUD_PROVIDER, SECRETS_STORE, REMOTE_FILE_STORE, DISCORD_RECEIVER, AUDIT_LOG_STORE],
+  exports: [
+    CLOUD_PROVIDER,
+    SECRETS_STORE,
+    REMOTE_FILE_STORE,
+    DISCORD_RECEIVER,
+    AUDIT_LOG_STORE,
+    RUN_RECORD_STORE,
+  ],
 })
 export class CloudProviderModule {}

--- a/app/packages/desktop-main/src/modules/cloud-provider.tokens.ts
+++ b/app/packages/desktop-main/src/modules/cloud-provider.tokens.ts
@@ -22,3 +22,6 @@ export const DISCORD_RECEIVER = Symbol('DISCORD_RECEIVER');
 
 /** Injection token for the `AuditLogStore` implementation bound by `CloudProviderModule`. */
 export const AUDIT_LOG_STORE = Symbol('AUDIT_LOG_STORE');
+
+/** Injection token for the `RunRecordStore` implementation bound by `CloudProviderModule`. */
+export const RUN_RECORD_STORE = Symbol('RUN_RECORD_STORE');

--- a/app/packages/desktop-main/src/modules/terraform.module.ts
+++ b/app/packages/desktop-main/src/modules/terraform.module.ts
@@ -2,32 +2,41 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from './config.module.js';
 import { CloudProviderModule } from './cloud-provider.module.js';
 import { TerraformService } from '../services/TerraformService.js';
+import { RunRecordService } from '../services/RunRecordService.js';
 
 /**
  * Feature module for `TerraformService`, the local `terraform` CLI
  * detection/orchestration seam (see `TerraformService`'s file-level doc
- * comment). Construction is synchronous and never throws — binary lookup and
+ * comment), and `RunRecordService`, the inline-vs-offload run-history
+ * persistence facade (see its own file-level doc comment) `terraform`
+ * subcommand runners will eventually write their `TerraformRunRecord`s
+ * through instead of (or alongside) the local `run.json` file.
+ * Construction is synchronous and never throws — binary lookup and
  * version resolution are deferred to first use of `getBinaryPath()` /
  * `getVersion()` — so the provider is wired as a plain class provider rather
  * than an async `useFactory`, and `AppModule` can import this module safely
  * even on machines without `terraform` on PATH.
  *
- * Imports `ConfigModule` because `TerraformService` takes `ConfigService` as
- * a constructor dependency (used to resolve the working directory and the
- * per-run artifacts directory) and `CloudProviderModule` for the
+ * Imports `ConfigModule` because both `TerraformService` and
+ * `RunRecordService` take `ConfigService` as a constructor dependency
+ * (`TerraformService` to resolve the working directory and the per-run
+ * artifacts directory; `RunRecordService` to guard `persist()` on the
+ * `runs_table_name` Terraform output, mirroring `AuditService`'s
+ * table-not-deployed guard) and `CloudProviderModule` for the
  * `REMOTE_FILE_STORE` token — `TerraformService.plan()` pulls the current
  * tfvars snapshot from it in S3 mode, mirroring `TfvarsModule`'s wiring —
- * both re-exported alongside `TerraformService` so any consumer that only
- * needs `TerraformModule` gets the full dependency chain without also
- * importing `AwsModule`. Plain Nest DI, no async factory needed since none of
- * these providers do async work at construction time.
+ * and for the `RUN_RECORD_STORE` token `RunRecordService` depends on. Both
+ * modules are re-exported alongside `TerraformService`/`RunRecordService` so
+ * any consumer that only needs `TerraformModule` gets the full dependency
+ * chain without also importing `AwsModule`. Plain Nest DI, no async factory
+ * needed since none of these providers do async work at construction time.
  *
  * Imported by `AppModule` alongside `TerraformController`, which bridges
  * `TerraformService.init`'s async-generator output onto Electron IPC.
  */
 @Module({
   imports: [ConfigModule, CloudProviderModule],
-  providers: [TerraformService],
-  exports: [ConfigModule, CloudProviderModule, TerraformService],
+  providers: [TerraformService, RunRecordService],
+  exports: [ConfigModule, CloudProviderModule, TerraformService, RunRecordService],
 })
 export class TerraformModule {}

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -96,10 +96,10 @@ describe('RunRecordService', () => {
       expect(putLogMock).not.toHaveBeenCalled();
       expect(putRecordMock).toHaveBeenCalledTimes(1);
       const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
-      expect(record.log).toBe(smallLog);
+      expect(record.logInline).toBe(smallLog);
     });
 
-    it('should offload a log larger than the inline threshold to the store and record the returned key', async () => {
+    it('should offload a log larger than the inline threshold to the store and record the returned key on logS3Key, not log', async () => {
       putRecordMock.mockResolvedValue(undefined);
       putLogMock.mockResolvedValue('runs/run-123.log');
       const service = makeService();
@@ -113,7 +113,8 @@ describe('RunRecordService', () => {
       expect(new TextDecoder().decode(body)).toBe(oversizedLog);
 
       const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
-      expect(record.log).toBe('runs/run-123.log');
+      expect(record.logS3Key).toBe('runs/run-123.log');
+      expect(record).not.toHaveProperty('logInline');
     });
 
     it('should embed a log exactly at the inline threshold without offloading', async () => {
@@ -125,17 +126,19 @@ describe('RunRecordService', () => {
 
       expect(putLogMock).not.toHaveBeenCalled();
       const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
-      expect(record.log).toBe(exactLog);
+      expect(record.logInline).toBe(exactLog);
+      expect(record).not.toHaveProperty('logS3Key');
     });
 
-    it('should omit the log attribute entirely when no log was captured', async () => {
+    it('should omit both log attributes entirely when no log was captured', async () => {
       putRecordMock.mockResolvedValue(undefined);
       const service = makeService();
 
       await service.persist(makeParams(), null);
 
       const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
-      expect(record).not.toHaveProperty('log');
+      expect(record).not.toHaveProperty('logInline');
+      expect(record).not.toHaveProperty('logS3Key');
     });
 
     it('should build the record sk from startedAt and runId, and derive status from exitCode', async () => {
@@ -189,7 +192,8 @@ describe('RunRecordService', () => {
       expect(putLogMock).toHaveBeenCalledTimes(1);
       expect(putRecordMock).toHaveBeenCalledTimes(1);
       const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
-      expect(record).not.toHaveProperty('log');
+      expect(record).not.toHaveProperty('logInline');
+      expect(record).not.toHaveProperty('logS3Key');
     });
 
     it('should persist the record without a log when the oversized log cannot be offloaded because no remote file store is configured', async () => {
@@ -203,7 +207,8 @@ describe('RunRecordService', () => {
       expect(putLogMock).toHaveBeenCalledTimes(1);
       expect(putRecordMock).toHaveBeenCalledTimes(1);
       const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
-      expect(record).not.toHaveProperty('log');
+      expect(record).not.toHaveProperty('logInline');
+      expect(record).not.toHaveProperty('logS3Key');
     });
 
     it('should skip persistence entirely and log a warning when runs_table_name is not configured', async () => {

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for `RunRecordService` — the write/read facade over the
+ * cloud-agnostic `RunRecordStore` (a stub here; the real `AwsRunRecordStore`
+ * has its own tests under `@hyveon/cloud-aws`). Covers the inline-vs-offload
+ * log decision, the missing-table no-op, the swallow-on-error persistence
+ * contract, and the `getLogUrl` delegation.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RunRecord, RunRecordStore } from '@hyveon/shared';
+import { INLINE_LOG_LIMIT_BYTES, RunRecordService, type PersistRunRecordParams } from './RunRecordService.js';
+import { ConfigService, type TfOutputs } from './ConfigService.js';
+
+/** Minimal `TfOutputs` stub exposing just `runs_table_name`. */
+const TF: TfOutputs = {
+  aws_region: 'us-east-1',
+  ecs_cluster_name: '',
+  ecs_cluster_arn: '',
+  subnet_ids: '',
+  security_group_id: '',
+  file_manager_security_group_id: '',
+  efs_file_system_id: '',
+  efs_access_points: {},
+  domain_name: '',
+  game_names: [],
+  alb_dns_name: null,
+  acm_certificate_arn: null,
+  discord_table_name: '',
+  audit_table_name: '',
+  runs_table_name: 'test-runs',
+  discord_bot_token_secret_arn: '',
+  discord_public_key_secret_arn: '',
+  interactions_invoke_url: null,
+  discord_interactions_url: null,
+  applied_game_servers: null,
+};
+
+const putRecordMock = vi.fn<RunRecordStore['putRecord']>();
+const putLogMock = vi.fn<RunRecordStore['putLog']>();
+const getLogUrlMock = vi.fn<RunRecordStore['getLogUrl']>();
+
+/** Builds a `RunRecordStore`-shaped stub backed by the shared mocks above. */
+function makeStore(): RunRecordStore {
+  return { putRecord: putRecordMock, putLog: putLogMock, getLogUrl: getLogUrlMock };
+}
+
+/** Builds a `RunRecordService` with a `ConfigService` stub returning `outputs` and the given (or default) store stub. */
+function makeService(outputs: TfOutputs | null = TF, store: RunRecordStore = makeStore()): RunRecordService {
+  const config = { getTfOutputs: () => outputs } as Partial<ConfigService> as ConfigService;
+  return new RunRecordService(config, store);
+}
+
+/** Builds a sample {@link PersistRunRecordParams}, overridable per-test. */
+function makeParams(overrides: Partial<PersistRunRecordParams> = {}): PersistRunRecordParams {
+  return {
+    runId: 'run-123',
+    kind: 'apply',
+    startedAt: '2026-07-17T00:00:00.000Z',
+    completedAt: '2026-07-17T00:05:00.000Z',
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+let workDir: string;
+
+/** Writes `contents` to a fresh temp file under `workDir` and returns its absolute path. */
+function writeLogFile(contents: string): string {
+  const path = join(workDir, `run.log`);
+  writeFileSync(path, contents, 'utf8');
+  return path;
+}
+
+beforeEach(() => {
+  putRecordMock.mockReset();
+  putLogMock.mockReset();
+  getLogUrlMock.mockReset();
+  workDir = mkdtempSync(join(tmpdir(), 'run-record-service-test-'));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('RunRecordService', () => {
+  describe('persist', () => {
+    it('should embed a small log directly on the record and never call store.putLog', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+      const smallLog = 'terraform plan output\nPlan: 1 to add, 0 to change, 0 to destroy.';
+
+      await service.persist(makeParams(), writeLogFile(smallLog));
+
+      expect(putLogMock).not.toHaveBeenCalled();
+      expect(putRecordMock).toHaveBeenCalledTimes(1);
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.log).toBe(smallLog);
+    });
+
+    it('should offload a log larger than the inline threshold to the store and record the returned key', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      putLogMock.mockResolvedValue('runs/run-123.log');
+      const service = makeService();
+      const oversizedLog = 'x'.repeat(INLINE_LOG_LIMIT_BYTES + 1);
+
+      await service.persist(makeParams(), writeLogFile(oversizedLog));
+
+      expect(putLogMock).toHaveBeenCalledTimes(1);
+      const [runId, body] = putLogMock.mock.calls[0]!;
+      expect(runId).toBe('run-123');
+      expect(new TextDecoder().decode(body)).toBe(oversizedLog);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.log).toBe('runs/run-123.log');
+    });
+
+    it('should embed a log exactly at the inline threshold without offloading', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+      const exactLog = 'x'.repeat(INLINE_LOG_LIMIT_BYTES);
+
+      await service.persist(makeParams(), writeLogFile(exactLog));
+
+      expect(putLogMock).not.toHaveBeenCalled();
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.log).toBe(exactLog);
+    });
+
+    it('should omit the log attribute entirely when no log was captured', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams(), null);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record).not.toHaveProperty('log');
+    });
+
+    it('should build the record sk from startedAt and runId, and derive status from exitCode', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams({ exitCode: 1 }), null);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.sk).toBe('2026-07-17T00:00:00.000Z#run-123');
+      expect(record.status).toBe('failed');
+    });
+
+    it('should derive an aborted status when exitCode is null', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams({ exitCode: null }), null);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.status).toBe('aborted');
+    });
+
+    it('should include tfvarsVersionId on the record when present on params', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams({ tfvarsVersionId: 'v-1' }), null);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.tfvarsVersionId).toBe('v-1');
+    });
+
+    it('should swallow a store.putRecord failure and log a warning instead of throwing', async () => {
+      putRecordMock.mockRejectedValue(new Error('DynamoDB is down'));
+      const service = makeService();
+
+      await expect(service.persist(makeParams(), null)).resolves.toBeUndefined();
+
+      expect(putRecordMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should persist the record without a log when store.putLog rejects, rather than aborting the whole write', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      putLogMock.mockRejectedValue(new Error('S3 is down'));
+      const service = makeService();
+      const oversizedLog = 'x'.repeat(INLINE_LOG_LIMIT_BYTES + 1);
+
+      await expect(service.persist(makeParams(), writeLogFile(oversizedLog))).resolves.toBeUndefined();
+
+      expect(putLogMock).toHaveBeenCalledTimes(1);
+      expect(putRecordMock).toHaveBeenCalledTimes(1);
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record).not.toHaveProperty('log');
+    });
+
+    it('should persist the record without a log when the oversized log cannot be offloaded because no remote file store is configured', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      putLogMock.mockRejectedValue(new Error('remote file store not configured: no bucket'));
+      const service = makeService();
+      const oversizedLog = 'x'.repeat(INLINE_LOG_LIMIT_BYTES + 1);
+
+      await expect(service.persist(makeParams(), writeLogFile(oversizedLog))).resolves.toBeUndefined();
+
+      expect(putLogMock).toHaveBeenCalledTimes(1);
+      expect(putRecordMock).toHaveBeenCalledTimes(1);
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record).not.toHaveProperty('log');
+    });
+
+    it('should skip persistence entirely and log a warning when runs_table_name is not configured', async () => {
+      const service = makeService(null);
+
+      await expect(service.persist(makeParams(), writeLogFile('some log text'))).resolves.toBeUndefined();
+
+      expect(putRecordMock).not.toHaveBeenCalled();
+      expect(putLogMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getLogUrl', () => {
+    it("should return the store's presigned URL for a given log key", async () => {
+      getLogUrlMock.mockResolvedValue('https://example.com/signed');
+      const service = makeService();
+
+      const url = await service.getLogUrl('runs/run-123.log');
+
+      expect(url).toBe('https://example.com/signed');
+      expect(getLogUrlMock).toHaveBeenCalledWith('runs/run-123.log', undefined);
+    });
+
+    it('should pass a custom expiresInSeconds through to the store', async () => {
+      getLogUrlMock.mockResolvedValue('https://example.com/signed');
+      const service = makeService();
+
+      await service.getLogUrl('runs/run-123.log', 60);
+
+      expect(getLogUrlMock).toHaveBeenCalledWith('runs/run-123.log', 60);
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/RunRecordService.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.ts
@@ -1,0 +1,194 @@
+/**
+ * Write/read facade over the cloud-agnostic `RunRecordStore` contract (see
+ * `@hyveon/shared/cloud.js`), backing the `terraform` plan/apply/destroy run
+ * history table (`terraform/aws/runs_store.tf`).
+ *
+ * `persist()` decides, per call, whether a run's captured log is small
+ * enough to embed directly on the `RunRecord.log` attribute or must be
+ * offloaded to the store's remote file backend (S3 for AWS) via
+ * `RunRecordStore.putLog` — see {@link INLINE_LOG_LIMIT_BYTES}. It is
+ * intentionally best-effort: a run-history write failure must never mask
+ * (or retroactively fail) an otherwise-successful `terraform` run, so every
+ * failure path logs a winston warning and falls back to the least-lossy
+ * option it can rather than throwing — mirrors `AuditService.record`'s
+ * swallow-on-error contract.
+ */
+import { readFileSync } from 'node:fs';
+import { Inject, Injectable } from '@nestjs/common';
+import { buildRunSk, deriveRunStatus } from '@hyveon/shared';
+import type { RunKind, RunRecord, RunRecordStore } from '@hyveon/shared';
+import { logger } from '../logger.js';
+import { ConfigService } from './ConfigService.js';
+import { RUN_RECORD_STORE } from '../modules/cloud-provider.tokens.js';
+
+/**
+ * Maximum size, in UTF-8 encoded bytes, of a captured run log that
+ * {@link RunRecordService.persist} will embed directly on the persisted
+ * `RunRecord.log` attribute instead of offloading to the store's remote file
+ * backend (S3 for AWS, via {@link RunRecordStore.putLog}). Set to 350KB
+ * (`350 * 1024`) — well under DynamoDB's 400KB item size limit once the
+ * record's other attributes are accounted for. This intentionally deviates
+ * from the 5MB figure floated in issue #179: 5MB is roughly an order of
+ * magnitude past DynamoDB's hard per-item ceiling, so a log anywhere near
+ * that size could never be embedded inline regardless — 350KB is the
+ * largest threshold that still leaves comfortable headroom for the rest of
+ * the item.
+ */
+export const INLINE_LOG_LIMIT_BYTES = 350 * 1024;
+
+/**
+ * Input to {@link RunRecordService.persist} — everything about a finished
+ * `terraform` run except its derived `status`, sort key, and captured log,
+ * which the service fills in / reads itself (`status` via
+ * {@link deriveRunStatus}, `sk` via {@link buildRunSk}, log contents from the
+ * `logFilePath` passed alongside these params).
+ */
+export interface PersistRunRecordParams {
+  /** Unique identifier of the run — matches the `runId` minted by `TerraformService` when the subcommand was spawned. */
+  runId: string;
+  /** Which `terraform` subcommand produced this run. */
+  kind: RunKind;
+  /** ISO-8601 timestamp captured immediately before the process was spawned. */
+  startedAt: string;
+  /** ISO-8601 timestamp captured immediately after the process closed. */
+  completedAt: string;
+  /** The process's exit code, or `null` if it never reported one (e.g. killed via abort signal). */
+  exitCode: number | null;
+  /** The tfvars version id the run was executed against, if the caller supplied one. */
+  tfvarsVersionId?: string;
+}
+
+/**
+ * Persists `terraform` plan/apply/destroy run history to (and resolves
+ * presigned log URLs from) the run-history DynamoDB table + remote log
+ * storage via the injected {@link RunRecordStore}. See the file-level doc
+ * comment above for the best-effort-write contract.
+ */
+@Injectable()
+export class RunRecordService {
+  /**
+   * `store` is typed against the cloud-agnostic `RunRecordStore` contract
+   * (not a concrete AWS class) so this service depends only on the
+   * interface; `@Inject(RUN_RECORD_STORE)` tells Nest which concrete
+   * provider (bound by `CloudProviderModule` for whichever cloud is active)
+   * to resolve for that parameter, since interfaces don't survive to
+   * runtime for Nest's reflection-based DI to key off of.
+   */
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(RUN_RECORD_STORE) private readonly store: RunRecordStore,
+  ) {}
+
+  /**
+   * Builds a {@link RunRecord} from `params` (`status` derived via
+   * {@link deriveRunStatus}, `sk` via {@link buildRunSk}) and persists it via
+   * `store.putRecord`.
+   *
+   * Never throws, and never lets a run-history write failure mask (or
+   * retroactively fail) the `terraform` run it describes:
+   *
+   * - When `runs_table_name` isn't in the Terraform outputs yet (table not
+   *   deployed — the same chicken-and-egg case `AuditService.record` guards
+   *   against, since the very `terraform apply` that creates the table
+   *   can't itself be recorded to it), a winston warning is logged and the
+   *   method returns without touching `store` at all.
+   * - `logFilePath`, when non-`null`, is read via the filesystem and
+   *   embedded on `RunRecord.log` when at or under
+   *   {@link INLINE_LOG_LIMIT_BYTES} (UTF-8 encoded), or offloaded first via
+   *   `store.putLog` (which, for `AwsRunRecordStore`, lands at
+   *   `runs/<runId>.log`) with the store-assigned key stored on
+   *   `RunRecord.log` instead of the raw text. `logFilePath` being `null`
+   *   leaves `RunRecord.log` unset entirely — no read/offload attempt is
+   *   made.
+   * - If the log file can't be read, or an oversized log fails to offload
+   *   (e.g. no remote file store configured, or the offload call fails),
+   *   a winston warning is logged and the record is still persisted via
+   *   `store.putRecord` — just without a `log` attribute — rather than
+   *   abandoning the whole write. Losing the log transcript is preferable
+   *   to losing the run's existence/status from history.
+   * - If the final `store.putRecord` call itself fails, a winston warning is
+   *   logged and the method returns.
+   *
+   * @param params - Everything about the finished run except its log.
+   * @param logFilePath - Path to the run's captured stdout+stderr transcript
+   *   on disk, or `null` when no log was captured for this run.
+   */
+  async persist(params: PersistRunRecordParams, logFilePath: string | null): Promise<void> {
+    const tableName = this.config.getTfOutputs()?.runs_table_name;
+    if (!tableName) {
+      logger.warn('RunRecordService.persist: runs_table_name not configured, skipping run record persistence', {
+        runId: params.runId,
+        kind: params.kind,
+      });
+      return;
+    }
+
+    let log: string | undefined;
+    if (logFilePath !== null) {
+      let logText: string | undefined;
+      try {
+        logText = readFileSync(logFilePath, 'utf8');
+      } catch (err) {
+        logger.warn('RunRecordService.persist: failed to read captured log file, persisting record without log', {
+          err,
+          runId: params.runId,
+          kind: params.kind,
+          logFilePath,
+        });
+      }
+
+      if (logText !== undefined) {
+        const byteLength = Buffer.byteLength(logText, 'utf8');
+        if (byteLength > INLINE_LOG_LIMIT_BYTES) {
+          try {
+            log = await this.store.putLog(params.runId, new TextEncoder().encode(logText));
+          } catch (err) {
+            logger.warn(
+              'RunRecordService.persist: failed to offload log to remote store, persisting record without log',
+              { err, runId: params.runId, kind: params.kind },
+            );
+          }
+        } else {
+          log = logText;
+        }
+      }
+    }
+
+    try {
+      const record: RunRecord = {
+        sk: buildRunSk(params.startedAt, params.runId),
+        runId: params.runId,
+        kind: params.kind,
+        status: deriveRunStatus(params.exitCode),
+        startedAt: params.startedAt,
+        completedAt: params.completedAt,
+        exitCode: params.exitCode,
+        ...(params.tfvarsVersionId !== undefined ? { tfvarsVersionId: params.tfvarsVersionId } : {}),
+        ...(log !== undefined ? { log } : {}),
+      };
+
+      await this.store.putRecord(record);
+    } catch (err) {
+      logger.warn('RunRecordService.persist: failed to persist run record', {
+        err,
+        runId: params.runId,
+        kind: params.kind,
+      });
+    }
+  }
+
+  /**
+   * Resolves a temporary, fetchable URL for a previously stored run log,
+   * delegating directly to `store.getLogUrl` — `logKey` is expected to be a
+   * value previously stored on `RunRecord.log` by {@link persist} once a log
+   * was offloaded (embedded logs have no key to resolve a URL for).
+   *
+   * @param logKey - The key returned by a prior offload, as stored on `RunRecord.log`.
+   * @param expiresInSeconds - How long the returned URL should remain valid, in
+   *   seconds. The underlying store applies its own default when omitted.
+   * @returns The store's presigned/temporary URL the caller can fetch the log from directly.
+   */
+  async getLogUrl(logKey: string, expiresInSeconds?: number): Promise<string> {
+    return this.store.getLogUrl(logKey, expiresInSeconds);
+  }
+}

--- a/app/packages/desktop-main/src/services/RunRecordService.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.ts
@@ -4,9 +4,11 @@
  * history table (`terraform/aws/runs_store.tf`).
  *
  * `persist()` decides, per call, whether a run's captured log is small
- * enough to embed directly on the `RunRecord.log` attribute or must be
+ * enough to embed directly on the `RunRecord.logInline` attribute or must be
  * offloaded to the store's remote file backend (S3 for AWS) via
- * `RunRecordStore.putLog` — see {@link INLINE_LOG_LIMIT_BYTES}. It is
+ * `RunRecordStore.putLog`, with the resulting key stored on
+ * `RunRecord.logS3Key` instead — see {@link INLINE_LOG_LIMIT_BYTES}. The two
+ * attributes are mutually exclusive; a record never has both set. It is
  * intentionally best-effort: a run-history write failure must never mask
  * (or retroactively fail) an otherwise-successful `terraform` run, so every
  * failure path logs a winston warning and falls back to the least-lossy
@@ -24,8 +26,8 @@ import { RUN_RECORD_STORE } from '../modules/cloud-provider.tokens.js';
 /**
  * Maximum size, in UTF-8 encoded bytes, of a captured run log that
  * {@link RunRecordService.persist} will embed directly on the persisted
- * `RunRecord.log` attribute instead of offloading to the store's remote file
- * backend (S3 for AWS, via {@link RunRecordStore.putLog}). Set to 350KB
+ * `RunRecord.logInline` attribute instead of offloading to the store's
+ * remote file backend (S3 for AWS, via {@link RunRecordStore.putLog}). Set to 350KB
  * (`350 * 1024`) — well under DynamoDB's 400KB item size limit once the
  * record's other attributes are accounted for. This intentionally deviates
  * from the 5MB figure floated in issue #179: 5MB is roughly an order of
@@ -93,19 +95,20 @@ export class RunRecordService {
    *   can't itself be recorded to it), a winston warning is logged and the
    *   method returns without touching `store` at all.
    * - `logFilePath`, when non-`null`, is read via the filesystem and
-   *   embedded on `RunRecord.log` when at or under
+   *   embedded on `RunRecord.logInline` when at or under
    *   {@link INLINE_LOG_LIMIT_BYTES} (UTF-8 encoded), or offloaded first via
    *   `store.putLog` (which, for `AwsRunRecordStore`, lands at
    *   `runs/<runId>.log`) with the store-assigned key stored on
-   *   `RunRecord.log` instead of the raw text. `logFilePath` being `null`
-   *   leaves `RunRecord.log` unset entirely — no read/offload attempt is
-   *   made.
+   *   `RunRecord.logS3Key` instead — `logInline` and `logS3Key` are mutually
+   *   exclusive, so callers (e.g. `getLogUrl`) can tell which one they got
+   *   without guessing. `logFilePath` being `null` leaves both attributes
+   *   unset entirely — no read/offload attempt is made.
    * - If the log file can't be read, or an oversized log fails to offload
    *   (e.g. no remote file store configured, or the offload call fails),
    *   a winston warning is logged and the record is still persisted via
-   *   `store.putRecord` — just without a `log` attribute — rather than
-   *   abandoning the whole write. Losing the log transcript is preferable
-   *   to losing the run's existence/status from history.
+   *   `store.putRecord` — just without a `logInline`/`logS3Key` attribute —
+   *   rather than abandoning the whole write. Losing the log transcript is
+   *   preferable to losing the run's existence/status from history.
    * - If the final `store.putRecord` call itself fails, a winston warning is
    *   logged and the method returns.
    *
@@ -123,7 +126,8 @@ export class RunRecordService {
       return;
     }
 
-    let log: string | undefined;
+    let logInline: string | undefined;
+    let logS3Key: string | undefined;
     if (logFilePath !== null) {
       let logText: string | undefined;
       try {
@@ -141,7 +145,7 @@ export class RunRecordService {
         const byteLength = Buffer.byteLength(logText, 'utf8');
         if (byteLength > INLINE_LOG_LIMIT_BYTES) {
           try {
-            log = await this.store.putLog(params.runId, new TextEncoder().encode(logText));
+            logS3Key = await this.store.putLog(params.runId, new TextEncoder().encode(logText));
           } catch (err) {
             logger.warn(
               'RunRecordService.persist: failed to offload log to remote store, persisting record without log',
@@ -149,7 +153,7 @@ export class RunRecordService {
             );
           }
         } else {
-          log = logText;
+          logInline = logText;
         }
       }
     }
@@ -164,7 +168,8 @@ export class RunRecordService {
         completedAt: params.completedAt,
         exitCode: params.exitCode,
         ...(params.tfvarsVersionId !== undefined ? { tfvarsVersionId: params.tfvarsVersionId } : {}),
-        ...(log !== undefined ? { log } : {}),
+        ...(logInline !== undefined ? { logInline } : {}),
+        ...(logS3Key !== undefined ? { logS3Key } : {}),
       };
 
       await this.store.putRecord(record);
@@ -180,10 +185,11 @@ export class RunRecordService {
   /**
    * Resolves a temporary, fetchable URL for a previously stored run log,
    * delegating directly to `store.getLogUrl` — `logKey` is expected to be a
-   * value previously stored on `RunRecord.log` by {@link persist} once a log
-   * was offloaded (embedded logs have no key to resolve a URL for).
+   * value previously stored on `RunRecord.logS3Key` by {@link persist} once a
+   * log was offloaded (embedded logs, stored on `RunRecord.logInline`
+   * instead, have no key to resolve a URL for).
    *
-   * @param logKey - The key returned by a prior offload, as stored on `RunRecord.log`.
+   * @param logKey - The key returned by a prior offload, as stored on `RunRecord.logS3Key`.
    * @param expiresInSeconds - How long the returned URL should remain valid, in
    *   seconds. The underlying store applies its own default when omitted.
    * @returns The store's presigned/temporary URL the caller can fetch the log from directly.

--- a/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
@@ -593,8 +593,12 @@ describe('TerraformService.apply abort handling', () => {
     child.close(null);
     await returnPromise;
 
-    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    // One write for run.json, one for the accumulated terraform.log — both
+    // persisted from the outer finally's force-killed branch.
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+    const [path, contents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === '/repo/runs/run-31/run.json',
+    ) as [string, string];
     expect(path).toBe('/repo/runs/run-31/run.json');
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.runId).toBe('run-31');
@@ -620,8 +624,11 @@ describe('TerraformService.apply run.json persistence', () => {
     );
 
     expect(mkdirSyncMock).toHaveBeenCalledWith('/repo/runs/run-16', { recursive: true });
-    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    // One write for run.json, one for the accumulated terraform.log.
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+    const [path, contents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === '/repo/runs/run-16/run.json',
+    ) as [string, string];
     expect(path).toBe('/repo/runs/run-16/run.json');
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.runId).toBe('run-16');
@@ -648,7 +655,9 @@ describe('TerraformService.apply run.json persistence', () => {
       ),
     ).rejects.toBeInstanceOf(TerraformApplyError);
 
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    const [path, contents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === '/repo/runs/run-17/run.json',
+    ) as [string, string];
     expect(path).toBe('/repo/runs/run-17/run.json');
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.exitCode).toBe(1);
@@ -672,10 +681,127 @@ describe('TerraformService.apply run.json persistence', () => {
     child.close(null);
     await pendingNext;
 
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    const [path, contents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === '/repo/runs/run-18/run.json',
+    ) as [string, string];
     expect(path).toBe('/repo/runs/run-18/run.json');
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.exitCode).toBeNull();
+  });
+});
+
+describe('TerraformService.apply run log capture', () => {
+  it('should write the accumulated stdout+stderr transcript to <runsDir>/<runId>/terraform.log in a single writeFileSync once the process closes', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+
+    await collectApplyChunks(service.apply('run-32', undefined, '/repo/runs/run-32/run-32.tfplan'), () => {
+      child.emitStdout('aws_instance.game: Creating...\n');
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-32/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('aws_instance.game: Creating...\nWarning: something\n');
+  });
+
+  it('should still write the accumulated transcript to terraform.log when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+
+    await expect(
+      collectApplyChunks(service.apply('run-33', undefined, '/repo/runs/run-33/run-33.tfplan'), () => {
+        child.emitStdout('Error: something went wrong\n');
+        child.close(1);
+      }),
+    ).rejects.toBeInstanceOf(TerraformApplyError);
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-33/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('Error: something went wrong\n');
+  });
+
+  it('should still write whatever transcript was captured to terraform.log when the run is aborted mid-flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const gen = service.apply('run-34', undefined, '/repo/runs/run-34/run-34.tfplan', controller.signal);
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Creating...\n');
+    const firstResult = await first;
+    expect(firstResult.done).toBe(false);
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const secondResult = await gen.next();
+    expect(secondResult.done).toBe(true);
+    expect(secondResult.value).toBeUndefined();
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-34/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('aws_instance.game: Creating...\n');
+  });
+
+  it('should write whatever transcript was captured to terraform.log when the generator is force-closed early', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const gen = service.apply('run-35', undefined, '/repo/runs/run-35/run-35.tfplan');
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Creating...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    child.close(null);
+    await returnPromise;
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-35/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('aws_instance.game: Creating...\n');
   });
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
@@ -6,14 +6,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * vi.mock() calls are lifted to the top of the compiled output above regular
  * declarations.
  */
-const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock } = vi.hoisted(() => {
-  const execFileMock = vi.fn();
-  const spawnMock = vi.fn();
-  const mkdirSyncMock = vi.fn();
-  const writeFileSyncMock = vi.fn();
-  const existsSyncMock = vi.fn();
-  return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock };
-});
+const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock } =
+  vi.hoisted(() => {
+    const execFileMock = vi.fn();
+    const spawnMock = vi.fn();
+    const mkdirSyncMock = vi.fn();
+    const writeFileSyncMock = vi.fn();
+    const existsSyncMock = vi.fn();
+    const runRecordPersistMock = vi.fn();
+    return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock };
+  });
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
@@ -38,6 +40,7 @@ import {
   type TerraformRunRecord,
 } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RunRecordService } from './RunRecordService.js';
 import type { RemoteFileStore } from '@hyveon/shared';
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
@@ -111,6 +114,16 @@ function stubRemoteFileStore(): RemoteFileStore & {
   return store as RemoteFileStore & {
     listVersions: ReturnType<typeof vi.fn>;
   };
+}
+
+/**
+ * `RunRecordService` stub for `apply()` tests: `persist` is backed by the
+ * shared, hoisted `runRecordPersistMock` so tests can assert on the exact
+ * `RunRecord` params and log path `apply()` persisted, regardless of which
+ * test constructed the `TerraformService` instance under test.
+ */
+function stubRunRecordService(): RunRecordService {
+  return { persist: runRecordPersistMock } as Partial<RunRecordService> as RunRecordService;
 }
 
 /**
@@ -206,6 +219,7 @@ beforeEach(() => {
   // pre-spawn existsSync(planFile) guard aren't tripped up by it — only the
   // dedicated "missing planFile" test below overrides this.
   existsSyncMock.mockReturnValue(true);
+  runRecordPersistMock.mockReset();
 });
 
 describe('TerraformService.apply stale-plan guard', () => {
@@ -221,6 +235,7 @@ describe('TerraformService.apply stale-plan guard', () => {
     const service = new TerraformService(
       stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await expect(
@@ -245,6 +260,7 @@ describe('TerraformService.apply stale-plan guard', () => {
     const service = new TerraformService(
       stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await collectApplyChunks(service.apply('run-2', 'v2', '/repo/runs/run-2/run-2.tfplan'), () =>
@@ -265,7 +281,7 @@ describe('TerraformService.apply stale-plan guard', () => {
     queueSpawn(child);
 
     const remoteFileStore = stubRemoteFileStore();
-    const service = new TerraformService(stubApplyConfigService({ tfvarsBucket: null }), remoteFileStore);
+    const service = new TerraformService(stubApplyConfigService({ tfvarsBucket: null }), remoteFileStore, stubRunRecordService());
 
     await collectApplyChunks(service.apply('run-3', 'v1', '/repo/runs/run-3/run-3.tfplan'), () =>
       child.close(0),
@@ -284,6 +300,7 @@ describe('TerraformService.apply stale-plan guard', () => {
     const service = new TerraformService(
       stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await collectApplyChunks(service.apply('run-4', undefined, '/repo/runs/run-4/run-4.tfplan'), () =>
@@ -297,7 +314,7 @@ describe('TerraformService.apply stale-plan guard', () => {
   it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(
       collectApplyChunks(service.apply('run-5', undefined, '/repo/runs/run-5/run-5.tfplan')),
@@ -312,7 +329,7 @@ describe('TerraformService.apply streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.apply('run-6', undefined, '/repo/runs/run-6/run-6.tfplan');
 
     // Drive and await the first yielded chunk *before* emitting stderr or
@@ -344,7 +361,7 @@ describe('TerraformService.apply summary parsing and return value', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const { result } = await collectApplyChunks(
       service.apply('run-7', undefined, '/repo/runs/run-7/run-7.tfplan'),
@@ -363,7 +380,7 @@ describe('TerraformService.apply summary parsing and return value', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const { result } = await collectApplyChunks(
       service.apply('run-8', undefined, '/repo/runs/run-8/run-8.tfplan'),
@@ -383,7 +400,7 @@ describe('TerraformService.apply exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectApplyChunks(service.apply('run-9', undefined, '/repo/runs/run-9/run-9.tfplan'), () =>
       child.close(1),
@@ -398,7 +415,7 @@ describe('TerraformService.apply exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectApplyChunks(
       service.apply('run-10', undefined, '/repo/runs/run-10/run-10.tfplan'),
@@ -413,7 +430,7 @@ describe('TerraformService.apply planFile existence guard', () => {
   it('should throw a descriptive Error synchronously and never call spawn when planFile does not exist on disk', async () => {
     existsSyncMock.mockReturnValue(false);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.apply('run-25', undefined, '/repo/runs/run-25/run-25.tfplan');
 
     await expect(gen.next()).rejects.toThrow(/plan file .* does not exist/i);
@@ -430,7 +447,7 @@ describe('TerraformService.apply abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.apply('run-11', undefined, '/repo/runs/run-11/run-11.tfplan', controller.signal);
 
     const pendingNext = gen.next();
@@ -452,7 +469,7 @@ describe('TerraformService.apply abort handling', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.apply('run-12', undefined, '/repo/runs/run-12/run-12.tfplan', controller.signal);
 
     const result = await gen.next();
@@ -472,6 +489,7 @@ describe('TerraformService.apply abort handling', () => {
     const service = new TerraformService(
       stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
     const gen = service.apply('run-26', 'v1', '/repo/runs/run-26/run-26.tfplan', controller.signal);
 
@@ -492,7 +510,7 @@ describe('TerraformService.apply abort handling', () => {
     });
     queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.apply('run-13', undefined, '/repo/runs/run-13/run-13.tfplan', controller.signal);
 
     const result = await gen.next();
@@ -515,6 +533,7 @@ describe('TerraformService.apply abort handling', () => {
     const service = new TerraformService(
       stubApplyConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
     const gen = service.apply('run-14', 'v1', '/repo/runs/run-14/run-14.tfplan', controller.signal);
 
@@ -530,7 +549,7 @@ describe('TerraformService.apply abort handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.apply('run-15', undefined, '/repo/runs/run-15/run-15.tfplan');
 
     // Drive the generator to its first yielded chunk, mirroring a consumer
@@ -573,6 +592,7 @@ describe('TerraformService.apply abort handling', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const gen = service.apply('run-31', 'v1', '/repo/runs/run-31/run-31.tfplan');
 
@@ -617,6 +637,7 @@ describe('TerraformService.apply run.json persistence', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await collectApplyChunks(service.apply('run-16', 'v1', '/repo/runs/run-16/run-16.tfplan'), () =>
@@ -647,6 +668,7 @@ describe('TerraformService.apply run.json persistence', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await expect(
@@ -672,6 +694,7 @@ describe('TerraformService.apply run.json persistence', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const gen = service.apply('run-18', undefined, '/repo/runs/run-18/run-18.tfplan', controller.signal);
 
@@ -690,6 +713,160 @@ describe('TerraformService.apply run.json persistence', () => {
   });
 });
 
+describe('TerraformService.apply RunRecordService persistence', () => {
+  it('should call RunRecordService.persist exactly once with a matching RunRecord and the captured terraform.log path when the process exits cleanly', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    await collectApplyChunks(service.apply('run-store-16', 'v1', '/repo/runs/run-store-16/run-store-16.tfplan'), () =>
+      child.close(0),
+    );
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string },
+      string,
+    ];
+    expect(params).toMatchObject({
+      runId: 'run-store-16',
+      kind: 'apply',
+      exitCode: 0,
+      tfvarsVersionId: 'v1',
+    });
+    expect(logFilePath).toBe('/repo/runs/run-store-16/terraform.log');
+
+    // The persisted record's timestamps must match the local run.json's own
+    // timestamps — both are written from the same captured values.
+    const [, localContents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === '/repo/runs/run-store-16/run.json',
+    ) as [string, string];
+    const localRecord = JSON.parse(localContents) as TerraformRunRecord;
+    expect((params as { startedAt: string }).startedAt).toBe(localRecord.startedAt);
+    expect((params as { completedAt: string }).completedAt).toBe(localRecord.completedAt);
+  });
+
+  it('should call RunRecordService.persist exactly once with the non-zero exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    await expect(
+      collectApplyChunks(
+        service.apply('run-store-17', undefined, '/repo/runs/run-store-17/run-store-17.tfplan'),
+        () => child.close(1),
+      ),
+    ).rejects.toBeInstanceOf(TerraformApplyError);
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-store-17', kind: 'apply', exitCode: 1 });
+    expect(logFilePath).toBe('/repo/runs/run-store-17/terraform.log');
+  });
+
+  it('should call RunRecordService.persist exactly once with a null exit code when the run was aborted mid-flight', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const controller = new AbortController();
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const gen = service.apply('run-store-18', undefined, '/repo/runs/run-store-18/run-store-18.tfplan', controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+    controller.abort();
+    child.close(null);
+    await pendingNext;
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-store-18', kind: 'apply', exitCode: null });
+    expect(logFilePath).toBe('/repo/runs/run-store-18/terraform.log');
+  });
+
+  it('should call RunRecordService.persist exactly once with a null exit code when the generator is force-closed before the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const gen = service.apply('run-store-31', 'v1', '/repo/runs/run-store-31/run-store-31.tfplan');
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Creating...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    child.close(null);
+    await returnPromise;
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-store-31', kind: 'apply', exitCode: null, tfvarsVersionId: 'v1' });
+    expect(logFilePath).toBe('/repo/runs/run-store-31/terraform.log');
+  });
+
+  it('should still resolve the generator with the real apply result when RunRecordService.persist rejects', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockRejectedValue(new Error('DynamoDB unavailable'));
+
+    const service = new TerraformService(
+      stubApplyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    const { result } = await collectApplyChunks(
+      service.apply('run-store-32', 'v1', '/repo/runs/run-store-32/run-store-32.tfplan'),
+      () => {
+        child.emitStdout('Apply complete! Resources: 3 added, 1 changed, 0 destroyed.\n');
+        child.close(0);
+      },
+    );
+
+    expect(result).toMatchObject({ runId: 'run-store-32', added: 3, changed: 1, destroyed: 0 });
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('TerraformService.apply run log capture', () => {
   it('should write the accumulated stdout+stderr transcript to <runsDir>/<runId>/terraform.log in a single writeFileSync once the process closes', async () => {
     queueSuccessfulResolution();
@@ -699,6 +876,7 @@ describe('TerraformService.apply run log capture', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await collectApplyChunks(service.apply('run-32', undefined, '/repo/runs/run-32/run-32.tfplan'), () => {
@@ -723,6 +901,7 @@ describe('TerraformService.apply run log capture', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await expect(
@@ -749,6 +928,7 @@ describe('TerraformService.apply run log capture', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const gen = service.apply('run-34', undefined, '/repo/runs/run-34/run-34.tfplan', controller.signal);
 
@@ -783,6 +963,7 @@ describe('TerraformService.apply run log capture', () => {
     const service = new TerraformService(
       stubApplyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const gen = service.apply('run-35', undefined, '/repo/runs/run-35/run-35.tfplan');
 
@@ -811,7 +992,7 @@ describe('TerraformService.apply concurrency guard', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const firstGen = service.apply('run-19', undefined, '/repo/runs/run-19/run-19.tfplan');
     const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
 
@@ -830,7 +1011,7 @@ describe('TerraformService.apply concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectApplyChunks(service.apply('run-21', undefined, '/repo/runs/run-21/run-21.tfplan'), () =>
       firstChild.close(0),
     );
@@ -850,7 +1031,7 @@ describe('TerraformService.apply concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await expect(
       collectApplyChunks(service.apply('run-23', undefined, '/repo/runs/run-23/run-23.tfplan'), () =>
         firstChild.close(1),
@@ -874,7 +1055,7 @@ describe('TerraformService.apply cross-subcommand lock enforcement', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const planGen = service.plan();
     const planNext = planGen.next(); // starts plan()'s body, setting the shared in-flight flag synchronously
 
@@ -893,7 +1074,7 @@ describe('TerraformService.apply cross-subcommand lock enforcement', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const initGen = service.init(sampleInitConfig);
     const initNext = initGen.next(); // starts init()'s body, setting the shared in-flight flag synchronously
 
@@ -912,7 +1093,7 @@ describe('TerraformService.apply cross-subcommand lock enforcement', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const applyGen = service.apply('run-29', undefined, '/repo/runs/run-29/run-29.tfplan');
     const applyNext = applyGen.next(); // starts apply()'s body, setting the shared in-flight flag synchronously
 
@@ -931,7 +1112,7 @@ describe('TerraformService.apply cross-subcommand lock enforcement', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubApplyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const applyGen = service.apply('run-30', undefined, '/repo/runs/run-30/run-30.tfplan');
     const applyNext = applyGen.next(); // starts apply()'s body, setting the shared in-flight flag synchronously
 

--- a/app/packages/desktop-main/src/services/TerraformService.destroy.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.destroy.test.ts
@@ -6,14 +6,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * vi.mock() calls are lifted to the top of the compiled output above regular
  * declarations.
  */
-const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock } = vi.hoisted(() => {
-  const execFileMock = vi.fn();
-  const spawnMock = vi.fn();
-  const mkdirSyncMock = vi.fn();
-  const writeFileSyncMock = vi.fn();
-  const existsSyncMock = vi.fn();
-  return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock };
-});
+const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock } =
+  vi.hoisted(() => {
+    const execFileMock = vi.fn();
+    const spawnMock = vi.fn();
+    const mkdirSyncMock = vi.fn();
+    const writeFileSyncMock = vi.fn();
+    const existsSyncMock = vi.fn();
+    const runRecordPersistMock = vi.fn();
+    return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock };
+  });
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
@@ -42,6 +44,7 @@ import {
   type TerraformRunRecord,
 } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RunRecordService } from './RunRecordService.js';
 import type { RemoteFileStore } from '@hyveon/shared';
 import { logger } from '../logger.js';
 
@@ -121,6 +124,16 @@ function stubRemoteFileStore(): RemoteFileStore {
     listVersions: vi.fn(),
   };
   return store as RemoteFileStore;
+}
+
+/**
+ * `RunRecordService` stub for `destroy()` tests: `persist` is backed by the
+ * shared, hoisted `runRecordPersistMock` so tests can assert on the exact
+ * `RunRecord` params and log path `destroy()` persisted, regardless of which
+ * test constructed the `TerraformService` instance under test.
+ */
+function stubRunRecordService(): RunRecordService {
+  return { persist: runRecordPersistMock } as Partial<RunRecordService> as RunRecordService;
 }
 
 /**
@@ -205,11 +218,12 @@ beforeEach(() => {
   mkdirSyncMock.mockReset();
   writeFileSyncMock.mockReset();
   existsSyncMock.mockReset();
+  runRecordPersistMock.mockReset();
 });
 
 describe('TerraformService.destroy confirmation gate', () => {
   it('should reject with a DestroyNotConfirmedError instance and never call spawn when no confirmation token has ever been minted', async () => {
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectDestroyChunks(service.destroy('guessed-token'))).rejects.toBeInstanceOf(
       DestroyNotConfirmedError,
@@ -220,7 +234,7 @@ describe('TerraformService.destroy confirmation gate', () => {
   });
 
   it('should reject with a DestroyNotConfirmedError instance and never call spawn when the supplied token does not match the most recently minted token', async () => {
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     service.mintDestroyConfirmationToken();
 
     await expect(collectDestroyChunks(service.destroy('some-other-token'))).rejects.toBeInstanceOf(
@@ -230,7 +244,7 @@ describe('TerraformService.destroy confirmation gate', () => {
   });
 
   it('should reject with a DestroyNotConfirmedError instance when the most recently minted token has expired', async () => {
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const dateNowSpy = vi.spyOn(Date, 'now');
     dateNowSpy.mockReturnValueOnce(1_000_000);
@@ -244,7 +258,7 @@ describe('TerraformService.destroy confirmation gate', () => {
   });
 
   it('should reject with a DestroyNotConfirmedError instance on a second destroy() call reusing an already-consumed token', async () => {
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const token = service.mintDestroyConfirmationToken();
 
     // Consume the token via a first call whose signal is already aborted —
@@ -269,6 +283,7 @@ describe('TerraformService.destroy confirmed run', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ terraformDir: '/repo/terraform', runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
 
@@ -313,6 +328,7 @@ describe('TerraformService.destroy confirmed run', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
 
@@ -335,7 +351,7 @@ describe('TerraformService.destroy confirmed run', () => {
   it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved, even with a valid confirmation token', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const token = service.mintDestroyConfirmationToken();
 
     await expect(collectDestroyChunks(service.destroy(token))).rejects.toBeInstanceOf(TerraformNotFoundError);
@@ -350,7 +366,7 @@ describe('TerraformService.destroy concurrency guard', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const firstToken = service.mintDestroyConfirmationToken();
     const firstGen = service.destroy(firstToken);
     const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
@@ -375,6 +391,7 @@ describe('TerraformService.destroy concurrency guard', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const applyGen = service.apply('run-1', undefined, '/repo/runs/run-1/run-1.tfplan');
     const applyNext = applyGen.next(); // starts apply()'s body, setting the shared in-flight flag synchronously
@@ -399,7 +416,7 @@ describe('TerraformService.destroy concurrency guard', () => {
     // spawn (and the shared workspace lock) the same way destroy() would.
     existsSyncMock.mockReturnValue(true);
 
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const planGen = service.plan();
     const planNext = planGen.next(); // starts plan()'s body, setting the shared in-flight flag synchronously
 
@@ -434,6 +451,7 @@ describe('TerraformService.destroy run.json persistence failure', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
 
@@ -466,7 +484,7 @@ describe('TerraformService.destroy forced early termination', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubDestroyConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const token = service.mintDestroyConfirmationToken();
     const gen = service.destroy(token);
 
@@ -510,6 +528,7 @@ describe('TerraformService.destroy forced early termination', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
     const gen = service.destroy(token);
@@ -545,6 +564,131 @@ describe('TerraformService.destroy forced early termination', () => {
   });
 });
 
+describe('TerraformService.destroy RunRecordService persistence', () => {
+  it('should call RunRecordService.persist exactly once with a matching RunRecord and the captured terraform.log path when the process exits cleanly', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+
+    const { result } = await collectDestroyChunks(service.destroy(token), () => {
+      child.emitStdout('Destroy complete! Resources: 3 destroyed.\n');
+      child.close(0);
+    });
+    const runId = result?.runId as string;
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null },
+      string,
+    ];
+    expect(params).toMatchObject({ runId, kind: 'destroy', exitCode: 0 });
+    expect(logFilePath).toBe(`/repo/runs/${runId}/terraform.log`);
+
+    // The persisted record's timestamps must match the local run.json's own
+    // timestamps — both are written from the same captured values.
+    const [, localContents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === `/repo/runs/${runId}/run.json`,
+    ) as [string, string];
+    const localRecord = JSON.parse(localContents) as TerraformRunRecord;
+    expect((params as { startedAt: string }).startedAt).toBe(localRecord.startedAt);
+    expect((params as { completedAt: string }).completedAt).toBe(localRecord.completedAt);
+  });
+
+  it('should call RunRecordService.persist exactly once with the non-zero exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+
+    const pending = collectDestroyChunks(service.destroy(token), () => child.close(1));
+    await expect(pending).rejects.toBeInstanceOf(TerraformDestroyError);
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params] = runRecordPersistMock.mock.calls[0] as [{ runId: string; kind: string; exitCode: number | null }];
+    expect(params).toMatchObject({ kind: 'destroy', exitCode: 1 });
+  });
+
+  it('should call RunRecordService.persist exactly once with a null exit code when the generator is force-closed before the process exits', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+    const gen = service.destroy(token);
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Destroying...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    child.close(null);
+    await returnPromise;
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params] = runRecordPersistMock.mock.calls[0] as [{ runId: string; kind: string; exitCode: number | null }];
+    expect(params).toMatchObject({ kind: 'destroy', exitCode: null });
+  });
+
+  it('should never call RunRecordService.persist when the run never spawns (e.g. no confirmation token was minted)', async () => {
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    await expect(
+      collectDestroyChunks(service.destroy('guessed-token')),
+    ).rejects.toBeInstanceOf(DestroyNotConfirmedError);
+
+    expect(runRecordPersistMock).not.toHaveBeenCalled();
+  });
+
+  it('should still resolve the generator with the real destroy result when RunRecordService.persist rejects', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockRejectedValue(new Error('DynamoDB unavailable'));
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+
+    const { result } = await collectDestroyChunks(service.destroy(token), () => {
+      child.emitStdout('Destroy complete! Resources: 3 destroyed.\n');
+      child.close(0);
+    });
+
+    expect(result).toMatchObject({ destroyed: 3 });
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('TerraformService.destroy run log capture', () => {
   it('should write the accumulated stdout+stderr transcript to <runsDir>/<runId>/terraform.log in a single writeFileSync once the process closes', async () => {
     queueSuccessfulResolution();
@@ -554,6 +698,7 @@ describe('TerraformService.destroy run log capture', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
 
@@ -580,6 +725,7 @@ describe('TerraformService.destroy run log capture', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
 
@@ -606,6 +752,7 @@ describe('TerraformService.destroy run log capture', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
     const gen = service.destroy(token);
@@ -644,6 +791,7 @@ describe('TerraformService.destroy forced-cleanup persistence failure', () => {
     const service = new TerraformService(
       stubDestroyConfigService({ terraformDir: '/repo/terraform' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const token = service.mintDestroyConfirmationToken();
     const gen = service.destroy(token);

--- a/app/packages/desktop-main/src/services/TerraformService.destroy.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.destroy.test.ts
@@ -291,8 +291,11 @@ describe('TerraformService.destroy confirmed run', () => {
     expect(typeof runId).toBe('string');
 
     expect(mkdirSyncMock).toHaveBeenCalledWith(`/repo/runs/${runId}`, { recursive: true });
-    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    // One write for run.json, one for the accumulated terraform.log.
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+    const [path, contents] = writeFileSyncMock.mock.calls.find(
+      ([callPath]) => callPath === `/repo/runs/${runId}/run.json`,
+    ) as [string, string];
     expect(path).toBe(`/repo/runs/${runId}/run.json`);
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.runId).toBe(runId);
@@ -318,8 +321,11 @@ describe('TerraformService.destroy confirmed run', () => {
     await expect(pending).rejects.toBeInstanceOf(TerraformDestroyError);
     await expect(pending).rejects.toMatchObject({ exitCode: 1 });
 
-    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    // One write for run.json, one for the accumulated terraform.log.
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+    const [path, contents] = writeFileSyncMock.mock.calls.find(([callPath]) =>
+      (callPath as string).endsWith('run.json'),
+    ) as [string, string];
     expect(path).toMatch(/^\/repo\/runs\/.+\/run\.json$/);
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.kind).toBe('destroy');
@@ -415,8 +421,14 @@ describe('TerraformService.destroy run.json persistence failure', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
     const persistFailure = new Error('ENOSPC: no space left on device');
-    writeFileSyncMock.mockImplementationOnce(() => {
-      throw persistFailure;
+    // Only the run.json write fails — the terraform.log write (which now
+    // also happens once the process closes) uses the default no-op mock, so
+    // this targets the specific writeFileSync call the assertions below care
+    // about regardless of the order the two writes happen in.
+    writeFileSyncMock.mockImplementation((path: unknown) => {
+      if (typeof path === 'string' && path.endsWith('run.json')) {
+        throw persistFailure;
+      }
     });
 
     const service = new TerraformService(
@@ -520,12 +532,100 @@ describe('TerraformService.destroy forced early termination', () => {
     child.close(null);
     await returnPromise;
 
-    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
-    const [path, contents] = writeFileSyncMock.mock.calls[0] as [string, string];
+    // One write for run.json, one for the accumulated terraform.log — both
+    // persisted from the outer finally's force-killed branch.
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+    const [path, contents] = writeFileSyncMock.mock.calls.find(([callPath]) =>
+      (callPath as string).endsWith('run.json'),
+    ) as [string, string];
     expect(path).toMatch(/^\/repo\/runs\/.+\/run\.json$/);
     const record = JSON.parse(contents) as TerraformRunRecord;
     expect(record.kind).toBe('destroy');
     expect(record.exitCode).toBeNull();
+  });
+});
+
+describe('TerraformService.destroy run log capture', () => {
+  it('should write the accumulated stdout+stderr transcript to <runsDir>/<runId>/terraform.log in a single writeFileSync once the process closes', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+
+    const { result } = await collectDestroyChunks(service.destroy(token), () => {
+      child.emitStdout('aws_instance.game: Destroying...\n');
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
+    const runId = result?.runId as string;
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === `/repo/runs/${runId}/terraform.log`,
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('aws_instance.game: Destroying...\nWarning: something\n');
+  });
+
+  it('should still write the accumulated transcript to terraform.log when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+
+    const pending = collectDestroyChunks(service.destroy(token), () => {
+      child.emitStdout('Error: something went wrong\n');
+      child.close(1);
+    });
+
+    await expect(pending).rejects.toBeInstanceOf(TerraformDestroyError);
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(([path]) =>
+      (path as string).endsWith('/terraform.log'),
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('Error: something went wrong\n');
+  });
+
+  it('should write whatever transcript was captured to terraform.log when the generator is force-closed early', async () => {
+    queueSuccessfulResolution();
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubDestroyConfigService({ runsDir: '/repo/runs' }),
+      stubRemoteFileStore(),
+    );
+    const token = service.mintDestroyConfirmationToken();
+    const gen = service.destroy(token);
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('aws_instance.game: Destroying...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    child.close(null);
+    await returnPromise;
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(([path]) =>
+      (path as string).endsWith('/terraform.log'),
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('aws_instance.game: Destroying...\n');
   });
 });
 
@@ -569,8 +669,9 @@ describe('TerraformService.destroy forced-cleanup persistence failure', () => {
     const result = await returnPromise;
 
     // The forced-cleanup writeRunRecord attempt is swallowed (best-effort)
-    // rather than crashing the generator's teardown or rejecting return().
+    // rather than crashing the generator's teardown or rejecting return() —
+    // and so is the equally-failing writeRunLog attempt alongside it.
     expect(result.done).toBe(true);
-    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/packages/desktop-main/src/services/TerraformService.init.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.init.test.ts
@@ -52,6 +52,7 @@ import {
   type TerraformPlanResult,
 } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RunRecordService } from './RunRecordService.js';
 import type { RemoteFileStore } from '@hyveon/shared';
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
@@ -134,6 +135,17 @@ function stubRemoteFileStore(): RemoteFileStore & {
     get: ReturnType<typeof vi.fn>;
     listVersions: ReturnType<typeof vi.fn>;
   };
+}
+
+/**
+ * Minimal `RunRecordService` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. This file's `plan()` usages only exercise the
+ * cross-subcommand locking behaviour alongside `init()`, not run-record
+ * persistence itself (see `TerraformService.plan.test.ts` for those
+ * assertions), so a no-op `persist` is enough.
+ */
+function stubRunRecordService(): RunRecordService {
+  return { persist: vi.fn().mockResolvedValue(undefined) } as Partial<RunRecordService> as RunRecordService;
 }
 
 /**
@@ -260,7 +272,7 @@ describe('TerraformService.init spawning', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService('/repo/terraform'), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService('/repo/terraform'), stubRemoteFileStore(), stubRunRecordService());
 
     await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
@@ -281,7 +293,7 @@ describe('TerraformService.init spawning', () => {
   it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectAllChunks(service.init(sampleConfig))).rejects.toBeInstanceOf(
       TerraformNotFoundError,
@@ -296,7 +308,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.init(sampleConfig);
 
     const first = gen.next();
@@ -327,7 +339,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => {
       child.emitStderr('Warning: something\n');
       child.close(0);
@@ -341,7 +353,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => {
       child.emitStdout('line one\nline two\nline three\n');
       child.close(0);
@@ -359,7 +371,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => {
       child.emitStdout('no trailing newline');
       child.close(0);
@@ -373,7 +385,7 @@ describe('TerraformService.init streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const chunks = await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
     expect(chunks).toEqual([]);
@@ -386,7 +398,7 @@ describe('TerraformService.init exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectAllChunks(service.init(sampleConfig), () => child.close(0))).resolves.toEqual(
       [],
@@ -398,7 +410,7 @@ describe('TerraformService.init exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectAllChunks(service.init(sampleConfig), () => child.close(1));
 
@@ -411,7 +423,7 @@ describe('TerraformService.init exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectAllChunks(service.init(sampleConfig), () =>
       child.emit('error', new Error('spawn ENOENT')),
@@ -427,7 +439,7 @@ describe('TerraformService.init idempotency', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -443,7 +455,7 @@ describe('TerraformService.init idempotency', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectAllChunks(service.init(sampleConfig), () => child.close(0));
 
     spawnMock.mockClear();
@@ -461,7 +473,7 @@ describe('TerraformService.init idempotency', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectAllChunks(service.init(sampleConfig), () => firstChild.close(0));
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -480,7 +492,7 @@ describe('TerraformService.init idempotency', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await expect(
       collectAllChunks(service.init(sampleConfig), () => firstChild.close(1)),
     ).rejects.toBeInstanceOf(TerraformInitError);
@@ -502,7 +514,7 @@ describe('TerraformService.init abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.init(sampleConfig, controller.signal);
 
     const pendingNext = gen.next();
@@ -526,7 +538,7 @@ describe('TerraformService.init abort handling', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.init(sampleConfig, controller.signal);
 
     const result = await gen.next();
@@ -542,7 +554,7 @@ describe('TerraformService.init abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const pendingNext = service.init(sampleConfig, controller.signal).next();
     await flushMicrotasks();
@@ -564,7 +576,7 @@ describe('TerraformService.init concurrency guard', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const firstGen = service.init(sampleConfig);
     const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
 
@@ -583,7 +595,7 @@ describe('TerraformService.init concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectAllChunks(service.init(sampleConfig), () => firstChild.close(0));
 
     const secondChild = new FakeChildProcess();
@@ -611,6 +623,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
         tfvarsPath: '/repo/terraform/terraform.tfvars',
       }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan(), () => child.close(0));
@@ -648,6 +661,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan(), () => child.close(0));
@@ -679,6 +693,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan('v2'), () => child.close(0));
@@ -700,6 +715,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await expect(collectPlanChunks(service.plan('v1'))).rejects.toThrow(/stale/i);
@@ -712,7 +728,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     queueSuccessfulResolution();
     existsSyncMock.mockReturnValue(false);
 
-    const service = new TerraformService(stubPlanConfigService({ tfvarsBucket: null }), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService({ tfvarsBucket: null }), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectPlanChunks(service.plan())).rejects.toThrow(/tfvars file not found/i);
     expect(spawnMock).not.toHaveBeenCalled();
@@ -721,7 +737,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
   it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectPlanChunks(service.plan())).rejects.toBeInstanceOf(TerraformNotFoundError);
     expect(spawnMock).not.toHaveBeenCalled();
@@ -734,7 +750,7 @@ describe('TerraformService.plan streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const { chunks } = await collectPlanChunks(service.plan(), () => {
       child.emitStdout('Refreshing state...\n');
       child.emitStderr('Warning: something\n');
@@ -756,6 +772,7 @@ describe('TerraformService.plan summary parsing and return value', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     const { result } = await collectPlanChunks(service.plan(), () => {
@@ -779,7 +796,7 @@ describe('TerraformService.plan summary parsing and return value', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const { result } = await collectPlanChunks(service.plan(), () => {
       child.emitStdout('No changes. Your infrastructure matches the configuration.\n');
@@ -796,7 +813,7 @@ describe('TerraformService.plan exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectPlanChunks(service.plan(), () => child.close(1));
 
@@ -812,7 +829,7 @@ describe('TerraformService.plan abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.plan(undefined, controller.signal);
 
     const pendingNext = gen.next();
@@ -834,7 +851,7 @@ describe('TerraformService.plan abort handling', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.plan(undefined, controller.signal);
 
     const result = await gen.next();
@@ -852,7 +869,7 @@ describe('TerraformService.plan concurrency guard', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const firstGen = service.plan();
     const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
 
@@ -871,7 +888,7 @@ describe('TerraformService.plan concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectPlanChunks(service.plan(), () => firstChild.close(0));
 
     const secondChild = new FakeChildProcess();

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -14,6 +14,7 @@ const {
   writeFileSyncMock,
   copyFileSyncMock,
   randomUUIDMock,
+  runRecordPersistMock,
 } = vi.hoisted(() => {
   const execFileMock = vi.fn();
   const spawnMock = vi.fn();
@@ -22,6 +23,7 @@ const {
   const writeFileSyncMock = vi.fn();
   const copyFileSyncMock = vi.fn();
   const randomUUIDMock = vi.fn();
+  const runRecordPersistMock = vi.fn();
   return {
     execFileMock,
     spawnMock,
@@ -30,6 +32,7 @@ const {
     writeFileSyncMock,
     copyFileSyncMock,
     randomUUIDMock,
+    runRecordPersistMock,
   };
 });
 
@@ -58,6 +61,7 @@ import {
   type TerraformPlanResult,
 } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RunRecordService } from './RunRecordService.js';
 import type { RemoteFileStore } from '@hyveon/shared';
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
@@ -131,6 +135,16 @@ function stubRemoteFileStore(): RemoteFileStore & {
     get: ReturnType<typeof vi.fn>;
     listVersions: ReturnType<typeof vi.fn>;
   };
+}
+
+/**
+ * `RunRecordService` stub for `plan()` tests: `persist` is backed by the
+ * shared, hoisted `runRecordPersistMock` so tests can assert on the exact
+ * `RunRecord` params and log path `plan()` persisted, regardless of which
+ * test constructed the `TerraformService` instance under test.
+ */
+function stubRunRecordService(): RunRecordService {
+  return { persist: runRecordPersistMock } as Partial<RunRecordService> as RunRecordService;
 }
 
 /**
@@ -218,6 +232,7 @@ beforeEach(() => {
   copyFileSyncMock.mockReset();
   randomUUIDMock.mockReset();
   randomUUIDMock.mockReturnValue('run-123');
+  runRecordPersistMock.mockReset();
 });
 
 describe('TerraformService.plan spawning and artifact persistence', () => {
@@ -235,6 +250,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
         tfvarsPath: '/repo/terraform/terraform.tfvars',
       }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan(), () => child.close(0));
@@ -272,6 +288,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan(), () => child.close(0));
@@ -303,6 +320,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan('v2'), () => child.close(0));
@@ -324,6 +342,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await expect(collectPlanChunks(service.plan('v1'))).rejects.toThrow(/stale/i);
@@ -341,6 +360,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars', tfvarsPath: '/repo/terraform/terraform.tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
 
     await expect(collectPlanChunks(service.plan())).rejects.toThrow(/not found in S3 bucket/i);
@@ -351,7 +371,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
     queueSuccessfulResolution();
     existsSyncMock.mockReturnValue(false);
 
-    const service = new TerraformService(stubPlanConfigService({ tfvarsBucket: null }), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService({ tfvarsBucket: null }), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectPlanChunks(service.plan())).rejects.toThrow(/tfvars file not found/i);
     expect(spawnMock).not.toHaveBeenCalled();
@@ -360,7 +380,7 @@ describe('TerraformService.plan spawning and artifact persistence', () => {
   it('should reject with a TerraformNotFoundError instance and never call spawn when the binary cannot be resolved', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(collectPlanChunks(service.plan())).rejects.toBeInstanceOf(TerraformNotFoundError);
     expect(spawnMock).not.toHaveBeenCalled();
@@ -373,7 +393,7 @@ describe('TerraformService.plan streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const { chunks } = await collectPlanChunks(service.plan(), () => {
       child.emitStdout('Refreshing state...\n');
       child.emitStderr('Warning: something\n');
@@ -389,7 +409,7 @@ describe('TerraformService.plan streaming', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const { chunks } = await collectPlanChunks(service.plan(), () => {
       child.emitStdout('line one\nline two\nline three\n');
       child.close(0);
@@ -413,6 +433,7 @@ describe('TerraformService.plan run log capture', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan(), () => {
@@ -438,6 +459,7 @@ describe('TerraformService.plan run log capture', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await expect(
@@ -465,6 +487,7 @@ describe('TerraformService.plan run log capture', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const gen = service.plan(undefined, controller.signal);
 
@@ -502,6 +525,7 @@ describe('TerraformService.plan run record persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await collectPlanChunks(service.plan('tfvars-version-abc'), () => child.close(0));
@@ -531,6 +555,7 @@ describe('TerraformService.plan run record persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     await expect(
@@ -556,6 +581,7 @@ describe('TerraformService.plan run record persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
     const gen = service.plan(undefined, controller.signal);
 
@@ -599,6 +625,7 @@ describe('TerraformService.plan run record persistence', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     const pending = collectPlanChunks(service.plan(), () => {
@@ -623,6 +650,149 @@ describe('TerraformService.plan run record persistence', () => {
   });
 });
 
+describe('TerraformService.plan RunRecordService persistence', () => {
+  it('should call RunRecordService.persist exactly once with a matching RunRecord and the captured terraform.log path when the process exits successfully', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-store-1');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    await collectPlanChunks(service.plan('tfvars-version-abc'), () => child.close(0));
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string },
+      string,
+    ];
+    expect(params).toMatchObject({
+      runId: 'run-store-1',
+      kind: 'plan',
+      exitCode: 0,
+      tfvarsVersionId: 'tfvars-version-abc',
+    });
+    expect(logFilePath).toBe('/repo/runs/run-store-1/terraform.log');
+
+    // The persisted record's completedAt must match the local run.json's own
+    // completedAt — both are written from the same captured timestamp.
+    const recordCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-store-1/run.json',
+    );
+    const [, localContents] = recordCalls[0] as [string, string];
+    const localRecord = JSON.parse(localContents);
+    expect((params as { completedAt: string }).completedAt).toBe(localRecord.completedAt);
+    expect((params as { startedAt: string }).startedAt).toBe(localRecord.startedAt);
+  });
+
+  it('should call RunRecordService.persist exactly once with the non-zero exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-store-2');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    await expect(
+      collectPlanChunks(service.plan(), () => child.close(1)),
+    ).rejects.toBeInstanceOf(TerraformPlanError);
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-store-2', kind: 'plan', exitCode: 1 });
+    expect(logFilePath).toBe('/repo/runs/run-store-2/terraform.log');
+  });
+
+  it('should call RunRecordService.persist exactly once with a null exit code when the run is aborted mid-flight', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-store-3');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const controller = new AbortController();
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const gen = service.plan(undefined, controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+    controller.abort();
+    child.close(null);
+    await pendingNext;
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-store-3', kind: 'plan', exitCode: null });
+    expect(logFilePath).toBe('/repo/runs/run-store-3/terraform.log');
+  });
+
+  it('should never call RunRecordService.persist when the local run.json write fails', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-store-4');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    writeFileSyncMock.mockImplementation((path: unknown) => {
+      if (typeof path === 'string' && path.endsWith('run.json')) {
+        throw new Error('ENOSPC: no space left on device');
+      }
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    await expect(
+      collectPlanChunks(service.plan(), () => child.close(0)),
+    ).rejects.toBeInstanceOf(TerraformRunPersistError);
+
+    expect(runRecordPersistMock).not.toHaveBeenCalled();
+  });
+
+  it('should still resolve the generator with the real plan result when RunRecordService.persist rejects', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-store-5');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockRejectedValue(new Error('DynamoDB unavailable'));
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    const { result } = await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Plan: 3 to add, 1 to change, 2 to destroy.\n');
+      child.close(0);
+    });
+
+    expect(result).toMatchObject({ runId: 'run-store-5', add: 3, change: 1, destroy: 2 });
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('TerraformService.plan summary parsing and return value', () => {
   it('should parse the add/change/destroy counts from the Plan: summary line and return them alongside the artifact/var-file paths', async () => {
     queueSuccessfulResolution();
@@ -633,6 +803,7 @@ describe('TerraformService.plan summary parsing and return value', () => {
     const service = new TerraformService(
       stubPlanConfigService({ runsDir: '/repo/runs' }),
       stubRemoteFileStore(),
+      stubRunRecordService(),
     );
 
     const { result } = await collectPlanChunks(service.plan(), () => {
@@ -656,7 +827,7 @@ describe('TerraformService.plan summary parsing and return value', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const { result } = await collectPlanChunks(service.plan(), () => {
       child.emitStdout('No changes. Your infrastructure matches the configuration.\n');
@@ -673,7 +844,7 @@ describe('TerraformService.plan exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectPlanChunks(service.plan(), () => child.close(1));
 
@@ -686,7 +857,7 @@ describe('TerraformService.plan exit handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const result = collectPlanChunks(service.plan(), () => child.emit('error', new Error('spawn ENOENT')));
 
@@ -701,7 +872,7 @@ describe('TerraformService.plan abort handling', () => {
     queueSpawn(child);
 
     const controller = new AbortController();
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.plan(undefined, controller.signal);
 
     const pendingNext = gen.next();
@@ -723,7 +894,7 @@ describe('TerraformService.plan abort handling', () => {
     const controller = new AbortController();
     controller.abort();
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.plan(undefined, controller.signal);
 
     const result = await gen.next();
@@ -742,7 +913,7 @@ describe('TerraformService.plan abort handling', () => {
     });
     queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.plan(undefined, controller.signal);
 
     const result = await gen.next();
@@ -765,6 +936,7 @@ describe('TerraformService.plan abort handling', () => {
     const service = new TerraformService(
       stubPlanConfigService({ tfvarsBucket: 'hyveon-tfvars' }),
       remoteFileStore,
+      stubRunRecordService(),
     );
     const gen = service.plan(undefined, controller.signal);
 
@@ -780,7 +952,7 @@ describe('TerraformService.plan abort handling', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const gen = service.plan();
 
     // Drive the generator to its first yielded chunk, mirroring a consumer
@@ -822,7 +994,7 @@ describe('TerraformService.plan concurrency guard', () => {
     const child = new FakeChildProcess();
     queueSpawn(child);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const firstGen = service.plan();
     const firstNext = firstGen.next(); // starts the generator body, setting the in-flight flag synchronously
 
@@ -841,7 +1013,7 @@ describe('TerraformService.plan concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await collectPlanChunks(service.plan(), () => firstChild.close(0));
 
     const secondChild = new FakeChildProcess();
@@ -856,7 +1028,7 @@ describe('TerraformService.plan concurrency guard', () => {
     const firstChild = new FakeChildProcess();
     queueSpawn(firstChild);
 
-    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubPlanConfigService(), stubRemoteFileStore(), stubRunRecordService());
     await expect(
       collectPlanChunks(service.plan(), () => firstChild.close(1)),
     ).rejects.toBeInstanceOf(TerraformPlanError);

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -402,6 +402,95 @@ describe('TerraformService.plan streaming', () => {
   });
 });
 
+describe('TerraformService.plan run log capture', () => {
+  it('should write the accumulated stdout+stderr transcript to <runsDir>/<runId>/terraform.log in a single writeFileSync once the process closes', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-log-1');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+
+    await collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Refreshing state...\n');
+      child.emitStderr('Warning: something\n');
+      child.close(0);
+    });
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-log-1/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('Refreshing state...\nWarning: something\n');
+  });
+
+  it('should still write the accumulated transcript to terraform.log when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-log-2');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+
+    await expect(
+      collectPlanChunks(service.plan(), () => {
+        child.emitStdout('Error: something went wrong\n');
+        child.close(1);
+      }),
+    ).rejects.toBeInstanceOf(TerraformPlanError);
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-log-2/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('Error: something went wrong\n');
+  });
+
+  it('should still write whatever transcript was captured to terraform.log when the run is aborted mid-flight', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-log-3');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+    const gen = service.plan(undefined, controller.signal);
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('Refreshing state...\n');
+    const firstResult = await first;
+    expect(firstResult.done).toBe(false);
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const secondResult = await gen.next();
+    expect(secondResult.done).toBe(true);
+    expect(secondResult.value).toBeUndefined();
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-log-3/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('Refreshing state...\n');
+  });
+});
+
 describe('TerraformService.plan summary parsing and return value', () => {
   it('should parse the add/change/destroy counts from the Plan: summary line and return them alongside the artifact/var-file paths', async () => {
     queueSuccessfulResolution();

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -513,6 +513,40 @@ describe('TerraformService.plan run log capture', () => {
     const [, contents] = logCalls[0] as [string, string];
     expect(contents).toBe('Refreshing state...\n');
   });
+
+  it('should write whatever transcript was captured to terraform.log when the generator is force-closed early', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-log-4');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const gen = service.plan();
+
+    // Drive the generator to its first yielded chunk, then force-close it —
+    // as `for await...of` `break`/`throw` would — before the child process
+    // has closed.
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('Refreshing state...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    child.close(null);
+    await returnPromise;
+
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-log-4/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+    const [, contents] = logCalls[0] as [string, string];
+    expect(contents).toBe('Refreshing state...\n');
+  });
 });
 
 describe('TerraformService.plan run record persistence', () => {
@@ -647,6 +681,49 @@ describe('TerraformService.plan run record persistence', () => {
     const rejection = (await pending.catch((err: unknown) => err)) as TerraformRunPersistError;
     expect(rejection.cause).toBeInstanceOf(Error);
     expect((rejection.cause as Error).cause).toBe(persistFailure);
+  });
+
+  it('should write exactly one run.json record with a null exitCode when the generator is force-closed before the process exits', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-record-5');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const gen = service.plan('v1');
+
+    // Drive the generator to its first yielded chunk, then force-close it —
+    // as `for await...of` `break`/`throw` would — before the child process
+    // has closed. writeRunRecord() lives after the inner try/finally in
+    // plan()'s body, which a forced completion unwinds straight past; the
+    // persistence must instead happen from the outer finally's
+    // `forceKilled` branch.
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('Refreshing state...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+
+    child.close(null);
+    await returnPromise;
+
+    const recordCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-record-5/run.json',
+    );
+    expect(recordCalls).toHaveLength(1);
+    const [, contents] = recordCalls[0] as [string, string];
+    const record = JSON.parse(contents);
+    expect(record.runId).toBe('run-record-5');
+    expect(record.kind).toBe('plan');
+    expect(record.exitCode).toBeNull();
+    expect(record.tfvarsVersionId).toBe('v1');
   });
 });
 
@@ -790,6 +867,39 @@ describe('TerraformService.plan RunRecordService persistence', () => {
 
     expect(result).toMatchObject({ runId: 'run-store-5', add: 3, change: 1, destroy: 2 });
     expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call RunRecordService.persist exactly once with a null exit code when the generator is force-closed before the process exits', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-store-6');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+    const gen = service.plan('v1');
+
+    const first = gen.next();
+    await flushMicrotasks();
+    child.emitStdout('Refreshing state...\n');
+    await first;
+
+    const returnPromise = gen.return(undefined);
+    await flushMicrotasks();
+    child.close(null);
+    await returnPromise;
+
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-store-6', kind: 'plan', exitCode: null, tfvarsVersionId: 'v1' });
+    expect(logFilePath).toBe('/repo/runs/run-store-6/terraform.log');
   });
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -53,6 +53,7 @@ import {
   TerraformService,
   TerraformNotFoundError,
   TerraformPlanError,
+  TerraformRunPersistError,
   type TerraformRunChunk,
   type TerraformPlanResult,
 } from './TerraformService.js';
@@ -488,6 +489,137 @@ describe('TerraformService.plan run log capture', () => {
     expect(logCalls).toHaveLength(1);
     const [, contents] = logCalls[0] as [string, string];
     expect(contents).toBe('Refreshing state...\n');
+  });
+});
+
+describe('TerraformService.plan run record persistence', () => {
+  it('should write a TerraformRunRecord with kind "plan", exitCode 0, and the propagated tfvarsVersionId to <runsDir>/<runId>/run.json when the process exits successfully', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-record-1');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+
+    await collectPlanChunks(service.plan('tfvars-version-abc'), () => child.close(0));
+
+    const recordCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-record-1/run.json',
+    );
+    expect(recordCalls).toHaveLength(1);
+    const [, contents] = recordCalls[0] as [string, string];
+    const record = JSON.parse(contents);
+    expect(record).toMatchObject({
+      runId: 'run-record-1',
+      kind: 'plan',
+      exitCode: 0,
+      tfvarsVersionId: 'tfvars-version-abc',
+    });
+    expect(typeof record.startedAt).toBe('string');
+    expect(typeof record.completedAt).toBe('string');
+  });
+
+  it('should write a TerraformRunRecord with kind "plan" and the non-zero exit code when the process exits non-zero', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-record-2');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+
+    await expect(
+      collectPlanChunks(service.plan(), () => child.close(1)),
+    ).rejects.toBeInstanceOf(TerraformPlanError);
+
+    const recordCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-record-2/run.json',
+    );
+    expect(recordCalls).toHaveLength(1);
+    const [, contents] = recordCalls[0] as [string, string];
+    const record = JSON.parse(contents);
+    expect(record).toMatchObject({ runId: 'run-record-2', kind: 'plan', exitCode: 1 });
+  });
+
+  it('should write a TerraformRunRecord with kind "plan" and a null exit code when the run is aborted mid-flight', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-record-3');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const controller = new AbortController();
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+    const gen = service.plan(undefined, controller.signal);
+
+    const pendingNext = gen.next();
+    await flushMicrotasks();
+
+    controller.abort();
+    // The fake child doesn't auto-emit `close` on `kill()` — simulate the
+    // real process actually terminating in response to the kill signal.
+    child.close(null);
+
+    const result = await pendingNext;
+    expect(result.done).toBe(true);
+    expect(result.value).toBeUndefined();
+
+    const recordCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-record-3/run.json',
+    );
+    expect(recordCalls).toHaveLength(1);
+    const [, contents] = recordCalls[0] as [string, string];
+    const record = JSON.parse(contents);
+    expect(record).toMatchObject({ runId: 'run-record-3', kind: 'plan', exitCode: null });
+  });
+
+  it('should throw TerraformRunPersistError carrying the real outcome when the run record write fails', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-record-4');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    const persistFailure = new Error('ENOSPC: no space left on device');
+    // Only the run.json write fails — the terraform.log write (which also
+    // happens once the process closes) uses the default no-op mock, so this
+    // targets the specific writeFileSync call the assertions below care
+    // about regardless of the order the two writes happen in.
+    writeFileSyncMock.mockImplementation((path: unknown) => {
+      if (typeof path === 'string' && path.endsWith('run.json')) {
+        throw persistFailure;
+      }
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+    );
+
+    const pending = collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Plan: 3 to add, 1 to change, 2 to destroy.\n');
+      child.close(0);
+    });
+
+    await expect(pending).rejects.toBeInstanceOf(TerraformRunPersistError);
+    // The real plan outcome (the process succeeded and planned changes) must
+    // survive the persistence failure rather than being discarded behind it.
+    await expect(pending).rejects.toMatchObject({
+      runId: 'run-record-4',
+      outcome: { kind: 'success', result: { runId: 'run-record-4', add: 3, change: 1, destroy: 2 } },
+    });
+    // `writeRunRecord` wraps the raw filesystem error in a descriptive
+    // `Error` (with `{ cause }`) before `plan()` re-wraps *that* as the
+    // `TerraformRunPersistError`'s own `cause` — assert the original
+    // `persistFailure` is still reachable two levels down rather than lost.
+    const rejection = (await pending.catch((err: unknown) => err)) as TerraformRunPersistError;
+    expect(rejection.cause).toBeInstanceOf(Error);
+    expect((rejection.cause as Error).cause).toBe(persistFailure);
   });
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.test.ts
@@ -16,6 +16,7 @@ vi.mock('node:child_process', () => ({
 
 import { TerraformService, TerraformNotFoundError, lookupCommandFor } from './TerraformService.js';
 import type { ConfigService } from './ConfigService.js';
+import type { RunRecordService } from './RunRecordService.js';
 import type { RemoteFileStore } from '@hyveon/shared';
 
 /**
@@ -35,6 +36,16 @@ function stubConfigService(): ConfigService {
  */
 function stubRemoteFileStore(): RemoteFileStore {
   return {} as RemoteFileStore;
+}
+
+/**
+ * Minimal `RunRecordService` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency. None of the tests in this file exercise
+ * `plan()`/`apply()`/`destroy()` (the only methods that call it), so a stub
+ * with a no-op `persist` is enough.
+ */
+function stubRunRecordService(): RunRecordService {
+  return { persist: vi.fn() } as Partial<RunRecordService> as RunRecordService;
 }
 
 /** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
@@ -108,12 +119,14 @@ describe('TerraformNotFoundError', () => {
 
 describe('TerraformService construction', () => {
   it('should never throw when constructing the service, even without any execFile mocks queued', () => {
-    expect(() => new TerraformService(stubConfigService(), stubRemoteFileStore())).not.toThrow();
+    expect(
+      () => new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService()),
+    ).not.toThrow();
   });
 
   it('should not shell out to resolve the binary until an accessor is called', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     expect(execFileMock).not.toHaveBeenCalled();
   });
 });
@@ -122,7 +135,7 @@ describe('TerraformService binary detection', () => {
   it('should resolve the binary path from the which/where.exe output', async () => {
     queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.0');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).resolves.toBe('/usr/local/bin/terraform');
   });
@@ -131,7 +144,7 @@ describe('TerraformService binary detection', () => {
     queueExecFileSuccess('\n  /opt/homebrew/bin/terraform  \nsome-other-line\n');
     queueExecFileSuccess(JSON.stringify({ terraform_version: '1.7.0' }));
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).resolves.toBe('/opt/homebrew/bin/terraform');
   });
@@ -139,7 +152,7 @@ describe('TerraformService binary detection', () => {
   it('should reject getBinaryPath with a TerraformNotFoundError instance on first use when the lookup command fails', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -147,7 +160,7 @@ describe('TerraformService binary detection', () => {
   it('should reject getVersion with a TerraformNotFoundError instance on first use when the lookup command fails', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getVersion()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -155,7 +168,7 @@ describe('TerraformService binary detection', () => {
   it('should reject with a TerraformNotFoundError instance when the lookup command produces no output', async () => {
     queueExecFileSuccess('');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -163,7 +176,7 @@ describe('TerraformService binary detection', () => {
   it('should reject with a TerraformNotFoundError instance when the lookup command output is only whitespace', async () => {
     queueExecFileSuccess('   \n  \n');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
   });
@@ -173,7 +186,7 @@ describe('TerraformService version parsing', () => {
   it('should parse the terraform_version field from terraform version -json output', async () => {
     queueSuccessfulResolution('/usr/local/bin/terraform', '1.7.5');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getVersion()).resolves.toBe('1.7.5');
   });
@@ -183,7 +196,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('Terraform v1.6.2\non linux_amd64\n');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getVersion()).resolves.toBe('1.6.2');
   });
@@ -193,7 +206,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess(JSON.stringify({ some_other_field: true }));
     queueExecFileSuccess('Terraform v1.5.0\n');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getVersion()).resolves.toBe('1.5.0');
   });
@@ -203,7 +216,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('Terraform v1.9.0-beta1\n');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getVersion()).resolves.toBe('1.9.0-beta1');
   });
@@ -213,7 +226,7 @@ describe('TerraformService version parsing', () => {
     queueExecFileSuccess('not json');
     queueExecFileSuccess('garbage output with no version');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
     const result = service.getVersion();
 
     await expect(result).rejects.toThrow('Unable to parse terraform version');
@@ -225,7 +238,7 @@ describe('TerraformService instance accessors', () => {
   it('should expose the resolved binary path via getBinaryPath', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).resolves.toBe('/usr/bin/terraform');
   });
@@ -233,7 +246,7 @@ describe('TerraformService instance accessors', () => {
   it('should expose the resolved version via getVersion', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getVersion()).resolves.toBe('1.8.1');
   });
@@ -243,7 +256,7 @@ describe('TerraformService resolution memoization', () => {
   it('should only shell out once across multiple getBinaryPath calls', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await service.getBinaryPath();
     await service.getBinaryPath();
@@ -254,7 +267,7 @@ describe('TerraformService resolution memoization', () => {
   it('should reuse the memoized resolution between getBinaryPath and getVersion', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await service.getBinaryPath();
     await service.getVersion();
@@ -265,7 +278,7 @@ describe('TerraformService resolution memoization', () => {
   it('should resolve concurrent getBinaryPath calls to the same memoized result with a single lookup', async () => {
     queueSuccessfulResolution('/usr/bin/terraform', '1.8.1');
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     const [first, second] = await Promise.all([service.getBinaryPath(), service.getBinaryPath()]);
 
@@ -277,7 +290,7 @@ describe('TerraformService resolution memoization', () => {
   it('should memoize a TerraformNotFoundError rejection so a second call does not re-invoke execFile', async () => {
     queueExecFileFailure();
 
-    const service = new TerraformService(stubConfigService(), stubRemoteFileStore());
+    const service = new TerraformService(stubConfigService(), stubRemoteFileStore(), stubRunRecordService());
 
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);
     await expect(service.getBinaryPath()).rejects.toBeInstanceOf(TerraformNotFoundError);

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -4,10 +4,11 @@ import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { promisify } from 'node:util';
 import { Inject, Injectable } from '@nestjs/common';
-import type { RemoteFileStore } from '@hyveon/shared';
+import type { RemoteFileStore, RunKind } from '@hyveon/shared';
 import { logger } from '../logger.js';
 import { ConfigService, projectTfOutputs, type TfOutputs } from './ConfigService.js';
 import { REMOTE_FILE_STORE } from '../modules/cloud-provider.tokens.js';
+import { RunRecordService } from './RunRecordService.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -409,7 +410,10 @@ export type TerraformDestroyOutcome =
  * and {@link TerraformService.output}, which runs `terraform output -json`
  * and projects the result through the same {@link projectTfOutputs} helper
  * `ConfigService.getTfOutputs()` uses, caching the resolved value for 60s
- * (bypassable via `force: true`).
+ * (bypassable via `force: true`). Alongside each local {@link TerraformRunRecord}
+ * write, {@link plan}/{@link apply}/{@link destroy} also persist the run to the
+ * cloud-agnostic run-history `RunRecordStore` (DynamoDB for AWS) via the
+ * injected `RunRecordService` — see {@link persistRunRecord}.
  *
  * Construction is synchronous and never throws — the binary lookup +
  * `terraform version` shell-outs are deferred until {@link getBinaryPath} or
@@ -475,11 +479,15 @@ export class TerraformService {
    * tells Nest which concrete provider (bound by `CloudProviderModule` for
    * whichever cloud is active) to resolve for that parameter. Used by
    * {@link plan} to pull the current tfvars snapshot when S3 tfvars sync is
-   * configured (mirrors `TfvarsService`'s local-vs-S3 read).
+   * configured (mirrors `TfvarsService`'s local-vs-S3 read). `runRecordService`
+   * persists the run-history record to the cloud-agnostic `RunRecordStore`
+   * (DynamoDB for AWS) alongside the local `<runsDir>/<runId>/run.json` write
+   * — see {@link persistRunRecord}.
    */
   constructor(
     private readonly config: ConfigService,
     @Inject(REMOTE_FILE_STORE) private readonly remoteFileStore: RemoteFileStore,
+    private readonly runRecordService: RunRecordService,
   ) {}
 
   /**
@@ -831,11 +839,17 @@ export class TerraformService {
       // the record fails, the already-computed plan outcome is wrapped in
       // TerraformRunPersistError and thrown instead of being discarded
       // behind the persistence failure — mirrors apply()/destroy().
+      const completedAt = new Date().toISOString();
+      const planExitCode = result.aborted ? null : result.exitCode;
       try {
-        this.writeRunRecord(runId, 'plan', startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
+        this.writeRunRecord(runId, 'plan', startedAt, completedAt, planExitCode, tfvarsVersionId);
       } catch (err) {
         throw new TerraformRunPersistError(runId, outcome, err);
       }
+      // Persists the same run to the cloud-agnostic RunRecordStore (DynamoDB
+      // for AWS) alongside the local run.json write above — see
+      // persistRunRecord's TSDoc for why this is best-effort and awaited.
+      await this.persistRunRecord(runId, 'plan', startedAt, completedAt, planExitCode, tfvarsVersionId);
 
       if (outcome.kind === 'aborted') {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
@@ -1096,11 +1110,17 @@ export class TerraformService {
       // same spot the run record is written — a single writeFileSync now
       // that the process has closed, rather than one append per line.
       this.writeRunLog(runId, logLines);
+      const completedAt = new Date().toISOString();
+      const applyExitCode = result.aborted ? null : result.exitCode;
       try {
-        this.writeRunRecord(runId, 'apply', startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
+        this.writeRunRecord(runId, 'apply', startedAt, completedAt, applyExitCode, tfvarsVersionId);
       } catch (err) {
         throw new TerraformRunPersistError(runId, outcome, err);
       }
+      // Persists the same run to the cloud-agnostic RunRecordStore (DynamoDB
+      // for AWS) alongside the local run.json write above — see
+      // persistRunRecord's TSDoc for why this is best-effort and awaited.
+      await this.persistRunRecord(runId, 'apply', startedAt, completedAt, applyExitCode, tfvarsVersionId);
 
       if (outcome.kind === 'aborted') {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
@@ -1144,12 +1164,18 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
+        const completedAt = new Date().toISOString();
         try {
-          this.writeRunRecord(runId, 'apply', startedAt, null, tfvarsVersionId);
+          this.writeRunRecord(runId, 'apply', startedAt, completedAt, null, tfvarsVersionId);
         } catch {
           // Nothing meaningful to do with a persistence failure while the
           // generator is already tearing down for an unrelated reason.
         }
+        // Also persist to the cloud-agnostic RunRecordStore — best-effort,
+        // mirrors the normal-completion path above, so a force-killed run
+        // still shows up in run history even though the generator itself is
+        // already tearing down.
+        await this.persistRunRecord(runId, 'apply', startedAt, completedAt, null, tfvarsVersionId);
       }
       this.workspaceInFlight = null;
     }
@@ -1335,11 +1361,17 @@ export class TerraformService {
       // same spot the run record is written — a single writeFileSync now
       // that the process has closed, rather than one append per line.
       this.writeRunLog(runId, logLines);
+      const completedAt = new Date().toISOString();
+      const destroyExitCode = result.aborted ? null : result.exitCode;
       try {
-        this.writeRunRecord(runId, 'destroy', startedAt, result.aborted ? null : result.exitCode, undefined);
+        this.writeRunRecord(runId, 'destroy', startedAt, completedAt, destroyExitCode, undefined);
       } catch (err) {
         throw new TerraformRunPersistError(runId, outcome, err);
       }
+      // Persists the same run to the cloud-agnostic RunRecordStore (DynamoDB
+      // for AWS) alongside the local run.json write above — see
+      // persistRunRecord's TSDoc for why this is best-effort and awaited.
+      await this.persistRunRecord(runId, 'destroy', startedAt, completedAt, destroyExitCode, undefined);
 
       if (outcome.kind === 'aborted') {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
@@ -1366,12 +1398,18 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
+        const completedAt = new Date().toISOString();
         try {
-          this.writeRunRecord(runId, 'destroy', startedAt, null, undefined);
+          this.writeRunRecord(runId, 'destroy', startedAt, completedAt, null, undefined);
         } catch {
           // Nothing meaningful to do with a persistence failure while the
           // generator is already tearing down for an unrelated reason.
         }
+        // Also persist to the cloud-agnostic RunRecordStore — best-effort,
+        // mirrors the normal-completion path above, so a force-killed run
+        // still shows up in run history even though the generator itself is
+        // already tearing down.
+        await this.persistRunRecord(runId, 'destroy', startedAt, completedAt, null, undefined);
       }
       this.workspaceInFlight = null;
     }
@@ -1531,11 +1569,17 @@ export class TerraformService {
    * `runDir` — both `apply()`/`destroy()` already validate/mint `runId`
    * before this is called, but this guard is repeated here defensively so a
    * future caller can never bypass it by skipping those pre-spawn checks.
+   *
+   * `completedAt` is supplied by the caller (rather than computed here)
+   * so the exact same timestamp can also be handed to
+   * {@link persistRunRecord} — the local `run.json` and the remote
+   * `RunRecordStore` entry for a given run always agree on `completedAt`.
    */
   private writeRunRecord(
     runId: string,
     kind: 'plan' | 'apply' | 'destroy',
     startedAt: string,
+    completedAt: string,
     exitCode: number | null,
     tfvarsVersionId: string | undefined,
   ): void {
@@ -1545,7 +1589,7 @@ export class TerraformService {
       runId,
       kind,
       startedAt,
-      completedAt: new Date().toISOString(),
+      completedAt,
       exitCode,
       tfvarsVersionId,
     };
@@ -1558,6 +1602,55 @@ export class TerraformService {
           `${err instanceof Error ? err.message : String(err)}`,
         { cause: err },
       );
+    }
+  }
+
+  /**
+   * Persists the cloud-agnostic run-history counterpart of
+   * {@link writeRunRecord}'s local `<runsDir>/<runId>/run.json` write —
+   * delegates to `RunRecordService.persist`, which writes the equivalent
+   * `RunRecord` to the run-history `RunRecordStore` (DynamoDB for AWS),
+   * embedding or offloading the captured `<runsDir>/<runId>/terraform.log`
+   * (see {@link getRunLogPath}) as the run's log.
+   *
+   * Called from the exact same points {@link writeRunRecord} is — once per
+   * completed {@link plan}/{@link apply}/{@link destroy} run, whether it
+   * succeeded, failed, or was aborted — so a run always appears in the
+   * run-history table alongside its local `run.json`.
+   *
+   * `RunRecordService.persist` is documented as best-effort and never
+   * throwing (see its own TSDoc), but this method wraps the call in its own
+   * try/catch anyway as a defense-in-depth guard: should `persist` ever
+   * reject despite that contract, the rejection is logged and swallowed here
+   * rather than propagating out of this `async` method — since every caller
+   * `await`s {@link persistRunRecord} directly inline with (not merely
+   * alongside) its own return/throw statements, an unguarded rejection here
+   * would otherwise replace the already-computed plan/apply/destroy outcome
+   * with this unrelated persistence failure. This method is `async` and
+   * awaited by its callers purely so the write is deterministically
+   * observable (e.g. in tests), not because its outcome affects the
+   * already-computed plan/apply/destroy outcome those callers act on
+   * afterward.
+   */
+  private async persistRunRecord(
+    runId: string,
+    kind: RunKind,
+    startedAt: string,
+    completedAt: string,
+    exitCode: number | null,
+    tfvarsVersionId: string | undefined,
+  ): Promise<void> {
+    try {
+      await this.runRecordService.persist(
+        { runId, kind, startedAt, completedAt, exitCode, tfvarsVersionId },
+        this.getRunLogPath(runId),
+      );
+    } catch (err) {
+      logger.warn('failed to persist run record to RunRecordStore', {
+        runId,
+        kind,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -684,8 +684,10 @@ export class TerraformService {
    * through, and — once the spawned process has closed, regardless of
    * whether the run succeeded, failed, or was aborted — written in a single
    * `writeFileSync` to `<runsDir>/<runId>/terraform.log` (see
-   * {@link writeRunLog}) — a full stdout+stderr transcript of the run that
-   * survives after the generator itself has been consumed.
+   * {@link writeRunLog}), at the same point the {@link TerraformRunRecord} is
+   * persisted (including the force-killed outer-`finally` fallback below) —
+   * a full stdout+stderr transcript of the run that survives after the
+   * generator itself has been consumed.
    *
    * At that same point — once the process has closed, regardless of outcome —
    * a {@link TerraformRunRecord} (`kind: 'plan'`) is also written to
@@ -698,6 +700,16 @@ export class TerraformService {
    * and thrown instead of being discarded behind the persistence failure. No
    * record is written if the process never spawned (e.g. `signal` was
    * already aborted before `getBinaryPath()`/`pullVarFile()`/spawn).
+   *
+   * The same record is also written (with a `null` `exitCode`, mirroring the
+   * abort outcome) if this generator itself is force-closed by its consumer
+   * (`break`/`.return()`/`.throw()`) while the spawned `terraform plan`
+   * process is still genuinely running — the finalization above lives inside
+   * the generator's own body and is skipped when a forced completion unwinds
+   * straight past it, so an outer `finally` persists a cancelled record on
+   * that path instead, ensuring a still-running `terraform plan` killed by
+   * forced cleanup is never left unrecorded. Mirrors {@link apply}'s
+   * `forceKilled` handling.
    *
    * `signal`, if provided, aborts the run the same way {@link init} does: the
    * spawned child process is killed and the generator ends cleanly — no
@@ -730,6 +742,29 @@ export class TerraformService {
       );
     }
     this.workspaceInFlight = 'plan';
+    // Hoisted above the try block — mirrors apply()/destroy()'s equivalents.
+    // A force-closed generator (consumer break/.return()/.throw()) unwinds
+    // straight from `yield chunk` below, past the writeRunRecord call
+    // further down, to the outer finally, which needs to see these.
+    // `runId` is additionally hoisted here (unlike destroy(), which mints it
+    // before the try) because plan() doesn't create one until after the
+    // signal-aborted / getBinaryPath() guards have already passed.
+    let runId: string | undefined;
+    let startedAt: string | undefined;
+    let runRecordWritten = false;
+    // Set to `true` only from the `onForceKill` callback passed to
+    // `spawnAndStream` below — see apply()'s equivalent comment for why this
+    // is deliberately not inferred from `startedAt !== undefined &&
+    // !runRecordWritten` alone.
+    let forceKilled = false;
+    // Accumulates every yielded chunk's `line` (stdout+stderr, in the order
+    // they were streamed) so the full transcript can be written to
+    // `<runsDir>/<runId>/terraform.log` in a single `writeFileSync` once the
+    // process has closed, rather than one disk write per line. Hoisted
+    // alongside `startedAt`/`runRecordWritten`/`forceKilled` so the outer
+    // `finally`'s force-killed branch can also write whatever was captured
+    // before the forced completion unwound past the normal persistence point.
+    const logLines: string[] = [];
     try {
       if (signal?.aborted) {
         // Already aborted before we even started resolving the binary path —
@@ -744,7 +779,7 @@ export class TerraformService {
         return undefined;
       }
 
-      const runId = randomUUID();
+      runId = randomUUID();
       const runDir = join(this.config.getRunsDir(), runId);
       mkdirSync(runDir, { recursive: true });
 
@@ -768,20 +803,19 @@ export class TerraformService {
       let add = 0;
       let change = 0;
       let destroy = 0;
-      // Accumulates every yielded chunk's `line` (stdout+stderr, in the
-      // order they were streamed) so the full transcript can be written to
-      // `<runsDir>/<runId>/terraform.log` in a single `writeFileSync` once
-      // the process has closed, rather than one disk write per line.
-      const logLines: string[] = [];
       // Captured immediately before the process is spawned so it can be
       // recorded in the `TerraformRunRecord` written below once the process
       // closes.
-      const startedAt = new Date().toISOString();
+      startedAt = new Date().toISOString();
 
       // Driven manually (rather than `yield*`) so each stdout line can be
       // scanned for the plan summary as it streams through, in addition to
-      // being forwarded to the caller unmodified.
-      const stream = this.spawnAndStream(binaryPath, args, cwd, signal);
+      // being forwarded to the caller unmodified. The `onForceKill` callback
+      // mirrors apply()/destroy() so a consumer force-closing this generator
+      // while terraform is still running can still be persisted below.
+      const stream = this.spawnAndStream(binaryPath, args, cwd, signal, () => {
+        forceKilled = true;
+      });
       let next = await stream.next();
       try {
         while (!next.done) {
@@ -816,12 +850,6 @@ export class TerraformService {
 
       const result = next.value;
 
-      // The process has closed by this point regardless of `aborted` — write
-      // the accumulated transcript now, before branching on the outcome
-      // below, so every exit path (success/failure/abort) leaves a
-      // terraform.log behind.
-      this.writeRunLog(runId, logLines);
-
       // Compute the outcome the generator would return/throw *before*
       // attempting to persist the run record, so a persistence failure below
       // can still report the real plan outcome instead of losing it behind
@@ -831,6 +859,17 @@ export class TerraformService {
         : result.exitCode === 0
           ? { kind: 'success', result: { runId, artifactPath, varFilePath, add, change, destroy } }
           : { kind: 'failed', error: new TerraformPlanError(result.exitCode) };
+
+      // `runRecordWritten` is flipped *before* the write is attempted (not
+      // only on success) so the outer `finally` below never re-attempts a
+      // write this block already tried — whether it succeeded or threw —
+      // mirrors apply()/destroy().
+      runRecordWritten = true;
+      // The process has closed by this point regardless of `aborted` — write
+      // the accumulated transcript now, before branching on the outcome
+      // below, so every exit path (success/failure/abort) leaves a
+      // terraform.log behind.
+      this.writeRunLog(runId, logLines);
 
       // Same guarantee for the run record: written on every exit path
       // (success/failure/abort) so a future run-history UI can list this
@@ -862,6 +901,41 @@ export class TerraformService {
       }
       throw outcome.error;
     } finally {
+      // Covers the force-closed generator case (consumer `break` /
+      // `.return()` / `.throw()`): a forced completion unwinds straight from
+      // `yield chunk` above to the inner finally (which drains
+      // `spawnAndStream`, killing the child and waiting for it to actually
+      // close), then continues unwinding *past* the `writeRunRecord` call
+      // above — that statement is never reached — straight to this outer
+      // `finally`. Mirrors apply()/destroy()'s outer finally; see apply()'s
+      // comment for the full rationale of the `forceKilled` gate. `runId`
+      // is also checked here (unlike apply()/destroy(), where it's always
+      // defined by the time the try block starts) because plan() may abort
+      // before a runId is ever minted, in which case there's nothing to
+      // persist.
+      if (runId !== undefined && startedAt !== undefined && !runRecordWritten && forceKilled) {
+        // Mirrors apply()/destroy()'s forceKilled WARN — a cancellation via
+        // forced generator termination is still a plan outcome worth
+        // surfacing.
+        logger.warn('terraform plan cancelled — generator force-closed while running', {
+          runId,
+        });
+        // Persist whatever transcript was captured before the forced
+        // completion unwound past the normal writeRunLog() call above.
+        this.writeRunLog(runId, logLines);
+        const completedAt = new Date().toISOString();
+        try {
+          this.writeRunRecord(runId, 'plan', startedAt, completedAt, null, tfvarsVersionId);
+        } catch {
+          // Nothing meaningful to do with a persistence failure while the
+          // generator is already tearing down for an unrelated reason.
+        }
+        // Also persist to the cloud-agnostic RunRecordStore — best-effort,
+        // mirrors the normal-completion path above, so a force-killed run
+        // still shows up in run history even though the generator itself is
+        // already tearing down.
+        await this.persistRunRecord(runId, 'plan', startedAt, completedAt, null, tfvarsVersionId);
+      }
       this.workspaceInFlight = null;
     }
   }

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -214,19 +214,18 @@ const APPLY_SUMMARY_PATTERN =
   /Apply complete!\s*Resources:\s*(\d+) added,\s*(\d+) changed,\s*(\d+) destroyed\./;
 
 /**
- * Persisted to `<runsDir>/<runId>/run.json` once an {@link TerraformService.apply}
- * or {@link TerraformService.destroy} run's spawned process has closed
- * (whether it exited cleanly, non-zero, or was killed via an abort signal) —
- * a lightweight local run history so a future Apply-history UI can list past
- * runs without a database. `kind` reflects which subcommand produced the
- * record; the union leaves room for a future `plan` record to reuse the same
- * shape without a breaking change later.
+ * Persisted to `<runsDir>/<runId>/run.json` once a {@link TerraformService.plan},
+ * {@link TerraformService.apply}, or {@link TerraformService.destroy} run's
+ * spawned process has closed (whether it exited cleanly, non-zero, or was
+ * killed via an abort signal) — a lightweight local run history so a future
+ * run-history UI can list past runs without a database. `kind` reflects
+ * which subcommand produced the record.
  */
 export interface TerraformRunRecord {
   /** The `runId` this record describes — matches the directory it's written into. */
   runId: string;
   /** Which subcommand produced this record. */
-  kind: 'apply' | 'destroy';
+  kind: 'plan' | 'apply' | 'destroy';
   /** ISO-8601 timestamp captured immediately before the process was spawned. */
   startedAt: string;
   /** ISO-8601 timestamp captured immediately after the process closed. */
@@ -250,21 +249,35 @@ export type TerraformApplyOutcome =
   | { kind: 'failed'; error: TerraformApplyError };
 
 /**
- * Thrown by {@link TerraformService.apply} or {@link TerraformService.destroy}
- * when persisting the {@link TerraformRunRecord} to `<runsDir>/<runId>/run.json`
- * fails (e.g. a filesystem error surfaced from `mkdirSync`/`writeFileSync`
- * inside {@link TerraformService.writeRunRecord}) — distinct from a failure of
- * `terraform apply`/`terraform destroy` itself. Carries the
- * {@link TerraformApplyOutcome} or {@link TerraformDestroyOutcome} that had
- * already been computed before the persistence attempt (success, abort, or a
- * subcommand-specific error) so callers can recover the real outcome instead
- * of only seeing an unrelated filesystem exception, plus `cause` — the
- * underlying error `writeRunRecord` raised.
+ * Describes what {@link TerraformService.plan} was about to return/throw the
+ * moment its spawned process closed — captured before
+ * {@link TerraformService.writeRunRecord} is attempted so a persistence
+ * failure (see {@link TerraformRunPersistError}) doesn't discard the real
+ * outcome of the plan run. Mirrors {@link TerraformApplyOutcome}.
+ */
+export type TerraformPlanOutcome =
+  | { kind: 'success'; result: TerraformPlanResult }
+  | { kind: 'aborted' }
+  | { kind: 'failed'; error: TerraformPlanError };
+
+/**
+ * Thrown by {@link TerraformService.plan}, {@link TerraformService.apply}, or
+ * {@link TerraformService.destroy} when persisting the
+ * {@link TerraformRunRecord} to `<runsDir>/<runId>/run.json` fails (e.g. a
+ * filesystem error surfaced from `mkdirSync`/`writeFileSync` inside
+ * {@link TerraformService.writeRunRecord}) — distinct from a failure of
+ * `terraform plan`/`terraform apply`/`terraform destroy` itself. Carries the
+ * {@link TerraformPlanOutcome}, {@link TerraformApplyOutcome}, or
+ * {@link TerraformDestroyOutcome} that had already been computed before the
+ * persistence attempt (success, abort, or a subcommand-specific error) so
+ * callers can recover the real outcome instead of only seeing an unrelated
+ * filesystem exception, plus `cause` — the underlying error `writeRunRecord`
+ * raised.
  */
 export class TerraformRunPersistError extends Error {
   constructor(
     public readonly runId: string,
-    public readonly outcome: TerraformApplyOutcome | TerraformDestroyOutcome,
+    public readonly outcome: TerraformPlanOutcome | TerraformApplyOutcome | TerraformDestroyOutcome,
     public readonly cause: unknown,
   ) {
     super(
@@ -276,10 +289,13 @@ export class TerraformRunPersistError extends Error {
   }
 
   /**
-   * Renders a {@link TerraformApplyOutcome} or {@link TerraformDestroyOutcome}
-   * as a short phrase for the error message above.
+   * Renders a {@link TerraformPlanOutcome}, {@link TerraformApplyOutcome}, or
+   * {@link TerraformDestroyOutcome} as a short phrase for the error message
+   * above.
    */
-  private static describeOutcome(outcome: TerraformApplyOutcome | TerraformDestroyOutcome): string {
+  private static describeOutcome(
+    outcome: TerraformPlanOutcome | TerraformApplyOutcome | TerraformDestroyOutcome,
+  ): string {
     switch (outcome.kind) {
       case 'success':
         return 'succeeded';
@@ -382,8 +398,9 @@ export type TerraformDestroyOutcome =
  * and semver version, and orchestrates `terraform` subcommands against it:
  * {@link TerraformService.init}, the streaming/idempotent `terraform init`
  * runner; {@link TerraformService.plan}, the streaming `terraform plan`
- * runner that persists its `.tfplan` artifact and the pulled tfvars snapshot
- * under `ConfigService.getRunsDir()`; {@link TerraformService.apply}, the
+ * runner that persists its `.tfplan` artifact, the pulled tfvars snapshot,
+ * and a {@link TerraformRunRecord} (`kind: 'plan'`) under
+ * `ConfigService.getRunsDir()`; {@link TerraformService.apply}, the
  * streaming `terraform apply <planFile>` runner that persists a
  * {@link TerraformRunRecord} to the same per-run directory once the process
  * closes; {@link TerraformService.destroy}, the streaming
@@ -662,6 +679,18 @@ export class TerraformService {
    * {@link writeRunLog}) — a full stdout+stderr transcript of the run that
    * survives after the generator itself has been consumed.
    *
+   * At that same point — once the process has closed, regardless of outcome —
+   * a {@link TerraformRunRecord} (`kind: 'plan'`) is also written to
+   * `<runsDir>/<runId>/run.json` (see {@link writeRunRecord}), capturing
+   * `runId`, `startedAt`/`completedAt` timestamps, the process's `exitCode`
+   * (`null` when aborted), and `tfvarsVersionId`. Mirrors {@link apply}/
+   * {@link destroy}: if persisting that record fails (e.g. a filesystem
+   * error), the already-computed plan outcome (success/abort/
+   * {@link TerraformPlanError}) is wrapped in {@link TerraformRunPersistError}
+   * and thrown instead of being discarded behind the persistence failure. No
+   * record is written if the process never spawned (e.g. `signal` was
+   * already aborted before `getBinaryPath()`/`pullVarFile()`/spawn).
+   *
    * `signal`, if provided, aborts the run the same way {@link init} does: the
    * spawned child process is killed and the generator ends cleanly — no
    * further chunks, no throw, and the generator resolves to `undefined`
@@ -676,9 +705,11 @@ export class TerraformService {
    *
    * Throws {@link TerraformNotFoundError} if the `terraform` binary can't be
    * resolved, a plain `Error` if the configured tfvars source can't be read
-   * or `tfvarsVersionId` is stale (see {@link pullVarFile}), or
-   * {@link TerraformPlanError} if the spawned process exits with a non-zero
-   * status code (and the run wasn't aborted).
+   * or `tfvarsVersionId` is stale (see {@link pullVarFile}), {@link TerraformPlanError}
+   * if the spawned process exits with a non-zero status code (and the run
+   * wasn't aborted), or {@link TerraformRunPersistError} if the process
+   * closed successfully (or was aborted) but the run record couldn't be
+   * persisted afterward.
    */
   async *plan(
     tfvarsVersionId?: string,
@@ -734,6 +765,10 @@ export class TerraformService {
       // `<runsDir>/<runId>/terraform.log` in a single `writeFileSync` once
       // the process has closed, rather than one disk write per line.
       const logLines: string[] = [];
+      // Captured immediately before the process is spawned so it can be
+      // recorded in the `TerraformRunRecord` written below once the process
+      // closes.
+      const startedAt = new Date().toISOString();
 
       // Driven manually (rather than `yield*`) so each stdout line can be
       // scanned for the plan summary as it streams through, in addition to
@@ -779,16 +814,39 @@ export class TerraformService {
       // terraform.log behind.
       this.writeRunLog(runId, logLines);
 
-      if (result.aborted) {
+      // Compute the outcome the generator would return/throw *before*
+      // attempting to persist the run record, so a persistence failure below
+      // can still report the real plan outcome instead of losing it behind
+      // an unrelated filesystem exception — mirrors apply()/destroy().
+      const outcome: TerraformPlanOutcome = result.aborted
+        ? { kind: 'aborted' }
+        : result.exitCode === 0
+          ? { kind: 'success', result: { runId, artifactPath, varFilePath, add, change, destroy } }
+          : { kind: 'failed', error: new TerraformPlanError(result.exitCode) };
+
+      // Same guarantee for the run record: written on every exit path
+      // (success/failure/abort) so a future run-history UI can list this
+      // plan run regardless of its outcome. `exitCode` is recorded as `null`
+      // when the run was aborted, mirroring apply()/destroy(). If persisting
+      // the record fails, the already-computed plan outcome is wrapped in
+      // TerraformRunPersistError and thrown instead of being discarded
+      // behind the persistence failure — mirrors apply()/destroy().
+      try {
+        this.writeRunRecord(runId, 'plan', startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
+      } catch (err) {
+        throw new TerraformRunPersistError(runId, outcome, err);
+      }
+
+      if (outcome.kind === 'aborted') {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
         // the generator cleanly rather than surfacing the resulting
         // error/exit code.
         return undefined;
       }
-      if (result.exitCode === 0) {
-        return { runId, artifactPath, varFilePath, add, change, destroy };
+      if (outcome.kind === 'success') {
+        return outcome.result;
       }
-      throw new TerraformPlanError(result.exitCode);
+      throw outcome.error;
     } finally {
       this.workspaceInFlight = null;
     }
@@ -1454,11 +1512,12 @@ export class TerraformService {
 
   /**
    * Writes a {@link TerraformRunRecord} to `<runsDir>/<runId>/run.json` once
-   * an {@link apply} or {@link destroy} run's spawned process has closed.
-   * Creates the run directory if it doesn't already exist (defensive —
-   * {@link plan} normally creates it ahead of `apply`, and `destroy` creates
-   * its own run directory itself, but nothing prevents a caller from applying
-   * a plan file whose directory was cleaned up in between).
+   * a {@link plan}, {@link apply}, or {@link destroy} run's spawned process
+   * has closed. Creates the run directory if it doesn't already exist
+   * (defensive — {@link plan} normally creates it ahead of `apply`, and
+   * `destroy` creates its own run directory itself, but nothing prevents a
+   * caller from applying a plan file whose directory was cleaned up in
+   * between).
    *
    * `mkdirSync`/`writeFileSync` are wrapped in a try/catch so a filesystem
    * error here (e.g. permissions, disk full, cleaned-up parent directory)
@@ -1475,7 +1534,7 @@ export class TerraformService {
    */
   private writeRunRecord(
     runId: string,
-    kind: 'apply' | 'destroy',
+    kind: 'plan' | 'apply' | 'destroy',
     startedAt: string,
     exitCode: number | null,
     tfvarsVersionId: string | undefined,

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -655,6 +655,13 @@ export class TerraformService {
    * value alongside `runId`, `artifactPath`, and `varFilePath`. A "no changes"
    * plan (no summary line present) resolves all three counts to `0`.
    *
+   * Every yielded chunk's `line` is also accumulated in-memory as it streams
+   * through, and — once the spawned process has closed, regardless of
+   * whether the run succeeded, failed, or was aborted — written in a single
+   * `writeFileSync` to `<runsDir>/<runId>/terraform.log` (see
+   * {@link writeRunLog}) — a full stdout+stderr transcript of the run that
+   * survives after the generator itself has been consumed.
+   *
    * `signal`, if provided, aborts the run the same way {@link init} does: the
    * spawned child process is killed and the generator ends cleanly — no
    * further chunks, no throw, and the generator resolves to `undefined`
@@ -722,6 +729,11 @@ export class TerraformService {
       let add = 0;
       let change = 0;
       let destroy = 0;
+      // Accumulates every yielded chunk's `line` (stdout+stderr, in the
+      // order they were streamed) so the full transcript can be written to
+      // `<runsDir>/<runId>/terraform.log` in a single `writeFileSync` once
+      // the process has closed, rather than one disk write per line.
+      const logLines: string[] = [];
 
       // Driven manually (rather than `yield*`) so each stdout line can be
       // scanned for the plan summary as it streams through, in addition to
@@ -731,6 +743,7 @@ export class TerraformService {
       try {
         while (!next.done) {
           const chunk = next.value;
+          logLines.push(chunk.line);
           if (chunk.stream === 'stdout') {
             const match = PLAN_SUMMARY_PATTERN.exec(chunk.line);
             if (match) {
@@ -759,6 +772,13 @@ export class TerraformService {
       }
 
       const result = next.value;
+
+      // The process has closed by this point regardless of `aborted` — write
+      // the accumulated transcript now, before branching on the outcome
+      // below, so every exit path (success/failure/abort) leaves a
+      // terraform.log behind.
+      this.writeRunLog(runId, logLines);
+
       if (result.aborted) {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
         // the generator cleanly rather than surfacing the resulting
@@ -800,6 +820,14 @@ export class TerraformService {
    * plan being applied was generated against tfvars that have since changed
    * underneath the caller. Ignored entirely in local-file mode or when
    * `tfvarsVersionId` is omitted.
+   *
+   * Every yielded chunk's `line` is also accumulated in-memory as it streams
+   * through, and — once the spawned process has closed — written in a
+   * single `writeFileSync` to `<runsDir>/<runId>/terraform.log` (see
+   * {@link writeRunLog}), at the same point the {@link TerraformRunRecord} is
+   * persisted (including the force-killed outer-`finally` fallback below) —
+   * a full stdout+stderr transcript of the run that survives after the
+   * generator itself has been consumed.
    *
    * While streaming, stdout lines are scanned via {@link APPLY_SUMMARY_PATTERN}
    * for Terraform's summary line (`Apply complete! Resources: N added, N changed, N destroyed.`)
@@ -903,6 +931,14 @@ export class TerraformService {
     // exception occurs after the child already finished successfully or
     // failed, and neither of those is an actual cancellation.
     let forceKilled = false;
+    // Accumulates every yielded chunk's `line` (stdout+stderr, in the order
+    // they were streamed) so the full transcript can be written to
+    // `<runsDir>/<runId>/terraform.log` in a single `writeFileSync` once the
+    // process has closed, rather than one disk write per line. Hoisted
+    // alongside `startedAt`/`runRecordWritten`/`forceKilled` so the outer
+    // `finally`'s force-killed branch can also write whatever was captured
+    // before the forced completion unwound past the normal persistence point.
+    const logLines: string[] = [];
     try {
       if (signal?.aborted) {
         // Already aborted before we even started the stale-plan guard — end
@@ -947,6 +983,7 @@ export class TerraformService {
       try {
         while (!next.done) {
           const chunk = next.value;
+          logLines.push(chunk.line);
           if (chunk.stream === 'stdout') {
             const match = APPLY_SUMMARY_PATTERN.exec(chunk.line);
             if (match) {
@@ -997,6 +1034,10 @@ export class TerraformService {
       // only on success) so the outer `finally` below never re-attempts a
       // write this block already tried — whether it succeeded or threw.
       runRecordWritten = true;
+      // Persist the full stdout+stderr transcript accumulated above in the
+      // same spot the run record is written — a single writeFileSync now
+      // that the process has closed, rather than one append per line.
+      this.writeRunLog(runId, logLines);
       try {
         this.writeRunRecord(runId, 'apply', startedAt, result.aborted ? null : result.exitCode, tfvarsVersionId);
       } catch (err) {
@@ -1042,6 +1083,9 @@ export class TerraformService {
         logger.warn('terraform apply cancelled — generator force-closed while running', {
           runId,
         });
+        // Persist whatever transcript was captured before the forced
+        // completion unwound past the normal writeRunLog() call above.
+        this.writeRunLog(runId, logLines);
         try {
           this.writeRunRecord(runId, 'apply', startedAt, null, tfvarsVersionId);
         } catch {
@@ -1081,6 +1125,13 @@ export class TerraformService {
    * return value alongside `runId`. A run that never reaches the summary line
    * (e.g. it errors out first) resolves the count to `0`, but in that case
    * the generator throws {@link TerraformDestroyError} instead of returning.
+   *
+   * Every yielded chunk's `line` is also accumulated in-memory as it streams
+   * through, and — once the spawned process has closed — written in a
+   * single `writeFileSync` to `<runsDir>/<runId>/terraform.log` (see
+   * {@link writeRunLog}), at the same point the {@link TerraformRunRecord} is
+   * persisted (including the force-killed outer-`finally` fallback below) —
+   * mirrors {@link apply}'s equivalent handling.
    *
    * `signal`, if provided, aborts the run the same way {@link apply} does:
    * the spawned child process is killed and the generator ends cleanly — no
@@ -1134,6 +1185,11 @@ export class TerraformService {
     let startedAt: string | undefined;
     let runRecordWritten = false;
     let forceKilled = false;
+    // Accumulates every yielded chunk's `line` (stdout+stderr, in the order
+    // they were streamed) so the full transcript can be written to
+    // `<runsDir>/<runId>/terraform.log` in a single `writeFileSync` once the
+    // process has closed — mirrors apply()'s equivalent.
+    const logLines: string[] = [];
     try {
       if (signal?.aborted) {
         // Already aborted before we even started resolving the binary path —
@@ -1174,6 +1230,7 @@ export class TerraformService {
       try {
         while (!next.done) {
           const chunk = next.value;
+          logLines.push(chunk.line);
           if (chunk.stream === 'stdout') {
             const match = DESTROY_SUMMARY_PATTERN.exec(chunk.line);
             if (match) {
@@ -1216,6 +1273,10 @@ export class TerraformService {
       });
 
       runRecordWritten = true;
+      // Persist the full stdout+stderr transcript accumulated above in the
+      // same spot the run record is written — a single writeFileSync now
+      // that the process has closed, rather than one append per line.
+      this.writeRunLog(runId, logLines);
       try {
         this.writeRunRecord(runId, 'destroy', startedAt, result.aborted ? null : result.exitCode, undefined);
       } catch (err) {
@@ -1244,6 +1305,9 @@ export class TerraformService {
         logger.warn('terraform destroy cancelled — generator force-closed while running', {
           runId,
         });
+        // Persist whatever transcript was captured before the forced
+        // completion unwound past the normal writeRunLog() call above.
+        this.writeRunLog(runId, logLines);
         try {
           this.writeRunRecord(runId, 'destroy', startedAt, null, undefined);
         } catch {
@@ -1340,6 +1404,51 @@ export class TerraformService {
     const head = versions[0];
     if (!head || head.versionId !== tfvarsVersionId) {
       throw new StalePlanError(key, bucket, tfvarsVersionId, head?.versionId);
+    }
+  }
+
+  /**
+   * Returns the single filesystem path every subcommand runner
+   * ({@link plan}, {@link apply}, {@link destroy}) writes its captured
+   * stdout/stderr transcript to — `<runsDir>/<runId>/terraform.log`.
+   * Centralized (rather than each caller inlining the equivalent
+   * `join(runDir, 'terraform.log')` expression) so a later consumer (e.g. a
+   * "view full run log" IPC handler) has exactly one place to compute the
+   * same path a given `runId` was logged to.
+   */
+  private getRunLogPath(runId: string): string {
+    return join(this.config.getRunsDir(), runId, 'terraform.log');
+  }
+
+  /**
+   * Writes `lines` (the full stdout+stderr transcript accumulated in-memory
+   * by {@link plan}/{@link apply}/{@link destroy} as they streamed
+   * {@link spawnAndStream}'s chunks) to `<runsDir>/<runId>/terraform.log` in
+   * a single `writeFileSync` call, one line per `\n`-terminated row in the
+   * order they were produced. Called exactly once per run, from the same
+   * point each subcommand runner learns its spawned process has closed —
+   * i.e. immediately alongside the {@link writeRunRecord} call in
+   * `apply()`/`destroy()` (including their force-killed outer-`finally`
+   * fallback), and immediately before `plan()` returns/throws its own
+   * result — rather than appending to disk once per streamed line.
+   *
+   * Creates the run directory if it doesn't already exist (mirrors
+   * {@link writeRunRecord}'s defensive `mkdirSync`). Failures are logged at
+   * WARN and swallowed rather than thrown: losing the on-disk log transcript
+   * must never mask (or retroactively fail) an otherwise-successful
+   * `terraform` run, unlike a `run.json` persistence failure which the
+   * caller does surface via {@link TerraformRunPersistError}.
+   */
+  private writeRunLog(runId: string, lines: string[]): void {
+    const runDir = join(this.config.getRunsDir(), runId);
+    try {
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(this.getRunLogPath(runId), lines.map((line) => `${line}\n`).join(''));
+    } catch (err) {
+      logger.warn('failed to write terraform run log', {
+        runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -229,7 +229,8 @@ export interface RunRecordStore {
   /**
    * Creates or overwrites a run record, keyed on {@link RunRecord.sk}. Called
    * once the run's process has closed, with `status`/`exitCode`/`completedAt`
-   * (and, if the log was offloaded, `log`) already populated.
+   * (and, depending on whether the log was embedded or offloaded,
+   * `logInline` or `logS3Key`) already populated.
    *
    * @param record - The record to persist, including its `sk` (see `buildRunSk`).
    */
@@ -242,7 +243,7 @@ export interface RunRecordStore {
    * @param body  - The raw log contents to store.
    * @returns The store-assigned key the log was written under, suitable for
    *   passing to {@link RunRecordStore.getLogUrl} and for stashing on
-   *   {@link RunRecord.log}.
+   *   {@link RunRecord.logS3Key}.
    */
   putLog(runId: string, body: Uint8Array): Promise<string>;
 

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -1,4 +1,5 @@
 import type { AuditEntry, AuditPageResult } from './audit.js';
+import type { RunRecord } from './runs.js';
 
 /** Options for launching a game workload. Intentionally open/opaque for v1; implementations may accept provider-specific keys or refine this via intersection. */
 export interface StartOpts {
@@ -213,4 +214,45 @@ export interface AuditLogStore {
    * @returns The requested page of entries plus a cursor for the next page.
    */
   listEntries(limit: number, before?: string): Promise<AuditPageResult>;
+}
+
+/**
+ * Cloud-agnostic interface for persisting `terraform` plan/apply/destroy run
+ * history and offloading their captured logs. Implementations may target AWS
+ * DynamoDB + S3, Azure Table Storage + Blob Storage, GCP Firestore + Cloud
+ * Storage, or any other backend — callers depend only on this contract. No
+ * `@aws-sdk/*` shapes appear in this interface or its parameter/return
+ * types. Listing/pagination of persisted runs is deferred to a follow-up
+ * issue (apply-history UI) and intentionally not part of this contract yet.
+ */
+export interface RunRecordStore {
+  /**
+   * Creates or overwrites a run record, keyed on {@link RunRecord.sk}. Called
+   * once the run's process has closed, with `status`/`exitCode`/`completedAt`
+   * (and, if the log was offloaded, `log`) already populated.
+   *
+   * @param record - The record to persist, including its `sk` (see `buildRunSk`).
+   */
+  putRecord(record: RunRecord): Promise<void>;
+
+  /**
+   * Writes a run's captured log to the remote file store, keyed by `runId`.
+   *
+   * @param runId - Unique identifier of the run the log belongs to.
+   * @param body  - The raw log contents to store.
+   * @returns The store-assigned key the log was written under, suitable for
+   *   passing to {@link RunRecordStore.getLogUrl} and for stashing on
+   *   {@link RunRecord.log}.
+   */
+  putLog(runId: string, body: Uint8Array): Promise<string>;
+
+  /**
+   * Resolves a temporary, publicly-fetchable URL for a previously stored log.
+   *
+   * @param logKey - The key returned by a prior {@link RunRecordStore.putLog} call.
+   * @param expiresInSeconds - How long the returned URL should remain valid, in
+   *   seconds. Implementations may apply their own default when omitted.
+   * @returns A presigned/temporary URL the caller can fetch the log from directly.
+   */
+  getLogUrl(logKey: string, expiresInSeconds?: number): Promise<string>;
 }

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from './gameServerValidator.js';
 export * from './gamesWrite.js';
 export * from './drift.js';
 export * from './audit.js';
+export * from './runs.js';
 export * from './cloud.js';
 export * from './sanitize.js';
 export * from './canRun.js';

--- a/app/packages/shared/src/runs.test.ts
+++ b/app/packages/shared/src/runs.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildRunSk, deriveRunStatus } from './runs.js';
+
+describe('buildRunSk', () => {
+  it('should join startedAt and runId with a hash separator', () => {
+    const sk = buildRunSk('2026-07-17T12:34:56.789Z', 'run-123');
+    expect(sk).toBe('2026-07-17T12:34:56.789Z#run-123');
+  });
+
+  it('should prefix the sort key with the exact startedAt string it was given', () => {
+    const startedAt = '2020-01-01T00:00:00.000Z';
+    const sk = buildRunSk(startedAt, 'abc');
+    expect(sk.startsWith(`${startedAt}#`)).toBe(true);
+  });
+
+  it('should suffix the sort key with the exact runId it was given', () => {
+    const sk = buildRunSk('2020-01-01T00:00:00.000Z', 'run-xyz');
+    expect(sk.endsWith('#run-xyz')).toBe(true);
+  });
+
+  it('should produce sort keys that sort chronologically for increasing startedAt values', () => {
+    const earlier = buildRunSk('2026-01-01T00:00:00.000Z', 'a');
+    const later = buildRunSk('2026-06-01T00:00:00.000Z', 'a');
+    expect(earlier < later).toBe(true);
+  });
+
+  it('should not mutate any shared state across calls (pure)', () => {
+    const first = buildRunSk('2026-07-17T12:34:56.789Z', 'run-1');
+    const second = buildRunSk('2026-07-17T12:34:56.789Z', 'run-1');
+    expect(first).toBe(second);
+  });
+});
+
+describe('deriveRunStatus', () => {
+  it('should return success when exitCode is 0', () => {
+    expect(deriveRunStatus(0)).toBe('success');
+  });
+
+  it('should return failed when exitCode is a non-zero number', () => {
+    expect(deriveRunStatus(1)).toBe('failed');
+  });
+
+  it('should return aborted when exitCode is null (e.g. killed via abort signal)', () => {
+    expect(deriveRunStatus(null)).toBe('aborted');
+  });
+});

--- a/app/packages/shared/src/runs.ts
+++ b/app/packages/shared/src/runs.ts
@@ -41,12 +41,23 @@ export interface RunRecord {
   /** The tfvars version id the run was executed against, if the caller supplied one. */
   tfvarsVersionId?: string;
   /**
+   * The run's captured log text, embedded directly on the record because it
+   * was small enough to fit under the caller's inline-size threshold (see
+   * `RunRecordService.INLINE_LOG_LIMIT_BYTES`). Mutually exclusive with
+   * {@link logS3Key} — a record has at most one of the two set, never both.
+   * Absent when the log was offloaded instead, or was never captured.
+   */
+  logInline?: string;
+  /**
    * Key returned by {@link RunRecordStore.putLog} identifying where the run's
    * captured log was written (e.g. `runs/${runId}.log` in the remote file
-   * store) once it exceeded the inline-attribute size threshold. Absent when
-   * the log was small enough to be embedded elsewhere or was never captured.
+   * store) once it exceeded the inline-attribute size threshold. Pass this
+   * value to {@link RunRecordStore.getLogUrl} to resolve a fetchable URL.
+   * Mutually exclusive with {@link logInline} — a record has at most one of
+   * the two set, never both. Absent when the log was small enough to be
+   * embedded inline instead, or was never captured.
    */
-  log?: string;
+  logS3Key?: string;
 }
 
 /**

--- a/app/packages/shared/src/runs.ts
+++ b/app/packages/shared/src/runs.ts
@@ -1,0 +1,100 @@
+/**
+ * Which `terraform` subcommand a {@link RunRecord} describes. Mirrors the
+ * subset of `TerraformService`'s public surface that produces a run worth
+ * tracking in history (`init` is idempotent/frequent and is intentionally
+ * excluded).
+ */
+export type RunKind = 'plan' | 'apply' | 'destroy';
+
+/**
+ * Lifecycle status of a {@link RunRecord}, derived (never stored ad hoc) via
+ * {@link deriveRunStatus}. Also the hash key of the `status-index` GSI on the
+ * `${project_name}-runs` DynamoDB table (see `terraform/aws/runs_store.tf`),
+ * so callers can list all runs in a given status ordered by `startedAt`
+ * without scanning the table. There is no `pending` status — a
+ * {@link RunRecord} is only persisted once the subcommand has finished.
+ */
+export type RunStatus = 'success' | 'failed' | 'aborted';
+
+/**
+ * A single row in the DynamoDB run-history table (`${project_name}-runs`,
+ * `pk = "RUN"`, `sk = ` {@link buildRunSk}). Records one `terraform`
+ * plan/apply/destroy invocation driven through the management app's
+ * apply-history view — see `terraform/aws/runs_store.tf` for the table
+ * definition and issue #179 for the field list this mirrors.
+ */
+export interface RunRecord {
+  /** Sort key: `<startedAt>#<runId>` — see {@link buildRunSk}. */
+  sk: string;
+  /** Unique identifier for the run — matches the `runId` minted by `TerraformService` when the subcommand was spawned. */
+  runId: string;
+  /** Which `terraform` subcommand produced this record. */
+  kind: RunKind;
+  /** Lifecycle status, derived via {@link deriveRunStatus} from the process's exit code rather than set directly by callers. */
+  status: RunStatus;
+  /** ISO-8601 timestamp captured immediately before the process was spawned. Duplicated from `sk` for cheap reads without parsing, and doubles as the `status-index` GSI's range key. */
+  startedAt: string;
+  /** ISO-8601 timestamp captured immediately after the process closed. */
+  completedAt: string;
+  /** The process's exit code, or `null` if it never reported one (e.g. killed via abort signal). */
+  exitCode: number | null;
+  /** The tfvars version id the run was executed against, if the caller supplied one. */
+  tfvarsVersionId?: string;
+  /**
+   * Key returned by {@link RunRecordStore.putLog} identifying where the run's
+   * captured log was written (e.g. `runs/${runId}.log` in the remote file
+   * store) once it exceeded the inline-attribute size threshold. Absent when
+   * the log was small enough to be embedded elsewhere or was never captured.
+   */
+  log?: string;
+}
+
+/**
+ * A page of run records returned by a future listing API, newest-first, plus
+ * an optional cursor for fetching the next page. Not yet wired into
+ * {@link RunRecordStore} — listing/pagination is deferred to a follow-up
+ * issue; kept here so the shape is ready when that lands.
+ */
+export interface RunPageResult {
+  /** The page of records, newest-first. */
+  records: RunRecord[];
+  /** Cursor (a {@link RunRecord.sk} value) to pass as `before` to fetch the next, older page. Absent on the last page. */
+  nextBefore?: string;
+}
+
+/**
+ * Builds a DynamoDB sort key for a new {@link RunRecord}: the run's ISO-8601
+ * `startedAt` timestamp followed by a `#`-separated `runId`, e.g.
+ * `2026-07-17T12:34:56.789Z#01J...`. The ISO prefix keeps records sorted
+ * chronologically within the fixed `RUN` partition; the `runId` suffix
+ * disambiguates records started within the same millisecond.
+ *
+ * Pure: takes both `startedAt` and `runId` as arguments rather than minting
+ * either internally, so callers can pass fixed values for deterministic
+ * ordering/testing.
+ *
+ * @param startedAt - ISO-8601 timestamp the run was spawned at.
+ * @param runId - Unique identifier of the run (matches {@link RunRecord.runId}).
+ * @returns The `<startedAt>#<runId>` sort key.
+ */
+export function buildRunSk(startedAt: string, runId: string): string {
+  return `${startedAt}#${runId}`;
+}
+
+/**
+ * Derives a {@link RunStatus} from the run's process exit code, so `status`
+ * never has to be set independently of it (and can't drift out of sync).
+ *
+ * A run is `success` when the process exited `0`, `aborted` when it never
+ * reported an exit code (i.e. it was killed via an abort signal, surfaced as
+ * `exitCode === null`), and `failed` for any other non-zero exit code.
+ *
+ * @param exitCode - The process's exit code, or `null` if it never reported one (e.g. killed via abort signal).
+ * @returns The derived {@link RunStatus}.
+ */
+export function deriveRunStatus(exitCode: number | null): RunStatus {
+  if (exitCode === null) {
+    return 'aborted';
+  }
+  return exitCode === 0 ? 'success' : 'failed';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@aws-sdk/client-s3": "^3.600.0",
         "@aws-sdk/client-secrets-manager": "^3.600.0",
         "@aws-sdk/lib-dynamodb": "^3.600.0",
+        "@aws-sdk/s3-request-presigner": "^3.600.0",
         "@hyveon/shared": "*"
       }
     },
@@ -883,17 +884,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
-      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.0",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1274,15 +1275,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
-      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1090.0.tgz",
+      "integrity": "sha512-DaYXp8GMptWJUDbvpoB51xZztOw6tcbpXjYAZMXTu17E0aR+5g8FWBU3t3t0KEhhrUiKyfLpVi6uNQxNSXfbhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.15",
-        "@smithy/signature-v4": "^5.6.1",
-        "@smithy/types": "^4.15.1",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1307,12 +1325,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
-      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1415,12 +1433,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4893,12 +4911,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
-      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5145,13 +5163,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
-      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.1",
-        "@smithy/types": "^4.15.1",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5173,9 +5191,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
-      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"


### PR DESCRIPTION
Closes #179

## Summary

- Adds `AwsRunRecordStore` (`@hyveon/cloud-aws`) implementing the cloud-agnostic `RunRecordStore` contract from `@hyveon/shared/cloud.ts` — writes/reads `RunRecord` rows to the `${project_name}-runs` DynamoDB table (delivered by #105).
- Adds `RunRecordService` (`desktop-main`) which decides inline-vs-S3 log offload: logs under the DynamoDB item-size threshold are stored inline, logs over it are streamed to `s3://${bucket}/runs/${runId}.log` and the record's `logS3Key` points at the object, with a presigned-URL accessor for retrieval.
- Wires `RUN_RECORD_STORE` through `CloudProviderModule`/`TerraformModule` DI (new token in `cloud-provider.tokens.ts`) and threads `RunRecordService` into `TerraformService` so a `RunRecord` (`{ runId, kind, startedAt, completedAt, exitCode, tfvarsVersionId, logS3Key }`) is persisted to DynamoDB after every plan/apply/destroy run, alongside the existing local `<runsDir>/<runId>/run.json` + `terraform.log` artifacts.
- Adds `kind: 'plan'` local run-record writes to `TerraformService` (previously only `apply`/`destroy` wrote `run.json`) and fixes `plan()` to finalize its run record on early/forced generator close, matching `apply()`/`destroy()` behavior.
- Adds a discriminator to the shared `RunRecord.log` union (`@hyveon/shared/runs.ts`) so consumers can distinguish an inline log payload from an S3-offloaded one without inspecting optional fields.

## Changes

```
 app/packages/cloud-aws/package.json                       |   1 +
 app/packages/cloud-aws/src/AwsRunRecordStore.test.ts       | 182 ++++++++
 app/packages/cloud-aws/src/AwsRunRecordStore.ts            | 191 +++++++++
 app/packages/cloud-aws/src/index.ts                        |   1 +
 .../src/modules/cloud-provider.module.test.ts              |  45 +-
 .../desktop-main/src/modules/cloud-provider.module.ts      |  72 +++-
 .../desktop-main/src/modules/cloud-provider.tokens.ts      |   3 +
 app/packages/desktop-main/src/modules/terraform.module.ts  |  29 +-
 .../desktop-main/src/services/RunRecordService.test.ts     | 244 +++++++++++
 app/packages/desktop-main/src/services/RunRecordService.ts | 200 +++++++++
 .../src/services/TerraformService.apply.test.ts            | 373 ++++++++++++++--
 .../src/services/TerraformService.destroy.test.ts          | 301 ++++++++++++-
 .../src/services/TerraformService.init.test.ts             |  73 +---
 .../src/services/TerraformService.plan.test.ts              | 531 ++++++++++++++++++++-
 .../desktop-main/src/services/TerraformService.test.ts     |  51 ++-
 app/packages/desktop-main/src/services/TerraformService.ts | 431 +++++++++++++++++--
 app/packages/shared/src/cloud.ts                            |  43 ++
 app/packages/shared/src/index.ts                            |   1 +
 app/packages/shared/src/runs.test.ts                        |  46 ++
 app/packages/shared/src/runs.ts                              | 111 ++++++
 package-lock.json                                            |  86 ++--
 21 files changed, 2791 insertions(+), 224 deletions(-)
```

## Test plan

- [x] A `RunRecord` is written to DynamoDB after every plan/apply/destroy run via `RunRecordService` → `AwsRunRecordStore`.
- [x] Logs over the inline-storage threshold are streamed to `s3://${bucket}/runs/${runId}.log` instead of embedded in the DynamoDB item.
- [x] The persisted `RunRecord` exposes a presigned-URL accessor for S3-offloaded logs.
- [x] `RUN_RECORD_STORE` resolves through `CloudProviderModule` off `ConfigService.getActiveCloud()`, matching the existing token pattern (`CLOUD_PROVIDER`, `SECRETS_STORE`, `REMOTE_FILE_STORE`, `DISCORD_RECEIVER`).
- [x] `TerraformService.plan()` now writes a local `kind: 'plan'` run record and finalizes it on early/forced generator close (previously only `apply`/`destroy` did).
- [x] `RunRecord.log` union carries a discriminator distinguishing inline vs. S3-offloaded payloads.
- [x] `npm run app:test` passing for the touched workspaces (shared, cloud-aws, desktop-main).
- [x] `npm run app:lint` clean.
