### PR TITLE
feat(desktop-main): gsd.terraform.runs IPC + log stream channel

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -26,6 +26,7 @@ import { DriftHttpController } from './controllers/drift-http.controller.js';
 import { AuditController } from './controllers/audit.controller.js';
 import { AuditHttpController } from './controllers/audit-http.controller.js';
 import { TerraformController } from './controllers/terraform.controller.js';
+import { TerraformRunsController } from './controllers/terraform-runs.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
 import { DriftService } from './services/DriftService.js';
 import { GamesWriteService } from './services/GamesWriteService.js';
@@ -60,6 +61,7 @@ import { AuditService } from './services/AuditService.js';
     AuditController,
     AuditHttpController,
     TerraformController,
+    TerraformRunsController,
   ],
   providers: [
     {

--- a/app/packages/desktop-main/src/controllers/terraform-runs.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform-runs.controller.test.ts
@@ -1,10 +1,32 @@
 import 'reflect-metadata';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BadRequestException } from '@nestjs/common';
 import type { RunLock } from '@hyveon/shared';
 import { TerraformRunsController } from './terraform-runs.controller.js';
-import type { TerraformService, TerraformRunRecord } from '../services/TerraformService.js';
+import type { TerraformService, TerraformRunChunk, TerraformRunRecord } from '../services/TerraformService.js';
 import type { RunService } from '../services/RunService.js';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state — must be declared before any vi.mock() factory runs.
+// ---------------------------------------------------------------------------
+
+/**
+ * Captures every `ipcMain.handle`/`ipcMain.removeHandler` call so
+ * `onModuleInit` tests can assert on bridge registration without a real
+ * Electron main process.
+ */
+const { mockIpcMainHandle, mockIpcMainRemoveHandler } = vi.hoisted(() => {
+  const mockIpcMainHandle = vi.fn();
+  const mockIpcMainRemoveHandler = vi.fn();
+  return { mockIpcMainHandle, mockIpcMainRemoveHandler };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mockIpcMainHandle,
+    removeHandler: mockIpcMainRemoveHandler,
+  },
+}));
 
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -13,7 +35,9 @@ vi.mock('../logger.js', () => ({
 /**
  * Build a `TerraformService` stub. `record` seeds what `readRunRecord`
  * resolves for any `runId` (defaults to `null`, i.e. no persisted run);
- * `planArtifactExists` seeds `hasPlanArtifact`'s return value.
+ * `planArtifactExists` seeds `hasPlanArtifact`'s return value;
+ * `streamRunOutput` seeds an empty async generator by default so `logs()`
+ * tests can override it per-case via `vi.mocked(...).mockImplementation(...)`.
  */
 function makeTerraform(
   record: TerraformRunRecord | null = null,
@@ -22,7 +46,36 @@ function makeTerraform(
   return {
     readRunRecord: vi.fn().mockReturnValue(record),
     hasPlanArtifact: vi.fn().mockReturnValue(planArtifactExists),
+    streamRunOutput: vi.fn().mockImplementation(async function* () { /* empty */ }),
   } as unknown as TerraformService;
+}
+
+/**
+ * Build a minimal `IpcMainInvokeEvent` stub with a controlled `sender`
+ * (WebContents). Tests can inspect calls on `sender.send` and control the
+ * return value of `sender.isDestroyed()`, plus fire the `'destroyed'` event
+ * listener registered via `sender.once('destroyed', ...)`.
+ */
+function makeCtx(isDestroyed = false) {
+  const destroyedListeners: Array<() => void> = [];
+  const sender = {
+    send: vi.fn(),
+    isDestroyed: vi.fn().mockReturnValue(isDestroyed),
+    once: vi.fn().mockImplementation((event: string, listener: () => void) => {
+      if (event === 'destroyed') destroyedListeners.push(listener);
+    }),
+    removeListener: vi.fn(),
+  };
+  return {
+    ctx: { evt: { sender } } as unknown as { evt: { sender: typeof sender } },
+    sender,
+    fireDestroyed: () => destroyedListeners.forEach((listener) => listener()),
+  };
+}
+
+/** Flush the microtask queue so async fire-and-forget loops fully settle. */
+function flushPromises(): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 /** Build a `RunService` stub whose `getCurrentLock()` returns `lock` (defaults to `undefined`, i.e. no run in flight). */
@@ -143,5 +196,214 @@ describe('TerraformRunsController.get', () => {
     const controller = new TerraformRunsController(makeTerraform(), makeRunService());
 
     await expect(controller.get({ runId: '' })).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+
+describe('TerraformRunsController.onModuleInit', () => {
+  // onModuleInit only wires the bridge when running inside a real Electron
+  // main process, detected via `process.versions.electron`. Vitest runs under
+  // plain Node where it's undefined, so fake it for the "is Electron" cases
+  // and restore afterwards.
+  const realElectronVersion = process.versions.electron;
+  const setElectron = (value: string | undefined): void => {
+    if (value === undefined) {
+      delete (process.versions as { electron?: string }).electron;
+    } else {
+      Object.defineProperty(process.versions, 'electron', { value, configurable: true });
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setElectron('30.0.0');
+  });
+  afterEach(() => setElectron(realElectronVersion));
+
+  it('should skip the ipcMain bridge when not running inside an Electron main process', async () => {
+    setElectron(undefined);
+    await new TerraformRunsController(makeTerraform(), makeRunService()).onModuleInit();
+
+    expect(mockIpcMainHandle).not.toHaveBeenCalled();
+    expect(mockIpcMainRemoveHandler).not.toHaveBeenCalled();
+  });
+
+  it('should register ipcMain.handle for "terraform.runs.logs" so ipcRenderer.invoke can resolve', async () => {
+    await new TerraformRunsController(makeTerraform(), makeRunService()).onModuleInit();
+
+    expect(mockIpcMainHandle).toHaveBeenCalledWith('terraform.runs.logs', expect.any(Function));
+  });
+
+  it('should remove any existing "terraform.runs.logs" handler before registering so hot-reload re-bootstrap does not throw', async () => {
+    await new TerraformRunsController(makeTerraform(), makeRunService()).onModuleInit();
+
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith('terraform.runs.logs');
+    expect(mockIpcMainRemoveHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      mockIpcMainHandle.mock.invocationCallOrder[0],
+    );
+  });
+});
+
+describe('TerraformRunsController.logs', () => {
+  it('should return a non-empty streamId string immediately', async () => {
+    const { ctx } = makeCtx();
+    const controller = new TerraformRunsController(makeTerraform(), makeRunService());
+
+    const result = await controller.logs({ runId: 'run-1' }, ctx);
+
+    expect(result).toHaveProperty('streamId');
+    expect(typeof result.streamId).toBe('string');
+    expect(result.streamId.length).toBeGreaterThan(0);
+  });
+
+  it('should reject a payload with a missing runId without opening a stream', async () => {
+    const terraform = makeTerraform();
+    const { ctx } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    await expect(
+      controller.logs({} as unknown as { runId: string }, ctx),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(terraform.streamRunOutput).not.toHaveBeenCalled();
+  });
+
+  it('should reject a payload with an empty-string runId without opening a stream', async () => {
+    const terraform = makeTerraform();
+    const { ctx } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    await expect(controller.logs({ runId: '' }, ctx)).rejects.toBeInstanceOf(BadRequestException);
+    expect(terraform.streamRunOutput).not.toHaveBeenCalled();
+  });
+
+  it('should forward every chunk, in order, on terraform.runs.logs.chunk tagged with the streamId', async () => {
+    const chunks: TerraformRunChunk[] = [
+      { stream: 'stdout', line: 'Terraform will perform the following actions:' },
+      { stream: 'stdout', line: 'Plan: 1 to add, 0 to change, 0 to destroy.' },
+    ];
+    async function* twoChunks() {
+      for (const chunk of chunks) yield chunk;
+    }
+    const terraform = makeTerraform();
+    vi.mocked(terraform.streamRunOutput).mockImplementation(twoChunks);
+    const { ctx, sender } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    const { streamId } = await controller.logs({ runId: 'run-1' }, ctx);
+    await flushPromises();
+
+    const chunkCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.runs.logs.chunk');
+    expect(chunkCalls).toEqual([
+      ['terraform.runs.logs.chunk', { streamId, chunk: chunks[0] }],
+      ['terraform.runs.logs.chunk', { streamId, chunk: chunks[1] }],
+    ]);
+  });
+
+  it('should call TerraformService.streamRunOutput with the runId and an AbortSignal', async () => {
+    const terraform = makeTerraform();
+    const { ctx } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    await controller.logs({ runId: 'run-42' }, ctx);
+    await flushPromises();
+
+    expect(terraform.streamRunOutput).toHaveBeenCalledWith('run-42', expect.any(AbortSignal));
+  });
+
+  it('should send exactly one terraform.runs.logs.end message with no error when the run reaches a terminal status', async () => {
+    async function* empty() { /* run already settled — no further chunks */ }
+    const terraform = makeTerraform();
+    vi.mocked(terraform.streamRunOutput).mockImplementation(empty);
+    const { ctx, sender } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    const { streamId } = await controller.logs({ runId: 'run-1' }, ctx);
+    await flushPromises();
+
+    const endCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.runs.logs.end');
+    expect(endCalls).toEqual([['terraform.runs.logs.end', { streamId }]]);
+  });
+
+  it('should send exactly one terraform.runs.logs.end message with an error when the stream throws', async () => {
+    async function* throwsError(): AsyncGenerator<TerraformRunChunk> {
+      yield { stream: 'stdout', line: 'partial' };
+      throw new Error('no run found for runId "run-1"');
+    }
+    const terraform = makeTerraform();
+    vi.mocked(terraform.streamRunOutput).mockImplementation(throwsError);
+    const { ctx, sender } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    const { streamId } = await controller.logs({ runId: 'run-1' }, ctx);
+    await flushPromises();
+
+    const endCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.runs.logs.end');
+    expect(endCalls).toHaveLength(1);
+    const [, message] = endCalls[0] as [string, { streamId: string; error?: string }];
+    expect(message.streamId).toBe(streamId);
+    expect(message.error).toContain('no run found for runId "run-1"');
+  });
+
+  it('should stop sending chunks once the WebContents is destroyed mid-stream', async () => {
+    let sawAbort = false;
+    async function* waitForAbort(
+      runId: string,
+      signal: AbortSignal,
+    ): AsyncGenerator<TerraformRunChunk> {
+      yield { stream: 'stdout', line: 'first' };
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => {
+          sawAbort = true;
+          resolve();
+        });
+      });
+      yield { stream: 'stdout', line: 'should never be sent' };
+    }
+    const terraform = makeTerraform();
+    vi.mocked(terraform.streamRunOutput).mockImplementation(waitForAbort);
+    const { ctx, sender, fireDestroyed } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    await controller.logs({ runId: 'run-1' }, ctx);
+    await flushPromises();
+
+    fireDestroyed();
+    // Once destroyed, sender.isDestroyed() should also reflect that a real
+    // WebContents would report — simulate that alongside the abort.
+    sender.isDestroyed.mockReturnValue(true);
+    await flushPromises();
+
+    expect(sawAbort).toBe(true);
+    const chunkCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.runs.logs.chunk');
+    expect(chunkCalls).toHaveLength(1);
+    const endCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.runs.logs.end');
+    expect(endCalls).toHaveLength(0);
+  });
+
+  it('should not send any messages when the WebContents is already destroyed before the first chunk', async () => {
+    async function* oneChunk(): AsyncGenerator<TerraformRunChunk> {
+      yield { stream: 'stdout', line: 'line' };
+    }
+    const terraform = makeTerraform();
+    vi.mocked(terraform.streamRunOutput).mockImplementation(oneChunk);
+    const { ctx, sender } = makeCtx(true);
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    await controller.logs({ runId: 'run-1' }, ctx);
+    await flushPromises();
+
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('should remove the destroyed listener after the stream ends naturally', async () => {
+    async function* empty() { /* terminates immediately */ }
+    const terraform = makeTerraform();
+    vi.mocked(terraform.streamRunOutput).mockImplementation(empty);
+    const { ctx, sender } = makeCtx();
+    const controller = new TerraformRunsController(terraform, makeRunService());
+
+    await controller.logs({ runId: 'run-1' }, ctx);
+    await flushPromises();
+
+    expect(sender.removeListener).toHaveBeenCalledWith('destroyed', expect.any(Function));
   });
 });

--- a/app/packages/desktop-main/src/controllers/terraform-runs.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform-runs.controller.test.ts
@@ -1,0 +1,147 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import type { RunLock } from '@hyveon/shared';
+import { TerraformRunsController } from './terraform-runs.controller.js';
+import type { TerraformService, TerraformRunRecord } from '../services/TerraformService.js';
+import type { RunService } from '../services/RunService.js';
+
+vi.mock('../logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/**
+ * Build a `TerraformService` stub. `record` seeds what `readRunRecord`
+ * resolves for any `runId` (defaults to `null`, i.e. no persisted run);
+ * `planArtifactExists` seeds `hasPlanArtifact`'s return value.
+ */
+function makeTerraform(
+  record: TerraformRunRecord | null = null,
+  planArtifactExists = false,
+): TerraformService {
+  return {
+    readRunRecord: vi.fn().mockReturnValue(record),
+    hasPlanArtifact: vi.fn().mockReturnValue(planArtifactExists),
+  } as unknown as TerraformService;
+}
+
+/** Build a `RunService` stub whose `getCurrentLock()` returns `lock` (defaults to `undefined`, i.e. no run in flight). */
+function makeRunService(lock: RunLock | undefined = undefined): RunService {
+  return {
+    getCurrentLock: vi.fn().mockReturnValue(lock),
+  } as unknown as RunService;
+}
+
+/** A `TerraformRunRecord` fixture for a successful `plan` run. */
+function buildRecord(overrides: Partial<TerraformRunRecord> = {}): TerraformRunRecord {
+  return {
+    runId: 'run-1',
+    kind: 'plan',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    completedAt: '2026-01-01T00:01:00.000Z',
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+/** A `RunLock` fixture for a run currently holding the apply lock. */
+function buildLock(overrides: Partial<RunLock> = {}): RunLock {
+  return {
+    runId: 'run-1',
+    kind: 'plan',
+    initiator: 'operator',
+    acquiredAt: '2026-01-01T00:00:00.000Z',
+    expiresAt: '2026-01-01T01:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('TerraformRunsController.get', () => {
+  it('should return found: true, status: running for the runId currently holding the apply lock', async () => {
+    const runService = makeRunService(buildLock({ runId: 'run-live' }));
+    const terraform = makeTerraform();
+    const controller = new TerraformRunsController(terraform, runService);
+
+    const result = await controller.get({ runId: 'run-live' });
+
+    expect(result).toEqual({ found: true, status: 'running' });
+    expect(terraform.readRunRecord).not.toHaveBeenCalled();
+  });
+
+  it('should return found: true, status: success plus the record for a finished apply run', async () => {
+    const record = buildRecord({ runId: 'run-apply', kind: 'apply', exitCode: 0 });
+    const terraform = makeTerraform(record);
+    const runService = makeRunService();
+    const controller = new TerraformRunsController(terraform, runService);
+
+    const result = await controller.get({ runId: 'run-apply' });
+
+    expect(result).toEqual({ found: true, status: 'success', record });
+  });
+
+  it('should return found: true, status: failed plus the record for a plan run that exited non-zero', async () => {
+    const record = buildRecord({ runId: 'run-failed', kind: 'plan', exitCode: 1 });
+    const terraform = makeTerraform(record, false);
+    const runService = makeRunService();
+    const controller = new TerraformRunsController(terraform, runService);
+
+    const result = await controller.get({ runId: 'run-failed' });
+
+    expect(result).toEqual({ found: true, status: 'failed', record });
+  });
+
+  it('should return found: true, status: aborted plus the record for a run with no exit code', async () => {
+    const record = buildRecord({ runId: 'run-aborted', kind: 'destroy', exitCode: null });
+    const terraform = makeTerraform(record);
+    const runService = makeRunService();
+    const controller = new TerraformRunsController(terraform, runService);
+
+    const result = await controller.get({ runId: 'run-aborted' });
+
+    expect(result).toEqual({ found: true, status: 'aborted', record });
+  });
+
+  it('should return found: true, status: awaiting_approval plus the record for a successful plan run whose .tfplan artifact still exists', async () => {
+    const record = buildRecord({ runId: 'run-plan', kind: 'plan', exitCode: 0 });
+    const terraform = makeTerraform(record, true);
+    const runService = makeRunService();
+    const controller = new TerraformRunsController(terraform, runService);
+
+    const result = await controller.get({ runId: 'run-plan' });
+
+    expect(result).toEqual({ found: true, status: 'awaiting_approval', record });
+    expect(terraform.hasPlanArtifact).toHaveBeenCalledWith('run-plan');
+  });
+
+  it('should return found: false when runId is neither the held lock nor a persisted run', async () => {
+    const terraform = makeTerraform(null);
+    const runService = makeRunService();
+    const controller = new TerraformRunsController(terraform, runService);
+
+    const result = await controller.get({ runId: 'does-not-exist' });
+
+    expect(result).toEqual({ found: false });
+  });
+
+  it('should reject a payload with a missing runId', async () => {
+    const controller = new TerraformRunsController(makeTerraform(), makeRunService());
+
+    await expect(
+      controller.get({} as unknown as { runId: string }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should reject a payload with a non-string runId', async () => {
+    const controller = new TerraformRunsController(makeTerraform(), makeRunService());
+
+    await expect(
+      controller.get({ runId: 42 } as unknown as { runId: string }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('should reject a payload with an empty-string runId', async () => {
+    const controller = new TerraformRunsController(makeTerraform(), makeRunService());
+
+    await expect(controller.get({ runId: '' })).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/app/packages/desktop-main/src/controllers/terraform-runs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform-runs.controller.ts
@@ -1,8 +1,15 @@
-import { BadRequestException, Controller } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { BadRequestException, Controller, OnModuleInit } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
+import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
 import { computeRunDetailStatus, type RunDetailStatus } from '@hyveon/shared';
-import { TerraformService, type TerraformRunRecord } from '../services/TerraformService.js';
+import {
+  TerraformService,
+  type TerraformRunChunk,
+  type TerraformRunRecord,
+} from '../services/TerraformService.js';
 import { RunService } from '../services/RunService.js';
+import { logger } from '../logger.js';
 
 /** Payload accepted by {@link TerraformRunsController.get}. */
 export interface TerraformRunsGetPayload {
@@ -22,6 +29,51 @@ export type TerraformRunsGetResult =
   | { found: false }
   | { found: true; status: RunDetailStatus; record?: TerraformRunRecord };
 
+/** Payload accepted by {@link TerraformRunsController.logs}. */
+export interface TerraformRunsLogsPayload {
+  runId: string;
+}
+
+/** Fixed side-channel {@link TerraformRunsController.logs} pushes streamed output on. */
+const LOGS_CHUNK_CHANNEL = 'terraform.runs.logs.chunk';
+
+/** Fixed side-channel {@link TerraformRunsController.logs} sends its terminal message on. */
+const LOGS_END_CHANNEL = 'terraform.runs.logs.end';
+
+/**
+ * Message payload sent, in order, on {@link LOGS_CHUNK_CHANNEL} for every
+ * chunk `TerraformService.streamRunOutput` yields. `streamId` ties the chunk
+ * back to the `logs()` call that produced it (see
+ * {@link TerraformRunsLogsAck.streamId}) so the renderer can never mix up
+ * output from two overlapping subscriptions.
+ */
+interface TerraformRunsLogsChunkMessage {
+  streamId: string;
+  chunk: TerraformRunChunk;
+}
+
+/**
+ * Message payload sent exactly once on {@link LOGS_END_CHANNEL} once the run
+ * identified by `logs()`'s `runId` reaches a terminal status — either
+ * `TerraformService.streamRunOutput`'s generator ends cleanly (the run
+ * settled, or a finished run's persisted log finished replaying) or it threw
+ * (`error` carries the stringified failure). `streamId` identifies which
+ * `logs()` call this terminates.
+ */
+interface TerraformRunsLogsEndMessage {
+  streamId: string;
+  error?: string;
+}
+
+/**
+ * Immediate acknowledgement `logs()` resolves with — `streamId` tags every
+ * subsequent chunk/end message pushed for this subscription on
+ * {@link LOGS_CHUNK_CHANNEL} / {@link LOGS_END_CHANNEL}.
+ */
+interface TerraformRunsLogsAck {
+  streamId: string;
+}
+
 /**
  * IPC-only controller for reading the status/detail of a single `terraform`
  * plan/apply/destroy run (issue #108) — no HTTP routes are registered here.
@@ -32,13 +84,55 @@ export type TerraformRunsGetResult =
  * a still-running run, and `TerraformService.readRunRecord()` /
  * `TerraformService.hasPlanArtifact()` (the local `<runsDir>/<runId>/run.json`
  * + `.tfplan` artifact, #108's `TerraformService` half) for a finished one.
+ *
+ * `logs()` bridges `TerraformService.streamRunOutput`'s async-generator
+ * output onto the fixed `terraform.runs.logs.chunk` / `terraform.runs.logs.end`
+ * side channels, mirroring `TerraformController.init`/`plan`'s streaming
+ * shape, so the renderer can watch (or re-attach to) a run's live or
+ * persisted output.
  */
 @Controller()
-export class TerraformRunsController {
+export class TerraformRunsController implements OnModuleInit {
   constructor(
     private readonly terraform: TerraformService,
     private readonly runService: RunService,
   ) {}
+
+  /**
+   * Registers an `ipcMain.handle` bridge for the `terraform.runs.logs`
+   * channel after the Nest module initialises, so that
+   * `ipcRenderer.invoke('terraform.runs.logs', { runId })` in the preload
+   * actually resolves.
+   *
+   * `@MessagePattern('terraform.runs.logs')` only wires the transport's
+   * internal dispatcher — it does **not** call `ipcMain.handle`, so
+   * `ipcRenderer.invoke` would otherwise hang. This hook bridges the gap,
+   * mirroring `TerraformController.onModuleInit`'s handling of
+   * `terraform.init`/`terraform.plan` — see `SELF_BRIDGED_PATTERNS` in
+   * `../ipc-main-bridge.ts`, which excludes `terraform.runs.logs` from the
+   * generic bridge for the same reason: the handler pushes follow-up
+   * chunk/end messages over side channels for the duration of a run's output
+   * rather than resolving a single value.
+   *
+   * Only runs inside a real Electron main process. In plain-Node runtimes
+   * (integration test server, Docker, CI) `process.versions.electron` is
+   * undefined and importing `electron` would throw, so the bridge is skipped
+   * entirely rather than guessing which error means "no Electron" from the
+   * message.
+   */
+  async onModuleInit(): Promise<void> {
+    if (!process.versions.electron) {
+      // Not running inside the Electron main process — ipcMain bridge skipped.
+      return;
+    }
+    const { ipcMain } = (await import('electron')) as unknown as { ipcMain: IpcMain };
+    // Remove any existing handler first so hot-reload re-registration does
+    // not throw "IPC channel already registered".
+    ipcMain.removeHandler('terraform.runs.logs');
+    ipcMain.handle('terraform.runs.logs', (evt, payload: TerraformRunsLogsPayload) =>
+      this.logs(payload, { evt: evt as IpcMainInvokeEvent }),
+    );
+  }
 
   /**
    * Looks up a single run by `runId` and returns its current
@@ -90,5 +184,82 @@ export class TerraformRunsController {
     });
 
     return { found: true, status, record };
+  }
+
+  /**
+   * Opens a live/replayed log stream for the run identified by `payload.runId`
+   * and returns an opaque `streamId` immediately. Chunks are pushed to the
+   * renderer via `sender.send` on {@link LOGS_CHUNK_CHANNEL} as
+   * `{ streamId, chunk }`, forwarded in order straight from
+   * `TerraformService.streamRunOutput` — which itself either replays an
+   * in-flight run's buffered + live output or, for a finished run, replays
+   * its persisted `terraform.log`.
+   *
+   * Exactly one terminal message is sent on {@link LOGS_END_CHANNEL} once the
+   * run reaches a terminal status: `{ streamId }` when
+   * `TerraformService.streamRunOutput`'s generator ends cleanly (the run
+   * settled, or a finished run's log finished replaying), or
+   * `{ streamId, error }` when it throws (e.g. `runId` doesn't match any
+   * known run).
+   *
+   * Mirrors `LogsController.streamLogs`/`TerraformController.init`'s
+   * fire-and-forget streaming shape: the controller creates its own
+   * `AbortController` per invocation (since `ElectronIPCTransport` passes
+   * `{ evt }` as the execution context, with no `signal` injected), and a
+   * `'destroyed'` listener on the `WebContents` aborts it — and stops any
+   * further `sender.send` calls — the instant the window/webview goes away,
+   * in addition to the chunk loop's own `isDestroyed()` check between chunks.
+   *
+   * @throws `BadRequestException` when `payload.runId` isn't a non-empty
+   *   string.
+   *
+   * Reachable via the Electron IPC transport (`terraform.runs.logs`).
+   */
+  @MessagePattern('terraform.runs.logs')
+  async logs(
+    @Payload() payload: TerraformRunsLogsPayload,
+    ctx: { evt: IpcMainInvokeEvent },
+  ): Promise<TerraformRunsLogsAck> {
+    const runId = payload?.runId;
+    if (typeof runId !== 'string' || runId.length === 0) {
+      throw new BadRequestException({
+        success: false,
+        error: 'terraform.runs.logs requires a non-empty runId string',
+      });
+    }
+
+    const sender: WebContents = ctx.evt.sender;
+    const streamId = randomUUID();
+    const ac = new AbortController();
+
+    const onDestroyed = () => ac.abort();
+    sender.once('destroyed', onDestroyed);
+
+    // Fire-and-forget the streaming loop. Chunks are pushed back to the
+    // renderer directly via WebContents.send rather than through the normal
+    // invoke reply mechanism, which only supports a single return value.
+    void (async () => {
+      try {
+        for await (const chunk of this.terraform.streamRunOutput(runId, ac.signal)) {
+          if (sender.isDestroyed()) { ac.abort(); return; }
+          const chunkMessage: TerraformRunsLogsChunkMessage = { streamId, chunk };
+          sender.send(LOGS_CHUNK_CHANNEL, chunkMessage);
+        }
+        if (!sender.isDestroyed()) {
+          const message: TerraformRunsLogsEndMessage = { streamId };
+          sender.send(LOGS_END_CHANNEL, message);
+        }
+      } catch (err) {
+        logger.error('terraform.runs.logs error', { err, runId, streamId });
+        if (!sender.isDestroyed()) {
+          const message: TerraformRunsLogsEndMessage = { streamId, error: String(err) };
+          sender.send(LOGS_END_CHANNEL, message);
+        }
+      } finally {
+        sender.removeListener('destroyed', onDestroyed);
+      }
+    })();
+
+    return { streamId };
   }
 }

--- a/app/packages/desktop-main/src/controllers/terraform-runs.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform-runs.controller.ts
@@ -1,0 +1,94 @@
+import { BadRequestException, Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { computeRunDetailStatus, type RunDetailStatus } from '@hyveon/shared';
+import { TerraformService, type TerraformRunRecord } from '../services/TerraformService.js';
+import { RunService } from '../services/RunService.js';
+
+/** Payload accepted by {@link TerraformRunsController.get}. */
+export interface TerraformRunsGetPayload {
+  runId: string;
+}
+
+/**
+ * Result of {@link TerraformRunsController.get}: `found: false` when `runId`
+ * is neither the currently held apply lock nor a persisted
+ * `TerraformRunRecord` on disk. `found: true` always carries the derived
+ * {@link RunDetailStatus}; `record` is present only once the run has produced
+ * a persisted `TerraformRunRecord` (i.e. every status except `running`, since
+ * a run in flight hasn't closed its process yet — see
+ * `TerraformRunRecord`'s file-level doc comment).
+ */
+export type TerraformRunsGetResult =
+  | { found: false }
+  | { found: true; status: RunDetailStatus; record?: TerraformRunRecord };
+
+/**
+ * IPC-only controller for reading the status/detail of a single `terraform`
+ * plan/apply/destroy run (issue #108) — no HTTP routes are registered here.
+ *
+ * `get()` combines two data sources to derive the run's
+ * {@link RunDetailStatus} via the shared, pure `computeRunDetailStatus`
+ * helper: `RunService.getCurrentLock()` (the in-flight apply lock, #106) for
+ * a still-running run, and `TerraformService.readRunRecord()` /
+ * `TerraformService.hasPlanArtifact()` (the local `<runsDir>/<runId>/run.json`
+ * + `.tfplan` artifact, #108's `TerraformService` half) for a finished one.
+ */
+@Controller()
+export class TerraformRunsController {
+  constructor(
+    private readonly terraform: TerraformService,
+    private readonly runService: RunService,
+  ) {}
+
+  /**
+   * Looks up a single run by `runId` and returns its current
+   * {@link RunDetailStatus}:
+   *
+   * - `{ found: true, status: 'running' }` when `runId` matches the run
+   *   currently holding the apply lock (`RunService.getCurrentLock()`) — no
+   *   `record` is attached, since a {@link TerraformRunRecord} is only ever
+   *   persisted once the run's process has closed.
+   * - `{ found: true, status, record }` when a persisted
+   *   {@link TerraformRunRecord} exists for `runId` — `status` is derived via
+   *   `computeRunDetailStatus`, checking `TerraformService.hasPlanArtifact()`
+   *   for `plan` records to distinguish `awaiting_approval` from a terminal
+   *   `success`/`failed`/`aborted`.
+   * - `{ found: false }` when `runId` is neither in flight nor has a
+   *   persisted record.
+   *
+   * @throws `BadRequestException` when `payload.runId` isn't a non-empty
+   *   string.
+   *
+   * Reachable via the Electron IPC transport (`terraform.runs.get`).
+   */
+  @MessagePattern('terraform.runs.get')
+  async get(@Payload() payload: TerraformRunsGetPayload): Promise<TerraformRunsGetResult> {
+    const runId = payload?.runId;
+    if (typeof runId !== 'string' || runId.length === 0) {
+      throw new BadRequestException({
+        success: false,
+        error: 'terraform.runs.get requires a non-empty runId string',
+      });
+    }
+
+    const currentLock = this.runService.getCurrentLock();
+    if (currentLock?.runId === runId) {
+      return { found: true, status: 'running' };
+    }
+
+    const record = this.terraform.readRunRecord(runId);
+    if (!record) {
+      return { found: false };
+    }
+
+    const planArtifactExists = record.kind === 'plan' ? this.terraform.hasPlanArtifact(runId) : false;
+    const status = computeRunDetailStatus({
+      isInFlight: false,
+      kind: record.kind,
+      exitCode: record.exitCode,
+      planArtifactExists,
+    });
+
+    return { found: true, status, record };
+  }
+}

--- a/app/packages/desktop-main/src/ipc-main-bridge.ts
+++ b/app/packages/desktop-main/src/ipc-main-bridge.ts
@@ -17,11 +17,17 @@ import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
  * - `terraform.plan`: bridged manually by the same controller for the same
  *   reason as `terraform.init` — it streams `terraform plan` progress over a
  *   side channel for the duration of a long-running run.
+ * - `terraform.runs.logs`: bridged manually by `TerraformRunsController`
+ *   because the handler streams a run's live/replayed output over a side
+ *   channel derived from a `streamId` it mints itself, the same
+ *   self-bridging pattern `terraform.init`/`terraform.plan` use — see
+ *   `app/packages/desktop-main/src/controllers/terraform-runs.controller.ts`.
  */
 export const SELF_BRIDGED_PATTERNS: ReadonlySet<string> = new Set([
   'logs.stream',
   'terraform.init',
   'terraform.plan',
+  'terraform.runs.logs',
 ]);
 
 /**

--- a/app/packages/desktop-main/src/services/TerraformService.runs.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.runs.test.ts
@@ -1,0 +1,441 @@
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Spy variables must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const {
+  execFileMock,
+  spawnMock,
+  mkdirSyncMock,
+  existsSyncMock,
+  writeFileSyncMock,
+  copyFileSyncMock,
+  readFileSyncMock,
+  randomUUIDMock,
+  runRecordPersistMock,
+} = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  const mkdirSyncMock = vi.fn();
+  const existsSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  const copyFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const randomUUIDMock = vi.fn();
+  const runRecordPersistMock = vi.fn();
+  return {
+    execFileMock,
+    spawnMock,
+    mkdirSyncMock,
+    existsSyncMock,
+    writeFileSyncMock,
+    copyFileSyncMock,
+    readFileSyncMock,
+    randomUUIDMock,
+    runRecordPersistMock,
+  };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  spawn: spawnMock,
+}));
+
+vi.mock('node:fs', () => ({
+  mkdirSync: mkdirSyncMock,
+  existsSync: existsSyncMock,
+  writeFileSync: writeFileSyncMock,
+  copyFileSync: copyFileSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+vi.mock('node:crypto', () => ({
+  randomUUID: randomUUIDMock,
+}));
+
+import { TerraformService, type TerraformRunChunk, type TerraformRunRecord } from './TerraformService.js';
+import type { ConfigService } from './ConfigService.js';
+import type { RunRecordService } from './RunRecordService.js';
+import type { RemoteFileStore } from '@hyveon/shared';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Extracts the error-first callback from an `execFile` call's arguments,
+ * regardless of whether `util.promisify` invoked it with or without an
+ * `options` object.
+ */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
+/** Queues a successful `execFile` invocation (stdout/stderr) for the next call. */
+function queueExecFileSuccess(stdout: string, stderr = ''): void {
+  execFileMock.mockImplementationOnce((...args: unknown[]) => {
+    lastArgAsCallback(args)(null, { stdout, stderr });
+  });
+}
+
+/** Queues a successful binary lookup followed by a successful `-json` version response. */
+function queueSuccessfulResolution(binaryPath = '/usr/local/bin/terraform', version = '1.7.0'): void {
+  queueExecFileSuccess(`${binaryPath}\n`);
+  queueExecFileSuccess(JSON.stringify({ terraform_version: version }));
+}
+
+/**
+ * `ConfigService` stub sufficient for `plan()`/`streamRunOutput()`/
+ * `readRunRecord()`/`hasPlanArtifact()` tests: exposes `getTerraformDir`, `getRunsDir`,
+ * `getTfvarsBucket`, and `getTfvarsPath` — the accessors those methods read.
+ */
+function stubConfigService(
+  opts: {
+    terraformDir?: string;
+    runsDir?: string;
+    tfvarsBucket?: string | null;
+    tfvarsPath?: string;
+  } = {},
+): ConfigService {
+  return {
+    getTerraformDir: () => opts.terraformDir ?? '/repo/terraform',
+    getRunsDir: () => opts.runsDir ?? '/repo/runs',
+    getTfvarsBucket: () => opts.tfvarsBucket ?? null,
+    getTfvarsPath: () => opts.tfvarsPath ?? '/repo/terraform/terraform.tfvars',
+  } as ConfigService;
+}
+
+/**
+ * Minimal `RemoteFileStore` stub sufficient to satisfy `TerraformService`'s
+ * constructor dependency for these tests, which all exercise local-file
+ * tfvars mode.
+ */
+function stubRemoteFileStore(): RemoteFileStore {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    listVersions: vi.fn(),
+  } as Partial<RemoteFileStore> as RemoteFileStore;
+}
+
+/**
+ * `RunRecordService` stub: `persist` is backed by the shared, hoisted
+ * `runRecordPersistMock` so tests don't need to care about its resolution —
+ * it defaults to resolving `undefined`, matching the real best-effort
+ * contract.
+ */
+function stubRunRecordService(): RunRecordService {
+  return { persist: runRecordPersistMock } as Partial<RunRecordService> as RunRecordService;
+}
+
+/**
+ * A fake `child_process.ChildProcess` sufficient for driving `plan()`'s
+ * streaming logic from a test: an `EventEmitter` standing in for the process
+ * itself, with `stdout`/`stderr` sub-emitters standing in for the piped
+ * streams. Tests drive it manually via `emitStdout`/`close` rather than
+ * relying on any real process lifecycle.
+ */
+class FakeChildProcess extends EventEmitter {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+  readonly kill = vi.fn();
+
+  emitStdout(chunk: string): void {
+    this.stdout.emit('data', Buffer.from(chunk));
+  }
+
+  close(code: number | null): void {
+    this.emit('close', code);
+  }
+}
+
+/** Queues the next `spawn()` call to return `child` instead of a real process. */
+function queueSpawn(child: FakeChildProcess): void {
+  spawnMock.mockImplementationOnce(() => child);
+}
+
+/**
+ * Waits for every already-queued microtask to drain (via a macrotask
+ * boundary) before returning — see the equivalent helper in
+ * `TerraformService.plan.test.ts` for the full rationale.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * Continuously drains a `plan()` (or `apply()`/`destroy()`) async generator
+ * in the background — mirroring what a real IPC handler forwarding chunks to
+ * a renderer would do — so `TerraformService`'s internal `recordRunChunk`/
+ * `endActiveRun` hooks actually fire as the underlying process streams
+ * output. Returns a promise that resolves with every yielded chunk plus the
+ * generator's final return value once the run completes.
+ */
+async function drainInBackground<TReturn>(
+  gen: AsyncGenerator<TerraformRunChunk, TReturn>,
+): Promise<{ chunks: TerraformRunChunk[]; result: TReturn }> {
+  const chunks: TerraformRunChunk[] = [];
+  let next = await gen.next();
+  while (!next.done) {
+    chunks.push(next.value);
+    next = await gen.next();
+  }
+  return { chunks, result: next.value };
+}
+
+/** Collects every chunk (and the final `done` signal) a `streamRunOutput()` generator yields, without blocking on completion. */
+async function collectStreamChunks(gen: AsyncGenerator<TerraformRunChunk, void>): Promise<TerraformRunChunk[]> {
+  const chunks: TerraformRunChunk[] = [];
+  let next = await gen.next();
+  while (!next.done) {
+    chunks.push(next.value);
+    next = await gen.next();
+  }
+  return chunks;
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+  spawnMock.mockReset();
+  mkdirSyncMock.mockReset();
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(true);
+  writeFileSyncMock.mockReset();
+  copyFileSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  randomUUIDMock.mockReset();
+  randomUUIDMock.mockReturnValue('run-123');
+  runRecordPersistMock.mockReset();
+});
+
+function buildService(): TerraformService {
+  return new TerraformService(
+    stubConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+    stubRemoteFileStore(),
+    stubRunRecordService(),
+  );
+}
+
+describe('TerraformService.streamRunOutput for an in-flight run', () => {
+  it('should yield chunks buffered before the subscription, then live chunks as they arrive, and complete once the run settles', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-live-1');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = buildService();
+
+    // Drive plan() in the background exactly like a real caller (e.g. an
+    // IPC handler forwarding chunks to the renderer) would — this is what
+    // actually causes TerraformService to record chunks into the run's
+    // active buffer.
+    const planDone = drainInBackground(service.plan());
+    await flushMicrotasks();
+
+    // Emit one chunk *before* anyone has subscribed via streamRunOutput —
+    // this becomes "buffered" once a subscriber attaches afterward.
+    child.emitStdout('Refreshing state...\n');
+    await flushMicrotasks();
+
+    const streamGen = service.streamRunOutput('run-live-1');
+    const first = await streamGen.next();
+    expect(first).toEqual({
+      done: false,
+      value: { stream: 'stdout', line: 'Refreshing state...' },
+    });
+
+    // Now request the next chunk before it exists, then emit it live.
+    const secondPromise = streamGen.next();
+    child.emitStdout('Apply complete!\n');
+    await flushMicrotasks();
+    const second = await secondPromise;
+    expect(second).toEqual({
+      done: false,
+      value: { stream: 'stdout', line: 'Apply complete!' },
+    });
+
+    // Closing the process settles the run — the subscription should end
+    // cleanly (done: true) rather than hang or throw.
+    const donePromise = streamGen.next();
+    child.close(0);
+    await flushMicrotasks();
+    const done = await donePromise;
+    expect(done.done).toBe(true);
+
+    await planDone;
+  });
+
+  it('should deliver every chunk to a late subscriber that attaches after several chunks have already streamed', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-live-2');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = buildService();
+    const planDone = drainInBackground(service.plan());
+    await flushMicrotasks();
+
+    child.emitStdout('line one\n');
+    await flushMicrotasks();
+    child.emitStdout('line two\n');
+    await flushMicrotasks();
+
+    const chunksPromise = collectStreamChunks(service.streamRunOutput('run-live-2'));
+
+    child.close(0);
+    await flushMicrotasks();
+
+    const chunks = await chunksPromise;
+    expect(chunks).toEqual([
+      { stream: 'stdout', line: 'line one' },
+      { stream: 'stdout', line: 'line two' },
+    ]);
+
+    await planDone;
+  });
+
+  it('should support multiple independent subscribers to the same in-flight run', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-live-3');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+
+    const service = buildService();
+    const planDone = drainInBackground(service.plan());
+    await flushMicrotasks();
+
+    const subscriberAChunks = collectStreamChunks(service.streamRunOutput('run-live-3'));
+    const subscriberBChunks = collectStreamChunks(service.streamRunOutput('run-live-3'));
+
+    child.emitStdout('shared line\n');
+    await flushMicrotasks();
+    child.close(0);
+    await flushMicrotasks();
+
+    expect(await subscriberAChunks).toEqual([{ stream: 'stdout', line: 'shared line' }]);
+    expect(await subscriberBChunks).toEqual([{ stream: 'stdout', line: 'shared line' }]);
+
+    await planDone;
+  });
+});
+
+describe('TerraformService.streamRunOutput for a finished run', () => {
+  it('should replay the persisted terraform.log for a run that is no longer in flight', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue('Refreshing state...\nApply complete! Resources: 1 added.\n');
+
+    const service = buildService();
+
+    const chunks = await collectStreamChunks(service.streamRunOutput('run-finished-1'));
+
+    expect(existsSyncMock).toHaveBeenCalledWith('/repo/runs/run-finished-1/terraform.log');
+    expect(readFileSyncMock).toHaveBeenCalledWith('/repo/runs/run-finished-1/terraform.log', 'utf8');
+    expect(chunks).toEqual([
+      { stream: 'stdout', line: 'Refreshing state...' },
+      { stream: 'stdout', line: 'Apply complete! Resources: 1 added.' },
+    ]);
+  });
+
+  it('should not yield a spurious trailing empty chunk for a log ending in a newline', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockReturnValue('only line\n');
+
+    const service = buildService();
+
+    const chunks = await collectStreamChunks(service.streamRunOutput('run-finished-2'));
+
+    expect(chunks).toEqual([{ stream: 'stdout', line: 'only line' }]);
+  });
+});
+
+describe('TerraformService.streamRunOutput for an unknown run', () => {
+  it('should throw when runId is neither in flight nor has a terraform.log on disk', async () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const service = buildService();
+
+    await expect(collectStreamChunks(service.streamRunOutput('does-not-exist'))).rejects.toThrow(
+      /no run found for runId "does-not-exist"/,
+    );
+  });
+
+  it('should throw synchronously for a runId containing path-traversal segments before ever touching the filesystem', async () => {
+    const service = buildService();
+
+    await expect(collectStreamChunks(service.streamRunOutput('../../etc/passwd'))).rejects.toThrow(
+      /not a valid run id/,
+    );
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.readRunRecord', () => {
+  it('should return the parsed run.json record for a finished run', () => {
+    existsSyncMock.mockReturnValue(true);
+    const record: TerraformRunRecord = {
+      runId: 'run-detail-1',
+      kind: 'plan',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      completedAt: '2026-01-01T00:01:00.000Z',
+      exitCode: 0,
+    };
+    readFileSyncMock.mockReturnValue(JSON.stringify(record));
+
+    const service = buildService();
+
+    const result = service.readRunRecord('run-detail-1');
+
+    expect(existsSyncMock).toHaveBeenCalledWith('/repo/runs/run-detail-1/run.json');
+    expect(readFileSyncMock).toHaveBeenCalledWith('/repo/runs/run-detail-1/run.json', 'utf8');
+    expect(result).toEqual(record);
+  });
+
+  it('should return null when no run.json exists for the given runId', () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const service = buildService();
+
+    expect(service.readRunRecord('run-detail-missing')).toBeNull();
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should throw synchronously for an invalid runId without touching the filesystem', () => {
+    const service = buildService();
+
+    expect(() => service.readRunRecord('../escape')).toThrow(/not a valid run id/);
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('TerraformService.hasPlanArtifact', () => {
+  it('should return true when the .tfplan artifact exists on disk for the given runId', () => {
+    existsSyncMock.mockReturnValue(true);
+
+    const service = buildService();
+
+    const result = service.hasPlanArtifact('run-plan-1');
+
+    expect(existsSyncMock).toHaveBeenCalledWith('/repo/runs/run-plan-1/run-plan-1.tfplan');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when no .tfplan artifact exists on disk for the given runId', () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const service = buildService();
+
+    const result = service.hasPlanArtifact('run-plan-missing');
+
+    expect(existsSyncMock).toHaveBeenCalledWith('/repo/runs/run-plan-missing/run-plan-missing.tfplan');
+    expect(result).toBe(false);
+  });
+
+  it('should throw synchronously for an invalid runId without touching the filesystem', () => {
+    const service = buildService();
+
+    expect(() => service.hasPlanArtifact('../escape')).toThrow(/not a valid run id/);
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -832,6 +832,24 @@ export class TerraformService {
         return undefined;
       }
 
+      // Mint (or adopt the pre-minted) runId and register its active-run
+      // buffer *here* — before the pre-spawn awaits below
+      // (`getBinaryPath()`, then `pullVarFile()`'s S3 round-trip) — rather
+      // than just before the process is spawned. `TerraformController.plan()`
+      // drives this generator's first `.next()` synchronously and hands
+      // `runId` back to the renderer in its ack without waiting for those
+      // awaits to settle, so a `streamRunOutput()`/`terraform.runs.logs`
+      // subscriber can legitimately arrive before either of them resolves.
+      // Registering the buffer immediately means that subscriber finds the
+      // run already in flight (an empty, unsettled buffer it can wait on)
+      // instead of falling through to the "unknown run" log-replay path and
+      // erroring out. Every early-abort `return` below leaves `runId` set,
+      // so the outer `finally`'s unconditional `endActiveRun(runId)` call
+      // still settles the buffer for that subscriber even when the run
+      // never reaches the spawn point — see beginActiveRun's TSDoc.
+      runId = preMintedRunId ?? randomUUID();
+      this.beginActiveRun(runId);
+
       const binaryPath = await this.getBinaryPath();
 
       if (signal?.aborted) {
@@ -839,7 +857,6 @@ export class TerraformService {
         return undefined;
       }
 
-      runId = preMintedRunId ?? randomUUID();
       const runDir = join(this.config.getRunsDir(), runId);
       mkdirSync(runDir, { recursive: true });
 
@@ -865,12 +882,9 @@ export class TerraformService {
       let destroy = 0;
       // Captured immediately before the process is spawned so it can be
       // recorded in the `TerraformRunRecord` written below once the process
-      // closes.
+      // closes. (The active-run buffer itself was already registered above,
+      // ahead of the pre-spawn awaits — see the comment there.)
       startedAt = new Date().toISOString();
-      // Registers this run as in-flight so a concurrent streamRunOutput()
-      // subscriber observes it immediately, even before its first chunk
-      // arrives — see beginActiveRun's TSDoc.
-      this.beginActiveRun(runId);
 
       // Driven manually (rather than `yield*`) so each stdout line can be
       // scanned for the plan summary as it streams through, in addition to
@@ -982,6 +996,19 @@ export class TerraformService {
       // defined by the time the try block starts) because plan() may abort
       // before a runId is ever minted, in which case there's nothing to
       // persist.
+      //
+      // `endActiveRun` itself is called unconditionally below (not gated on
+      // `forceKilled`) — it's the only guarantee that a live
+      // `streamRunOutput()` subscriber never hangs forever, and `forceKilled`
+      // being false doesn't mean the normal-completion path above already
+      // settled the run: e.g. `spawnAndStream` throwing a spawn `error`
+      // (ENOENT/EACCES) unwinds straight past that call too.
+      if (runId !== undefined) {
+        // Idempotent via `endActiveRun`'s `if (!active) return` guard, so
+        // this is a safe no-op on every path where the normal-completion
+        // call above already ran.
+        this.endActiveRun(runId);
+      }
       if (runId !== undefined && startedAt !== undefined && !runRecordWritten && forceKilled) {
         // Mirrors apply()/destroy()'s forceKilled WARN — a cancellation via
         // forced generator termination is still a plan outcome worth
@@ -992,9 +1019,7 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
-        // Mirrors the normal-completion path above — settle any
-        // streamRunOutput() subscribers even on this force-killed path.
-        this.endActiveRun(runId);
+        // endActiveRun() already called unconditionally above.
         const completedAt = new Date().toISOString();
         try {
           this.writeRunRecord(runId, 'plan', startedAt, completedAt, null, tfvarsVersionId);
@@ -1310,6 +1335,16 @@ export class TerraformService {
       // persist a cancelled (`exitCode: null`) run record here so the run is
       // never silently lost. Best-effort: a failure here doesn't override
       // whatever completion the generator was already unwinding for.
+      //
+      // `endActiveRun` itself is called unconditionally below (not gated on
+      // `forceKilled`) — it's the only guarantee that a live
+      // `streamRunOutput()` subscriber never hangs forever, and `forceKilled`
+      // being false doesn't mean the normal-completion path above already
+      // settled the run: e.g. `spawnAndStream` throwing a spawn `error`
+      // (ENOENT/EACCES) unwinds straight past that call too. Idempotent via
+      // `endActiveRun`'s `if (!active) return` guard, so this is a safe
+      // no-op on every path where the normal-completion call already ran.
+      this.endActiveRun(runId);
       if (startedAt !== undefined && !runRecordWritten && forceKilled) {
         // Mirrors destroy()'s forceKilled WARN — a cancellation via forced
         // generator termination is still an apply outcome worth surfacing.
@@ -1319,9 +1354,7 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
-        // Mirrors the normal-completion path above — settle any
-        // streamRunOutput() subscribers even on this force-killed path.
-        this.endActiveRun(runId);
+        // endActiveRun() already called unconditionally above.
         const completedAt = new Date().toISOString();
         try {
           this.writeRunRecord(runId, 'apply', startedAt, completedAt, null, tfvarsVersionId);
@@ -1554,6 +1587,16 @@ export class TerraformService {
       // Covers the force-closed generator case — mirrors apply()'s outer
       // finally; see its comment for the full rationale of the `forceKilled`
       // gate.
+      //
+      // `endActiveRun` itself is called unconditionally below (not gated on
+      // `forceKilled`) — it's the only guarantee that a live
+      // `streamRunOutput()` subscriber never hangs forever, and `forceKilled`
+      // being false doesn't mean the normal-completion path above already
+      // settled the run: e.g. `spawnAndStream` throwing a spawn `error`
+      // (ENOENT/EACCES) unwinds straight past that call too. Idempotent via
+      // `endActiveRun`'s `if (!active) return` guard, so this is a safe
+      // no-op on every path where the normal-completion call already ran.
+      this.endActiveRun(runId);
       if (startedAt !== undefined && !runRecordWritten && forceKilled) {
         // Same WARN-level guarantee as the normal-completion path above:
         // a cancellation via forced generator termination is still a
@@ -1565,9 +1608,7 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
-        // Mirrors the normal-completion path above — settle any
-        // streamRunOutput() subscribers even on this force-killed path.
-        this.endActiveRun(runId);
+        // endActiveRun() already called unconditionally above.
         const completedAt = new Date().toISOString();
         try {
           this.writeRunRecord(runId, 'destroy', startedAt, completedAt, null, undefined);
@@ -1818,10 +1859,15 @@ export class TerraformService {
 
   /**
    * Registers a fresh, empty {@link ActiveRunBuffer} for `runId` — called by
-   * {@link plan}/{@link apply}/{@link destroy} immediately before their
-   * spawned process starts, so a concurrent {@link streamRunOutput} call
-   * observes the run as in-flight (even before its first chunk arrives)
-   * rather than falling through to the "unknown run" / log-replay path.
+   * {@link apply}/{@link destroy} immediately before their spawned process
+   * starts, so a concurrent {@link streamRunOutput} call observes the run as
+   * in-flight (even before its first chunk arrives) rather than falling
+   * through to the "unknown run" / log-replay path. {@link plan} calls this
+   * earlier — as soon as its `runId` is resolved, ahead of its own pre-spawn
+   * awaits (`getBinaryPath()`/`pullVarFile()`) — because
+   * `TerraformController.plan()` hands `runId` back to the renderer in its
+   * ack before those awaits settle; see the inline comment at plan()'s call
+   * site.
    */
   private beginActiveRun(runId: string): void {
     this.activeRuns.set(runId, {

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { promisify } from 'node:util';
 import { Inject, Injectable } from '@nestjs/common';
@@ -69,6 +69,30 @@ export interface TerraformInitConfig {
 export interface TerraformRunChunk {
   stream: 'stdout' | 'stderr';
   line: string;
+}
+
+/**
+ * In-memory fan-out buffer for a single in-flight {@link TerraformService.plan}/
+ * {@link TerraformService.apply}/{@link TerraformService.destroy} run's
+ * streamed output, keyed by `runId` in `TerraformService`'s private
+ * `activeRuns` map. Populated by `TerraformService`'s private
+ * `recordRunChunk` as the owning subcommand runner's own generator streams
+ * each {@link TerraformRunChunk} through, and consumed by
+ * {@link TerraformService.streamRunOutput} so a second caller (e.g. a
+ * renderer reconnecting to a run-output IPC channel mid-run) can observe the
+ * exact same run's output without being the generator that originally drove
+ * the spawned process — replaying every chunk buffered so far, then being
+ * notified of every subsequent chunk live, until the run settles.
+ */
+interface ActiveRunBuffer {
+  /** Every chunk streamed so far, in production order — replayed in full to a new subscriber before it starts receiving live chunks. */
+  chunks: TerraformRunChunk[];
+  /** Callbacks invoked synchronously, in registration order, each time a new chunk is recorded. */
+  listeners: Set<(chunk: TerraformRunChunk) => void>;
+  /** Flips to `true` once the owning run's spawned process has closed — never flips back. */
+  settled: boolean;
+  /** Callbacks invoked exactly once, when the run is marked settled. */
+  settledListeners: Set<() => void>;
 }
 
 /**
@@ -471,6 +495,18 @@ export class TerraformService {
   private outputCache: { value: TfOutputs | null; resolvedAt: number } | null = null;
 
   /**
+   * Fan-out buffers for every currently in-flight {@link plan}/{@link apply}/
+   * {@link destroy} run, keyed by `runId`. An entry exists from
+   * `beginActiveRun` (called just before the subcommand's process is
+   * spawned) until `endActiveRun` (called once the process has closed and
+   * the run's `terraform.log` has been written), at which point the entry is
+   * removed — a subsequent {@link streamRunOutput} call for the same `runId`
+   * then falls through to replaying the persisted `terraform.log` instead.
+   * See {@link ActiveRunBuffer}.
+   */
+  private readonly activeRuns = new Map<string, ActiveRunBuffer>();
+
+  /**
    * `config` resolves the terraform working directory (`getTerraformDir()`)
    * and the per-run artifacts directory (`getRunsDir()`) for
    * `init`/`plan`/`apply`/`destroy`/`output`. `remoteFileStore` is typed
@@ -831,6 +867,10 @@ export class TerraformService {
       // recorded in the `TerraformRunRecord` written below once the process
       // closes.
       startedAt = new Date().toISOString();
+      // Registers this run as in-flight so a concurrent streamRunOutput()
+      // subscriber observes it immediately, even before its first chunk
+      // arrives — see beginActiveRun's TSDoc.
+      this.beginActiveRun(runId);
 
       // Driven manually (rather than `yield*`) so each stdout line can be
       // scanned for the plan summary as it streams through, in addition to
@@ -845,6 +885,7 @@ export class TerraformService {
         while (!next.done) {
           const chunk = next.value;
           logLines.push(chunk.line);
+          this.recordRunChunk(runId, chunk);
           if (chunk.stream === 'stdout') {
             const match = PLAN_SUMMARY_PATTERN.exec(chunk.line);
             if (match) {
@@ -894,6 +935,10 @@ export class TerraformService {
       // below, so every exit path (success/failure/abort) leaves a
       // terraform.log behind.
       this.writeRunLog(runId, logLines);
+      // The run has settled — notify any streamRunOutput() subscribers and
+      // drop the in-flight buffer, so a subsequent call for this runId falls
+      // through to replaying the terraform.log just written above.
+      this.endActiveRun(runId);
 
       // Same guarantee for the run record: written on every exit path
       // (success/failure/abort) so a future run-history UI can list this
@@ -947,6 +992,9 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
+        // Mirrors the normal-completion path above — settle any
+        // streamRunOutput() subscribers even on this force-killed path.
+        this.endActiveRun(runId);
         const completedAt = new Date().toISOString();
         try {
           this.writeRunRecord(runId, 'plan', startedAt, completedAt, null, tfvarsVersionId);
@@ -1138,6 +1186,10 @@ export class TerraformService {
       const cwd = this.config.getTerraformDir();
       const args = ['apply', '-input=false', '-no-color', planFile];
       startedAt = new Date().toISOString();
+      // Registers this run as in-flight so a concurrent streamRunOutput()
+      // subscriber observes it immediately, even before its first chunk
+      // arrives — see beginActiveRun's TSDoc.
+      this.beginActiveRun(runId);
 
       let added = 0;
       let changed = 0;
@@ -1154,6 +1206,7 @@ export class TerraformService {
         while (!next.done) {
           const chunk = next.value;
           logLines.push(chunk.line);
+          this.recordRunChunk(runId, chunk);
           if (chunk.stream === 'stdout') {
             const match = APPLY_SUMMARY_PATTERN.exec(chunk.line);
             if (match) {
@@ -1208,6 +1261,10 @@ export class TerraformService {
       // same spot the run record is written — a single writeFileSync now
       // that the process has closed, rather than one append per line.
       this.writeRunLog(runId, logLines);
+      // The run has settled — notify any streamRunOutput() subscribers and
+      // drop the in-flight buffer, so a subsequent call for this runId falls
+      // through to replaying the terraform.log just written above.
+      this.endActiveRun(runId);
       const completedAt = new Date().toISOString();
       const applyExitCode = result.aborted ? null : result.exitCode;
       try {
@@ -1262,6 +1319,9 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
+        // Mirrors the normal-completion path above — settle any
+        // streamRunOutput() subscribers even on this force-killed path.
+        this.endActiveRun(runId);
         const completedAt = new Date().toISOString();
         try {
           this.writeRunRecord(runId, 'apply', startedAt, completedAt, null, tfvarsVersionId);
@@ -1393,6 +1453,10 @@ export class TerraformService {
       const cwd = this.config.getTerraformDir();
       const args = ['destroy', '-input=false', '-no-color', '-auto-approve'];
       startedAt = new Date().toISOString();
+      // Registers this run as in-flight so a concurrent streamRunOutput()
+      // subscriber observes it immediately, even before its first chunk
+      // arrives — see beginActiveRun's TSDoc.
+      this.beginActiveRun(runId);
 
       logger.warn('terraform destroy confirmed — spawning terraform destroy -auto-approve', {
         runId,
@@ -1413,6 +1477,7 @@ export class TerraformService {
         while (!next.done) {
           const chunk = next.value;
           logLines.push(chunk.line);
+          this.recordRunChunk(runId, chunk);
           if (chunk.stream === 'stdout') {
             const match = DESTROY_SUMMARY_PATTERN.exec(chunk.line);
             if (match) {
@@ -1459,6 +1524,10 @@ export class TerraformService {
       // same spot the run record is written — a single writeFileSync now
       // that the process has closed, rather than one append per line.
       this.writeRunLog(runId, logLines);
+      // The run has settled — notify any streamRunOutput() subscribers and
+      // drop the in-flight buffer, so a subsequent call for this runId falls
+      // through to replaying the terraform.log just written above.
+      this.endActiveRun(runId);
       const completedAt = new Date().toISOString();
       const destroyExitCode = result.aborted ? null : result.exitCode;
       try {
@@ -1496,6 +1565,9 @@ export class TerraformService {
         // Persist whatever transcript was captured before the forced
         // completion unwound past the normal writeRunLog() call above.
         this.writeRunLog(runId, logLines);
+        // Mirrors the normal-completion path above — settle any
+        // streamRunOutput() subscribers even on this force-killed path.
+        this.endActiveRun(runId);
         const completedAt = new Date().toISOString();
         try {
           this.writeRunRecord(runId, 'destroy', startedAt, completedAt, null, undefined);
@@ -1562,6 +1634,136 @@ export class TerraformService {
   }
 
   /**
+   * Streams every {@link TerraformRunChunk} produced by the {@link plan},
+   * {@link apply}, or {@link destroy} run identified by `runId` — the exact
+   * same chunks the run's own generator yielded to whichever caller
+   * originally drove it, replayed to this independent subscriber instead.
+   * This is the seam a `terraform.run.output`-style IPC channel uses to feed
+   * a renderer that's watching (or re-attaching to) a build's live log.
+   *
+   * Two sources, depending on whether `runId` is currently in flight (see
+   * {@link activeRuns}):
+   *
+   * - **In-flight run**: yields every chunk buffered so far (in production
+   *   order), then every subsequent chunk live as it's recorded, until the
+   *   run settles (its spawned process has closed and `terraform.log` has
+   *   been written), at which point the generator ends cleanly. A caller can
+   *   subscribe at any point during the run — even after it has already
+   *   produced output — and never misses a chunk, since the buffered replay
+   *   and the live subscription are registered atomically (no `await`
+   *   between reading {@link ActiveRunBuffer.chunks} and subscribing to
+   *   {@link ActiveRunBuffer.listeners}).
+   * - **Finished (or unknown) run**: when no {@link ActiveRunBuffer} is
+   *   registered for `runId`, falls through to {@link replayRunLog}, which
+   *   replays the persisted `<runsDir>/<runId>/terraform.log` line-by-line,
+   *   or throws if no such log exists.
+   *
+   * `signal`, if provided, ends the generator cleanly (no further chunks, no
+   * throw) the moment it fires, mirroring {@link init}/{@link plan}/
+   * {@link apply}/{@link destroy} — this only detaches this subscriber; it
+   * has no effect on the underlying `terraform` run itself.
+   *
+   * @throws A plain `Error` synchronously (on the first `.next()` call) if
+   *   `runId` isn't a bare path segment matching {@link RUN_ID_PATTERN}, or —
+   *   via {@link replayRunLog} — if `runId` is neither currently in flight
+   *   nor has a `terraform.log` on disk, i.e. no run by that id was ever
+   *   spawned.
+   */
+  async *streamRunOutput(runId: string, signal?: AbortSignal): AsyncGenerator<TerraformRunChunk, void> {
+    TerraformService.assertValidRunId(runId);
+
+    const active = this.activeRuns.get(runId);
+    if (!active) {
+      yield* this.replayRunLog(runId);
+      return;
+    }
+
+    // Snapshot the buffer and subscribe in the same synchronous tick (no
+    // `await` in between) so no chunk recorded between the snapshot and the
+    // subscription can ever be missed or double-delivered.
+    const queue: TerraformRunChunk[] = [...active.chunks];
+    let settled = active.settled;
+    let wake: (() => void) | null = null;
+
+    const onChunk = (chunk: TerraformRunChunk): void => {
+      queue.push(chunk);
+      wake?.();
+      wake = null;
+    };
+    const onSettled = (): void => {
+      settled = true;
+      wake?.();
+      wake = null;
+    };
+
+    active.listeners.add(onChunk);
+    active.settledListeners.add(onSettled);
+
+    const onAbort = (): void => {
+      wake?.();
+      wake = null;
+    };
+    signal?.addEventListener('abort', onAbort);
+
+    try {
+      while (true) {
+        if (queue.length > 0) {
+          yield queue.shift()!;
+          continue;
+        }
+        if (settled || signal?.aborted) {
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+    } finally {
+      active.listeners.delete(onChunk);
+      active.settledListeners.delete(onSettled);
+      signal?.removeEventListener('abort', onAbort);
+    }
+  }
+
+  /**
+   * Reads and parses the persisted {@link TerraformRunRecord} for `runId`
+   * from `<runsDir>/<runId>/run.json` (see {@link writeRunRecord}) — the
+   * run-detail counterpart to {@link streamRunOutput}'s output feed. Returns
+   * `null` (rather than throwing) when no `run.json` exists for `runId` yet
+   * — e.g. the run is still in flight and hasn't closed, or `runId` doesn't
+   * exist at all. Callers that need to distinguish "still running" from
+   * "unknown run" should also consult {@link getWorkspaceInFlight} or attempt
+   * a live {@link streamRunOutput} subscription.
+   *
+   * @throws A plain `Error` synchronously if `runId` isn't a bare path
+   *   segment matching {@link RUN_ID_PATTERN}.
+   */
+  readRunRecord(runId: string): TerraformRunRecord | null {
+    TerraformService.assertValidRunId(runId);
+    const recordPath = join(this.config.getRunsDir(), runId, 'run.json');
+    if (!existsSync(recordPath)) {
+      return null;
+    }
+    return JSON.parse(readFileSync(recordPath, 'utf8')) as TerraformRunRecord;
+  }
+
+  /**
+   * Reports whether {@link plan}'s persisted `.tfplan` artifact exists on
+   * disk for `runId` — `<runsDir>/<runId>/<runId>.tfplan`, the same path
+   * {@link expectedPlanFilePath} computes and {@link apply} validates a
+   * caller-supplied `planFile` against. Intended for a run-detail IPC handler
+   * (or the renderer's "Apply" button) to check whether a given plan run
+   * still has an applyable artifact on disk before offering to apply it.
+   *
+   * @throws A plain `Error` synchronously if `runId` isn't a bare path
+   *   segment matching {@link RUN_ID_PATTERN}.
+   */
+  hasPlanArtifact(runId: string): boolean {
+    TerraformService.assertValidRunId(runId);
+    return existsSync(TerraformService.expectedPlanFilePath(this.config.getRunsDir(), runId));
+  }
+
+  /**
    * Throws {@link DestroyNotConfirmedError} unless `token` matches the most
    * recently minted, not-yet-expired, not-yet-consumed confirmation token
    * (see {@link mintDestroyConfirmationToken}). On success, consumes the
@@ -1612,6 +1814,88 @@ export class TerraformService {
    */
   private getRunLogPath(runId: string): string {
     return join(this.config.getRunsDir(), runId, 'terraform.log');
+  }
+
+  /**
+   * Registers a fresh, empty {@link ActiveRunBuffer} for `runId` — called by
+   * {@link plan}/{@link apply}/{@link destroy} immediately before their
+   * spawned process starts, so a concurrent {@link streamRunOutput} call
+   * observes the run as in-flight (even before its first chunk arrives)
+   * rather than falling through to the "unknown run" / log-replay path.
+   */
+  private beginActiveRun(runId: string): void {
+    this.activeRuns.set(runId, {
+      chunks: [],
+      listeners: new Set(),
+      settled: false,
+      settledListeners: new Set(),
+    });
+  }
+
+  /**
+   * Appends `chunk` to `runId`'s {@link ActiveRunBuffer} (a no-op if no
+   * buffer is currently registered for `runId`) and synchronously notifies
+   * every subscriber registered via {@link streamRunOutput}. Called by
+   * {@link plan}/{@link apply}/{@link destroy} from the same point each
+   * accumulates the chunk into its own `logLines` transcript, so the two
+   * stay in lockstep.
+   */
+  private recordRunChunk(runId: string, chunk: TerraformRunChunk): void {
+    const active = this.activeRuns.get(runId);
+    if (!active) return;
+    active.chunks.push(chunk);
+    for (const listener of active.listeners) {
+      listener(chunk);
+    }
+  }
+
+  /**
+   * Marks `runId`'s {@link ActiveRunBuffer} as settled — notifying every
+   * subscriber registered via {@link streamRunOutput} that no further chunks
+   * are coming, so their generator can end — then removes the entry from
+   * {@link activeRuns}. Called by {@link plan}/{@link apply}/{@link destroy}
+   * immediately after they've written the run's full transcript to
+   * `terraform.log` (see {@link writeRunLog}), on every exit path
+   * (success/failure/abort/force-killed). A no-op if no buffer is currently
+   * registered for `runId` (e.g. the process never actually spawned).
+   */
+  private endActiveRun(runId: string): void {
+    const active = this.activeRuns.get(runId);
+    if (!active) return;
+    active.settled = true;
+    for (const listener of active.settledListeners) {
+      listener();
+    }
+    active.settledListeners.clear();
+    this.activeRuns.delete(runId);
+  }
+
+  /**
+   * Replays a finished run's persisted `<runsDir>/<runId>/terraform.log` (see
+   * {@link getRunLogPath}) line-by-line as `stdout`-tagged {@link TerraformRunChunk}
+   * values — the fallback path {@link streamRunOutput} takes once `runId` is
+   * no longer in flight. Drops a single trailing empty line produced by
+   * `terraform.log`'s trailing newline (see {@link writeRunLog}) so replaying
+   * never yields a spurious empty final chunk. `terraform.log` doesn't retain
+   * which stream (`stdout`/`stderr`) each line originally came from, so every
+   * replayed chunk is tagged `'stdout'` regardless of its original source.
+   *
+   * @throws A plain `Error` when no `terraform.log` exists for `runId` — i.e.
+   *   no run by that id was ever spawned (or its directory was cleaned up).
+   */
+  private async *replayRunLog(runId: string): AsyncGenerator<TerraformRunChunk, void> {
+    const logPath = this.getRunLogPath(runId);
+    if (!existsSync(logPath)) {
+      throw new Error(`TerraformService.streamRunOutput(): no run found for runId "${runId}".`);
+    }
+    const contents = readFileSync(logPath, 'utf8');
+    const lines = contents.split('\n');
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+    for (const line of lines) {
+      yield { stream: 'stdout', line };
+    }
   }
 
   /**

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -519,6 +519,68 @@ export interface TerraformInitConfig {
 }
 
 /**
+ * Which `terraform` subcommand produced a {@link TerraformRunRecord}.
+ *
+ * Mirrors the `kind` field of `TerraformRunRecord` in
+ * `@hyveon/desktop-main/src/services/TerraformService.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export type TerraformRunKind = 'plan' | 'apply' | 'destroy';
+
+/**
+ * Persisted local run record for a finished `terraform` plan/apply/destroy
+ * run — a lightweight run history entry written once the run's spawned
+ * process has closed.
+ *
+ * Mirrors `TerraformRunRecord` in
+ * `@hyveon/desktop-main/src/services/TerraformService.ts` — that file is the
+ * source of truth; keep this copy in sync with it.
+ */
+export interface TerraformRunRecord {
+  /** The `runId` this record describes — matches the directory it's written into. */
+  runId: string;
+  /** Which subcommand produced this record. */
+  kind: TerraformRunKind;
+  /** ISO-8601 timestamp captured immediately before the process was spawned. */
+  startedAt: string;
+  /** ISO-8601 timestamp captured immediately after the process closed. */
+  completedAt: string;
+  /** The process's exit code, or `null` if it never reported one (e.g. killed via abort signal). */
+  exitCode: number | null;
+  /** The tfvars version id the applied plan was generated against, if the caller supplied one. */
+  tfvarsVersionId?: string;
+}
+
+/**
+ * Lifecycle status surfaced by the run-detail view — a superset of the
+ * persisted `success` / `failed` / `aborted` run status with two additional,
+ * non-persisted values computed at read time: `running` (no
+ * {@link TerraformRunRecord} exists yet because the run hasn't finished) and
+ * `awaiting_approval` (a `plan` run finished successfully but its `.tfplan`
+ * artifact still exists on disk, awaiting an operator's explicit apply).
+ *
+ * Mirrors `RunDetailStatus` in `@hyveon/shared/src/runs.ts` — that file is
+ * the source of truth; keep this copy in sync with it.
+ */
+export type RunDetailStatus = 'success' | 'failed' | 'aborted' | 'running' | 'awaiting_approval';
+
+/**
+ * Result of the `terraform.runs.get` IPC channel: `found: false` when the
+ * requested `runId` is neither the currently in-flight run nor a persisted
+ * {@link TerraformRunRecord} on disk. `found: true` always carries the
+ * derived {@link RunDetailStatus}; `record` is present only once the run has
+ * produced a persisted {@link TerraformRunRecord} (i.e. every status except
+ * `running`, since a run in flight hasn't closed its process yet).
+ *
+ * Mirrors `TerraformRunsGetResult` in
+ * `@hyveon/desktop-main/src/controllers/terraform-runs.controller.ts` — that
+ * file is the source of truth; keep this copy in sync with it.
+ */
+export type TerraformRunsGetResult =
+  | { found: false }
+  | { found: true; status: RunDetailStatus; record?: TerraformRunRecord };
+
+/**
  * Payload accepted by the `terraform.plan` IPC channel. `tfvarsVersionId`,
  * when the configured tfvars source is S3-backed, is forwarded verbatim to
  * `TerraformService.plan`'s pre-spawn staleness check against the current
@@ -730,6 +792,46 @@ export interface GsdAuditApi {
 }
 
 /**
+ * Terraform run history: look up a single plan/apply/destroy run's current
+ * status and stream its live/replayed log output (issue #108).
+ */
+export interface GsdTerraformRunsApi {
+  /**
+   * Looks up the run identified by `runId` and returns its current
+   * {@link TerraformRunsGetResult} — `{ found: false }` if `runId` is
+   * neither the in-flight run nor a persisted {@link TerraformRunRecord},
+   * otherwise `{ found: true, status, record? }`.
+   *
+   * Internally this is a plain `invoke('terraform.runs.get', { runId })`
+   * call — unlike {@link streamLogs}, there is no streaming involved.
+   */
+  get: (runId: string) => Promise<TerraformRunsGetResult>;
+  /**
+   * Opens a live/replayed log stream for the run identified by `runId` as an
+   * async iterable of {@link TerraformRunChunk}. Consume it with
+   * `for await (const chunk of terraform.runs.streamLogs(runId, signal))`.
+   *
+   * Mirrors {@link GsdTerraformApi.init}'s streaming shape: the
+   * `terraform.runs.logs` invoke call resolves immediately with an opaque
+   * `streamId`, and subsequent chunk/end messages arrive on the fixed
+   * `terraform.runs.logs.chunk` / `terraform.runs.logs.end` side channels,
+   * tagged with that `streamId` so overlapping subscriptions to different
+   * runs can never cross-terminate one another.
+   *
+   * Pass an `AbortSignal` to stop consuming the stream early: aborting (or
+   * breaking out of the `for await` loop) stops the generator from yielding
+   * further chunks. There is no dedicated cancel side channel — the run
+   * itself (and its log tailing on the main-process side) keeps going in the
+   * background; only this caller's consumption stops.
+   *
+   * The iterator completes normally once the run's output finishes
+   * replaying/streaming, and throws (using the `terraform.runs.logs.end`
+   * payload's `error` field) if it terminated due to an error.
+   */
+  streamLogs: (runId: string, signal?: AbortSignal) => AsyncIterable<TerraformRunChunk>;
+}
+
+/**
  * Terraform orchestration: streams `terraform init` output live as the
  * process runs.
  */
@@ -784,6 +886,8 @@ export interface GsdTerraformApi {
    * when Terraform reports no outputs (infra not yet deployed).
    */
   output: (force?: boolean) => Promise<TfOutputs | null>;
+  /** Terraform run history: look up a single run's status and stream its log output. */
+  runs: GsdTerraformRunsApi;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -1169,4 +1169,420 @@ describe('preload dispatcher', () => {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // terraform.runs.get
+  // -------------------------------------------------------------------------
+
+  describe('terraform.runs.get', () => {
+    describe('real-IPC fallthrough', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should invoke the terraform.runs.get channel with a { runId } payload and resolve the result', async () => {
+        const result = { found: true, status: 'success', record: { runId: 'run-001', kind: 'plan', startedAt: '2026-07-17T00:00:00.000Z', completedAt: '2026-07-17T00:01:00.000Z', exitCode: 0 } };
+        ipcInvoke.mockResolvedValue(result);
+        const terraformRuns = (bridge['terraform'] as { runs: { get: (runId: string) => Promise<unknown> } }).runs;
+
+        const actual = await terraformRuns.get('run-001');
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.runs.get', { runId: 'run-001' });
+        expect(actual).toEqual(result);
+      });
+
+      it('should resolve { found: false } when the run is unknown', async () => {
+        ipcInvoke.mockResolvedValue({ found: false });
+        const terraformRuns = (bridge['terraform'] as { runs: { get: (runId: string) => Promise<unknown> } }).runs;
+
+        const actual = await terraformRuns.get('run-missing');
+
+        expect(actual).toEqual({ found: false });
+      });
+    });
+
+    describe('mock-override', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should call the registered mock instead of ipcRenderer.invoke when terraform.runs.get is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+        const result = { found: true, status: 'running' };
+        const mockHandler = vi.fn().mockResolvedValue(result);
+        testApi.mock('terraform.runs.get', mockHandler);
+
+        const terraformRuns = (bridge['terraform'] as { runs: { get: (runId: string) => Promise<unknown> } }).runs;
+        const actual = await terraformRuns.get('run-002');
+
+        expect(mockHandler).toHaveBeenCalledWith({ runId: 'run-002' });
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(actual).toEqual(result);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // terraform.runs.streamLogs
+  // -------------------------------------------------------------------------
+
+  describe('terraform.runs.streamLogs', () => {
+    /** Helper to collect all chunks from the `terraform.runs.streamLogs` async iterable into an array. */
+    async function collectChunks(
+      iterable: AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>,
+    ): Promise<{ stream: 'stdout' | 'stderr'; line: string }[]> {
+      const chunks: { stream: 'stdout' | 'stderr'; line: string }[] = [];
+      for await (const chunk of iterable) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mocked-delegation branch
+    // -----------------------------------------------------------------------
+
+    describe('mocked-delegation branch', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should delegate to the registered mock iterable instead of ipcRenderer when terraform.runs.logs is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* fakeStream() {
+          yield { stream: 'stdout' as const, line: 'Refreshing state...' };
+          yield { stream: 'stdout' as const, line: 'Plan: 1 to add, 0 to change, 0 to destroy.' };
+        }
+
+        const mockHandler = vi.fn().mockReturnValue(fakeStream());
+        testApi.mock('terraform.runs.logs', mockHandler);
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (
+                runId: string,
+                signal?: AbortSignal,
+              ) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        const chunks = await collectChunks(terraformRuns.streamLogs('run-003'));
+
+        expect(mockHandler).toHaveBeenCalledWith('run-003', undefined);
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(ipcSend).not.toHaveBeenCalled();
+        expect(chunks).toEqual([
+          { stream: 'stdout', line: 'Refreshing state...' },
+          { stream: 'stdout', line: 'Plan: 1 to add, 0 to change, 0 to destroy.' },
+        ]);
+      });
+
+      it('should forward the AbortSignal to the mock handler when one is provided', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* emptyStream() {}
+        const mockHandler = vi.fn().mockReturnValue(emptyStream());
+        testApi.mock('terraform.runs.logs', mockHandler);
+
+        const controller = new AbortController();
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (
+                runId: string,
+                signal?: AbortSignal,
+              ) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        await collectChunks(terraformRuns.streamLogs('run-004', controller.signal));
+
+        expect(mockHandler).toHaveBeenCalledWith('run-004', controller.signal);
+      });
+
+      it('should not attach any ipcRenderer listeners when the mock handles the stream', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+
+        async function* emptyStream() {}
+        testApi.mock('terraform.runs.logs', vi.fn().mockReturnValue(emptyStream()));
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        await collectChunks(terraformRuns.streamLogs('run-005'));
+
+        expect(ipcOn).not.toHaveBeenCalled();
+        expect(ipcOnce).not.toHaveBeenCalled();
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Unmocked passthrough branch
+    // -----------------------------------------------------------------------
+
+    describe('unmocked passthrough branch', () => {
+      /**
+       * `TerraformRunsController.logs` mints a per-call `streamId` and tags every
+       * chunk/end payload with it (returning the same id in the invoke ack) so an
+       * overlapping subscription to a different run's log stream can't
+       * cross-terminate this call's stream. Tests below default to this id when
+       * simulating the ack/events.
+       */
+      const STREAM_ID = 'sid-terraform-runs-1';
+
+      /** Listener signatures captured off `ipcOn.mockImplementation` calls below. */
+      type ChunkListener = (
+        _evt: unknown,
+        data: { streamId: string; chunk: { stream: string; line: string } },
+      ) => void;
+      type EndListener = (_evt: unknown, data: { streamId: string; error?: string }) => void;
+
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        // Load with test-mode OFF so no mock registry is active — the real IPC
+        // path is always exercised.
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should attach the chunk/end listeners before calling ipcRenderer.invoke so no early chunk is dropped', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.end') {
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID }));
+          }
+        });
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        await collectChunks(terraformRuns.streamLogs('run-006'));
+
+        // Registration must happen strictly before the invoke call resolves —
+        // otherwise a chunk sent immediately after the main process
+        // acknowledges the call could be dropped.
+        const firstOnCallOrder = ipcOn.mock.invocationCallOrder[0];
+        const secondOnCallOrder = ipcOn.mock.invocationCallOrder[1];
+        const invokeCallOrder = ipcInvoke.mock.invocationCallOrder[0];
+
+        expect(firstOnCallOrder).toBeLessThan(invokeCallOrder);
+        expect(secondOnCallOrder).toBeLessThan(invokeCallOrder);
+      });
+
+      it('should invoke terraform.runs.logs on ipcRenderer with the { runId } payload', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.end') {
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID }));
+          }
+        });
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        const chunks = await collectChunks(terraformRuns.streamLogs('run-007'));
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.runs.logs', { runId: 'run-007' });
+        expect(chunks).toEqual([]);
+      });
+
+      it('should yield chunks received over the terraform.runs.logs.chunk IPC channel in order', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        const capturedChunkListener: { current: ChunkListener | null } = { current: null };
+        const capturedEndListener: { current: EndListener | null } = { current: null };
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.chunk') capturedChunkListener.current = listener as ChunkListener;
+          if (channel === 'terraform.runs.logs.end') capturedEndListener.current = listener as EndListener;
+        });
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        const collected = collectChunks(terraformRuns.streamLogs('run-008'));
+
+        await Promise.resolve();
+        await Promise.resolve();
+        capturedChunkListener.current?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Refreshing state...' } });
+        capturedChunkListener.current?.({}, {
+          streamId: STREAM_ID,
+          chunk: { stream: 'stdout', line: 'Plan: 1 to add, 0 to change, 0 to destroy.' },
+        });
+        capturedEndListener.current?.({}, { streamId: STREAM_ID });
+
+        const chunks = await collected;
+
+        expect(chunks).toEqual([
+          { stream: 'stdout', line: 'Refreshing state...' },
+          { stream: 'stdout', line: 'Plan: 1 to add, 0 to change, 0 to destroy.' },
+        ]);
+      });
+
+      it('should ignore chunk/end events tagged with a foreign streamId so an overlapping subscription to a different run cannot cross-terminate this stream', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        const capturedChunkListener: { current: ChunkListener | null } = { current: null };
+        const capturedEndListener: { current: EndListener | null } = { current: null };
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.chunk') capturedChunkListener.current = listener as ChunkListener;
+          if (channel === 'terraform.runs.logs.end') capturedEndListener.current = listener as EndListener;
+        });
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        const collected = collectChunks(terraformRuns.streamLogs('run-009'));
+
+        await Promise.resolve();
+        await Promise.resolve();
+        // A subscription to a different run's log stream fires first, tagged
+        // with a different streamId — must not terminate this stream.
+        capturedEndListener.current?.({}, { streamId: 'sid-other-run', error: 'boom' });
+        capturedChunkListener.current?.({}, { streamId: 'sid-other-run', chunk: { stream: 'stdout', line: 'not mine' } });
+        // This call's own chunk/end events still resolve the generator normally.
+        capturedChunkListener.current?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Refreshing state...' } });
+        capturedEndListener.current?.({}, { streamId: STREAM_ID });
+
+        const chunks = await collected;
+
+        expect(chunks).toEqual([{ stream: 'stdout', line: 'Refreshing state...' }]);
+      });
+
+      it('should throw when the terraform.runs.logs.end event carries an error field', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.end') {
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID, error: 'run not found' }));
+          }
+        });
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+
+        await expect(collectChunks(terraformRuns.streamLogs('run-010'))).rejects.toThrow('run not found');
+      });
+
+      it('should remove chunk/end listeners once the stream completes', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.end') {
+            Promise.resolve().then(() => listener({} as unknown, { streamId: STREAM_ID }));
+          }
+        });
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (runId: string) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        await collectChunks(terraformRuns.streamLogs('run-011'));
+
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.runs.logs.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.runs.logs.end', expect.any(Function));
+      });
+
+      // -----------------------------------------------------------------------
+      // AbortSignal cancellation
+      // -----------------------------------------------------------------------
+
+      it('should stop yielding and clean up listeners without calling invoke when the signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (
+                runId: string,
+                signal?: AbortSignal,
+              ) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        const chunks = await collectChunks(terraformRuns.streamLogs('run-012', controller.signal));
+
+        expect(chunks).toEqual([]);
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.runs.logs.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.runs.logs.end', expect.any(Function));
+      });
+
+      it('should stop the async iterable and clean up listeners when the signal aborts mid-stream', async () => {
+        ipcInvoke.mockResolvedValue({ streamId: STREAM_ID });
+
+        const capturedChunkListener: { current: ChunkListener | null } = { current: null };
+        ipcOn.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === 'terraform.runs.logs.chunk') capturedChunkListener.current = listener as ChunkListener;
+          // 'terraform.runs.logs.end' listener is captured but intentionally
+          // never invoked — the stream stays open until the signal aborts.
+        });
+
+        const controller = new AbortController();
+        const terraformRuns = (
+          bridge['terraform'] as {
+            runs: {
+              streamLogs: (
+                runId: string,
+                signal?: AbortSignal,
+              ) => AsyncIterable<{ stream: 'stdout' | 'stderr'; line: string }>;
+            };
+          }
+        ).runs;
+        const gen = terraformRuns.streamLogs('run-013', controller.signal)[Symbol.asyncIterator]();
+
+        const nextPromise = gen.next();
+        await Promise.resolve();
+        await Promise.resolve();
+        capturedChunkListener.current?.({}, { streamId: STREAM_ID, chunk: { stream: 'stdout', line: 'Refreshing state...' } });
+        const first = await nextPromise;
+        expect(first).toEqual({ done: false, value: { stream: 'stdout', line: 'Refreshing state...' } });
+
+        controller.abort();
+        const second = await gen.next();
+
+        expect(second).toEqual({ done: true, value: undefined });
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.runs.logs.chunk', expect.any(Function));
+        expect(ipcRemoveListener).toHaveBeenCalledWith('terraform.runs.logs.end', expect.any(Function));
+      }, 10_000);
+    });
+  });
 });

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -32,6 +32,15 @@
  * has been kicked off in the background, or `{ started: false, error, conflict? }`
  * when the submission was rejected outright (e.g. the shared Terraform
  * workspace was already busy running another subcommand).
+ *
+ * `terraform.runs.get(runId)` is a plain `invoke('terraform.runs.get', { runId })`
+ * call — it resolves a single `TerraformRunsGetResult` snapshot with no
+ * streaming involved. `terraform.runs.streamLogs(runId, signal)` mirrors
+ * `terraform.init`'s fixed-side-channel streaming shape: `TerraformRunsController.logs`
+ * pushes chunk/end messages on fixed `terraform.runs.logs.chunk` /
+ * `terraform.runs.logs.end` side channels shared by every call, each tagged
+ * with the `streamId` minted for that call, so overlapping subscriptions to
+ * different runs' log output can never cross-terminate one another.
  */
 
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
@@ -46,6 +55,7 @@ import type {
   TerraformPlanAck,
   TerraformPlanPayload,
   TerraformRunChunk,
+  TerraformRunsGetResult,
   TfOutputs,
   UpdateGamePayload,
 } from './gsd-api.js';
@@ -55,6 +65,12 @@ const TERRAFORM_INIT_CHUNK_CHANNEL = 'terraform.init.chunk';
 
 /** Fixed side-channel `TerraformController.init` sends its terminal message on. */
 const TERRAFORM_INIT_END_CHANNEL = 'terraform.init.end';
+
+/** Fixed side-channel `TerraformRunsController.logs` pushes streamed run output on. */
+const TERRAFORM_RUNS_LOGS_CHUNK_CHANNEL = 'terraform.runs.logs.chunk';
+
+/** Fixed side-channel `TerraformRunsController.logs` sends its terminal message on. */
+const TERRAFORM_RUNS_LOGS_END_CHANNEL = 'terraform.runs.logs.end';
 
 /**
  * Per-channel mock registry populated by tests via `window.gsd.__test.mock(channel, handler)`.
@@ -347,6 +363,156 @@ async function* streamTerraformInit(config: TerraformInitConfig, signal?: AbortS
   }
 }
 
+/**
+ * Bridges `TerraformRunsController.logs`'s fixed `terraform.runs.logs.chunk` /
+ * `terraform.runs.logs.end` side channels into an {@link AsyncIterable} of
+ * {@link TerraformRunChunk} for a single run identified by `runId`.
+ *
+ * Mirrors {@link streamTerraformInit}'s streaming shape: `TerraformRunsController.logs`
+ * tags every chunk/end payload with the `streamId` it minted for this call and
+ * returned in the invoke ack (`{ streamId }`), so events from an overlapping
+ * subscription to a *different* run's log stream (which share the same fixed
+ * channel names) are filtered out and can never cross-terminate this stream.
+ *
+ * When a mock is registered for the `'terraform.runs.logs'` channel (test mode
+ * only), the mock handler is called with `(runId, signal)` and its return
+ * value is treated as an `AsyncIterable<TerraformRunChunk>` — the real IPC
+ * listener path is never touched.
+ *
+ * In production (no mock registered), the `terraform.runs.logs.chunk` /
+ * `terraform.runs.logs.end` listeners are attached **before**
+ * `ipcRenderer.invoke('terraform.runs.logs', { runId })` is called, so no
+ * chunk sent immediately after the main process acknowledges the call can
+ * ever be dropped. Since this call's own `streamId` isn't known until the
+ * invoke resolves, events observed before then are held in a raw buffer and
+ * replayed (filtered by the now-known `streamId`) once the ack arrives.
+ * Chunks tagged with this call's `streamId` are buffered as they arrive and
+ * yielded in order; the generator completes when a `terraform.runs.logs.end`
+ * event tagged with this call's `streamId` fires with no `error`, or throws
+ * using its `error` field otherwise.
+ *
+ * Following the `logs.stream`/`terraform.init` pattern, an optional `signal`
+ * may be supplied to stop consumption early: aborting (or breaking out of the
+ * `for await` loop) stops the wait loop and the `finally` block detaches the
+ * listeners. There is no per-run cancel side channel — the run itself (and
+ * its log tailing in the main process) keeps going in the background; only
+ * this caller's consumption stops.
+ */
+async function* streamTerraformRunLogs(runId: string, signal?: AbortSignal): AsyncIterable<TerraformRunChunk> {
+  const logsMock = mockRegistry.get('terraform.runs.logs');
+  if (logsMock !== undefined) {
+    const mockIterable = logsMock(runId, signal) as AsyncIterable<TerraformRunChunk>;
+    yield* mockIterable;
+    return;
+  }
+
+  /** Chunks received but not yet yielded. */
+  const buffer: TerraformRunChunk[] = [];
+  let ended = false;
+  let endError: string | undefined;
+  let aborted = false;
+  /**
+   * This call's own `streamId`, known only once the `terraform.runs.logs`
+   * invoke resolves. `null` until then, at which point every raw chunk/end
+   * event buffered so far is replayed through the `streamId` filter below.
+   */
+  let ownStreamId: string | null = null;
+  /** Chunk events observed before `ownStreamId` is known. */
+  const rawChunkBuffer: Array<{ streamId: string; chunk: TerraformRunChunk }> = [];
+  /** End events observed before `ownStreamId` is known. */
+  const rawEndBuffer: Array<{ streamId: string; error?: string }> = [];
+  /** Resolves the pending `await` when a chunk arrives, the stream ends, or the signal aborts. */
+  let wake: (() => void) | null = null;
+  const signalWake = () => {
+    if (wake) {
+      const fn = wake;
+      wake = null;
+      fn();
+    }
+  };
+
+  /** Applies a chunk event, discarding it if it belongs to a different run's log subscription. */
+  const applyChunk = (data: { streamId: string; chunk: TerraformRunChunk }) => {
+    if (data.streamId !== ownStreamId) return;
+    buffer.push(data.chunk);
+    signalWake();
+  };
+  /** Applies an end event, discarding it if it belongs to a different run's log subscription. */
+  const applyEnd = (data: { streamId: string; error?: string }) => {
+    if (data.streamId !== ownStreamId) return;
+    ended = true;
+    endError = data.error;
+    signalWake();
+  };
+
+  const onChunk = (_evt: IpcRendererEvent, data: { streamId: string; chunk: TerraformRunChunk }) => {
+    if (ownStreamId === null) {
+      rawChunkBuffer.push(data);
+      return;
+    }
+    applyChunk(data);
+  };
+  const onEnd = (_evt: IpcRendererEvent, data: { streamId: string; error?: string }) => {
+    if (ownStreamId === null) {
+      rawEndBuffer.push(data);
+      return;
+    }
+    applyEnd(data);
+  };
+  const onAbort = () => {
+    aborted = true;
+    signalWake();
+  };
+
+  // Attach both listeners before invoking so no early event sent right after
+  // the main process acknowledges the call is ever dropped — the channel
+  // names here are fixed constants known up front, so there is no need to
+  // wait for the invoke response first. `onEnd` uses `ipcRenderer.on` (not
+  // `.once`): a subscription to a different run's log stream could deliver
+  // its end event on this same fixed channel before our own, and a `once`
+  // listener would consume and discard it, missing our own end event
+  // entirely.
+  ipcRenderer.on(TERRAFORM_RUNS_LOGS_CHUNK_CHANNEL, onChunk);
+  ipcRenderer.on(TERRAFORM_RUNS_LOGS_END_CHANNEL, onEnd);
+  if (signal) {
+    if (signal.aborted) aborted = true;
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
+
+  try {
+    if (aborted) return;
+
+    const ack = (await invoke('terraform.runs.logs', { runId })) as { streamId: string };
+    ownStreamId = ack.streamId;
+
+    // Replay anything observed before we knew our own streamId, filtering
+    // out events tagged with a different (foreign, overlapping) run.
+    for (const data of rawChunkBuffer) applyChunk(data);
+    rawChunkBuffer.length = 0;
+    for (const data of rawEndBuffer) applyEnd(data);
+    rawEndBuffer.length = 0;
+
+    while (true) {
+      while (buffer.length > 0) {
+        if (aborted) return;
+        yield buffer.shift()!;
+      }
+      if (aborted) return;
+      if (ended) {
+        if (endError) throw new Error(endError);
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  } finally {
+    ipcRenderer.removeListener(TERRAFORM_RUNS_LOGS_CHUNK_CHANNEL, onChunk);
+    ipcRenderer.removeListener(TERRAFORM_RUNS_LOGS_END_CHANNEL, onEnd);
+    signal?.removeEventListener('abort', onAbort);
+  }
+}
+
 const api: GsdApi = {
   games: {
     list: () => invoke('games.list'),
@@ -427,6 +593,10 @@ const api: GsdApi = {
     init: streamTerraformInit,
     plan: (opts?: TerraformPlanPayload) => invoke<TerraformPlanAck>('terraform.plan', opts),
     output: (force?: boolean) => invoke<TfOutputs | null>('terraform.output', { force }),
+    runs: {
+      get: (runId: string) => invoke<TerraformRunsGetResult>('terraform.runs.get', { runId }),
+      streamLogs: streamTerraformRunLogs,
+    },
   },
 };
 

--- a/app/packages/shared/src/runs.test.ts
+++ b/app/packages/shared/src/runs.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import { buildRunSk, deriveRunStatus, isRunLockExpired, type RunLock } from './runs.js';
+import {
+  buildRunSk,
+  computeRunDetailStatus,
+  deriveRunStatus,
+  isRunLockExpired,
+  type RunLock,
+} from './runs.js';
+
+/**
+ * Builds a minimal input for {@link computeRunDetailStatus}, overriding only
+ * the fields a given test cares about. Defaults describe a finished,
+ * successful `apply` run with no plan artifact.
+ */
+function buildStatusInput(
+  overrides: Partial<Parameters<typeof computeRunDetailStatus>[0]> = {},
+): Parameters<typeof computeRunDetailStatus>[0] {
+  return {
+    isInFlight: false,
+    kind: 'apply',
+    exitCode: 0,
+    planArtifactExists: false,
+    ...overrides,
+  };
+}
 
 /**
  * Builds a minimal {@link RunLock} fixture for {@link isRunLockExpired}
@@ -88,5 +111,56 @@ describe('isRunLockExpired', () => {
 
     expect(isRunLockExpired(pastLock)).toBe(true);
     expect(isRunLockExpired(futureLock)).toBe(false);
+  });
+});
+
+describe('computeRunDetailStatus', () => {
+  it('should return running when isInFlight is true regardless of the other fields', () => {
+    const input = buildStatusInput({
+      isInFlight: true,
+      kind: 'plan',
+      exitCode: 0,
+      planArtifactExists: true,
+    });
+
+    expect(computeRunDetailStatus(input)).toBe('running');
+  });
+
+  it('should return awaiting_approval for a successful plan whose artifact still exists', () => {
+    const input = buildStatusInput({ kind: 'plan', exitCode: 0, planArtifactExists: true });
+
+    expect(computeRunDetailStatus(input)).toBe('awaiting_approval');
+  });
+
+  it('should not return awaiting_approval for a successful plan whose artifact no longer exists', () => {
+    const input = buildStatusInput({ kind: 'plan', exitCode: 0, planArtifactExists: false });
+
+    expect(computeRunDetailStatus(input)).toBe('success');
+  });
+
+  it('should return success for a successful apply', () => {
+    const input = buildStatusInput({ kind: 'apply', exitCode: 0, planArtifactExists: false });
+
+    expect(computeRunDetailStatus(input)).toBe('success');
+  });
+
+  it('should return failed for a run with a non-zero exit code', () => {
+    const input = buildStatusInput({ kind: 'apply', exitCode: 1, planArtifactExists: false });
+
+    expect(computeRunDetailStatus(input)).toBe('failed');
+  });
+
+  it('should return aborted for a run with a null exit code', () => {
+    const input = buildStatusInput({ kind: 'destroy', exitCode: null, planArtifactExists: false });
+
+    expect(computeRunDetailStatus(input)).toBe('aborted');
+  });
+
+  it('should not rewrite a failed or aborted plan to awaiting_approval', () => {
+    const failedPlan = buildStatusInput({ kind: 'plan', exitCode: 1, planArtifactExists: true });
+    const abortedPlan = buildStatusInput({ kind: 'plan', exitCode: null, planArtifactExists: true });
+
+    expect(computeRunDetailStatus(failedPlan)).toBe('failed');
+    expect(computeRunDetailStatus(abortedPlan)).toBe('aborted');
   });
 });

--- a/app/packages/shared/src/runs.ts
+++ b/app/packages/shared/src/runs.ts
@@ -185,9 +185,15 @@ export type RunDetailStatus = RunStatus | 'running' | 'awaiting_approval';
  *    `.tfplan` artifact still exists on disk — because the epic's design
  *    (#83) gates `apply` behind an explicit operator approval (#109), a
  *    successful plan alone hasn't reached a terminal state from the
- *    operator's point of view. Once `TerraformService.apply` consumes the
- *    `.tfplan` artifact, `planArtifactExists` becomes `false` and this rule
- *    no longer applies, so the plan falls through to rule 3.
+ *    operator's point of view. `planArtifactExists` is plumbed in for that
+ *    future approval flow (#109), which is expected to delete the `.tfplan`
+ *    file once consumed; as of this writing nothing does, so this rule's
+ *    actual escape hatch is rule ordering, not artifact deletion —
+ *    `TerraformService.apply` writes its own {@link TerraformRunRecord}
+ *    (`kind: 'apply'`) to the same `<runsDir>/<runId>/run.json` that the
+ *    plan run used, so once an apply has run for this `runId` the caller
+ *    observes `kind === 'apply'` (not `'plan'`) and this rule no longer
+ *    matches, falling through to rule 3.
  * 3. Otherwise, the status is derived from `exitCode` via
  *    {@link deriveRunStatus}.
  *

--- a/app/packages/shared/src/runs.ts
+++ b/app/packages/shared/src/runs.ts
@@ -151,3 +151,65 @@ export interface RunLock {
 export function isRunLockExpired(lock: RunLock, now: Date = new Date()): boolean {
   return now.getTime() >= new Date(lock.expiresAt).getTime();
 }
+
+/**
+ * Status surfaced by the run-detail view (`GET /api/terraform/runs/:id`,
+ * issue #108) — a superset of the persisted {@link RunStatus} with two
+ * additional, non-persisted values computed at read time by
+ * {@link computeRunDetailStatus}:
+ *
+ * - `running` — no {@link RunRecord} exists yet for this run, because (per
+ *   {@link RunRecord}'s own doc) a record is only ever persisted once the
+ *   subcommand has finished.
+ * - `awaiting_approval` — a `plan` run finished successfully but, per the
+ *   epic's design (#83), an `apply` may not proceed until an operator
+ *   explicitly approves it (#109), so a bare `success` would be misleading.
+ */
+export type RunDetailStatus = RunStatus | 'running' | 'awaiting_approval';
+
+/**
+ * Derives the {@link RunDetailStatus} the run-detail view should render for
+ * a given run.
+ *
+ * Pure: takes primitive data describing the run's current state as
+ * arguments (mirroring {@link deriveRunStatus} and {@link isRunLockExpired}'s
+ * convention) rather than resolving a {@link RunRecord} internally, so
+ * callers control exactly which state is under test and no I/O happens here.
+ *
+ * Rules, applied in order:
+ * 1. `isInFlight` (the run's id matches the currently held {@link RunLock}
+ *    and hasn't expired) always maps to `running`, since {@link RunRecord} is
+ *    only ever persisted once the subcommand has finished (there is no
+ *    `pending` status to store).
+ * 2. A `plan` run that exited `0` maps to `awaiting_approval` only while its
+ *    `.tfplan` artifact still exists on disk — because the epic's design
+ *    (#83) gates `apply` behind an explicit operator approval (#109), a
+ *    successful plan alone hasn't reached a terminal state from the
+ *    operator's point of view. Once `TerraformService.apply` consumes the
+ *    `.tfplan` artifact, `planArtifactExists` becomes `false` and this rule
+ *    no longer applies, so the plan falls through to rule 3.
+ * 3. Otherwise, the status is derived from `exitCode` via
+ *    {@link deriveRunStatus}.
+ *
+ * @param input - The run's current state:
+ * - `isInFlight` - Whether this run is the one currently holding an unexpired {@link RunLock} (i.e. hasn't produced a persisted {@link RunRecord} yet).
+ * - `kind` - Which `terraform` subcommand the run is/was, or `null` if unknown.
+ * - `exitCode` - The process's exit code, or `null` if it never reported one.
+ * - `planArtifactExists` - Whether the run's `.tfplan` artifact still exists on disk (only meaningful for `plan` runs).
+ * @returns The computed {@link RunDetailStatus}.
+ */
+export function computeRunDetailStatus(input: {
+  isInFlight: boolean;
+  kind: RunKind | null;
+  exitCode: number | null;
+  planArtifactExists: boolean;
+}): RunDetailStatus {
+  const { isInFlight, kind, exitCode, planArtifactExists } = input;
+  if (isInFlight) {
+    return 'running';
+  }
+  if (kind === 'plan' && exitCode === 0 && planArtifactExists) {
+    return 'awaiting_approval';
+  }
+  return deriveRunStatus(exitCode);
+}


### PR DESCRIPTION
Closes #108

## Summary

- Adds a `terraform.runs.get` IPC handler (`TerraformRunsController`, `desktop-main`) that resolves a `runId` against the in-flight apply lock and persisted `TerraformRunRecord`s on disk, returning `{ found: false }` when neither matches or `{ found: true, status, record? }` — `status` is derived via the new shared `computeRunDetailStatus()` helper, `record` is present once the run has produced a persisted record.
- Adds a `terraform.runs.logs` streaming channel on the same controller: subscribes to `TerraformService.streamRunOutput()` and pushes chunks over a fixed `terraform.runs.logs.chunk` side-channel (tagged with a per-subscription `streamId`) plus a single terminal message on `terraform.runs.logs.end` once the run reaches a terminal status or the generator errors.
- Extends `TerraformService` with the live run-output feed and run-detail readers that back both handlers (in-flight process output plus replay of a finished run's persisted log).
- Adds a pure `computeRunDetailStatus()` helper and `RunDetailStatus` type to `@hyveon/shared` so the derived status logic has exactly one implementation, shared between the controller and its tests.
- Exposes `gsd.terraform.runs.get()` and `gsd.terraform.runs.streamLogs()` on the preload bridge (`desktop-preload`), with the two side-channels excluded from the generic IPC bridge allowlist (they're pushed proactively by the main process, not requested per-call).
- Registers `TerraformRunsController` in `AppModule`.
- Fixes: `endActiveRun` now only runs in the outer `finally` block (previously could double-fire), and removes an inaccurate `TerraformService` implementation detail leaking into `computeRunDetailStatus`'s derived status.

## Changes

```
 app/packages/desktop-main/src/app.module.ts        |   2 +
 .../controllers/terraform-runs.controller.test.ts  | 409 +++++++++++++++++++
 .../src/controllers/terraform-runs.controller.ts   | 265 +++++++++++++
 app/packages/desktop-main/src/ipc-main-bridge.ts   |   6 +
 .../src/services/TerraformService.runs.test.ts     | 441 +++++++++++++++++++++
 .../desktop-main/src/services/TerraformService.ts  | 336 +++++++++++++++-
 app/packages/desktop-preload/src/gsd-api.ts        | 104 +++++
 app/packages/desktop-preload/src/preload.test.ts   | 416 +++++++++++++++++++
 app/packages/desktop-preload/src/preload.ts        | 170 ++++++++
 app/packages/shared/src/runs.test.ts               |  76 +++-
 app/packages/shared/src/runs.ts                    |  68 ++++
 11 files changed, 2289 insertions(+), 4 deletions(-)
```

## Test plan

- [x] Run-detail lookup returns the persisted record + computed status (`terraform.runs.get`, covered by `terraform-runs.controller.test.ts` and `TerraformService.runs.test.ts`).
- [x] Log stream emits chunks in near-real-time while a run is in flight (`terraform.runs.logs` over the `terraform.runs.logs.chunk` side-channel).
- [x] Stream sends a terminal message on `terraform.runs.logs.end` once the run reaches a terminal status, and also replays a finished run's persisted log to completion.
- [x] Auth: reachable only through the existing IPC bridge, which the app gates the same way as every other `gsd.*` surface — no new unauthenticated path introduced.
- [x] `gsd.terraform.runs.get()` / `gsd.terraform.runs.streamLogs()` exposed on the preload bridge; new side-channels excluded from the generic bridge allowlist — covered by `preload.test.ts`.
- [x] `npm run app:test` passing for the touched workspaces (shared, desktop-main, desktop-preload).
- [x] `npm run app:lint` clean.

**Note:** issue #108's original acceptance criteria describe an HTTP `GET /api/terraform/runs/:id` + SSE `GET /api/terraform/runs/:id/logs` pair against a CodeBuild-driven backend — that reflects an earlier architecture. As with #107, the codebase has since moved to a local Terraform binary driven over Electron IPC, so this PR implements the equivalent `terraform.runs.get` request/response handler and `terraform.runs.logs` streaming channel through that IPC surface instead of HTTP/SSE/CodeBuild.
