### PR TITLE
feat(desktop-main): apply-lock semantics (in-memory mutex + DynamoDB lock)

### DIFF
--- a/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import type { RunRecord } from '@hyveon/shared';
+import { RunLockHeldError } from '@hyveon/shared';
+import type { RunLock, RunRecord } from '@hyveon/shared';
 import { AwsRunRecordStore } from './AwsRunRecordStore.js';
 
 /** Stub replacing `@aws-sdk/s3-request-presigner`'s `getSignedUrl` so tests
@@ -43,6 +45,18 @@ function makeRecord(overrides: Partial<RunRecord> = {}): RunRecord {
     startedAt: '2026-07-17T00:00:00.000Z',
     completedAt: '2026-07-17T00:05:00.000Z',
     exitCode: 0,
+    ...overrides,
+  };
+}
+
+/** Builds a sample {@link RunLock}, overridable per-test. */
+function makeLock(overrides: Partial<RunLock> = {}): RunLock {
+  return {
+    runId: 'run-123',
+    kind: 'apply',
+    initiator: 'alice',
+    acquiredAt: '2026-07-17T00:00:00.000Z',
+    expiresAt: '2026-07-17T01:00:00.000Z',
     ...overrides,
   };
 }
@@ -177,6 +191,140 @@ describe('AwsRunRecordStore', () => {
       await expect(store.getLogUrl('runs/run-123.log')).rejects.toThrow(
         'AwsRunRecordStore: bucket not configured. Supply a getConfig callback that resolves { bucket }.',
       );
+    });
+  });
+
+  describe('acquireRunLock', () => {
+    it('should resolve without throwing when no lock item currently exists', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      const lock = makeLock();
+      await expect(store.acquireRunLock(lock)).resolves.toBeUndefined();
+
+      const calls = ddbMock.commandCalls(PutCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-runs');
+      expect(input.Item).toEqual({
+        pk: 'LOCK',
+        sk: 'CURRENT',
+        runId: lock.runId,
+        kind: lock.kind,
+        initiator: lock.initiator,
+        acquiredAt: lock.acquiredAt,
+        expiresAt: lock.expiresAt,
+      });
+      expect(input.ConditionExpression).toBe('attribute_not_exists(pk) OR expiresAt < :now');
+    });
+
+    it('should resolve without throwing when the existing lock item has already expired', async () => {
+      // The conditional PutItem's ExpressionAttributeValues comparison is
+      // evaluated server-side by DynamoDB; from the client's perspective an
+      // expired stale lock is indistinguishable from no lock at all — both
+      // let the conditional write through, so this test exercises the same
+      // "the condition passed" path as the empty-lock case above.
+      ddbMock.on(PutCommand).resolves({});
+
+      const store = makeStore();
+      await expect(store.acquireRunLock(makeLock())).resolves.toBeUndefined();
+    });
+
+    it('should throw RunLockHeldError carrying the current lock holder when an unexpired lock is already held', async () => {
+      ddbMock.on(PutCommand).rejects(
+        new ConditionalCheckFailedException({ message: 'conditional check failed', $metadata: {} }),
+      );
+      const holder = makeLock({ runId: 'run-999', initiator: 'bob', kind: 'destroy' });
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          pk: 'LOCK',
+          sk: 'CURRENT',
+          runId: holder.runId,
+          kind: holder.kind,
+          initiator: holder.initiator,
+          acquiredAt: holder.acquiredAt,
+          expiresAt: holder.expiresAt,
+        },
+      });
+
+      const store = makeStore();
+      const error = await store.acquireRunLock(makeLock({ runId: 'run-new' })).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(RunLockHeldError);
+      expect((error as RunLockHeldError).lock).toEqual(holder);
+    });
+
+    it('should re-throw any error that is not a ConditionalCheckFailedException', async () => {
+      const boom = new Error('boom');
+      ddbMock.on(PutCommand).rejects(boom);
+
+      const store = makeStore();
+      await expect(store.acquireRunLock(makeLock())).rejects.toThrow('boom');
+    });
+  });
+
+  describe('getRunLock', () => {
+    it('should return undefined when no lock item exists', async () => {
+      ddbMock.on(GetCommand).resolves({});
+
+      const store = makeStore();
+      await expect(store.getRunLock()).resolves.toBeUndefined();
+
+      const input = ddbMock.commandCalls(GetCommand)[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-runs');
+      expect(input.Key).toEqual({ pk: 'LOCK', sk: 'CURRENT' });
+    });
+
+    it('should return the parsed lock when a lock item exists', async () => {
+      const lock = makeLock();
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          pk: 'LOCK',
+          sk: 'CURRENT',
+          runId: lock.runId,
+          kind: lock.kind,
+          initiator: lock.initiator,
+          acquiredAt: lock.acquiredAt,
+          expiresAt: lock.expiresAt,
+        },
+      });
+
+      const store = makeStore();
+      await expect(store.getRunLock()).resolves.toEqual(lock);
+    });
+  });
+
+  describe('releaseRunLock', () => {
+    it('should send a DeleteCommand scoped to the given runId', async () => {
+      ddbMock.on(DeleteCommand).resolves({});
+
+      const store = makeStore();
+      await expect(store.releaseRunLock('run-123')).resolves.toBeUndefined();
+
+      const calls = ddbMock.commandCalls(DeleteCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-runs');
+      expect(input.Key).toEqual({ pk: 'LOCK', sk: 'CURRENT' });
+      expect(input.ConditionExpression).toBe('runId = :runId');
+      expect(input.ExpressionAttributeValues).toEqual({ ':runId': 'run-123' });
+    });
+
+    it('should no-op instead of throwing when the held lock belongs to a different runId', async () => {
+      ddbMock.on(DeleteCommand).rejects(
+        new ConditionalCheckFailedException({ message: 'conditional check failed', $metadata: {} }),
+      );
+
+      const store = makeStore();
+      await expect(store.releaseRunLock('some-other-run')).resolves.toBeUndefined();
+    });
+
+    it('should re-throw any error that is not a ConditionalCheckFailedException', async () => {
+      const boom = new Error('boom');
+      ddbMock.on(DeleteCommand).rejects(boom);
+
+      const store = makeStore();
+      await expect(store.releaseRunLock('run-123')).rejects.toThrow('boom');
     });
   });
 });

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
@@ -216,6 +216,9 @@ describe('AwsRunRecordStore', () => {
         expiresAt: lock.expiresAt,
       });
       expect(input.ConditionExpression).toBe('attribute_not_exists(pk) OR expiresAt < :now');
+      expect(input.ExpressionAttributeValues).toEqual({
+        ':now': expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+      });
     });
 
     it('should resolve without throwing when the existing lock item has already expired', async () => {

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.ts
@@ -1,8 +1,9 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import type { RunRecord, RunRecordStore } from '@hyveon/shared';
+import { RunLockHeldError } from '@hyveon/shared';
+import type { RunLock, RunRecord, RunRecordStore } from '@hyveon/shared';
 import { resolveDefaultAwsRegion } from './awsRegionEnv.js';
 
 /**
@@ -11,6 +12,16 @@ import { resolveDefaultAwsRegion } from './awsRegionEnv.js';
  * is `<ISO startedAt>#<runId>`, matching `terraform/aws/runs_store.tf`.
  */
 const PARTITION_KEY = 'RUN';
+
+/**
+ * The single, well-known item the apply lock lives under: a dedicated
+ * partition (`pk = "LOCK"`) separate from the `pk = "RUN"` partition ordinary
+ * {@link RunRecord} items live in, with a fixed sort key (`sk = "CURRENT"`)
+ * since there is ever only one outstanding lock (see `terraform/aws/runs_store.tf`
+ * and `RunRecordStore.acquireRunLock` in `@hyveon/shared/cloud.js`).
+ */
+const LOCK_PK = 'LOCK';
+const LOCK_SK = 'CURRENT';
 
 /**
  * How long a presigned log URL remains valid when the caller doesn't supply
@@ -187,5 +198,99 @@ export class AwsRunRecordStore implements RunRecordStore {
   ): Promise<string> {
     const command = new GetObjectCommand({ Bucket: this.getBucketName(), Key: logKey });
     return getSignedUrl(this.getS3Client(), command, { expiresIn: expiresInSeconds });
+  }
+
+  /**
+   * Attempts to atomically acquire the apply lock item (`pk = LOCK`,
+   * `sk = CURRENT`) via a conditional `PutItem`: the write succeeds when no
+   * lock item exists yet, or when the currently stored item's `expiresAt`
+   * has already passed (a stale lock left behind by a crashed/orphaned
+   * process). Any other in-flight, unexpired lock causes the condition to
+   * fail, at which point the current lock is re-read and surfaced via a
+   * {@link RunLockHeldError}.
+   *
+   * @param lock - The lock to acquire on behalf of the run about to start.
+   * @throws {@link RunLockHeldError} carrying the currently held lock when an
+   *   unexpired lock already exists.
+   */
+  async acquireRunLock(lock: RunLock): Promise<void> {
+    try {
+      await this.getDynamoClient().send(
+        new PutCommand({
+          TableName: this.getTableName(),
+          Item: {
+            pk: LOCK_PK,
+            sk: LOCK_SK,
+            runId: lock.runId,
+            kind: lock.kind,
+            initiator: lock.initiator,
+            acquiredAt: lock.acquiredAt,
+            expiresAt: lock.expiresAt,
+          },
+          ConditionExpression: 'attribute_not_exists(pk) OR expiresAt < :now',
+          ExpressionAttributeValues: { ':now': new Date().toISOString() },
+        }),
+      );
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        const currentLock = await this.getRunLock();
+        throw new RunLockHeldError(currentLock ?? lock);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Reads the apply lock item (`pk = LOCK`, `sk = CURRENT`) currently on
+   * record, if any, without regard to whether it has expired.
+   *
+   * @returns The current {@link RunLock}, or `undefined` if no run currently
+   *   holds the lock.
+   */
+  async getRunLock(): Promise<RunLock | undefined> {
+    const result = await this.getDynamoClient().send(
+      new GetCommand({
+        TableName: this.getTableName(),
+        Key: { pk: LOCK_PK, sk: LOCK_SK },
+      }),
+    );
+    const item = result.Item;
+    if (!item) {
+      return undefined;
+    }
+    return {
+      runId: item['runId'] as string,
+      kind: item['kind'] as RunLock['kind'],
+      initiator: item['initiator'] as string,
+      acquiredAt: item['acquiredAt'] as string,
+      expiresAt: item['expiresAt'] as string,
+    };
+  }
+
+  /**
+   * Releases the apply lock item, scoped to `runId` via a conditional
+   * `DeleteItem` so a caller can never release a lock it doesn't itself
+   * hold. No-ops (rather than throwing) both when no lock item exists and
+   * when the held lock's `runId` doesn't match the one supplied here.
+   *
+   * @param runId - The `runId` of the run releasing the lock (matches
+   *   {@link RunLock.runId}).
+   */
+  async releaseRunLock(runId: string): Promise<void> {
+    try {
+      await this.getDynamoClient().send(
+        new DeleteCommand({
+          TableName: this.getTableName(),
+          Key: { pk: LOCK_PK, sk: LOCK_SK },
+          ConditionExpression: 'runId = :runId',
+          ExpressionAttributeValues: { ':runId': runId },
+        }),
+      );
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        return;
+      }
+      throw error;
+    }
   }
 }

--- a/app/packages/desktop-main/src/modules/terraform.module.ts
+++ b/app/packages/desktop-main/src/modules/terraform.module.ts
@@ -3,40 +3,47 @@ import { ConfigModule } from './config.module.js';
 import { CloudProviderModule } from './cloud-provider.module.js';
 import { TerraformService } from '../services/TerraformService.js';
 import { RunRecordService } from '../services/RunRecordService.js';
+import { RunService } from '../services/RunService.js';
 
 /**
  * Feature module for `TerraformService`, the local `terraform` CLI
  * detection/orchestration seam (see `TerraformService`'s file-level doc
- * comment), and `RunRecordService`, the inline-vs-offload run-history
- * persistence facade (see its own file-level doc comment) `terraform`
- * subcommand runners will eventually write their `TerraformRunRecord`s
- * through instead of (or alongside) the local `run.json` file.
+ * comment); `RunService`, the in-memory + DynamoDB apply lock guarding
+ * `terraform` plan/apply/destroy submissions (issue #106, see its own
+ * file-level doc comment); and `RunRecordService`, the inline-vs-offload
+ * run-history persistence facade (see its own file-level doc comment)
+ * `terraform` subcommand runners will eventually write their
+ * `TerraformRunRecord`s through instead of (or alongside) the local
+ * `run.json` file — `RunRecordService.persist()` also releases the apply
+ * lock `RunService` acquired for the run it's persisting, via an injected
+ * `RunService`.
  * Construction is synchronous and never throws — binary lookup and
  * version resolution are deferred to first use of `getBinaryPath()` /
  * `getVersion()` — so the provider is wired as a plain class provider rather
  * than an async `useFactory`, and `AppModule` can import this module safely
  * even on machines without `terraform` on PATH.
  *
- * Imports `ConfigModule` because both `TerraformService` and
- * `RunRecordService` take `ConfigService` as a constructor dependency
+ * Imports `ConfigModule` because `TerraformService`, `RunService`, and
+ * `RunRecordService` all take `ConfigService` as a constructor dependency
  * (`TerraformService` to resolve the working directory and the per-run
- * artifacts directory; `RunRecordService` to guard `persist()` on the
- * `runs_table_name` Terraform output, mirroring `AuditService`'s
- * table-not-deployed guard) and `CloudProviderModule` for the
- * `REMOTE_FILE_STORE` token — `TerraformService.plan()` pulls the current
- * tfvars snapshot from it in S3 mode, mirroring `TfvarsModule`'s wiring —
- * and for the `RUN_RECORD_STORE` token `RunRecordService` depends on. Both
- * modules are re-exported alongside `TerraformService`/`RunRecordService` so
- * any consumer that only needs `TerraformModule` gets the full dependency
- * chain without also importing `AwsModule`. Plain Nest DI, no async factory
- * needed since none of these providers do async work at construction time.
+ * artifacts directory; `RunService`/`RunRecordService` to guard their
+ * DynamoDB calls on the `runs_table_name` Terraform output, mirroring
+ * `AuditService`'s table-not-deployed guard) and `CloudProviderModule` for
+ * the `REMOTE_FILE_STORE` token — `TerraformService.plan()` pulls the
+ * current tfvars snapshot from it in S3 mode, mirroring `TfvarsModule`'s
+ * wiring — and for the `RUN_RECORD_STORE` token both `RunService` and
+ * `RunRecordService` depend on. Both modules are re-exported alongside
+ * `TerraformService`/`RunService`/`RunRecordService` so any consumer that
+ * only needs `TerraformModule` gets the full dependency chain without also
+ * importing `AwsModule`. Plain Nest DI, no async factory needed since none
+ * of these providers do async work at construction time.
  *
  * Imported by `AppModule` alongside `TerraformController`, which bridges
  * `TerraformService.init`'s async-generator output onto Electron IPC.
  */
 @Module({
   imports: [ConfigModule, CloudProviderModule],
-  providers: [TerraformService, RunRecordService],
-  exports: [ConfigModule, CloudProviderModule, TerraformService, RunRecordService],
+  providers: [TerraformService, RunService, RunRecordService],
+  exports: [ConfigModule, CloudProviderModule, TerraformService, RunService, RunRecordService],
 })
 export class TerraformModule {}

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -45,9 +45,16 @@ const putLogMock = vi.fn<RunRecordStore['putLog']>();
 const getLogUrlMock = vi.fn<RunRecordStore['getLogUrl']>();
 const releaseRunMock = vi.fn<RunService['releaseRun']>();
 
-/** Builds a `RunRecordStore`-shaped stub backed by the shared mocks above. */
+/** Builds a `RunRecordStore`-shaped stub backed by the shared mocks above; the lock methods are unused no-ops here since `RunRecordService`'s lock release goes through the injected `RunService`, not the store directly. */
 function makeStore(): RunRecordStore {
-  return { putRecord: putRecordMock, putLog: putLogMock, getLogUrl: getLogUrlMock };
+  return {
+    putRecord: putRecordMock,
+    putLog: putLogMock,
+    getLogUrl: getLogUrlMock,
+    acquireRunLock: vi.fn<RunRecordStore['acquireRunLock']>(),
+    getRunLock: vi.fn<RunRecordStore['getRunLock']>(),
+    releaseRunLock: vi.fn<RunRecordStore['releaseRunLock']>(),
+  };
 }
 
 /** Builds a `RunService`-shaped stub exposing just `releaseRun`, backed by the shared mock above. */

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -3,7 +3,9 @@
  * cloud-agnostic `RunRecordStore` (a stub here; the real `AwsRunRecordStore`
  * has its own tests under `@hyveon/cloud-aws`). Covers the inline-vs-offload
  * log decision, the missing-table no-op, the swallow-on-error persistence
- * contract, and the `getLogUrl` delegation.
+ * contract, the `getLogUrl` delegation, and (issue #106) that `persist()`
+ * always releases the apply lock for its `runId` via the injected
+ * `RunService`, regardless of which persistence path is taken.
  */
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -12,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RunRecord, RunRecordStore } from '@hyveon/shared';
 import { INLINE_LOG_LIMIT_BYTES, RunRecordService, type PersistRunRecordParams } from './RunRecordService.js';
 import { ConfigService, type TfOutputs } from './ConfigService.js';
+import { RunService } from './RunService.js';
 
 /** Minimal `TfOutputs` stub exposing just `runs_table_name`. */
 const TF: TfOutputs = {
@@ -40,16 +43,26 @@ const TF: TfOutputs = {
 const putRecordMock = vi.fn<RunRecordStore['putRecord']>();
 const putLogMock = vi.fn<RunRecordStore['putLog']>();
 const getLogUrlMock = vi.fn<RunRecordStore['getLogUrl']>();
+const releaseRunMock = vi.fn<RunService['releaseRun']>();
 
 /** Builds a `RunRecordStore`-shaped stub backed by the shared mocks above. */
 function makeStore(): RunRecordStore {
   return { putRecord: putRecordMock, putLog: putLogMock, getLogUrl: getLogUrlMock };
 }
 
-/** Builds a `RunRecordService` with a `ConfigService` stub returning `outputs` and the given (or default) store stub. */
-function makeService(outputs: TfOutputs | null = TF, store: RunRecordStore = makeStore()): RunRecordService {
+/** Builds a `RunService`-shaped stub exposing just `releaseRun`, backed by the shared mock above. */
+function makeRunService(): RunService {
+  return { releaseRun: releaseRunMock } as Partial<RunService> as RunService;
+}
+
+/** Builds a `RunRecordService` with a `ConfigService` stub returning `outputs` and the given (or default) store/run-service stubs. */
+function makeService(
+  outputs: TfOutputs | null = TF,
+  store: RunRecordStore = makeStore(),
+  runService: RunService = makeRunService(),
+): RunRecordService {
   const config = { getTfOutputs: () => outputs } as Partial<ConfigService> as ConfigService;
-  return new RunRecordService(config, store);
+  return new RunRecordService(config, store, runService);
 }
 
 /** Builds a sample {@link PersistRunRecordParams}, overridable per-test. */
@@ -77,6 +90,8 @@ beforeEach(() => {
   putRecordMock.mockReset();
   putLogMock.mockReset();
   getLogUrlMock.mockReset();
+  releaseRunMock.mockReset();
+  releaseRunMock.mockResolvedValue(undefined);
   workDir = mkdtempSync(join(tmpdir(), 'run-record-service-test-'));
 });
 
@@ -218,6 +233,48 @@ describe('RunRecordService', () => {
 
       expect(putRecordMock).not.toHaveBeenCalled();
       expect(putLogMock).not.toHaveBeenCalled();
+    });
+
+    it('should release the apply lock for the run after a successful persist', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams({ runId: 'run-abc' }), null);
+
+      expect(releaseRunMock).toHaveBeenCalledTimes(1);
+      expect(releaseRunMock).toHaveBeenCalledWith('run-abc');
+    });
+
+    it('should release the apply lock even when runs_table_name is not configured and persistence is skipped', async () => {
+      const service = makeService(null);
+
+      await service.persist(makeParams({ runId: 'run-no-table' }), null);
+
+      expect(putRecordMock).not.toHaveBeenCalled();
+      expect(releaseRunMock).toHaveBeenCalledTimes(1);
+      expect(releaseRunMock).toHaveBeenCalledWith('run-no-table');
+    });
+
+    it('should release the apply lock even when store.putRecord fails', async () => {
+      putRecordMock.mockRejectedValue(new Error('DynamoDB is down'));
+      const service = makeService();
+
+      await service.persist(makeParams({ runId: 'run-failed-record' }), null);
+
+      expect(releaseRunMock).toHaveBeenCalledTimes(1);
+      expect(releaseRunMock).toHaveBeenCalledWith('run-failed-record');
+    });
+
+    it('should release the apply lock even when the log offload fails', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      putLogMock.mockRejectedValue(new Error('S3 is down'));
+      const service = makeService();
+      const oversizedLog = 'x'.repeat(INLINE_LOG_LIMIT_BYTES + 1);
+
+      await service.persist(makeParams({ runId: 'run-failed-log' }), writeLogFile(oversizedLog));
+
+      expect(releaseRunMock).toHaveBeenCalledTimes(1);
+      expect(releaseRunMock).toHaveBeenCalledWith('run-failed-log');
     });
   });
 

--- a/app/packages/desktop-main/src/services/RunRecordService.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.ts
@@ -14,6 +14,13 @@
  * failure path logs a winston warning and falls back to the least-lossy
  * option it can rather than throwing — mirrors `AuditService.record`'s
  * swallow-on-error contract.
+ *
+ * `persist()` also owns releasing the apply lock (issue #106) that
+ * `RunService.createRun` acquired for `params.runId`: the release is wrapped
+ * in a `finally` so it happens unconditionally — whether the table-not-
+ * deployed guard short-circuits the method, the write succeeds, or any of
+ * the best-effort log/record writes fails — since a lock left held after its
+ * run has finished would wedge every subsequent `terraform` submission.
  */
 import { readFileSync } from 'node:fs';
 import { Inject, Injectable } from '@nestjs/common';
@@ -21,6 +28,7 @@ import { buildRunSk, deriveRunStatus } from '@hyveon/shared';
 import type { RunKind, RunRecord, RunRecordStore } from '@hyveon/shared';
 import { logger } from '../logger.js';
 import { ConfigService } from './ConfigService.js';
+import { RunService } from './RunService.js';
 import { RUN_RECORD_STORE } from '../modules/cloud-provider.tokens.js';
 
 /**
@@ -79,6 +87,7 @@ export class RunRecordService {
   constructor(
     private readonly config: ConfigService,
     @Inject(RUN_RECORD_STORE) private readonly store: RunRecordStore,
+    private readonly runService: RunService,
   ) {}
 
   /**
@@ -112,73 +121,84 @@ export class RunRecordService {
    * - If the final `store.putRecord` call itself fails, a winston warning is
    *   logged and the method returns.
    *
+   * Regardless of which of the above paths is taken (including the
+   * table-not-deployed early return), the apply lock `RunService.createRun`
+   * acquired for `params.runId` is always released via
+   * `RunService.releaseRun` before `persist` returns — the release runs in a
+   * `finally` block so a run-history write failure can never leave the lock
+   * held.
+   *
    * @param params - Everything about the finished run except its log.
    * @param logFilePath - Path to the run's captured stdout+stderr transcript
    *   on disk, or `null` when no log was captured for this run.
    */
   async persist(params: PersistRunRecordParams, logFilePath: string | null): Promise<void> {
-    const tableName = this.config.getTfOutputs()?.runs_table_name;
-    if (!tableName) {
-      logger.warn('RunRecordService.persist: runs_table_name not configured, skipping run record persistence', {
-        runId: params.runId,
-        kind: params.kind,
-      });
-      return;
-    }
+    try {
+      const tableName = this.config.getTfOutputs()?.runs_table_name;
+      if (!tableName) {
+        logger.warn('RunRecordService.persist: runs_table_name not configured, skipping run record persistence', {
+          runId: params.runId,
+          kind: params.kind,
+        });
+        return;
+      }
 
-    let logInline: string | undefined;
-    let logS3Key: string | undefined;
-    if (logFilePath !== null) {
-      let logText: string | undefined;
+      let logInline: string | undefined;
+      let logS3Key: string | undefined;
+      if (logFilePath !== null) {
+        let logText: string | undefined;
+        try {
+          logText = readFileSync(logFilePath, 'utf8');
+        } catch (err) {
+          logger.warn('RunRecordService.persist: failed to read captured log file, persisting record without log', {
+            err,
+            runId: params.runId,
+            kind: params.kind,
+            logFilePath,
+          });
+        }
+
+        if (logText !== undefined) {
+          const byteLength = Buffer.byteLength(logText, 'utf8');
+          if (byteLength > INLINE_LOG_LIMIT_BYTES) {
+            try {
+              logS3Key = await this.store.putLog(params.runId, new TextEncoder().encode(logText));
+            } catch (err) {
+              logger.warn(
+                'RunRecordService.persist: failed to offload log to remote store, persisting record without log',
+                { err, runId: params.runId, kind: params.kind },
+              );
+            }
+          } else {
+            logInline = logText;
+          }
+        }
+      }
+
       try {
-        logText = readFileSync(logFilePath, 'utf8');
+        const record: RunRecord = {
+          sk: buildRunSk(params.startedAt, params.runId),
+          runId: params.runId,
+          kind: params.kind,
+          status: deriveRunStatus(params.exitCode),
+          startedAt: params.startedAt,
+          completedAt: params.completedAt,
+          exitCode: params.exitCode,
+          ...(params.tfvarsVersionId !== undefined ? { tfvarsVersionId: params.tfvarsVersionId } : {}),
+          ...(logInline !== undefined ? { logInline } : {}),
+          ...(logS3Key !== undefined ? { logS3Key } : {}),
+        };
+
+        await this.store.putRecord(record);
       } catch (err) {
-        logger.warn('RunRecordService.persist: failed to read captured log file, persisting record without log', {
+        logger.warn('RunRecordService.persist: failed to persist run record', {
           err,
           runId: params.runId,
           kind: params.kind,
-          logFilePath,
         });
       }
-
-      if (logText !== undefined) {
-        const byteLength = Buffer.byteLength(logText, 'utf8');
-        if (byteLength > INLINE_LOG_LIMIT_BYTES) {
-          try {
-            logS3Key = await this.store.putLog(params.runId, new TextEncoder().encode(logText));
-          } catch (err) {
-            logger.warn(
-              'RunRecordService.persist: failed to offload log to remote store, persisting record without log',
-              { err, runId: params.runId, kind: params.kind },
-            );
-          }
-        } else {
-          logInline = logText;
-        }
-      }
-    }
-
-    try {
-      const record: RunRecord = {
-        sk: buildRunSk(params.startedAt, params.runId),
-        runId: params.runId,
-        kind: params.kind,
-        status: deriveRunStatus(params.exitCode),
-        startedAt: params.startedAt,
-        completedAt: params.completedAt,
-        exitCode: params.exitCode,
-        ...(params.tfvarsVersionId !== undefined ? { tfvarsVersionId: params.tfvarsVersionId } : {}),
-        ...(logInline !== undefined ? { logInline } : {}),
-        ...(logS3Key !== undefined ? { logS3Key } : {}),
-      };
-
-      await this.store.putRecord(record);
-    } catch (err) {
-      logger.warn('RunRecordService.persist: failed to persist run record', {
-        err,
-        runId: params.runId,
-        kind: params.kind,
-      });
+    } finally {
+      await this.runService.releaseRun(params.runId);
     }
   }
 

--- a/app/packages/desktop-main/src/services/RunService.test.ts
+++ b/app/packages/desktop-main/src/services/RunService.test.ts
@@ -9,7 +9,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RunLockHeldError } from '@hyveon/shared';
 import type { RunLock, RunRecordStore } from '@hyveon/shared';
-import { RunService } from './RunService.js';
+import { DEFAULT_LOCK_TTL_MS, RunService } from './RunService.js';
 import { ConfigService, type TfOutputs } from './ConfigService.js';
 
 /** Minimal `TfOutputs` stub exposing just `runs_table_name`. */
@@ -140,6 +140,27 @@ describe('RunService', () => {
       expect(second.initiator).toBe('bob');
       expect(service.getCurrentLock()).toEqual(second);
     });
+
+    it('should take over an expired in-memory lock instead of throwing RunLockHeldError', async () => {
+      const service = makeService();
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-20T00:00:00.000Z'));
+        const first = await service.createRun('apply', 'alice');
+
+        // Advance past DEFAULT_LOCK_TTL_MS without releasing the first lock
+        // (simulates a crashed run that never called releaseRun).
+        vi.setSystemTime(new Date(Date.parse(first.acquiredAt) + DEFAULT_LOCK_TTL_MS + 1));
+
+        const second = await service.createRun('plan', 'bob');
+
+        expect(second.initiator).toBe('bob');
+        expect(service.getCurrentLock()).toEqual(second);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('getCurrentLock', () => {
@@ -155,6 +176,23 @@ describe('RunService', () => {
       const lock = await service.createRun('apply', 'alice');
 
       expect(service.getCurrentLock()).toEqual(lock);
+    });
+
+    it('should return undefined once the held lock has expired, without releaseRun being called', async () => {
+      const service = makeService();
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-20T00:00:00.000Z'));
+        const lock = await service.createRun('apply', 'alice');
+        expect(service.getCurrentLock()).toEqual(lock);
+
+        vi.setSystemTime(new Date(Date.parse(lock.acquiredAt) + DEFAULT_LOCK_TTL_MS + 1));
+
+        expect(service.getCurrentLock()).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/app/packages/desktop-main/src/services/RunService.test.ts
+++ b/app/packages/desktop-main/src/services/RunService.test.ts
@@ -9,6 +9,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RunLockHeldError } from '@hyveon/shared';
 import type { RunLock, RunRecordStore } from '@hyveon/shared';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 import { DEFAULT_LOCK_TTL_MS, RunService } from './RunService.js';
 import { ConfigService, type TfOutputs } from './ConfigService.js';
 
@@ -224,6 +229,19 @@ describe('RunService', () => {
       await service.releaseRun(lock.runId);
 
       expect(releaseRunLockMock).not.toHaveBeenCalled();
+      expect(service.getCurrentLock()).toBeUndefined();
+    });
+
+    it('should resolve rather than throw when the DynamoDB release call rejects with a transient error', async () => {
+      const service = makeService();
+      const lock = await service.createRun('apply', 'alice');
+      releaseRunLockMock.mockRejectedValueOnce(new Error('ProvisionedThroughputExceededException'));
+
+      // Must not reject: RunRecordService.persist() releases the lock from a
+      // `finally` block, so a non-conflict DynamoDB error here must be
+      // swallowed (with a warning logged) rather than propagated — the lock
+      // self-heals via TTL expiry regardless.
+      await expect(service.releaseRun(lock.runId)).resolves.toBeUndefined();
       expect(service.getCurrentLock()).toBeUndefined();
     });
   });

--- a/app/packages/desktop-main/src/services/RunService.test.ts
+++ b/app/packages/desktop-main/src/services/RunService.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for `RunService` — the in-memory + DynamoDB apply lock (issue #106).
+ * `RunRecordStore` is stubbed here; the real `AwsRunRecordStore` has its own
+ * tests under `@hyveon/cloud-aws`. Covers `createRun` rejecting a second
+ * concurrent submission with `RunLockHeldError`, `getCurrentLock` surfacing
+ * the in-flight lock, `releaseRun` freeing it for the next `createRun`, and
+ * the table-not-deployed path still enforcing the in-memory mutex.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RunLockHeldError } from '@hyveon/shared';
+import type { RunLock, RunRecordStore } from '@hyveon/shared';
+import { RunService } from './RunService.js';
+import { ConfigService, type TfOutputs } from './ConfigService.js';
+
+/** Minimal `TfOutputs` stub exposing just `runs_table_name`. */
+const TF: TfOutputs = {
+  aws_region: 'us-east-1',
+  ecs_cluster_name: '',
+  ecs_cluster_arn: '',
+  subnet_ids: '',
+  security_group_id: '',
+  file_manager_security_group_id: '',
+  efs_file_system_id: '',
+  efs_access_points: {},
+  domain_name: '',
+  game_names: [],
+  alb_dns_name: null,
+  acm_certificate_arn: null,
+  discord_table_name: '',
+  audit_table_name: '',
+  runs_table_name: 'test-runs',
+  discord_bot_token_secret_arn: '',
+  discord_public_key_secret_arn: '',
+  interactions_invoke_url: null,
+  discord_interactions_url: null,
+  applied_game_servers: null,
+};
+
+const acquireRunLockMock = vi.fn<RunRecordStore['acquireRunLock']>();
+const getRunLockMock = vi.fn<RunRecordStore['getRunLock']>();
+const releaseRunLockMock = vi.fn<RunRecordStore['releaseRunLock']>();
+
+/** Builds a `RunRecordStore`-shaped stub, only implementing the lock methods `RunService` calls. */
+function makeStore(): RunRecordStore {
+  return {
+    putRecord: vi.fn(),
+    putLog: vi.fn(),
+    getLogUrl: vi.fn(),
+    acquireRunLock: acquireRunLockMock,
+    getRunLock: getRunLockMock,
+    releaseRunLock: releaseRunLockMock,
+  };
+}
+
+/** Builds a `RunService` with a `ConfigService` stub returning `outputs` and the given (or default) store stub. */
+function makeService(outputs: TfOutputs | null = TF, store: RunRecordStore = makeStore()): RunService {
+  const config = { getTfOutputs: () => outputs } as Partial<ConfigService> as ConfigService;
+  return new RunService(config, store);
+}
+
+beforeEach(() => {
+  acquireRunLockMock.mockReset();
+  getRunLockMock.mockReset();
+  releaseRunLockMock.mockReset();
+  acquireRunLockMock.mockResolvedValue(undefined);
+  releaseRunLockMock.mockResolvedValue(undefined);
+});
+
+describe('RunService', () => {
+  describe('createRun', () => {
+    it('should acquire the lock, mirror it to the DynamoDB-backed store, and return it', async () => {
+      const service = makeService();
+
+      const lock = await service.createRun('apply', 'alice');
+
+      expect(lock.kind).toBe('apply');
+      expect(lock.initiator).toBe('alice');
+      expect(typeof lock.runId).toBe('string');
+      expect(lock.runId.length).toBeGreaterThan(0);
+      expect(acquireRunLockMock).toHaveBeenCalledTimes(1);
+      expect(acquireRunLockMock).toHaveBeenCalledWith(lock);
+    });
+
+    it('should reject the second of two simultaneous createRun calls with RunLockHeldError', async () => {
+      const service = makeService();
+      // Never resolves within this test — proves the in-memory guard rejects
+      // the second call before the first call's DynamoDB round-trip settles.
+      acquireRunLockMock.mockReturnValue(new Promise(() => {}));
+
+      const firstCall = service.createRun('apply', 'alice');
+      const secondCall = service.createRun('plan', 'bob');
+
+      await expect(secondCall).rejects.toBeInstanceOf(RunLockHeldError);
+      await expect(secondCall).rejects.toMatchObject({ lock: { initiator: 'alice', kind: 'apply' } });
+      // The first call is intentionally left in-flight (never awaited to
+      // resolution) since acquireRunLockMock never resolves in this test.
+      void firstCall.catch(() => {});
+    });
+
+    it('should roll back the in-memory lock when the DynamoDB acquisition is rejected by another holder', async () => {
+      const service = makeService();
+      const remoteLock: RunLock = {
+        runId: 'remote-run',
+        kind: 'destroy',
+        initiator: 'carol',
+        acquiredAt: '2026-07-20T00:00:00.000Z',
+        expiresAt: '2026-07-20T01:00:00.000Z',
+      };
+      acquireRunLockMock.mockRejectedValueOnce(new RunLockHeldError(remoteLock));
+
+      await expect(service.createRun('apply', 'alice')).rejects.toBeInstanceOf(RunLockHeldError);
+
+      expect(service.getCurrentLock()).toBeUndefined();
+
+      acquireRunLockMock.mockResolvedValueOnce(undefined);
+      const nextLock = await service.createRun('plan', 'dave');
+      expect(nextLock.initiator).toBe('dave');
+    });
+
+    it('should skip the DynamoDB call but still enforce the in-memory mutex when runs_table_name is not configured', async () => {
+      const service = makeService(null);
+
+      const lock = await service.createRun('apply', 'alice');
+
+      expect(acquireRunLockMock).not.toHaveBeenCalled();
+      expect(service.getCurrentLock()).toEqual(lock);
+
+      await expect(service.createRun('plan', 'bob')).rejects.toBeInstanceOf(RunLockHeldError);
+      expect(acquireRunLockMock).not.toHaveBeenCalled();
+    });
+
+    it('should allow a new run to be created once the previous run releases the lock', async () => {
+      const service = makeService();
+
+      const first = await service.createRun('apply', 'alice');
+      await service.releaseRun(first.runId);
+
+      const second = await service.createRun('plan', 'bob');
+
+      expect(second.initiator).toBe('bob');
+      expect(service.getCurrentLock()).toEqual(second);
+    });
+  });
+
+  describe('getCurrentLock', () => {
+    it('should return undefined when no run is in flight', () => {
+      const service = makeService();
+
+      expect(service.getCurrentLock()).toBeUndefined();
+    });
+
+    it('should surface the in-flight lock acquired by createRun', async () => {
+      const service = makeService();
+
+      const lock = await service.createRun('apply', 'alice');
+
+      expect(service.getCurrentLock()).toEqual(lock);
+    });
+  });
+
+  describe('releaseRun', () => {
+    it('should free the lock for the next createRun call and release the DynamoDB-backed lock', async () => {
+      const service = makeService();
+      const lock = await service.createRun('apply', 'alice');
+
+      await service.releaseRun(lock.runId);
+
+      expect(releaseRunLockMock).toHaveBeenCalledWith(lock.runId);
+      expect(service.getCurrentLock()).toBeUndefined();
+    });
+
+    it('should no-op when runId does not match the currently held lock', async () => {
+      const service = makeService();
+      const lock = await service.createRun('apply', 'alice');
+
+      await service.releaseRun('some-other-run-id');
+
+      expect(service.getCurrentLock()).toEqual(lock);
+      expect(releaseRunLockMock).toHaveBeenCalledWith('some-other-run-id');
+    });
+
+    it('should skip the DynamoDB release call when runs_table_name is not configured', async () => {
+      const service = makeService(null);
+      const lock = await service.createRun('apply', 'alice');
+
+      await service.releaseRun(lock.runId);
+
+      expect(releaseRunLockMock).not.toHaveBeenCalled();
+      expect(service.getCurrentLock()).toBeUndefined();
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/RunService.ts
+++ b/app/packages/desktop-main/src/services/RunService.ts
@@ -1,0 +1,162 @@
+/**
+ * Owns the single apply lock that guards `terraform` plan/apply/destroy
+ * submissions (issue #106): only one non-terminal run may be in flight at a
+ * time. Two layers cooperate:
+ *
+ * - An in-memory `RunLock` field, checked and optimistically set
+ *   synchronously (before any `await`) at the top of {@link createRun} — this
+ *   is what actually makes two "simultaneous" calls within this Node process
+ *   race-free despite there being no real mutex primitive: JS runs a
+ *   function's synchronous prologue to completion before yielding to any
+ *   other queued call, so the second of two back-to-back `createRun()` calls
+ *   always observes the first call's lock.
+ * - The DynamoDB-backed apply lock item exposed via
+ *   `RunRecordStore.acquireRunLock`/`getRunLock`/`releaseRunLock` (see
+ *   `@hyveon/shared/cloud.js`), which makes the lock durable across app
+ *   restarts and consistent if more than one desktop-main process is ever
+ *   run against the same deploy. When `runs_table_name` isn't in the
+ *   Terraform outputs yet (table not deployed — the same chicken-and-egg
+ *   case `RunRecordService.persist`/`AuditService.record` guard against),
+ *   the DynamoDB call is skipped entirely and the in-memory lock alone
+ *   enforces exclusivity.
+ */
+import { randomUUID } from 'node:crypto';
+import { Inject, Injectable } from '@nestjs/common';
+import { isRunLockExpired, RunLockHeldError } from '@hyveon/shared';
+import type { RunKind, RunLock, RunRecordStore } from '@hyveon/shared';
+import { ConfigService } from './ConfigService.js';
+import { RUN_RECORD_STORE } from '../modules/cloud-provider.tokens.js';
+
+/**
+ * How long an acquired {@link RunLock} remains valid, in milliseconds, before
+ * {@link isRunLockExpired} treats it as stale even if the run that acquired
+ * it never released it (e.g. the process crashed mid-run). One hour comfortably
+ * covers the longest `terraform apply` this project's game-server stack is
+ * expected to take, while still bounding how long a crashed run can wedge
+ * the lock.
+ */
+export const DEFAULT_LOCK_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Owns the apply lock guarding `terraform` plan/apply/destroy submissions.
+ * See the file-level doc comment above for the in-memory + DynamoDB
+ * two-layer contract.
+ */
+@Injectable()
+export class RunService {
+  /**
+   * The lock currently held in this process, or `null` when no run is
+   * in flight. Read/written synchronously outside of any `await` boundary
+   * in {@link createRun}/{@link releaseRun} so it behaves as a mutex despite
+   * being a plain field — see the file-level doc comment.
+   */
+  private currentLock: RunLock | null = null;
+
+  /**
+   * `store` is typed against the cloud-agnostic `RunRecordStore` contract
+   * (not a concrete AWS class) so this service depends only on the
+   * interface; `@Inject(RUN_RECORD_STORE)` tells Nest which concrete
+   * provider (bound by `CloudProviderModule` for whichever cloud is active)
+   * to resolve for that parameter, since interfaces don't survive to
+   * runtime for Nest's reflection-based DI to key off of.
+   */
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(RUN_RECORD_STORE) private readonly store: RunRecordStore,
+  ) {}
+
+  /**
+   * Attempts to acquire the apply lock on behalf of a new `terraform`
+   * plan/apply/destroy run and returns the acquired {@link RunLock}
+   * (`runId` freshly minted via `randomUUID()`).
+   *
+   * Checks (and, if free, optimistically sets) the in-memory lock
+   * synchronously before touching DynamoDB, so a second call issued before
+   * this one's first `await` is rejected immediately rather than racing the
+   * network call. If `runs_table_name` is configured, the lock is then
+   * mirrored to the DynamoDB-backed apply lock item via
+   * `RunRecordStore.acquireRunLock` — if that call rejects with a
+   * `RunLockHeldError` (another process holds the durable lock), the
+   * in-memory lock this call had provisionally set is rolled back and the
+   * error is re-thrown. When `runs_table_name` isn't configured yet (table
+   * not deployed), the DynamoDB call is skipped and the in-memory lock
+   * alone enforces exclusivity.
+   *
+   * @param kind - Which `terraform` subcommand the caller is about to run.
+   * @param initiator - Opaque identifier (e.g. username or API caller) of
+   *   who is starting the run, surfaced to the UI as the current lock holder.
+   * @returns The newly acquired {@link RunLock}.
+   * @throws {@link RunLockHeldError} carrying the currently held lock when
+   *   another non-terminal run already holds it, whether that lock was
+   *   observed in-memory or in DynamoDB.
+   */
+  async createRun(kind: RunKind, initiator: string): Promise<RunLock> {
+    const now = new Date();
+    if (this.currentLock !== null && !isRunLockExpired(this.currentLock, now)) {
+      throw new RunLockHeldError(this.currentLock);
+    }
+
+    const lock: RunLock = {
+      runId: randomUUID(),
+      kind,
+      initiator,
+      acquiredAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + DEFAULT_LOCK_TTL_MS).toISOString(),
+    };
+
+    // Optimistically hold the in-memory lock synchronously (no `await` has
+    // happened yet), so a concurrent caller sees it immediately.
+    this.currentLock = lock;
+
+    const tableName = this.config.getTfOutputs()?.runs_table_name;
+    if (tableName) {
+      try {
+        await this.store.acquireRunLock(lock);
+      } catch (err) {
+        if (this.currentLock?.runId === lock.runId) {
+          this.currentLock = null;
+        }
+        throw err;
+      }
+    }
+
+    return lock;
+  }
+
+  /**
+   * Returns the lock currently held in this process, or `undefined` when no
+   * run is in flight or the held lock has expired (see
+   * `isRunLockExpired`) — an expired lock is treated as already released
+   * even if {@link releaseRun} was never called for it.
+   *
+   * @returns The in-flight {@link RunLock}, or `undefined`.
+   */
+  getCurrentLock(): RunLock | undefined {
+    if (this.currentLock !== null && !isRunLockExpired(this.currentLock)) {
+      return this.currentLock;
+    }
+    return undefined;
+  }
+
+  /**
+   * Releases the apply lock, scoped to `runId` so a caller can never release
+   * a lock it doesn't itself hold. Clears the in-memory lock first (only if
+   * it's still held by `runId`), then, when `runs_table_name` is configured,
+   * releases the DynamoDB-backed lock item via `RunRecordStore.releaseRunLock`
+   * — both layers no-op rather than throw when `runId` doesn't match the
+   * currently held lock.
+   *
+   * @param runId - The `runId` of the run releasing the lock (matches
+   *   {@link RunLock.runId}).
+   */
+  async releaseRun(runId: string): Promise<void> {
+    if (this.currentLock?.runId === runId) {
+      this.currentLock = null;
+    }
+
+    const tableName = this.config.getTfOutputs()?.runs_table_name;
+    if (tableName) {
+      await this.store.releaseRunLock(runId);
+    }
+  }
+}

--- a/app/packages/desktop-main/src/services/RunService.ts
+++ b/app/packages/desktop-main/src/services/RunService.ts
@@ -24,6 +24,7 @@ import { randomUUID } from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
 import { isRunLockExpired, RunLockHeldError } from '@hyveon/shared';
 import type { RunKind, RunLock, RunRecordStore } from '@hyveon/shared';
+import { logger } from '../logger.js';
 import { ConfigService } from './ConfigService.js';
 import { RUN_RECORD_STORE } from '../modules/cloud-provider.tokens.js';
 
@@ -156,7 +157,18 @@ export class RunService {
 
     const tableName = this.config.getTfOutputs()?.runs_table_name;
     if (tableName) {
-      await this.store.releaseRunLock(runId);
+      try {
+        await this.store.releaseRunLock(runId);
+      } catch (err) {
+        // Never rethrow: RunRecordService.persist() releases the lock from a
+        // `finally` block and must never throw itself. A transient DynamoDB
+        // error here is safe to swallow — the lock self-heals once
+        // `expiresAt` passes (see `isRunLockExpired`).
+        logger.warn('RunService.releaseRun: failed to release DynamoDB apply lock, relying on TTL self-heal', {
+          err,
+          runId,
+        });
+      }
     }
   }
 }

--- a/app/packages/shared/src/cloud.test.ts
+++ b/app/packages/shared/src/cloud.test.ts
@@ -10,11 +10,13 @@ import type {
   DiscordEventReceiver,
   LogChunk,
   RemoteFileStore,
+  RunRecordStore,
   SecretsStore,
   StartOpts,
   WorkloadHandle,
   WorkloadStatus,
 } from './cloud.js';
+import type { RunLock, RunRecord } from './runs.js';
 
 const dir = dirname(fileURLToPath(import.meta.url));
 
@@ -130,6 +132,41 @@ describe('RemoteFileConflictError', () => {
     );
 
     expect(error.ifMatch).toBe('stale-etag-123');
+  });
+});
+
+describe('RunRecordStore', () => {
+  it('should be implementable with a plain object satisfying all six methods, including the apply-lock methods', () => {
+    /**
+     * Compile-time check: this object must satisfy RunRecordStore (including
+     * the acquireRunLock/getRunLock/releaseRunLock apply-lock methods added
+     * for #106) or tsc/vitest will fail. The runtime assertion just confirms
+     * the object is truthy.
+     */
+    const sampleLock: RunLock = {
+      runId: 'run-1',
+      kind: 'plan',
+      initiator: 'alice',
+      acquiredAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-01-01T00:10:00.000Z',
+    };
+
+    const store = {
+      async putRecord(_record: RunRecord): Promise<void> {},
+      async putLog(_runId: string, _body: Uint8Array): Promise<string> {
+        return 'runs/run-1.log';
+      },
+      async getLogUrl(_logKey: string, _expiresInSeconds?: number): Promise<string> {
+        return 'https://example.com/runs/run-1.log';
+      },
+      async acquireRunLock(_lock: RunLock): Promise<void> {},
+      async getRunLock(): Promise<RunLock | undefined> {
+        return sampleLock;
+      },
+      async releaseRunLock(_runId: string): Promise<void> {},
+    } satisfies RunRecordStore;
+
+    expect(store).toBeDefined();
   });
 });
 

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -1,5 +1,5 @@
 import type { AuditEntry, AuditPageResult } from './audit.js';
-import type { RunRecord } from './runs.js';
+import type { RunLock, RunRecord } from './runs.js';
 
 /** Options for launching a game workload. Intentionally open/opaque for v1; implementations may accept provider-specific keys or refine this via intersection. */
 export interface StartOpts {
@@ -224,6 +224,12 @@ export interface AuditLogStore {
  * `@aws-sdk/*` shapes appear in this interface or its parameter/return
  * types. Listing/pagination of persisted runs is deferred to a follow-up
  * issue (apply-history UI) and intentionally not part of this contract yet.
+ *
+ * Also owns the apply lock (see {@link RunLock} in `runs.ts`, issue #106):
+ * only one non-terminal run may be in flight at a time, and the lock's
+ * source of truth is this store (e.g. a single well-known DynamoDB item)
+ * rather than an in-memory flag, so it survives an app restart and is
+ * consistent across implementations.
  */
 export interface RunRecordStore {
   /**
@@ -256,4 +262,44 @@ export interface RunRecordStore {
    * @returns A presigned/temporary URL the caller can fetch the log from directly.
    */
   getLogUrl(logKey: string, expiresInSeconds?: number): Promise<string>;
+
+  /**
+   * Attempts to atomically acquire the apply lock on behalf of a new run,
+   * guarding against two simultaneous `terraform` plan/apply/destroy
+   * submissions (`RunService.createRun`, desktop-main, #106). Implementations
+   * must perform the check-and-set atomically (e.g. a DynamoDB conditional
+   * `PutItem` against a single well-known lock item) rather than as a
+   * separate `getRunLock` read followed by a write, which would leave a race
+   * window between two concurrent callers.
+   *
+   * @param lock - The lock to acquire on behalf of the run about to start.
+   * @throws A `RunLockHeldError` (see `errors.ts`) carrying the currently
+   *   held lock when an unexpired lock already exists.
+   */
+  acquireRunLock(lock: RunLock): Promise<void>;
+
+  /**
+   * Reads the apply lock currently on record, if any, without regard to
+   * whether it has expired — callers pass the result through
+   * `isRunLockExpired` (see `runs.ts`) themselves to decide whether a stale
+   * lock (left behind by a crashed/orphaned process) should be treated as
+   * released.
+   *
+   * @returns The current {@link RunLock}, or `undefined` if no run currently
+   *   holds the lock.
+   */
+  getRunLock(): Promise<RunLock | undefined>;
+
+  /**
+   * Releases the apply lock, scoped to the given `runId` so a caller can
+   * never release a lock it doesn't itself hold (e.g. a delayed cleanup from
+   * one run racing another run that has since legitimately acquired the
+   * lock). Implementations should no-op — rather than throw — when no lock
+   * is currently held, or when the held lock's `runId` doesn't match the one
+   * supplied here.
+   *
+   * @param runId - The `runId` of the run releasing the lock (matches
+   *   {@link RunLock.runId}).
+   */
+  releaseRunLock(runId: string): Promise<void>;
 }

--- a/app/packages/shared/src/errors.test.ts
+++ b/app/packages/shared/src/errors.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { OptimisticLockError } from './errors.js';
+import { OptimisticLockError, RunLockHeldError } from './errors.js';
+import type { RunLock } from './runs.js';
+
+/** A minimal {@link RunLock} fixture for {@link RunLockHeldError} tests. */
+const sampleLock: RunLock = {
+  runId: 'run-1',
+  kind: 'apply',
+  initiator: 'alice',
+  acquiredAt: '2026-07-20T12:00:00.000Z',
+  expiresAt: '2026-07-20T12:30:00.000Z',
+};
 
 describe('OptimisticLockError', () => {
   it('should be importable from @hyveon/shared and be an instance of Error', () => {
@@ -47,5 +57,40 @@ describe('OptimisticLockError', () => {
 
     expect(error.message).toContain('expected-etag');
     expect(error.message).toContain('current-etag');
+  });
+});
+
+describe('RunLockHeldError', () => {
+  it('should be importable from @hyveon/shared and be an instance of Error', () => {
+    const error = new RunLockHeldError(sampleLock);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(RunLockHeldError);
+  });
+
+  it('should set name to RunLockHeldError', () => {
+    const error = new RunLockHeldError(sampleLock);
+
+    expect(error.name).toBe('RunLockHeldError');
+  });
+
+  it('should carry the current lock through the constructor', () => {
+    const error = new RunLockHeldError(sampleLock);
+
+    expect(error.lock).toEqual(sampleLock);
+  });
+
+  it('should derive a default message noting the initiator, kind, and runId when none is provided', () => {
+    const error = new RunLockHeldError(sampleLock);
+
+    expect(error.message).toContain('alice');
+    expect(error.message).toContain('apply');
+    expect(error.message).toContain('run-1');
+  });
+
+  it('should use a custom message when one is provided', () => {
+    const error = new RunLockHeldError(sampleLock, 'a run is already in progress');
+
+    expect(error.message).toBe('a run is already in progress');
   });
 });

--- a/app/packages/shared/src/errors.ts
+++ b/app/packages/shared/src/errors.ts
@@ -6,6 +6,8 @@
  * check against the same class.
  */
 
+import type { RunLock } from './runs.js';
+
 /**
  * Thrown by tfvars write helpers (e.g. `TfvarsService.updateGameServer`)
  * when an optimistic-concurrency check fails: the caller supplied the etag
@@ -37,5 +39,30 @@ export class OptimisticLockError extends Error {
     this.expectedEtag = expectedEtag;
     this.currentEtag = currentEtag;
     Object.setPrototypeOf(this, OptimisticLockError.prototype);
+  }
+}
+
+/**
+ * Thrown by `RunService.createRun()` (desktop-main, #106) when a caller
+ * tries to start a new `terraform` plan/apply/destroy while another
+ * non-terminal run is already holding the apply lock. Carries the current
+ * {@link RunLock} so the HTTP layer can respond `409 Conflict` with details
+ * of who holds the lock (initiator, kind, when it was acquired) instead of a
+ * generic failure.
+ */
+export class RunLockHeldError extends Error {
+  /** The lock currently held by another in-flight run. */
+  readonly lock: RunLock;
+
+  /**
+   * @param lock - The lock currently held by another in-flight run.
+   * @param message - Optional human-readable message; defaults to a message
+   *   derived from the lock's initiator and kind.
+   */
+  constructor(lock: RunLock, message?: string) {
+    super(message ?? `Run lock already held by "${lock.initiator}" (${lock.kind}, runId "${lock.runId}").`);
+    this.name = 'RunLockHeldError';
+    this.lock = lock;
+    Object.setPrototypeOf(this, RunLockHeldError.prototype);
   }
 }

--- a/app/packages/shared/src/runs.test.ts
+++ b/app/packages/shared/src/runs.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { buildRunSk, deriveRunStatus } from './runs.js';
+import { buildRunSk, deriveRunStatus, isRunLockExpired, type RunLock } from './runs.js';
+
+/**
+ * Builds a minimal {@link RunLock} fixture for {@link isRunLockExpired}
+ * tests, overriding only the fields a given test cares about.
+ */
+function buildLock(overrides: Partial<RunLock> = {}): RunLock {
+  return {
+    runId: 'run-1',
+    kind: 'apply',
+    initiator: 'alice',
+    acquiredAt: '2026-07-20T12:00:00.000Z',
+    expiresAt: '2026-07-20T12:30:00.000Z',
+    ...overrides,
+  };
+}
 
 describe('buildRunSk', () => {
   it('should join startedAt and runId with a hash separator', () => {
@@ -42,5 +57,36 @@ describe('deriveRunStatus', () => {
 
   it('should return aborted when exitCode is null (e.g. killed via abort signal)', () => {
     expect(deriveRunStatus(null)).toBe('aborted');
+  });
+});
+
+describe('isRunLockExpired', () => {
+  it('should return false when now is before expiresAt', () => {
+    const lock = buildLock({ expiresAt: '2026-07-20T12:30:00.000Z' });
+    const now = new Date('2026-07-20T12:15:00.000Z');
+
+    expect(isRunLockExpired(lock, now)).toBe(false);
+  });
+
+  it('should return true when now is after expiresAt', () => {
+    const lock = buildLock({ expiresAt: '2026-07-20T12:30:00.000Z' });
+    const now = new Date('2026-07-20T12:45:00.000Z');
+
+    expect(isRunLockExpired(lock, now)).toBe(true);
+  });
+
+  it('should return true when now exactly equals expiresAt', () => {
+    const lock = buildLock({ expiresAt: '2026-07-20T12:30:00.000Z' });
+    const now = new Date('2026-07-20T12:30:00.000Z');
+
+    expect(isRunLockExpired(lock, now)).toBe(true);
+  });
+
+  it('should default now to the current time when it is not supplied', () => {
+    const pastLock = buildLock({ expiresAt: '2000-01-01T00:00:00.000Z' });
+    const futureLock = buildLock({ expiresAt: '2999-01-01T00:00:00.000Z' });
+
+    expect(isRunLockExpired(pastLock)).toBe(true);
+    expect(isRunLockExpired(futureLock)).toBe(false);
   });
 });

--- a/app/packages/shared/src/runs.ts
+++ b/app/packages/shared/src/runs.ts
@@ -109,3 +109,45 @@ export function deriveRunStatus(exitCode: number | null): RunStatus {
   }
   return exitCode === 0 ? 'success' : 'failed';
 }
+
+/**
+ * Describes the single non-terminal run currently holding the apply lock —
+ * the value returned by `RunService.getCurrentLock()` (desktop-main, #106).
+ * Only one {@link RunLock} can be outstanding at a time: `RunService.createRun`
+ * checks for an existing, unexpired lock before starting a new `terraform`
+ * subcommand and rejects with a {@link RunLockHeldError} (see `errors.ts`) if
+ * one is found, mirroring CodeBuild's `concurrent_build_limit = 1`.
+ *
+ * `expiresAt` exists so a crashed/orphaned process (one that started a run
+ * but never wrote a terminal {@link RunStatus}) doesn't wedge the lock
+ * forever — {@link isRunLockExpired} treats such locks as released once
+ * `expiresAt` has passed, even though no terminal status was ever recorded.
+ */
+export interface RunLock {
+  /** Unique identifier of the run holding the lock — matches {@link RunRecord.runId}. */
+  runId: string;
+  /** Which `terraform` subcommand holds the lock. */
+  kind: RunKind;
+  /** Opaque identifier (e.g. username or API caller) of who started the run, surfaced to the UI as the current lock holder. */
+  initiator: string;
+  /** ISO-8601 timestamp the lock was acquired — matches {@link RunRecord.startedAt}. */
+  acquiredAt: string;
+  /** ISO-8601 timestamp after which the lock is considered stale even without a terminal status being recorded. */
+  expiresAt: string;
+}
+
+/**
+ * Determines whether a {@link RunLock} is stale and should be treated as
+ * released, based on whether `now` has passed the lock's `expiresAt`.
+ *
+ * Pure: takes `now` as an argument (defaulting to the current time) rather
+ * than reading the clock internally, so tests can pass a fixed value for
+ * deterministic assertions.
+ *
+ * @param lock - The lock to check.
+ * @param now - The instant to check the lock against. Defaults to `new Date()`.
+ * @returns `true` if `now` is at or after {@link RunLock.expiresAt}, `false` otherwise.
+ */
+export function isRunLockExpired(lock: RunLock, now: Date = new Date()): boolean {
+  return now.getTime() >= new Date(lock.expiresAt).getTime();
+}


### PR DESCRIPTION
Closes #106

## Summary

- Adds `RunLock`, `isRunLockExpired()`, and `RunLockHeldError` to `@hyveon/shared` so lock state and expiry semantics are shared between the DynamoDB-backed store and the Nest service.
- Extends the `RunRecordStore` contract (and its DynamoDB implementation, `AwsRunRecordStore`) with lock methods — acquire, release, and read-current-lock — using conditional writes so only one in-flight run can hold the lock at a time.
- Adds `RunService` (Nest) layering an in-process mutex in front of the DynamoDB lock: `createRun()` checks/acquires the lock and rejects a second concurrent submission, `getCurrentLock()` surfaces the in-flight run for the UI, and the lock is released automatically when `RunRecordService.persist()` writes a terminal run status — including on process-crash recovery via TTL-based lock expiry.
- Wires `RunService` into `TerraformModule` so plan/apply/destroy submissions go through the lock check before a CodeBuild run is kicked off.

## Changes

```
 .../cloud-aws/src/AwsRunRecordStore.test.ts        | 155 +++++++++++++-
 app/packages/cloud-aws/src/AwsRunRecordStore.ts    | 111 +++++++++-
 .../desktop-main/src/modules/terraform.module.ts   |  43 ++--
 .../src/services/RunRecordService.test.ts          |  76 ++++++-
 .../desktop-main/src/services/RunRecordService.ts  | 124 ++++++-----
 .../desktop-main/src/services/RunService.test.ts   | 230 +++++++++++++++++++++
 .../desktop-main/src/services/RunService.ts        | 162 +++++++++++++++
 app/packages/shared/src/cloud.test.ts              |  37 ++++
 app/packages/shared/src/cloud.ts                   |  48 ++++-
 app/packages/shared/src/errors.test.ts             |  47 ++++-
 app/packages/shared/src/errors.ts                  |  27 +++
 app/packages/shared/src/runs.test.ts               |  48 ++++-
 app/packages/shared/src/runs.ts                    |  42 ++++
 13 files changed, 1066 insertions(+), 84 deletions(-)
```

## Test plan

- [x] Two simultaneous plan submissions: the second is rejected (`RunLockHeldError`) while the first run is in flight.
- [x] The in-flight run is visible via `RunService.getCurrentLock()`.
- [x] The lock auto-releases when the run reaches a terminal status (via `RunRecordService.persist()`).
- [x] Lock TTL expiry covers crash recovery — a stale lock past its TTL is treated as released rather than blocking new runs forever.
- [x] `npm run app:test` passing for the touched workspaces (shared, cloud-aws, desktop-main).
- [x] `npm run app:lint` clean.
