### PR TITLE
feat(desktop-main): apply IPC handler (plan-hash-gated)

### DIFF
--- a/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
-import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { RunLockHeldError } from '@hyveon/shared';
 import type { RunLock, RunRecord } from '@hyveon/shared';
@@ -132,6 +138,85 @@ describe('AwsRunRecordStore', () => {
     it('should throw a clear error when constructed without a getConfig callback', async () => {
       const store = makeStore(null);
       await expect(store.putRecord(makeRecord())).rejects.toThrow(
+        'AwsRunRecordStore: table not configured. Supply a getConfig callback that resolves { tableName }.',
+      );
+    });
+  });
+
+  describe('getRecordByRunId', () => {
+    it('should query the RUN partition newest-first and return the matching record', async () => {
+      const record = makeRecord();
+      ddbMock.on(QueryCommand).resolves({ Items: [{ pk: 'RUN', ...record }] });
+
+      const store = makeStore();
+      await expect(store.getRecordByRunId('run-123')).resolves.toEqual(record);
+
+      const calls = ddbMock.commandCalls(QueryCommand);
+      expect(calls).toHaveLength(1);
+      const input = calls[0]!.args[0].input;
+      expect(input.TableName).toBe('hyveon-runs');
+      expect(input.KeyConditionExpression).toBe('pk = :pk');
+      expect(input.FilterExpression).toBe('runId = :runId');
+      expect(input.ExpressionAttributeValues).toEqual({ ':pk': 'RUN', ':runId': 'run-123' });
+      expect(input.ScanIndexForward).toBe(false);
+    });
+
+    it('should return the newest record when the query returns multiple items for the runId', async () => {
+      // ScanIndexForward: false means DynamoDB returns items sk-descending
+      // (sk is `<startedAt>#<runId>`), so the newest record is Items[0].
+      const newest = makeRecord({
+        sk: '2026-07-18T00:00:00.000Z#run-123',
+        startedAt: '2026-07-18T00:00:00.000Z',
+        status: 'success',
+      });
+      const older = makeRecord({
+        sk: '2026-07-17T00:00:00.000Z#run-123',
+        startedAt: '2026-07-17T00:00:00.000Z',
+        status: 'error',
+      });
+      ddbMock.on(QueryCommand).resolves({ Items: [{ pk: 'RUN', ...newest }, { pk: 'RUN', ...older }] });
+
+      const store = makeStore();
+      await expect(store.getRecordByRunId('run-123')).resolves.toEqual(newest);
+    });
+
+    it('should page through LastEvaluatedKey until a matching item is found', async () => {
+      const record = makeRecord();
+      ddbMock
+        .on(QueryCommand)
+        .resolvesOnce({ Items: [], LastEvaluatedKey: { pk: 'RUN', sk: 'cursor-1' } })
+        .resolvesOnce({ Items: [{ pk: 'RUN', ...record }] });
+
+      const store = makeStore();
+      await expect(store.getRecordByRunId('run-123')).resolves.toEqual(record);
+
+      const calls = ddbMock.commandCalls(QueryCommand);
+      expect(calls).toHaveLength(2);
+      expect(calls[0]!.args[0].input.ExclusiveStartKey).toBeUndefined();
+      expect(calls[1]!.args[0].input.ExclusiveStartKey).toEqual({ pk: 'RUN', sk: 'cursor-1' });
+    });
+
+    it('should return undefined once the partition is exhausted with no match', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const store = makeStore();
+      await expect(store.getRecordByRunId('missing-run')).resolves.toBeUndefined();
+    });
+
+    it('should restore optional fields (tfvarsVersionId, logS3Key) on the returned record when present', async () => {
+      const record = makeRecord({ tfvarsVersionId: 'v-1', logS3Key: 'runs/run-123.log' });
+      ddbMock.on(QueryCommand).resolves({ Items: [{ pk: 'RUN', ...record }] });
+
+      const store = makeStore();
+      const result = await store.getRecordByRunId('run-123');
+
+      expect(result?.tfvarsVersionId).toBe('v-1');
+      expect(result?.logS3Key).toBe('runs/run-123.log');
+    });
+
+    it('should throw a clear error when constructed without a getConfig callback', async () => {
+      const store = makeStore(null);
+      await expect(store.getRecordByRunId('run-123')).rejects.toThrow(
         'AwsRunRecordStore: table not configured. Supply a getConfig callback that resolves { tableName }.',
       );
     });

--- a/app/packages/cloud-aws/src/AwsRunRecordStore.ts
+++ b/app/packages/cloud-aws/src/AwsRunRecordStore.ts
@@ -1,5 +1,11 @@
 import { ConditionalCheckFailedException, DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { RunLockHeldError } from '@hyveon/shared';
@@ -165,6 +171,86 @@ export class AwsRunRecordStore implements RunRecordStore {
         },
       }),
     );
+  }
+
+  /**
+   * Looks up a previously persisted run record by its `runId`. The table's
+   * sort key is `<startedAt>#<runId>` (see `buildRunSk`) rather than `runId`
+   * alone, and there is no GSI keyed on `runId` (see `terraform/aws/runs_store.tf`),
+   * so this queries the fixed `pk = RUN` partition and filters on `runId`,
+   * paging through `LastEvaluatedKey` until a match is found or the
+   * partition is exhausted — acceptable at the run-history table's expected
+   * volume; a dedicated `runId`-index can be added later if this becomes a
+   * hot path. `ScanIndexForward: false` walks the partition newest-`sk`-first
+   * (sk is `<startedAt>#<runId>`, so lexicographic descending order is also
+   * chronological descending order), so the first matching item encountered
+   * — whether on the first page or a later one — is always the newest record
+   * for that `runId`.
+   *
+   * @param runId - Unique identifier of the run to look up (matches
+   *   {@link RunRecord.runId}).
+   * @returns The newest matching {@link RunRecord}, or `undefined` if no
+   *   record with that `runId` exists in the store.
+   */
+  async getRecordByRunId(runId: string): Promise<RunRecord | undefined> {
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+    do {
+      const result = await this.getDynamoClient().send(
+        new QueryCommand({
+          TableName: this.getTableName(),
+          KeyConditionExpression: 'pk = :pk',
+          FilterExpression: 'runId = :runId',
+          ExpressionAttributeValues: { ':pk': PARTITION_KEY, ':runId': runId },
+          ExclusiveStartKey: exclusiveStartKey,
+          ScanIndexForward: false,
+        }),
+      );
+      const item = result.Items?.[0];
+      if (item) {
+        return this.toRunRecord(item as Record<string, unknown>);
+      }
+      exclusiveStartKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (exclusiveStartKey);
+    return undefined;
+  }
+
+  /**
+   * Maps a raw DynamoDB item from the `pk = RUN` partition back into a
+   * {@link RunRecord}, restoring the optional fields {@link putRecord} wrote
+   * conditionally.
+   *
+   * @param item - The raw item read back from DynamoDB.
+   * @returns The reconstructed {@link RunRecord}.
+   */
+  private toRunRecord(item: Record<string, unknown>): RunRecord {
+    const record: RunRecord = {
+      sk: item['sk'] as string,
+      runId: item['runId'] as string,
+      kind: item['kind'] as RunRecord['kind'],
+      status: item['status'] as RunRecord['status'],
+      startedAt: item['startedAt'] as string,
+      completedAt: item['completedAt'] as string,
+      exitCode: item['exitCode'] as number | null,
+    };
+    if (item['tfvarsVersionId'] !== undefined) {
+      record.tfvarsVersionId = item['tfvarsVersionId'] as string;
+    }
+    if (item['planHash'] !== undefined) {
+      record.planHash = item['planHash'] as string;
+    }
+    if (item['approvedBy'] !== undefined) {
+      record.approvedBy = item['approvedBy'] as string;
+    }
+    if (item['approvedAt'] !== undefined) {
+      record.approvedAt = item['approvedAt'] as string;
+    }
+    if (item['logInline'] !== undefined) {
+      record.logInline = item['logInline'] as string;
+    }
+    if (item['logS3Key'] !== undefined) {
+      record.logS3Key = item['logS3Key'] as string;
+    }
+    return record;
   }
 
   /**

--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -1,15 +1,18 @@
 import 'reflect-metadata';
 import * as os from 'node:os';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TerraformController } from './terraform.controller.js';
 import {
   TerraformInitError,
   TerraformPlanError,
+  TerraformApplyError,
   type TerraformInitConfig,
   type TerraformRunChunk,
   type TerraformPlanResult,
+  type TerraformApplyResult,
 } from '../services/TerraformService.js';
-import type { TfOutputs } from '../services/ConfigService.js';
+import type { TfOutputs, ConfigService } from '../services/ConfigService.js';
 import type { TerraformService } from '../services/TerraformService.js';
 import type { AuditService, RecordAuditEntryParams } from '../services/AuditService.js';
 import {
@@ -19,7 +22,8 @@ import {
   RunRecordTableNotConfiguredError,
   type RunRecordService,
 } from '../services/RunRecordService.js';
-import type { RunRecord } from '@hyveon/shared';
+import type { RunService } from '../services/RunService.js';
+import { RunLockHeldError, APPROVAL_WINDOW_MS, type RunRecord, type RunLock } from '@hyveon/shared';
 
 // ---------------------------------------------------------------------------
 // Hoisted mock state — must be declared before any vi.mock() factory runs.
@@ -71,16 +75,23 @@ const CONFIG: TerraformInitConfig = {
 
 /**
  * Build a TerraformService stub whose `init` yields nothing by default,
- * whose `output` resolves `null` by default, whose `plan` yields nothing and
- * returns `undefined` by default, and whose `getWorkspaceInFlight` reports
- * `null` (no in-flight run) by default.
+ * whose `output` resolves `null` by default, whose `plan`/`apply` yield
+ * nothing and return `undefined` by default, whose `getWorkspaceInFlight`
+ * reports `null` (no in-flight run) by default, and whose
+ * `computePlanHash` resolves `'plan-hash-abc'` by default — matching the
+ * fixed `planHash` {@link makeApprovedPlanRecord} and `APPLY_PAYLOAD` both
+ * use, so an accepted `apply()` submission's on-disk artifact
+ * re-verification passes unmodified unless a test explicitly overrides it
+ * to simulate a forged/tampered `.tfplan` artifact.
  */
 function makeTerraform(): TerraformService {
   const stub: Partial<TerraformService> = {
     init: vi.fn().mockImplementation(async function* () { /* empty */ }),
     output: vi.fn().mockResolvedValue(null),
     plan: vi.fn().mockImplementation(async function* () { /* empty */ }),
+    apply: vi.fn().mockImplementation(async function* () { /* empty */ }),
     getWorkspaceInFlight: vi.fn().mockReturnValue(null),
+    computePlanHash: vi.fn().mockReturnValue('plan-hash-abc'),
   };
   return stub as TerraformService;
 }
@@ -145,10 +156,16 @@ function makeAudit(): { audit: AuditService; record: ReturnType<typeof vi.fn> } 
 /**
  * Build a `RunRecordService` stub whose `approveRun` resolves with the
  * approved record (`approvedBy`/`approvedAt` matching whatever it was called
- * with) by default. Tests can override `approveRun`'s implementation to
- * simulate any of `RunRecordService.approveRun`'s documented failure modes.
+ * with) by default, and whose `getByRunId` resolves `undefined` by default
+ * (no matching plan run — the "no run found" rejection path in
+ * `TerraformController.apply`). Tests can override either implementation to
+ * simulate any of `RunRecordService`'s documented failure modes.
  */
-function makeRunRecord(): { runRecord: RunRecordService; approveRun: ReturnType<typeof vi.fn> } {
+function makeRunRecord(): {
+  runRecord: RunRecordService;
+  approveRun: ReturnType<typeof vi.fn>;
+  getByRunId: ReturnType<typeof vi.fn>;
+} {
   const approveRun = vi.fn().mockImplementation(async (runId: string, approvedBy: string) => {
     const record: RunRecord = {
       sk: `2026-07-21T00:00:00.000Z#${runId}`,
@@ -163,8 +180,67 @@ function makeRunRecord(): { runRecord: RunRecordService; approveRun: ReturnType<
     };
     return record;
   });
-  const stub: Partial<RunRecordService> = { approveRun };
-  return { runRecord: stub as RunRecordService, approveRun };
+  const getByRunId = vi.fn().mockResolvedValue(undefined);
+  const stub: Partial<RunRecordService> = { approveRun, getByRunId };
+  return { runRecord: stub as RunRecordService, approveRun, getByRunId };
+}
+
+/**
+ * Builds an approved, successful `plan` {@link RunRecord} ready to be applied
+ * — `planHash` fixed at `'plan-hash-abc'` (matching {@link APPLY_PAYLOAD}'s
+ * own `planHash`) and `approvedAt` set to "now" (well within
+ * {@link APPROVAL_WINDOW_MS}), so `TerraformController.apply` accepts it
+ * unmodified. Tests override individual fields (e.g. `approvedBy: undefined`,
+ * a stale `approvedAt`, or a mismatched `planHash`) to exercise `apply`'s
+ * rejection paths.
+ */
+function makeApprovedPlanRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    sk: `2026-07-21T00:00:00.000Z#plan-run-1`,
+    runId: 'plan-run-1',
+    kind: 'plan',
+    status: 'success',
+    startedAt: '2026-07-21T00:00:00.000Z',
+    completedAt: '2026-07-21T00:00:05.000Z',
+    exitCode: 0,
+    planHash: 'plan-hash-abc',
+    tfvarsVersionId: 'tfvars-v1',
+    approvedBy: 'test-operator',
+    approvedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** The `terraform.apply` payload matching {@link makeApprovedPlanRecord}'s default fixture. */
+const APPLY_PAYLOAD = { planRunId: 'plan-run-1', planHash: 'plan-hash-abc' };
+
+/**
+ * Build a `RunService` stub whose `createRun` resolves a freshly "acquired"
+ * {@link RunLock} by default (mirroring the real service's fallback to a
+ * freshly minted id when no `runId` is supplied) and whose `releaseRun`
+ * resolves immediately. Tests override `createRun`'s implementation (e.g. to
+ * reject with {@link RunLockHeldError}) to simulate the durable apply lock
+ * already being held by another run.
+ */
+function makeRunService(): { runService: RunService; createRun: ReturnType<typeof vi.fn>; releaseRun: ReturnType<typeof vi.fn> } {
+  const createRun = vi.fn().mockImplementation(
+    async (kind: 'plan' | 'apply' | 'destroy', initiator: string, runId?: string): Promise<RunLock> => ({
+      runId: runId ?? 'minted-run-id',
+      kind,
+      initiator,
+      acquiredAt: '2026-07-21T00:00:00.000Z',
+      expiresAt: '2026-07-21T01:00:00.000Z',
+    }),
+  );
+  const releaseRun = vi.fn().mockResolvedValue(undefined);
+  const stub: Partial<RunService> = { createRun, releaseRun };
+  return { runService: stub as RunService, createRun, releaseRun };
+}
+
+/** Build a `ConfigService` stub whose `getRunsDir` resolves a fixed directory by default. */
+function makeConfig(runsDir = '/runs'): ConfigService {
+  const stub: Partial<ConfigService> = { getRunsDir: vi.fn().mockReturnValue(runsDir) };
+  return stub as ConfigService;
 }
 
 /**
@@ -233,6 +309,11 @@ describe('TerraformController', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.approve);
       expect(pattern).toEqual(['terraform.approve']);
     });
+
+    it('should register apply on the "terraform.apply" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.apply);
+      expect(pattern).toEqual(['terraform.apply']);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -279,6 +360,16 @@ describe('TerraformController', () => {
       expect(mockIpcMainRemoveHandler.mock.invocationCallOrder[0]).toBeLessThan(
         mockIpcMainHandle.mock.invocationCallOrder[0],
       );
+    });
+
+    it('should register ipcMain.handle for "terraform.apply" so ipcRenderer.invoke can resolve', async () => {
+      await new TerraformController(makeTerraform()).onModuleInit();
+      expect(mockIpcMainHandle).toHaveBeenCalledWith('terraform.apply', expect.any(Function));
+    });
+
+    it('should remove any existing "terraform.apply" handler before registering so hot-reload re-bootstrap does not throw', async () => {
+      await new TerraformController(makeTerraform()).onModuleInit();
+      expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith('terraform.apply');
     });
   });
 
@@ -649,6 +740,406 @@ describe('TerraformController', () => {
       expect(senderB.send).not.toHaveBeenCalled();
       const endCallA = senderA.send.mock.calls.find(([channel]) => channel === 'terraform.plan.end');
       expect(endCallA?.[1]).toMatchObject({ exitCode: 0 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // apply
+  // -------------------------------------------------------------------------
+
+  describe('apply', () => {
+    /**
+     * Wires up a `TerraformController` with every dependency `apply()` needs
+     * (`terraform`, `audit`, `runRecord`, `runService`, `config`), returning
+     * both the controller and the individual stubs/spies so each test can
+     * override just the piece it's exercising.
+     */
+    function makeApplyController(terraform: TerraformService = makeTerraform()) {
+      const { audit, record } = makeAudit();
+      const { runRecord, getByRunId } = makeRunRecord();
+      const { runService, createRun, releaseRun } = makeRunService();
+      const config = makeConfig('/runs');
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord());
+      const controller = new TerraformController(terraform, audit, runRecord, runService, config);
+      return { controller, terraform, getByRunId, createRun, releaseRun, config, record };
+    }
+
+    it('should reject with { started: false, error } and never call TerraformService.apply when planRunId is missing', async () => {
+      const { controller, terraform, createRun, record } = makeApplyController();
+      const { ctx, sender } = makeCtx();
+
+      const result = await controller.apply({ planRunId: '', planHash: 'plan-hash-abc' }, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(sender.send).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } and never call TerraformService.apply when planHash is missing', async () => {
+      const { controller, terraform, record } = makeApplyController();
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply({ planRunId: 'plan-run-1', planHash: '' }, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } when no plan run exists for planRunId, without ever calling TerraformService.apply', async () => {
+      const { controller, terraform, getByRunId, record } = makeApplyController();
+      getByRunId.mockResolvedValue(undefined);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } when the run record is not a "plan" run, without ever calling TerraformService.apply', async () => {
+      const { controller, terraform, getByRunId, record } = makeApplyController();
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord({ kind: 'apply' }));
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } when the plan run has not been approved (missing approval), without ever calling TerraformService.apply', async () => {
+      const { controller, terraform, getByRunId, createRun, record } = makeApplyController();
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord({ approvedBy: undefined, approvedAt: undefined }));
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } when the approval has expired, without ever calling TerraformService.apply', async () => {
+      const { controller, terraform, getByRunId, createRun, record } = makeApplyController();
+      const staleApprovedAt = new Date(Date.now() - (APPROVAL_WINDOW_MS + 60_000)).toISOString();
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord({ approvedAt: staleApprovedAt }));
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } when the supplied planHash does not match the approved plan record (mismatched/forged hash), without ever calling TerraformService.apply', async () => {
+      const { controller, terraform, getByRunId, createRun, record } = makeApplyController();
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord({ planHash: 'plan-hash-abc' }));
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply({ planRunId: 'plan-run-1', planHash: 'forged-hash' }, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } and never call TerraformService.apply or RunService.createRun when the on-disk plan artifact re-hashes to a different value (forged/tampered artifact), even though payload.planHash and record.planHash still agree', async () => {
+      // Simulates a swapped/tampered .tfplan file on disk: the stored
+      // RunRecord.planHash and payload.planHash both still say
+      // 'plan-hash-abc' (makeApprovedPlanRecord()'s default), but a fresh
+      // SHA-256 digest of the actual file content no longer matches — this
+      // is exactly the artifact-level re-verification issue #109 requires,
+      // on top of comparing the two in-memory hash values to each other.
+      const terraform = makeTerraform();
+      vi.mocked(terraform.computePlanHash).mockReturnValue('tampered-artifact-hash');
+      const { controller, createRun, record } = makeApplyController(terraform);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(terraform.computePlanHash).toHaveBeenCalledWith(
+        join('/runs', 'plan-run-1', 'plan-run-1.tfplan'),
+      );
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error } and never call TerraformService.apply when re-hashing the on-disk plan artifact throws (e.g. the file is missing)', async () => {
+      const terraform = makeTerraform();
+      vi.mocked(terraform.computePlanHash).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+      const { controller, createRun, record } = makeApplyController(terraform);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error, conflict } and never call TerraformService.apply or RunService.createRun when the shared workspace is busy', async () => {
+      const { controller, terraform, createRun, record } = makeApplyController();
+      vi.mocked(terraform.getWorkspaceInFlight).mockReturnValue('plan');
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result).toEqual({ started: false, error: expect.any(String), conflict: 'plan' });
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(createRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should reject with { started: false, error, conflict: "apply" } and never call TerraformService.apply when the durable apply lock is already held (RunLockHeldError)', async () => {
+      const { controller, terraform, createRun, releaseRun, record } = makeApplyController();
+      const heldLock: RunLock = {
+        runId: 'other-run',
+        kind: 'apply',
+        initiator: 'someone-else',
+        acquiredAt: '2026-07-21T00:00:00.000Z',
+        expiresAt: '2026-07-21T01:00:00.000Z',
+      };
+      createRun.mockRejectedValue(new RunLockHeldError(heldLock));
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result).toEqual({ started: false, error: expect.any(String), conflict: 'apply' });
+      expect(terraform.apply).not.toHaveBeenCalled();
+      // No lock was ever acquired by this call, so there is nothing to release.
+      expect(releaseRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should acquire the apply lock with the plan record\'s runId as initiator, and call TerraformService.apply with the plan\'s runId, its stored tfvarsVersionId, and the expected plan file path', async () => {
+      const { controller, terraform, createRun, config } = makeApplyController();
+      const { ctx } = makeCtx();
+
+      await controller.apply(APPLY_PAYLOAD, ctx);
+      await flushPromises();
+
+      expect(createRun).toHaveBeenCalledWith('apply', 'test-operator', 'plan-run-1');
+      expect(terraform.apply).toHaveBeenCalledWith(
+        'plan-run-1',
+        'tfvars-v1',
+        join(config.getRunsDir(), 'plan-run-1', 'plan-run-1.tfplan'),
+        expect.any(AbortSignal),
+      );
+    });
+
+    it('should record an audit entry with action "apply" for an accepted apply submission', async () => {
+      const { controller, record } = makeApplyController();
+      const { ctx } = makeCtx();
+
+      await controller.apply(APPLY_PAYLOAD, ctx);
+      await flushPromises();
+
+      expect(record).toHaveBeenCalledTimes(1);
+      const recordedEntry = record.mock.calls[0]?.[0] as RecordAuditEntryParams;
+      expect(recordedEntry).toMatchObject({ action: 'apply', versionId: 'tfvars-v1' });
+    });
+
+    it('should resolve { started: true, runId } immediately, then deliver a normal end-message error and release the just-acquired lock, when TerraformService.apply rejects before spawning (e.g. a stale-tfvars guard)', async () => {
+      // Mirrors plan()'s own synchronous-first-.next() workspace reservation
+      // shape: the reservation happens synchronously before the ack
+      // resolves, so a pre-spawn failure inside TerraformService.apply
+      // itself (e.g. a StalePlanError) is *not* observed before the ack —
+      // it surfaces later as a normal terraform.apply.end error once the
+      // fire-and-forget streaming loop awaits its already-in-flight first
+      // step, exactly like any other TerraformService.apply failure.
+      // eslint-disable-next-line require-yield -- generator must throw before yielding to simulate a pre-spawn (e.g. StalePlanError) failure
+      async function* rejectsBeforeSpawn(): AsyncGenerator<TerraformRunChunk> {
+        throw new Error('tfvars object is stale for this plan');
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.apply).mockImplementation(rejectsBeforeSpawn);
+      const { controller, releaseRun } = makeApplyController(terraform);
+      const { ctx, sender } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result).toEqual({ started: true, runId: 'plan-run-1' });
+
+      await flushPromises();
+
+      expect(sender.send).not.toHaveBeenCalledWith('terraform.apply.chunk', expect.anything());
+      const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.apply.end');
+      expect(endCall?.[1]).toMatchObject({ runId: 'plan-run-1', exitCode: null });
+      expect(String(endCall?.[1]?.error)).toContain('tfvars object is stale for this plan');
+      expect(releaseRun).toHaveBeenCalledWith('plan-run-1');
+    });
+
+    it('should return { started: true, runId } immediately without waiting for the run to settle', async () => {
+      // TerraformService.apply never yields/returns on its own here, so if
+      // apply() awaited the whole loop (or even just its first step)
+      // synchronously this call would hang.
+      const terraform = makeTerraform();
+      // eslint-disable-next-line require-yield -- generator intentionally never yields/returns to prove apply() doesn't await it
+      vi.mocked(terraform.apply).mockImplementation(async function* () {
+        await new Promise<void>(() => { /* never resolves */ });
+      });
+      const { controller } = makeApplyController(terraform);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result).toEqual({ started: true, runId: 'plan-run-1' });
+    });
+
+    it('should send each yielded chunk to the renderer via sender.send, in order, tagged with the plan\'s runId', async () => {
+      const chunks: TerraformRunChunk[] = [
+        { stream: 'stdout', line: 'terraform_appliance.game: Creating...' },
+        { stream: 'stdout', line: 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.' },
+      ];
+      async function* yieldChunks() {
+        for (const chunk of chunks) yield chunk;
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.apply).mockImplementation(yieldChunks);
+      const { controller } = makeApplyController(terraform);
+      const { ctx, sender } = makeCtx();
+
+      await controller.apply(APPLY_PAYLOAD, ctx);
+      await flushPromises();
+
+      const chunkCalls = sender.send.mock.calls.filter(([channel]) => channel === 'terraform.apply.chunk');
+      const runIds = new Set(chunkCalls.map(([, payload]) => (payload as { runId: string }).runId));
+      expect(runIds).toEqual(new Set(['plan-run-1']));
+      expect(chunkCalls.map(([, payload]) => (payload as { chunk: TerraformRunChunk }).chunk)).toEqual(chunks);
+    });
+
+    it('should send an end message with exitCode 0, the resolved result, and no error, and release the apply lock, when the run succeeds', async () => {
+      const applyResult: TerraformApplyResult = { runId: 'plan-run-1', added: 1, changed: 0, destroyed: 0 };
+      async function* succeeds(): AsyncGenerator<TerraformRunChunk, TerraformApplyResult> {
+        yield { stream: 'stdout', line: 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.' };
+        return applyResult;
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.apply).mockImplementation(succeeds);
+      const { controller, releaseRun } = makeApplyController(terraform);
+      const { ctx, sender } = makeCtx();
+
+      await controller.apply(APPLY_PAYLOAD, ctx);
+      await flushPromises();
+
+      expect(sender.send).toHaveBeenCalledWith('terraform.apply.end', {
+        runId: 'plan-run-1',
+        exitCode: 0,
+        result: applyResult,
+      });
+      const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.apply.end');
+      expect(endCall?.[1]).not.toHaveProperty('error');
+      expect(releaseRun).toHaveBeenCalledWith('plan-run-1');
+    });
+
+    it('should send an end message with the process exit code and a stringified error, and still release the apply lock, on TerraformApplyError', async () => {
+      async function* failsWithExitCode(): AsyncGenerator<TerraformRunChunk> {
+        yield { stream: 'stderr', line: 'Error: creation failed' };
+        throw new TerraformApplyError(1);
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.apply).mockImplementation(failsWithExitCode);
+      const { controller, releaseRun } = makeApplyController(terraform);
+      const { ctx, sender } = makeCtx();
+
+      await controller.apply(APPLY_PAYLOAD, ctx);
+      await flushPromises();
+
+      const endCall = sender.send.mock.calls.find(([channel]) => channel === 'terraform.apply.end');
+      expect(endCall?.[1]).toMatchObject({ exitCode: 1 });
+      expect(String(endCall?.[1]?.error)).toContain('terraform apply exited with code 1');
+      expect(releaseRun).toHaveBeenCalledWith('plan-run-1');
+    });
+
+    it('should not send further chunks or an end message, should finalize the generator via stream.return, and should still release the apply lock, once the WebContents is destroyed', async () => {
+      let returnCalled = false;
+      async function* twoLines(): AsyncGenerator<TerraformRunChunk, TerraformApplyResult | undefined> {
+        try {
+          yield { stream: 'stdout', line: 'first' };
+          yield { stream: 'stdout', line: 'second' };
+          return undefined;
+        } finally {
+          returnCalled = true;
+        }
+      }
+      const terraform = makeTerraform();
+      vi.mocked(terraform.apply).mockImplementation(twoLines);
+      const { controller, releaseRun } = makeApplyController(terraform);
+      // Simulate WebContents already destroyed before the loop runs.
+      const { ctx, sender } = makeCtx(true);
+
+      await controller.apply(APPLY_PAYLOAD, ctx);
+      await flushPromises();
+
+      expect(sender.send).not.toHaveBeenCalled();
+      expect(returnCalled).toBe(true);
+      expect(releaseRun).toHaveBeenCalledWith('plan-run-1');
+    });
+
+    it('should return { started: false, error } when no RunRecordService is available', async () => {
+      const terraform = makeTerraform();
+      const controller = new TerraformController(terraform);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+    });
+
+    it('should return { started: false, error } when no RunService is available', async () => {
+      const terraform = makeTerraform();
+      const { audit } = makeAudit();
+      const { runRecord, getByRunId } = makeRunRecord();
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord());
+      const controller = new TerraformController(terraform, audit, runRecord);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
+    });
+
+    it('should return { started: false, error } when no ConfigService is available', async () => {
+      const terraform = makeTerraform();
+      const { audit } = makeAudit();
+      const { runRecord, getByRunId } = makeRunRecord();
+      getByRunId.mockResolvedValue(makeApprovedPlanRecord());
+      const { runService } = makeRunService();
+      const controller = new TerraformController(terraform, audit, runRecord, runService);
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result.started).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(terraform.apply).not.toHaveBeenCalled();
     });
   });
 

--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -913,6 +913,20 @@ describe('TerraformController', () => {
       expect(record).not.toHaveBeenCalled();
     });
 
+    it('should release the just-acquired apply lock and reject with { started: false, error, conflict } when the workspace becomes busy between the pre-lock check and RunService.createRun (TOCTOU regression)', async () => {
+      const { controller, terraform, createRun, releaseRun, record } = makeApplyController();
+      vi.mocked(terraform.getWorkspaceInFlight).mockReturnValueOnce(null).mockReturnValueOnce('plan');
+      const { ctx } = makeCtx();
+
+      const result = await controller.apply(APPLY_PAYLOAD, ctx);
+
+      expect(result).toEqual({ started: false, error: expect.any(String), conflict: 'plan' });
+      expect(createRun).toHaveBeenCalledWith('apply', 'test-operator', 'plan-run-1');
+      expect(releaseRun).toHaveBeenCalledWith('plan-run-1');
+      expect(terraform.apply).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
     it('should reject with { started: false, error, conflict: "apply" } and never call TerraformService.apply when the durable apply lock is already held (RunLockHeldError)', async () => {
       const { controller, terraform, createRun, releaseRun, record } = makeApplyController();
       const heldLock: RunLock = {

--- a/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.test.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import * as os from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TerraformController } from './terraform.controller.js';
 import {
@@ -11,6 +12,14 @@ import {
 import type { TfOutputs } from '../services/ConfigService.js';
 import type { TerraformService } from '../services/TerraformService.js';
 import type { AuditService, RecordAuditEntryParams } from '../services/AuditService.js';
+import {
+  RunRecordNotFoundError,
+  RunRecordNotPlanError,
+  RunRecordNotSuccessfulError,
+  RunRecordTableNotConfiguredError,
+  type RunRecordService,
+} from '../services/RunRecordService.js';
+import type { RunRecord } from '@hyveon/shared';
 
 // ---------------------------------------------------------------------------
 // Hoisted mock state — must be declared before any vi.mock() factory runs.
@@ -36,6 +45,18 @@ vi.mock('electron', () => ({
 vi.mock('../logger.js', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
+
+// `TerraformController.approve` resolves the approver identity via
+// `os.userInfo().username` rather than trusting a client-supplied field —
+// stub it the same way `AuditService.test.ts` does so tests can assert on a
+// deterministic resolved username.
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    userInfo: vi.fn(() => ({ username: 'test-operator' })),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -122,6 +143,31 @@ function makeAudit(): { audit: AuditService; record: ReturnType<typeof vi.fn> } 
 }
 
 /**
+ * Build a `RunRecordService` stub whose `approveRun` resolves with the
+ * approved record (`approvedBy`/`approvedAt` matching whatever it was called
+ * with) by default. Tests can override `approveRun`'s implementation to
+ * simulate any of `RunRecordService.approveRun`'s documented failure modes.
+ */
+function makeRunRecord(): { runRecord: RunRecordService; approveRun: ReturnType<typeof vi.fn> } {
+  const approveRun = vi.fn().mockImplementation(async (runId: string, approvedBy: string) => {
+    const record: RunRecord = {
+      sk: `2026-07-21T00:00:00.000Z#${runId}`,
+      runId,
+      kind: 'plan',
+      status: 'success',
+      startedAt: '2026-07-21T00:00:00.000Z',
+      completedAt: '2026-07-21T00:00:05.000Z',
+      exitCode: 0,
+      approvedBy,
+      approvedAt: '2026-07-21T00:05:00.000Z',
+    };
+    return record;
+  });
+  const stub: Partial<RunRecordService> = { approveRun };
+  return { runRecord: stub as RunRecordService, approveRun };
+}
+
+/**
  * Build a minimal `IpcMainInvokeEvent` stub with a controlled `sender`
  * (WebContents). Tests can inspect calls on `sender.send` and control the
  * return value of `sender.isDestroyed()`.
@@ -160,6 +206,7 @@ const PATTERN_METADATA_KEY = 'microservices:pattern';
 describe('TerraformController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(os.userInfo).mockReturnValue({ username: 'test-operator' } as ReturnType<typeof os.userInfo>);
   });
 
   // -------------------------------------------------------------------------
@@ -180,6 +227,11 @@ describe('TerraformController', () => {
     it('should register plan on the "terraform.plan" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.plan);
       expect(pattern).toEqual(['terraform.plan']);
+    });
+
+    it('should register approve on the "terraform.approve" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, TerraformController.prototype.approve);
+      expect(pattern).toEqual(['terraform.approve']);
     });
   });
 
@@ -649,6 +701,122 @@ describe('TerraformController', () => {
       vi.mocked(terraform.output).mockRejectedValue(error);
 
       await expect(new TerraformController(terraform).output({})).rejects.toThrow(error);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // approve
+  // -------------------------------------------------------------------------
+
+  describe('approve', () => {
+    it('should write approvedBy/approvedAt to the run record, using the OS-resolved username, and return them on a successful plan run', async () => {
+      const terraform = makeTerraform();
+      const { runRecord, approveRun } = makeRunRecord();
+      const { audit, record } = makeAudit();
+
+      const result = await new TerraformController(terraform, audit, runRecord).approve({
+        planRunId: 'run-123',
+      });
+
+      // The approver identity is always resolved server-side from
+      // os.userInfo() — never taken from the (now nonexistent) client
+      // payload field — so approveRun must be called with the stubbed OS
+      // username rather than anything the caller supplied.
+      expect(approveRun).toHaveBeenCalledWith('run-123', 'test-operator');
+      expect(result).toEqual({
+        approved: true,
+        approvedBy: 'test-operator',
+        approvedAt: expect.any(String),
+      });
+      expect(record).toHaveBeenCalledTimes(1);
+      const recordedEntry = record.mock.calls[0][0] as RecordAuditEntryParams;
+      expect(recordedEntry).toMatchObject({ action: 'approve' });
+    });
+
+    it('should return { approved: false, error } and never call RunRecordService.approveRun or AuditService.record when planRunId is missing', async () => {
+      const terraform = makeTerraform();
+      const { runRecord, approveRun } = makeRunRecord();
+      const { audit, record } = makeAudit();
+
+      const result = await new TerraformController(terraform, audit, runRecord).approve({
+        planRunId: '',
+      });
+
+      expect(result.approved).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(approveRun).not.toHaveBeenCalled();
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should return { approved: false, error } when the run-history table is not configured, without writing anything or recording an audit entry', async () => {
+      const terraform = makeTerraform();
+      const { runRecord, approveRun } = makeRunRecord();
+      const { audit, record } = makeAudit();
+      const error = new RunRecordTableNotConfiguredError('run-123');
+      approveRun.mockRejectedValue(error);
+
+      const result = await new TerraformController(terraform, audit, runRecord).approve({
+        planRunId: 'run-123',
+      });
+
+      expect(result).toEqual({ approved: false, error: error.message });
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should return { approved: false, error } when no run record exists for planRunId, without writing anything or recording an audit entry', async () => {
+      const terraform = makeTerraform();
+      const { runRecord, approveRun } = makeRunRecord();
+      const { audit, record } = makeAudit();
+      const error = new RunRecordNotFoundError('run-123');
+      approveRun.mockRejectedValue(error);
+
+      const result = await new TerraformController(terraform, audit, runRecord).approve({
+        planRunId: 'run-123',
+      });
+
+      expect(result).toEqual({ approved: false, error: error.message });
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should return { approved: false, error } when the run record is not a plan run, without writing anything or recording an audit entry', async () => {
+      const terraform = makeTerraform();
+      const { runRecord, approveRun } = makeRunRecord();
+      const { audit, record } = makeAudit();
+      const error = new RunRecordNotPlanError('run-123', 'apply');
+      approveRun.mockRejectedValue(error);
+
+      const result = await new TerraformController(terraform, audit, runRecord).approve({
+        planRunId: 'run-123',
+      });
+
+      expect(result).toEqual({ approved: false, error: error.message });
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should return { approved: false, error } when the plan run did not succeed, without writing anything or recording an audit entry', async () => {
+      const terraform = makeTerraform();
+      const { runRecord, approveRun } = makeRunRecord();
+      const { audit, record } = makeAudit();
+      const error = new RunRecordNotSuccessfulError('run-123', 'failed');
+      approveRun.mockRejectedValue(error);
+
+      const result = await new TerraformController(terraform, audit, runRecord).approve({
+        planRunId: 'run-123',
+      });
+
+      expect(result).toEqual({ approved: false, error: error.message });
+      expect(record).not.toHaveBeenCalled();
+    });
+
+    it('should return { approved: false, error } when no RunRecordService is available', async () => {
+      const terraform = makeTerraform();
+
+      const result = await new TerraformController(terraform).approve({
+        planRunId: 'run-123',
+      });
+
+      expect(result.approved).toBe(false);
+      expect(typeof result.error).toBe('string');
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/terraform.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.ts
@@ -624,9 +624,18 @@ export class TerraformController implements OnModuleInit {
    *    is rejected with a {@link RunLockHeldError}-derived message and
    *    `conflict: 'apply'` and no lock is acquired by this call (so there is
    *    nothing for it to release).
+   * 7. Immediately after step 6's `await` settles, the workspace check from
+   *    step 5 is repeated (`TerraformService.getWorkspaceInFlight()` again).
+   *    Step 6 is itself an `await`, so a concurrent `plan`/`init` could have
+   *    reserved the workspace during that gap; this re-check closes it. If
+   *    the workspace is now busy, the apply lock acquired in step 6 is
+   *    released (`RunService.releaseRun`) and the call is rejected with
+   *    `conflict` set to the new in-flight run — mirroring step 5's ack
+   *    shape — before anything externally visible (the audit entry, the
+   *    streaming loop) has happened.
    *
-   * Any failure in 1–6 resolves immediately with `{ started: false, error }`
-   * (plus `conflict` for 5–6) — `TerraformService.apply` is never called, so
+   * Any failure in 1–7 resolves immediately with `{ started: false, error }`
+   * (plus `conflict` for 5–7) — `TerraformService.apply` is never called, so
    * no `terraform apply` process is ever spawned, and no run record is
    * written for the rejected attempt.
    *
@@ -641,15 +650,16 @@ export class TerraformController implements OnModuleInit {
    * `TerraformService.plan` persisted and what `TerraformService.apply`
    * itself independently re-validates before spawning).
    *
-   * Once the lock is acquired, the generator's first step is driven
-   * *synchronously* — the same synchronous-first-`.next()` workspace
-   * reservation (before anything is `await`ed) that {@link plan} uses, for
-   * the same TOCTOU reason described at that call site: `TerraformService`'s
-   * `workspaceInFlight` check-and-set runs synchronously, before its own
-   * first `await`, so driving `.next()` here — rather than only from inside
-   * the fire-and-forget block below — closes the gap a second concurrent
-   * call could otherwise race through. The un-awaited first-step promise is
-   * given a no-op `.catch()` purely so Node doesn't log an
+   * Once the lock is acquired and step 7's post-lock workspace re-check has
+   * passed, the generator's first step is driven *synchronously* — the same
+   * synchronous-first-`.next()` workspace reservation (before anything is
+   * `await`ed) that {@link plan} uses, for the same TOCTOU reason described
+   * at that call site: `TerraformService`'s `workspaceInFlight` check-and-set
+   * runs synchronously, before its own first `await`, so driving `.next()`
+   * here — rather than only from inside the fire-and-forget block below —
+   * closes the gap a second concurrent call could otherwise race through
+   * between this re-check and the reservation itself. The un-awaited
+   * first-step promise is given a no-op `.catch()` purely so Node doesn't log an
    * unhandledRejection warning while it sits unawaited; the real handling of
    * whatever it settles to happens in the streaming loop below, the same way
    * every later `.next()` result already is. This means a pre-spawn failure
@@ -794,6 +804,27 @@ export class TerraformController implements OnModuleInit {
       return { started: false, error };
     }
 
+    // `createRun` above is the first `await` since the `getWorkspaceInFlight()`
+    // check at the top of this method, so a concurrent `plan`/`init` could
+    // have reserved the shared workspace during that gap. Re-check here,
+    // synchronously before anything externally visible happens, and release
+    // the just-acquired apply lock if the workspace is now busy — otherwise
+    // this call would ack `{ started: true }`, record a spurious 'apply'
+    // audit entry, and only then fail on the end channel once the streaming
+    // loop's `await firstStep` rejects.
+    const inFlightAfterLock = this.terraform.getWorkspaceInFlight();
+    if (inFlightAfterLock) {
+      await this.runService.releaseRun(payload.planRunId);
+      const error =
+        `terraform apply refused: ${inFlightAfterLock} is already in flight; wait for it to finish ` +
+        'before submitting another apply';
+      logger.error('terraform apply rejected: workspace busy after acquiring apply lock', {
+        inFlight: inFlightAfterLock,
+        planRunId: payload.planRunId,
+      });
+      return { started: false, error, conflict: inFlightAfterLock };
+    }
+
     const runId = payload.planRunId;
     const sender: WebContents = ctx.evt.sender;
     const ac = new AbortController();
@@ -801,8 +832,8 @@ export class TerraformController implements OnModuleInit {
     // Reserve the shared workspace *synchronously* — mirrors plan()'s own
     // synchronous-first-`.next()` reservation (see the inline comment on
     // that call site for why the ordering matters): no `await` runs between
-    // the `getWorkspaceInFlight()` check above and this `stream.next()`
-    // call, which is the only thing that actually flips
+    // the `getWorkspaceInFlight()` re-check immediately above and this
+    // `stream.next()` call, which is the only thing that actually flips
     // `TerraformService`'s internal `workspaceInFlight` lock. The `.catch()`
     // below exists solely to mark `firstStep` as "handled" so Node doesn't
     // log an unhandledRejection warning while it sits unawaited; the real

--- a/app/packages/desktop-main/src/controllers/terraform.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
 import { Controller, OnModuleInit } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
@@ -12,6 +13,7 @@ import {
 } from '../services/TerraformService.js';
 import type { TfOutputs } from '../services/ConfigService.js';
 import { AuditService } from '../services/AuditService.js';
+import { RunRecordService } from '../services/RunRecordService.js';
 import { logger } from '../logger.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -133,6 +135,38 @@ interface TerraformPlanAck {
 }
 
 /**
+ * Payload accepted by {@link TerraformController.approve}. `planRunId`
+ * identifies the successful `plan` run to approve. Unlike the previous shape
+ * of this payload, there is no client-supplied approver identity — the
+ * approver is always resolved server-side (see
+ * {@link TerraformController.resolveApprover}) so an IPC caller can never
+ * spoof who approved a run.
+ *
+ * Mirrors `approve: (opts: { planRunId: string }) => ...` in
+ * `@hyveon/desktop-preload/src/gsd-api.ts` — keep this shape in sync with
+ * that sibling contract.
+ */
+interface TerraformApprovePayload {
+  planRunId: string;
+}
+
+/**
+ * Result `approve()` resolves with. `approved: true` means
+ * `RunRecordService.approveRun` succeeded — `approvedBy`/`approvedAt` mirror
+ * the values now stamped onto the persisted `RunRecord`. `approved: false`
+ * means no write was attempted (payload failed validation) or the write was
+ * attempted and rejected (table not configured, no matching record, record
+ * isn't a successful `plan` run) — `error` is always a human-readable
+ * description of why, and `approvedBy`/`approvedAt` are omitted.
+ */
+interface TerraformApproveAck {
+  approved: boolean;
+  approvedBy?: string;
+  approvedAt?: string;
+  error?: string;
+}
+
+/**
  * IPC-only Terraform controller. Handles Electron main-process messages via
  * `@MessagePattern` — no HTTP routes are registered here.
  *
@@ -142,19 +176,25 @@ interface TerraformPlanAck {
  * {@link plan} mirrors the same bridging shape for `terraform plan`, plus a
  * pre-flight `TerraformService.getWorkspaceInFlight()` conflict check and a
  * persisted `AuditService.record()` entry for every accepted submission.
+ * {@link approve} needs no such bridging — it resolves a single value, so
+ * the generic `ipcMain.handle` bridge in `../ipc-main-bridge.ts` wires it
+ * automatically — and delegates the actual write to
+ * `RunRecordService.approveRun` (see issue #109).
  */
 @Controller()
 export class TerraformController implements OnModuleInit {
   /**
-   * `audit` is typed optional (`?`) purely so existing test call sites that
-   * construct `new TerraformController(terraform)` directly (bypassing Nest's
-   * DI container) keep compiling without also stubbing it — every real
-   * bootstrap through `AppModule` still resolves a concrete `AuditService`
-   * instance regardless of this TS-level optionality.
+   * `audit`/`runRecord` are typed optional (`?`) purely so existing test call
+   * sites that construct `new TerraformController(terraform)` directly
+   * (bypassing Nest's DI container) keep compiling without also stubbing
+   * them — every real bootstrap through `AppModule` still resolves concrete
+   * `AuditService`/`RunRecordService` instances regardless of this
+   * TS-level optionality.
    */
   constructor(
     private readonly terraform: TerraformService,
     private readonly audit?: AuditService,
+    private readonly runRecord?: RunRecordService,
   ) {}
 
   /**
@@ -491,6 +531,89 @@ export class TerraformController implements OnModuleInit {
   }
 
   /**
+   * Approves a successful `plan` run for a later apply, delegating the
+   * actual write to `RunRecordService.approveRun` (see issue #109).
+   *
+   * Validates `payload` first: `planRunId` must be a non-empty string. If
+   * validation fails, neither `RunRecordService.approveRun` nor
+   * `AuditService.record` is ever called and the method resolves immediately
+   * with `{ approved: false, error }`.
+   *
+   * The approver identity is never taken from the client — it's resolved
+   * server-side via {@link resolveApprover} (the local OS username), so an
+   * IPC caller can't spoof who approved a run. `RunRecordService.approveRun`
+   * is then awaited directly (unlike {@link init}/{@link plan}, there is no
+   * streaming output to bridge — this resolves a single value):
+   *
+   * - On success, a best-effort `AuditService.record()` entry (action
+   *   `'approve'`) is recorded — mirroring {@link plan}'s audit shape, this
+   *   never throws and never blocks/fails the response — and the method
+   *   resolves `{ approved: true, approvedBy, approvedAt }` with the values
+   *   `RunRecordService.approveRun` stamped onto the persisted `RunRecord`.
+   * - On failure (the run-history table isn't configured, no record exists
+   *   for `planRunId`, the record isn't a `plan` run, or the record's status
+   *   isn't `success`), the thrown error's `message` — one of
+   *   `RunRecordTableNotConfiguredError` / `RunRecordNotFoundError` /
+   *   `RunRecordNotPlanError` / `RunRecordNotSuccessfulError`, each already
+   *   descriptive — is surfaced as `{ approved: false, error }`. Nothing is
+   *   written in this case: `RunRecordService.approveRun` only calls
+   *   `store.putRecord` after all of its validation has passed, and no audit
+   *   entry is recorded for a rejected approval.
+   *
+   * Reachable via the Electron IPC transport (`terraform.approve`), bridged
+   * automatically by the generic `ipcMain.handle` bridge in
+   * `../ipc-main-bridge.ts` since (unlike `terraform.init`/`terraform.plan`)
+   * it resolves a single value rather than streaming progress.
+   */
+  @MessagePattern('terraform.approve')
+  async approve(@Payload() payload: TerraformApprovePayload): Promise<TerraformApproveAck> {
+    const validationError = TerraformController.validateApprovePayload(payload);
+    if (validationError) {
+      logger.error('terraform approve rejected: invalid payload', { error: validationError });
+      return { approved: false, error: validationError };
+    }
+
+    if (!this.runRecord) {
+      const error = 'terraform.approve requires a configured RunRecordService';
+      logger.error('terraform approve rejected: no RunRecordService available', { planRunId: payload.planRunId });
+      return { approved: false, error };
+    }
+
+    try {
+      const approvedBy = TerraformController.resolveApprover();
+      const record = await this.runRecord.approveRun(payload.planRunId, approvedBy);
+
+      // Best-effort: AuditService.record() never throws (failures are logged
+      // and swallowed internally), mirroring the audit entry recorded by
+      // plan() for its own accepted submissions.
+      await this.audit?.record({
+        action: 'approve',
+        game: '',
+        before: null,
+        after: null,
+      });
+
+      return { approved: true, approvedBy: record.approvedBy, approvedAt: record.approvedAt };
+    } catch (err) {
+      logger.error('terraform approve error', { err, planRunId: payload.planRunId });
+      const error = err instanceof Error ? err.message : String(err);
+      return { approved: false, error };
+    }
+  }
+
+  /**
+   * Resolves the identity of the local operator approving a plan run, as the
+   * OS username reported by `node:os`'s `userInfo()`. Wrapped in its own
+   * method (rather than calling `os.userInfo().username` inline in
+   * {@link approve}) so it's a single, stubbable seam for tests — and so the
+   * approver identity is always derived server-side, never trusted from a
+   * client-supplied field.
+   */
+  private static resolveApprover(): string {
+    return os.userInfo().username;
+  }
+
+  /**
    * Validates that `config.bucket`, `config.region`, and
    * `config.dynamodbTable` are all non-empty strings. Returns a descriptive
    * error message when validation fails, or `null` when `config` is valid.
@@ -505,6 +628,21 @@ export class TerraformController implements OnModuleInit {
       !isNonEmptyString(config?.dynamodbTable)
     ) {
       return 'terraform.init requires non-empty bucket, region, and dynamodbTable strings';
+    }
+    return null;
+  }
+
+  /**
+   * Validates that `payload.planRunId` is a non-empty string. Returns a
+   * descriptive error message when validation fails, or `null` when
+   * `payload` is valid.
+   */
+  private static validateApprovePayload(payload: TerraformApprovePayload): string | null {
+    const isNonEmptyString = (value: unknown): value is string =>
+      typeof value === 'string' && value.length > 0;
+
+    if (!isNonEmptyString(payload?.planRunId)) {
+      return 'terraform.approve requires a non-empty planRunId string';
     }
     return null;
   }

--- a/app/packages/desktop-main/src/controllers/terraform.controller.ts
+++ b/app/packages/desktop-main/src/controllers/terraform.controller.ts
@@ -1,19 +1,24 @@
 import { randomUUID } from 'node:crypto';
 import * as os from 'node:os';
+import { join } from 'node:path';
 import { Controller, OnModuleInit } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import type { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron';
+import { RunLockHeldError, isApprovalExpired } from '@hyveon/shared';
 import {
   TerraformService,
   TerraformInitError,
   TerraformPlanError,
+  TerraformApplyError,
   type TerraformInitConfig,
   type TerraformRunChunk,
   type TerraformPlanResult,
+  type TerraformApplyResult,
 } from '../services/TerraformService.js';
-import type { TfOutputs } from '../services/ConfigService.js';
+import { ConfigService, type TfOutputs } from '../services/ConfigService.js';
 import { AuditService } from '../services/AuditService.js';
 import { RunRecordService } from '../services/RunRecordService.js';
+import { RunService } from '../services/RunService.js';
 import { logger } from '../logger.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -27,6 +32,12 @@ const PLAN_CHUNK_CHANNEL = 'terraform.plan.chunk';
 
 /** Fixed side-channel `TerraformController.plan` sends its terminal message on. */
 const PLAN_END_CHANNEL = 'terraform.plan.end';
+
+/** Fixed side-channel `TerraformController.apply` pushes streamed output on. */
+const APPLY_CHUNK_CHANNEL = 'terraform.apply.chunk';
+
+/** Fixed side-channel `TerraformController.apply` sends its terminal message on. */
+const APPLY_END_CHANNEL = 'terraform.apply.end';
 
 /**
  * Message payload sent, in order, on {@link CHUNK_CHANNEL} for every chunk
@@ -167,6 +178,51 @@ interface TerraformApproveAck {
 }
 
 /**
+ * Payload accepted by {@link TerraformController.apply}. `planRunId`
+ * identifies the approved `plan` run to apply — its own `runId` is reused as
+ * the apply run's `runId` too, so the plan and the apply that consumes it
+ * share one run history entry lineage (see {@link apply}'s TSDoc). `planHash`
+ * is the caller's expected plan hash, compared against the plan run's stored
+ * `planHash` so a forged or drifted hash can never slip an unreviewed
+ * `.tfplan` artifact through to `terraform apply`.
+ *
+ * Mirrors `TerraformApplyPayload` in
+ * `@hyveon/desktop-preload/src/gsd-api.ts` — keep this shape in sync with
+ * that sibling contract.
+ */
+interface TerraformApplyPayload {
+  planRunId: string;
+  planHash: string;
+}
+
+/**
+ * Message payload sent, in order, on {@link APPLY_CHUNK_CHANNEL} for every
+ * chunk `TerraformService.apply` yields. `runId` ties the chunk back to the
+ * `apply()` call that produced it — the same id already handed back in the
+ * ack `TerraformController.apply` resolves — mirrors
+ * {@link TerraformPlanChunkMessage}.
+ */
+interface TerraformApplyChunkMessage {
+  runId: string;
+  chunk: TerraformRunChunk;
+}
+
+/**
+ * Message payload sent once on {@link APPLY_END_CHANNEL} when a
+ * `terraform.apply` run finishes. `exitCode` is `0` on success. On failure it
+ * carries whatever exit code the spawned process reported (or `null` when
+ * the run failed before/without an exit code — e.g. a stale-tfvars rejection
+ * that never spawned `terraform`), plus a stringified `error`. `result` is
+ * present only on a successful run.
+ */
+interface TerraformApplyEndMessage {
+  runId: string;
+  exitCode: number | null;
+  error?: string;
+  result?: TerraformApplyResult;
+}
+
+/**
  * IPC-only Terraform controller. Handles Electron main-process messages via
  * `@MessagePattern` — no HTTP routes are registered here.
  *
@@ -179,22 +235,31 @@ interface TerraformApproveAck {
  * {@link approve} needs no such bridging — it resolves a single value, so
  * the generic `ipcMain.handle` bridge in `../ipc-main-bridge.ts` wires it
  * automatically — and delegates the actual write to
- * `RunRecordService.approveRun` (see issue #109).
+ * `RunRecordService.approveRun` (see issue #109). {@link apply} mirrors
+ * {@link plan}'s streaming/bridging shape once more, gated behind the
+ * plan-hash + approval + apply-lock checks described in its own TSDoc (issue
+ * #109).
  */
 @Controller()
 export class TerraformController implements OnModuleInit {
   /**
-   * `audit`/`runRecord` are typed optional (`?`) purely so existing test call
-   * sites that construct `new TerraformController(terraform)` directly
-   * (bypassing Nest's DI container) keep compiling without also stubbing
-   * them — every real bootstrap through `AppModule` still resolves concrete
-   * `AuditService`/`RunRecordService` instances regardless of this
-   * TS-level optionality.
+   * `audit`/`runRecord`/`runService`/`config` are typed optional (`?`) purely
+   * so existing test call sites that construct
+   * `new TerraformController(terraform)` directly (bypassing Nest's DI
+   * container) keep compiling without also stubbing them — every real
+   * bootstrap through `AppModule` still resolves concrete
+   * `AuditService`/`RunRecordService`/`RunService`/`ConfigService` instances
+   * regardless of this TS-level optionality. `runService` guards the single
+   * durable apply lock {@link apply} acquires before ever spawning
+   * `terraform apply` (issue #106); `config` resolves the expected `.tfplan`
+   * artifact path for a given `planRunId` via `ConfigService.getRunsDir()`.
    */
   constructor(
     private readonly terraform: TerraformService,
     private readonly audit?: AuditService,
     private readonly runRecord?: RunRecordService,
+    private readonly runService?: RunService,
+    private readonly config?: ConfigService,
   ) {}
 
   /**
@@ -214,6 +279,16 @@ export class TerraformController implements OnModuleInit {
    * the chunk loop's own `isDestroyed()` check.
    */
   private readonly activePlans = new Map<string, AbortController>();
+
+  /**
+   * Per-call `AbortController`s keyed by the `runId` (the applied plan's own
+   * `runId` — see {@link apply}) an in-flight `apply()` call is running
+   * against. Mirrors {@link activePlans} — lets a future
+   * `terraform.apply.cancel` channel reach the right in-flight run, and lets
+   * the `WebContents` `'destroyed'` listener in {@link apply} abort
+   * immediately without racing the chunk loop's own `isDestroyed()` check.
+   */
+  private readonly activeApplies = new Map<string, AbortController>();
 
   /**
    * Registers an `ipcMain.handle` bridge for the `terraform.init` channel
@@ -254,6 +329,14 @@ export class TerraformController implements OnModuleInit {
     ipcMain.removeHandler('terraform.plan');
     ipcMain.handle('terraform.plan', (evt, payload: TerraformPlanPayload) =>
       this.plan(payload, { evt: evt as IpcMainInvokeEvent }),
+    );
+    // `terraform.apply` streams chunk/end messages the same way
+    // `terraform.plan` does — see `SELF_BRIDGED_PATTERNS` in
+    // `../ipc-main-bridge.ts`, which excludes it from the generic bridge for
+    // the same reason.
+    ipcMain.removeHandler('terraform.apply');
+    ipcMain.handle('terraform.apply', (evt, payload: TerraformApplyPayload) =>
+      this.apply(payload, { evt: evt as IpcMainInvokeEvent }),
     );
   }
 
@@ -507,6 +590,298 @@ export class TerraformController implements OnModuleInit {
   }
 
   /**
+   * Kicks off `terraform apply <planFile>` for the approved plan run
+   * `payload.planRunId` and streams its output back to the renderer —
+   * mirrors {@link plan}'s streaming shape, but gated behind a chain of
+   * pre-spawn checks that must *all* pass before `terraform` is ever spawned
+   * (issue #109):
+   *
+   * 1. `payload` validation — `planRunId` and `planHash` must both be
+   *    non-empty strings.
+   * 2. A plan {@link RunRecord} for `payload.planRunId` must exist
+   *    (`RunRecordService.getByRunId`) and be a `kind: 'plan'` record.
+   * 3. That record must be approved (`approvedBy`/`approvedAt` both set —
+   *    see {@link TerraformController.approve}) and the approval must not
+   *    have expired (`isApprovalExpired(record.approvedAt)`, a fixed 15
+   *    minute window — see `APPROVAL_WINDOW_MS` in `@hyveon/shared/runs.ts`).
+   * 4. `payload.planHash` must match the plan record's own stored
+   *    `planHash` exactly — this is what stops a forged or stale hash from
+   *    ever reaching `terraform apply`: the tfvars/plan an admin reviewed
+   *    and approved is exactly what gets applied. That alone only proves the
+   *    two in-memory values agree with each other, so this step also
+   *    re-reads the actual `.tfplan` bytes at
+   *    `<runsDir>/<planRunId>/<planRunId>.tfplan` and recomputes their
+   *    SHA-256 digest via `TerraformService.computePlanHash` — a fresh
+   *    artifact-level hash that must *also* match `payload.planHash`. A
+   *    swapped/tampered `.tfplan` file on disk (with `record.planHash` left
+   *    untouched) fails this second check even though the two stored hashes
+   *    still agree, and never reaches `terraform apply`.
+   * 5. The shared Terraform workspace must be free
+   *    (`TerraformService.getWorkspaceInFlight()`), mirroring {@link plan}'s
+   *    own conflict check.
+   * 6. The durable apply lock (`RunService.createRun`, issue #106) must be
+   *    acquirable — if another non-terminal run already holds it, the call
+   *    is rejected with a {@link RunLockHeldError}-derived message and
+   *    `conflict: 'apply'` and no lock is acquired by this call (so there is
+   *    nothing for it to release).
+   *
+   * Any failure in 1–6 resolves immediately with `{ started: false, error }`
+   * (plus `conflict` for 5–6) — `TerraformService.apply` is never called, so
+   * no `terraform apply` process is ever spawned, and no run record is
+   * written for the rejected attempt.
+   *
+   * Once the lock is acquired, `TerraformService.apply` is invoked with the
+   * plan's own `runId` (`payload.planRunId` — so the applied plan and its
+   * apply run record share the same `<runsDir>/<runId>/` lineage, per
+   * `TerraformService.apply`'s own TSDoc), the plan record's stored
+   * `tfvarsVersionId` (so `TerraformService.apply`'s own pre-spawn
+   * stale-tfvars guard re-checks it against the current S3 head version),
+   * and the expected plan artifact path
+   * (`<runsDir>/<planRunId>/<planRunId>.tfplan`, matching exactly what
+   * `TerraformService.plan` persisted and what `TerraformService.apply`
+   * itself independently re-validates before spawning).
+   *
+   * Once the lock is acquired, the generator's first step is driven
+   * *synchronously* — the same synchronous-first-`.next()` workspace
+   * reservation (before anything is `await`ed) that {@link plan} uses, for
+   * the same TOCTOU reason described at that call site: `TerraformService`'s
+   * `workspaceInFlight` check-and-set runs synchronously, before its own
+   * first `await`, so driving `.next()` here — rather than only from inside
+   * the fire-and-forget block below — closes the gap a second concurrent
+   * call could otherwise race through. The un-awaited first-step promise is
+   * given a no-op `.catch()` purely so Node doesn't log an
+   * unhandledRejection warning while it sits unawaited; the real handling of
+   * whatever it settles to happens in the streaming loop below, the same way
+   * every later `.next()` result already is. This means a pre-spawn failure
+   * inside `TerraformService.apply` itself (most notably a
+   * {@link StalePlanError} when the tfvars drifted since the plan was
+   * generated, but also e.g. a workspace-conflict race or a missing plan
+   * artifact) is *not* observed before this method resolves its ack — it
+   * surfaces as a normal `{ runId, exitCode: null, error }` message on
+   * {@link APPLY_END_CHANNEL} once the streaming loop's `await firstStep`
+   * rejects, mirroring how any other pre-spawn failure is reported. The
+   * streaming loop's own `finally` block (see below) unconditionally
+   * releases the just-acquired apply lock on this path too, since
+   * `TerraformService.apply` never reaches its own lock-releasing
+   * `persistRunRecord` call for a run that never spawned.
+   *
+   * Only once that reservation has happened is a best-effort audit entry
+   * (`action: 'apply'`) recorded via `AuditService.record()` for the
+   * now-accepted submission — mirroring {@link plan}'s own audit-entry call —
+   * and the streaming loop fired and forgotten immediately afterward; the
+   * method resolves `{ started: true, runId }`
+   * (`runId` again being `payload.planRunId`) well before the
+   * `terraform apply` run itself settles. Each chunk
+   * `TerraformService.apply` yields is forwarded, in order, to the renderer
+   * via `sender.send` on {@link APPLY_CHUNK_CHANNEL} as
+   * `{ runId, chunk }`; once the run settles a single terminal message is
+   * sent on {@link APPLY_END_CHANNEL}: `{ runId, exitCode: 0, result }` on
+   * success, or `{ runId, exitCode, error }` on failure (`exitCode` from
+   * {@link TerraformApplyError} when the spawned process exited non-zero,
+   * `null` for any other failure).
+   *
+   * Regardless of how the streaming loop ends — success,
+   * {@link TerraformApplyError}, an unrelated exception, or the `WebContents`
+   * being destroyed mid-run (which aborts the run via `ac.signal` and
+   * finalizes the generator via `stream.return()`, mirroring {@link plan}) —
+   * its `finally` block unconditionally calls `RunService.releaseRun(runId)`
+   * once more. This is deliberately redundant with the release
+   * `TerraformService.apply`'s own `persistRunRecord` already performs
+   * internally on every path that reaches it (`RunService.releaseRun` is
+   * idempotent — see its own TSDoc) — the guarantee this method provides is
+   * that the lock is released on *every* exit path this method can take,
+   * not just the ones `TerraformService.apply` itself accounts for.
+   *
+   * Creates its own `AbortController` per invocation and registers it in
+   * {@link activeApplies} keyed by `runId`, the same reasoning as
+   * {@link plan}.
+   *
+   * Reachable via the Electron IPC transport (`terraform.apply`).
+   */
+  @MessagePattern('terraform.apply')
+  async apply(
+    @Payload() payload: TerraformApplyPayload,
+    ctx: { evt: IpcMainInvokeEvent },
+  ): Promise<TerraformPlanAck> {
+    const validationError = TerraformController.validateApplyPayload(payload);
+    if (validationError) {
+      logger.error('terraform apply rejected: invalid payload', { error: validationError });
+      return { started: false, error: validationError };
+    }
+
+    if (!this.runRecord) {
+      const error = 'terraform.apply requires a configured RunRecordService';
+      logger.error('terraform apply rejected: no RunRecordService available', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+    if (!this.runService) {
+      const error = 'terraform.apply requires a configured RunService';
+      logger.error('terraform apply rejected: no RunService available', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+    if (!this.config) {
+      const error = 'terraform.apply requires a configured ConfigService';
+      logger.error('terraform apply rejected: no ConfigService available', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+
+    const record = await this.runRecord.getByRunId(payload.planRunId);
+    if (!record) {
+      const error = `No plan run found for planRunId "${payload.planRunId}"`;
+      logger.error('terraform apply rejected: no plan run found', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+    if (record.kind !== 'plan') {
+      const error = `Run "${payload.planRunId}" is a "${record.kind}" run, not a "plan" run, and cannot be applied`;
+      logger.error('terraform apply rejected: run is not a plan run', { planRunId: payload.planRunId, kind: record.kind });
+      return { started: false, error };
+    }
+    if (!record.approvedBy || !record.approvedAt) {
+      const error = `Plan run "${payload.planRunId}" has not been approved`;
+      logger.error('terraform apply rejected: plan run not approved', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+    if (isApprovalExpired(record.approvedAt)) {
+      const error = `Approval for plan run "${payload.planRunId}" has expired; re-approve before applying`;
+      logger.error('terraform apply rejected: approval expired', { planRunId: payload.planRunId, approvedAt: record.approvedAt });
+      return { started: false, error };
+    }
+    if (!record.planHash || record.planHash !== payload.planHash) {
+      const error = `Plan hash mismatch for run "${payload.planRunId}": the supplied planHash does not match the approved plan`;
+      logger.error('terraform apply rejected: plan hash mismatch', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+
+    const planFile = join(this.config.getRunsDir(), payload.planRunId, `${payload.planRunId}.tfplan`);
+    let artifactHash: string;
+    try {
+      artifactHash = this.terraform.computePlanHash(planFile);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error('terraform apply rejected: failed to re-hash on-disk plan artifact', {
+        planRunId: payload.planRunId,
+        error,
+      });
+      return { started: false, error: `Failed to verify plan artifact for run "${payload.planRunId}": ${error}` };
+    }
+    if (artifactHash !== payload.planHash) {
+      const error =
+        `Plan artifact hash mismatch for run "${payload.planRunId}": the on-disk .tfplan artifact does not ` +
+        'match the approved plan hash';
+      logger.error('terraform apply rejected: plan artifact hash mismatch', { planRunId: payload.planRunId });
+      return { started: false, error };
+    }
+
+    const inFlight = this.terraform.getWorkspaceInFlight();
+    if (inFlight) {
+      const error =
+        `terraform apply refused: ${inFlight} is already in flight; wait for it to finish ` +
+        'before submitting another apply';
+      logger.error('terraform apply rejected: workspace busy', { inFlight });
+      return { started: false, error, conflict: inFlight };
+    }
+
+    const initiator = TerraformController.resolveApprover();
+    try {
+      await this.runService.createRun('apply', initiator, payload.planRunId);
+    } catch (err) {
+      if (err instanceof RunLockHeldError) {
+        logger.error('terraform apply rejected: apply lock already held', { planRunId: payload.planRunId, lock: err.lock });
+        return { started: false, error: err.message, conflict: 'apply' };
+      }
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error('terraform apply rejected: failed to acquire apply lock', { planRunId: payload.planRunId, error });
+      return { started: false, error };
+    }
+
+    const runId = payload.planRunId;
+    const sender: WebContents = ctx.evt.sender;
+    const ac = new AbortController();
+
+    // Reserve the shared workspace *synchronously* — mirrors plan()'s own
+    // synchronous-first-`.next()` reservation (see the inline comment on
+    // that call site for why the ordering matters): no `await` runs between
+    // the `getWorkspaceInFlight()` check above and this `stream.next()`
+    // call, which is the only thing that actually flips
+    // `TerraformService`'s internal `workspaceInFlight` lock. The `.catch()`
+    // below exists solely to mark `firstStep` as "handled" so Node doesn't
+    // log an unhandledRejection warning while it sits unawaited; the real
+    // handling of whatever it settles to happens in the streaming loop
+    // below, the same way every later `.next()` result already is. A
+    // pre-spawn failure (e.g. a StalePlanError from TerraformService.apply's
+    // own re-check, an invalid runId/planFile, or a workspace-conflict race)
+    // therefore surfaces as a normal end-message error on
+    // `terraform.apply.end` once the streaming loop awaits `firstStep`,
+    // rather than as a synchronous ack rejection.
+    const stream = this.terraform.apply(runId, record.tfvarsVersionId, planFile, ac.signal);
+    const firstStep = stream.next();
+    firstStep.catch(() => { /* handled in the streaming loop below */ });
+
+    this.activeApplies.set(runId, ac);
+
+    const onDestroyed = () => ac.abort();
+    sender.once('destroyed', onDestroyed);
+    const cleanup = () => {
+      this.activeApplies.delete(runId);
+      sender.removeListener('destroyed', onDestroyed);
+    };
+
+    // Best-effort: AuditService.record() never throws (failures are logged
+    // and swallowed internally), so awaiting it here cannot block or fail
+    // this now-accepted submission's ack. `game`/`before`/`after` are the
+    // fixed values the `game_servers`-shaped audit schema takes for a
+    // workspace-wide `apply` action that isn't scoped to a single game. By
+    // this point the workspace reservation above has already succeeded, so
+    // this audit entry is only ever recorded for a submission that really
+    // did start a run — mirrors plan()'s own audit-entry call.
+    await this.audit?.record({
+      action: 'apply',
+      game: '',
+      before: null,
+      after: null,
+      ...(record.tfvarsVersionId !== undefined ? { versionId: record.tfvarsVersionId } : {}),
+    });
+
+    // Fire-and-forget the streaming loop, mirroring plan()'s shape.
+    void (async () => {
+      try {
+        let next = await firstStep;
+        while (!next.done) {
+          if (sender.isDestroyed()) {
+            ac.abort();
+            await stream.return(undefined);
+            return;
+          }
+          const chunkMessage: TerraformApplyChunkMessage = { runId, chunk: next.value };
+          sender.send(APPLY_CHUNK_CHANNEL, chunkMessage);
+          next = await stream.next();
+        }
+        if (!sender.isDestroyed()) {
+          const message: TerraformApplyEndMessage = { runId, exitCode: 0, result: next.value };
+          sender.send(APPLY_END_CHANNEL, message);
+        }
+      } catch (err) {
+        logger.error('terraform apply error', { err });
+        if (!sender.isDestroyed()) {
+          const exitCode = err instanceof TerraformApplyError ? err.exitCode : null;
+          const message: TerraformApplyEndMessage = { runId, exitCode, error: String(err) };
+          sender.send(APPLY_END_CHANNEL, message);
+        }
+      } finally {
+        cleanup();
+        // Redundant with (but a safety net alongside) the release
+        // TerraformService.apply's own persistRunRecord already performs
+        // internally on every path that reaches it — releaseRun is
+        // idempotent, so this unconditionally guarantees the lock is
+        // released on every exit path this method can take.
+        await this.runService?.releaseRun(runId);
+      }
+    })();
+
+    return { started: true, runId };
+  }
+
+  /**
    * Returns the current Terraform outputs by delegating to
    * `TerraformService.output`. Unlike {@link init}, this channel needs no
    * manual bridging — it resolves a single value rather than streaming
@@ -643,6 +1018,21 @@ export class TerraformController implements OnModuleInit {
 
     if (!isNonEmptyString(payload?.planRunId)) {
       return 'terraform.approve requires a non-empty planRunId string';
+    }
+    return null;
+  }
+
+  /**
+   * Validates that `payload.planRunId` and `payload.planHash` are both
+   * non-empty strings. Returns a descriptive error message when validation
+   * fails, or `null` when `payload` is valid.
+   */
+  private static validateApplyPayload(payload: TerraformApplyPayload): string | null {
+    const isNonEmptyString = (value: unknown): value is string =>
+      typeof value === 'string' && value.length > 0;
+
+    if (!isNonEmptyString(payload?.planRunId) || !isNonEmptyString(payload?.planHash)) {
+      return 'terraform.apply requires non-empty planRunId and planHash strings';
     }
     return null;
   }

--- a/app/packages/desktop-main/src/ipc-main-bridge.ts
+++ b/app/packages/desktop-main/src/ipc-main-bridge.ts
@@ -17,11 +17,15 @@ import { ElectronIPCTransport } from 'nestjs-electron-ipc-transport';
  * - `terraform.plan`: bridged manually by the same controller for the same
  *   reason as `terraform.init` — it streams `terraform plan` progress over a
  *   side channel for the duration of a long-running run.
+ * - `terraform.apply`: bridged manually by the same controller for the same
+ *   reason as `terraform.plan` — it streams `terraform apply` progress over a
+ *   side channel for the duration of a long-running run (see #109).
  */
 export const SELF_BRIDGED_PATTERNS: ReadonlySet<string> = new Set([
   'logs.stream',
   'terraform.init',
   'terraform.plan',
+  'terraform.apply',
 ]);
 
 /**

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -12,7 +12,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RunRecord, RunRecordStore } from '@hyveon/shared';
-import { INLINE_LOG_LIMIT_BYTES, RunRecordService, type PersistRunRecordParams } from './RunRecordService.js';
+import {
+  INLINE_LOG_LIMIT_BYTES,
+  RunRecordNotFoundError,
+  RunRecordNotPlanError,
+  RunRecordNotSuccessfulError,
+  RunRecordService,
+  RunRecordTableNotConfiguredError,
+  type PersistRunRecordParams,
+} from './RunRecordService.js';
 import { ConfigService, type TfOutputs } from './ConfigService.js';
 import { RunService } from './RunService.js';
 
@@ -43,17 +51,33 @@ const TF: TfOutputs = {
 const putRecordMock = vi.fn<RunRecordStore['putRecord']>();
 const putLogMock = vi.fn<RunRecordStore['putLog']>();
 const getLogUrlMock = vi.fn<RunRecordStore['getLogUrl']>();
+const getRecordByRunIdMock = vi.fn<RunRecordStore['getRecordByRunId']>();
 const releaseRunMock = vi.fn<RunService['releaseRun']>();
 
 /** Builds a `RunRecordStore`-shaped stub backed by the shared mocks above; the lock methods are unused no-ops here since `RunRecordService`'s lock release goes through the injected `RunService`, not the store directly. */
 function makeStore(): RunRecordStore {
   return {
     putRecord: putRecordMock,
+    getRecordByRunId: getRecordByRunIdMock,
     putLog: putLogMock,
     getLogUrl: getLogUrlMock,
     acquireRunLock: vi.fn<RunRecordStore['acquireRunLock']>(),
     getRunLock: vi.fn<RunRecordStore['getRunLock']>(),
     releaseRunLock: vi.fn<RunRecordStore['releaseRunLock']>(),
+  };
+}
+
+/** Builds a sample successful `plan` {@link RunRecord}, overridable per-test. */
+function makeRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    sk: '2026-07-17T00:00:00.000Z#run-123',
+    runId: 'run-123',
+    kind: 'plan',
+    status: 'success',
+    startedAt: '2026-07-17T00:00:00.000Z',
+    completedAt: '2026-07-17T00:05:00.000Z',
+    exitCode: 0,
+    ...overrides,
   };
 }
 
@@ -97,6 +121,7 @@ beforeEach(() => {
   putRecordMock.mockReset();
   putLogMock.mockReset();
   getLogUrlMock.mockReset();
+  getRecordByRunIdMock.mockReset();
   releaseRunMock.mockReset();
   releaseRunMock.mockResolvedValue(undefined);
   workDir = mkdtempSync(join(tmpdir(), 'run-record-service-test-'));
@@ -323,6 +348,86 @@ describe('RunRecordService', () => {
       await service.getLogUrl('runs/run-123.log', 60);
 
       expect(getLogUrlMock).toHaveBeenCalledWith('runs/run-123.log', 60);
+    });
+  });
+
+  describe('getByRunId', () => {
+    it("should return the store's matching record for a known runId", async () => {
+      const record = makeRecord();
+      getRecordByRunIdMock.mockResolvedValue(record);
+      const service = makeService();
+
+      const result = await service.getByRunId('run-123');
+
+      expect(result).toBe(record);
+      expect(getRecordByRunIdMock).toHaveBeenCalledWith('run-123');
+    });
+
+    it('should return undefined when no record exists for the runId', async () => {
+      getRecordByRunIdMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      const result = await service.getByRunId('missing-run');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined and not call store.getRecordByRunId when runs_table_name is not configured', async () => {
+      const service = makeService(null);
+
+      const result = await service.getByRunId('run-123');
+
+      expect(result).toBeUndefined();
+      expect(getRecordByRunIdMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('approveRun', () => {
+    it('should persist approvedBy/approvedAt via putRecord and return the updated record for a successful plan run', async () => {
+      const record = makeRecord();
+      getRecordByRunIdMock.mockResolvedValue(record);
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      const result = await service.approveRun('run-123', 'alice');
+
+      expect(putRecordMock).toHaveBeenCalledTimes(1);
+      const persisted = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(persisted.approvedBy).toBe('alice');
+      expect(typeof persisted.approvedAt).toBe('string');
+      expect(result).toEqual(persisted);
+    });
+
+    it('should reject with RunRecordTableNotConfiguredError when runs_table_name is not configured', async () => {
+      const service = makeService(null);
+
+      await expect(service.approveRun('run-123', 'alice')).rejects.toThrow(RunRecordTableNotConfiguredError);
+      expect(getRecordByRunIdMock).not.toHaveBeenCalled();
+      expect(putRecordMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject with RunRecordNotFoundError when no record exists for the runId', async () => {
+      getRecordByRunIdMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await expect(service.approveRun('missing-run', 'alice')).rejects.toThrow(RunRecordNotFoundError);
+      expect(putRecordMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject with RunRecordNotPlanError when the record is not a plan run', async () => {
+      getRecordByRunIdMock.mockResolvedValue(makeRecord({ kind: 'apply' }));
+      const service = makeService();
+
+      await expect(service.approveRun('run-123', 'alice')).rejects.toThrow(RunRecordNotPlanError);
+      expect(putRecordMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject with RunRecordNotSuccessfulError when the plan run did not succeed', async () => {
+      getRecordByRunIdMock.mockResolvedValue(makeRecord({ status: 'failed', exitCode: 1 }));
+      const service = makeService();
+
+      await expect(service.approveRun('run-123', 'alice')).rejects.toThrow(RunRecordNotSuccessfulError);
+      expect(putRecordMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -194,6 +194,26 @@ describe('RunRecordService', () => {
       expect(record.tfvarsVersionId).toBe('v-1');
     });
 
+    it('should include planHash on the record when present on params', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams({ planHash: 'a'.repeat(64) }), null);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record.planHash).toBe('a'.repeat(64));
+    });
+
+    it('should omit planHash from the record when absent from params', async () => {
+      putRecordMock.mockResolvedValue(undefined);
+      const service = makeService();
+
+      await service.persist(makeParams(), null);
+
+      const record = putRecordMock.mock.calls[0]?.[0] as RunRecord;
+      expect(record).not.toHaveProperty('planHash');
+    });
+
     it('should swallow a store.putRecord failure and log a warning instead of throwing', async () => {
       putRecordMock.mockRejectedValue(new Error('DynamoDB is down'));
       const service = makeService();

--- a/app/packages/desktop-main/src/services/RunRecordService.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.ts
@@ -66,6 +66,12 @@ export interface PersistRunRecordParams {
   exitCode: number | null;
   /** The tfvars version id the run was executed against, if the caller supplied one. */
   tfvarsVersionId?: string;
+  /**
+   * SHA-256 hex digest of the `.tfplan` artifact this run produced (a
+   * successful `plan` run only — see `TerraformService.computePlanHash` and
+   * issue #109), if the caller supplied one.
+   */
+  planHash?: string;
 }
 
 /**
@@ -185,6 +191,7 @@ export class RunRecordService {
           completedAt: params.completedAt,
           exitCode: params.exitCode,
           ...(params.tfvarsVersionId !== undefined ? { tfvarsVersionId: params.tfvarsVersionId } : {}),
+          ...(params.planHash !== undefined ? { planHash: params.planHash } : {}),
           ...(logInline !== undefined ? { logInline } : {}),
           ...(logS3Key !== undefined ? { logS3Key } : {}),
         };

--- a/app/packages/desktop-main/src/services/RunRecordService.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.ts
@@ -25,11 +25,62 @@
 import { readFileSync } from 'node:fs';
 import { Inject, Injectable } from '@nestjs/common';
 import { buildRunSk, deriveRunStatus } from '@hyveon/shared';
-import type { RunKind, RunRecord, RunRecordStore } from '@hyveon/shared';
+import type { RunKind, RunRecord, RunRecordStore, RunStatus } from '@hyveon/shared';
 import { logger } from '../logger.js';
 import { ConfigService } from './ConfigService.js';
 import { RunService } from './RunService.js';
 import { RUN_RECORD_STORE } from '../modules/cloud-provider.tokens.js';
+
+/**
+ * Thrown by {@link RunRecordService.approveRun} when the run-history table
+ * isn't configured yet (`ConfigService.getTfOutputs().runs_table_name` is
+ * unset) — the same chicken-and-egg guard {@link RunRecordService.persist}
+ * applies, but here it's surfaced to the caller rather than swallowed, since
+ * an approval that silently no-ops would let a later apply attempt proceed
+ * without ever having recorded who approved it.
+ */
+export class RunRecordTableNotConfiguredError extends Error {
+  constructor(runId: string) {
+    super(`RunRecordService.approveRun: runs_table_name not configured, cannot approve run "${runId}"`);
+    this.name = 'RunRecordTableNotConfiguredError';
+  }
+}
+
+/**
+ * Thrown by {@link RunRecordService.approveRun} when no run record exists for
+ * the given `runId`.
+ */
+export class RunRecordNotFoundError extends Error {
+  constructor(runId: string) {
+    super(`No run record found for runId "${runId}"`);
+    this.name = 'RunRecordNotFoundError';
+  }
+}
+
+/**
+ * Thrown by {@link RunRecordService.approveRun} when the run record found for
+ * `runId` is not a `plan` run — only a `plan` run's `.tfplan` artifact is
+ * ever compared against an apply request's `planHash` (see #109), so
+ * approving an `apply`/`destroy` record makes no sense.
+ */
+export class RunRecordNotPlanError extends Error {
+  constructor(runId: string, kind: RunKind) {
+    super(`Run "${runId}" is a "${kind}" run, not a "plan" run, and cannot be approved`);
+    this.name = 'RunRecordNotPlanError';
+  }
+}
+
+/**
+ * Thrown by {@link RunRecordService.approveRun} when the plan run found for
+ * `runId` did not finish with `status: 'success'` — a failed or aborted plan
+ * produced no trustworthy `.tfplan` artifact for a later apply to reuse.
+ */
+export class RunRecordNotSuccessfulError extends Error {
+  constructor(runId: string, status: RunStatus) {
+    super(`Run "${runId}" has status "${status}", not "success", and cannot be approved`);
+    this.name = 'RunRecordNotSuccessfulError';
+  }
+}
 
 /**
  * Maximum size, in UTF-8 encoded bytes, of a captured run log that
@@ -223,5 +274,89 @@ export class RunRecordService {
    */
   async getLogUrl(logKey: string, expiresInSeconds?: number): Promise<string> {
     return this.store.getLogUrl(logKey, expiresInSeconds);
+  }
+
+  /**
+   * Looks up a previously persisted run record by its `runId`, delegating
+   * directly to `store.getRecordByRunId` — exposed on the service (rather
+   * than requiring callers to reach for the injected store themselves) so
+   * consumers such as the apply IPC handler (#109) depend only on
+   * `RunRecordService`.
+   *
+   * Guarded by the same `runs_table_name`-not-configured check as
+   * {@link persist}: when the run-history table isn't in the Terraform
+   * outputs yet, a winston warning is logged and `undefined` is returned
+   * without calling `store.getRecordByRunId`.
+   *
+   * @param runId - Unique identifier of the run to look up.
+   * @returns The matching {@link RunRecord}, or `undefined` if no record with
+   *   that `runId` exists in the store (or the run-history table isn't
+   *   configured yet).
+   */
+  async getByRunId(runId: string): Promise<RunRecord | undefined> {
+    const tableName = this.config.getTfOutputs()?.runs_table_name;
+    if (!tableName) {
+      logger.warn('RunRecordService.getByRunId: runs_table_name not configured, returning undefined', {
+        runId,
+      });
+      return undefined;
+    }
+
+    return this.store.getRecordByRunId(runId);
+  }
+
+  /**
+   * Approves a successful `plan` run for apply: stamps `approvedBy` and an
+   * `approvedAt` timestamp onto its persisted {@link RunRecord} and writes it
+   * back via `store.putRecord`.
+   *
+   * Unlike {@link persist}, this method is **not** best-effort — a failure
+   * here is thrown to the caller rather than logged and swallowed, since an
+   * approval that silently fails would let a later apply proceed without the
+   * approval actually having been recorded.
+   *
+   * Validates, in order, throwing a distinct error for each failure mode so
+   * callers (e.g. the approve IPC handler) can surface a precise message:
+   *
+   * - The run-history table is configured — throws
+   *   {@link RunRecordTableNotConfiguredError} otherwise.
+   * - A record exists for `runId` — throws {@link RunRecordNotFoundError}
+   *   otherwise.
+   * - The record's `kind` is `'plan'` — throws {@link RunRecordNotPlanError}
+   *   otherwise.
+   * - The record's `status` is `'success'` — throws
+   *   {@link RunRecordNotSuccessfulError} otherwise.
+   *
+   * @param runId - Unique identifier of the plan run to approve.
+   * @param approvedBy - Opaque identifier (e.g. username) of the admin approving the run.
+   * @returns The updated {@link RunRecord}, with `approvedBy`/`approvedAt` set.
+   */
+  async approveRun(runId: string, approvedBy: string): Promise<RunRecord> {
+    const tableName = this.config.getTfOutputs()?.runs_table_name;
+    if (!tableName) {
+      throw new RunRecordTableNotConfiguredError(runId);
+    }
+
+    const record = await this.store.getRecordByRunId(runId);
+    if (!record) {
+      throw new RunRecordNotFoundError(runId);
+    }
+
+    if (record.kind !== 'plan') {
+      throw new RunRecordNotPlanError(runId, record.kind);
+    }
+
+    if (record.status !== 'success') {
+      throw new RunRecordNotSuccessfulError(runId, record.status);
+    }
+
+    const updated: RunRecord = {
+      ...record,
+      approvedBy,
+      approvedAt: new Date().toISOString(),
+    };
+
+    await this.store.putRecord(updated);
+    return updated;
   }
 }

--- a/app/packages/desktop-main/src/services/RunService.test.ts
+++ b/app/packages/desktop-main/src/services/RunService.test.ts
@@ -146,6 +146,21 @@ describe('RunService', () => {
       expect(service.getCurrentLock()).toEqual(second);
     });
 
+    it('should acquire the lock under a pre-minted runId when one is passed, and release it by that runId', async () => {
+      const service = makeService();
+
+      const lock = await service.createRun('apply', 'alice', 'some-id');
+
+      expect(lock.runId).toBe('some-id');
+      expect(acquireRunLockMock).toHaveBeenCalledWith(lock);
+      expect(service.getCurrentLock()).toEqual(lock);
+
+      await service.releaseRun('some-id');
+
+      expect(releaseRunLockMock).toHaveBeenCalledWith('some-id');
+      expect(service.getCurrentLock()).toBeUndefined();
+    });
+
     it('should take over an expired in-memory lock instead of throwing RunLockHeldError', async () => {
       const service = makeService();
 

--- a/app/packages/desktop-main/src/services/RunService.ts
+++ b/app/packages/desktop-main/src/services/RunService.ts
@@ -86,19 +86,23 @@ export class RunService {
    * @param kind - Which `terraform` subcommand the caller is about to run.
    * @param initiator - Opaque identifier (e.g. username or API caller) of
    *   who is starting the run, surfaced to the UI as the current lock holder.
+   * @param runId - Optional pre-minted run identifier to use instead of a
+   *   freshly generated `randomUUID()`. Callers that already know the run's
+   *   id (e.g. because they created the `RunRecord` row before acquiring the
+   *   lock) can pass it here so the lock and the record share one id.
    * @returns The newly acquired {@link RunLock}.
    * @throws {@link RunLockHeldError} carrying the currently held lock when
    *   another non-terminal run already holds it, whether that lock was
    *   observed in-memory or in DynamoDB.
    */
-  async createRun(kind: RunKind, initiator: string): Promise<RunLock> {
+  async createRun(kind: RunKind, initiator: string, runId?: string): Promise<RunLock> {
     const now = new Date();
     if (this.currentLock !== null && !isRunLockExpired(this.currentLock, now)) {
       throw new RunLockHeldError(this.currentLock);
     }
 
     const lock: RunLock = {
-      runId: randomUUID(),
+      runId: runId ?? randomUUID(),
       kind,
       initiator,
       acquiredAt: now.toISOString(),

--- a/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.apply.test.ts
@@ -6,16 +6,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * vi.mock() calls are lifted to the top of the compiled output above regular
  * declarations.
  */
-const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock } =
-  vi.hoisted(() => {
-    const execFileMock = vi.fn();
-    const spawnMock = vi.fn();
-    const mkdirSyncMock = vi.fn();
-    const writeFileSyncMock = vi.fn();
-    const existsSyncMock = vi.fn();
-    const runRecordPersistMock = vi.fn();
-    return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock };
-  });
+const {
+  execFileMock,
+  spawnMock,
+  mkdirSyncMock,
+  writeFileSyncMock,
+  existsSyncMock,
+  readFileSyncMock,
+  runRecordPersistMock,
+} = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  const mkdirSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const runRecordPersistMock = vi.fn();
+  return {
+    execFileMock,
+    spawnMock,
+    mkdirSyncMock,
+    writeFileSyncMock,
+    existsSyncMock,
+    readFileSyncMock,
+    runRecordPersistMock,
+  };
+});
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
@@ -27,6 +43,12 @@ vi.mock('node:fs', () => ({
   existsSync: existsSyncMock,
   writeFileSync: writeFileSyncMock,
   copyFileSync: vi.fn(),
+  // Backs `TerraformService.computePlanHash`, which the cross-subcommand
+  // lock tests below exercise indirectly (a `plan()` call is driven to a
+  // successful close as part of asserting `apply()`'s workspace lock) —
+  // see #109. Real `createHash` (this file doesn't mock `node:crypto`)
+  // hashes whatever bytes this returns.
+  readFileSync: readFileSyncMock,
 }));
 
 import {
@@ -219,6 +241,8 @@ beforeEach(() => {
   // pre-spawn existsSync(planFile) guard aren't tripped up by it — only the
   // dedicated "missing planFile" test below overrides this.
   existsSyncMock.mockReturnValue(true);
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockReturnValue(Buffer.from('fake .tfplan artifact bytes'));
   runRecordPersistMock.mockReset();
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.destroy.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.destroy.test.ts
@@ -6,16 +6,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * vi.mock() calls are lifted to the top of the compiled output above regular
  * declarations.
  */
-const { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock } =
-  vi.hoisted(() => {
-    const execFileMock = vi.fn();
-    const spawnMock = vi.fn();
-    const mkdirSyncMock = vi.fn();
-    const writeFileSyncMock = vi.fn();
-    const existsSyncMock = vi.fn();
-    const runRecordPersistMock = vi.fn();
-    return { execFileMock, spawnMock, mkdirSyncMock, writeFileSyncMock, existsSyncMock, runRecordPersistMock };
-  });
+const {
+  execFileMock,
+  spawnMock,
+  mkdirSyncMock,
+  writeFileSyncMock,
+  existsSyncMock,
+  readFileSyncMock,
+  runRecordPersistMock,
+} = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  const mkdirSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const runRecordPersistMock = vi.fn();
+  return {
+    execFileMock,
+    spawnMock,
+    mkdirSyncMock,
+    writeFileSyncMock,
+    existsSyncMock,
+    readFileSyncMock,
+    runRecordPersistMock,
+  };
+});
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
@@ -27,6 +43,12 @@ vi.mock('node:fs', () => ({
   existsSync: existsSyncMock,
   writeFileSync: writeFileSyncMock,
   copyFileSync: vi.fn(),
+  // Backs `TerraformService.computePlanHash`, which the cross-subcommand
+  // lock tests below exercise indirectly (a `plan()` call is driven to a
+  // successful close as part of asserting `destroy()`'s workspace lock) —
+  // see #109. Real `createHash` (this file doesn't mock `node:crypto`)
+  // hashes whatever bytes this returns.
+  readFileSync: readFileSyncMock,
 }));
 
 vi.mock('../logger.js', () => ({
@@ -218,6 +240,8 @@ beforeEach(() => {
   mkdirSyncMock.mockReset();
   writeFileSyncMock.mockReset();
   existsSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockReturnValue(Buffer.from('fake .tfplan artifact bytes'));
   runRecordPersistMock.mockReset();
 });
 

--- a/app/packages/desktop-main/src/services/TerraformService.init.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.init.test.ts
@@ -6,25 +6,35 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * vi.mock() calls are lifted to the top of the compiled output above regular
  * declarations.
  */
-const { execFileMock, spawnMock, mkdirSyncMock, existsSyncMock, writeFileSyncMock, copyFileSyncMock, randomUUIDMock } =
-  vi.hoisted(() => {
-    const execFileMock = vi.fn();
-    const spawnMock = vi.fn();
-    const mkdirSyncMock = vi.fn();
-    const existsSyncMock = vi.fn();
-    const writeFileSyncMock = vi.fn();
-    const copyFileSyncMock = vi.fn();
-    const randomUUIDMock = vi.fn();
-    return {
-      execFileMock,
-      spawnMock,
-      mkdirSyncMock,
-      existsSyncMock,
-      writeFileSyncMock,
-      copyFileSyncMock,
-      randomUUIDMock,
-    };
-  });
+const {
+  execFileMock,
+  spawnMock,
+  mkdirSyncMock,
+  existsSyncMock,
+  writeFileSyncMock,
+  copyFileSyncMock,
+  readFileSyncMock,
+  randomUUIDMock,
+} = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  const spawnMock = vi.fn();
+  const mkdirSyncMock = vi.fn();
+  const existsSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  const copyFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const randomUUIDMock = vi.fn();
+  return {
+    execFileMock,
+    spawnMock,
+    mkdirSyncMock,
+    existsSyncMock,
+    writeFileSyncMock,
+    copyFileSyncMock,
+    readFileSyncMock,
+    randomUUIDMock,
+  };
+});
 
 vi.mock('node:child_process', () => ({
   execFile: execFileMock,
@@ -36,11 +46,20 @@ vi.mock('node:fs', () => ({
   existsSync: existsSyncMock,
   writeFileSync: writeFileSyncMock,
   copyFileSync: copyFileSyncMock,
+  readFileSync: readFileSyncMock,
 }));
 
-vi.mock('node:crypto', () => ({
-  randomUUID: randomUUIDMock,
-}));
+// `createHash` is delegated to the real `node:crypto` implementation (rather
+// than mocked) so `TerraformService.computePlanHash`'s SHA-256 digest is a
+// real, independently-verifiable hash of whatever bytes `readFileSyncMock`
+// returns — only `randomUUID` needs to be deterministically controlled here.
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return {
+    ...actual,
+    randomUUID: randomUUIDMock,
+  };
+});
 
 import {
   TerraformService,
@@ -262,6 +281,8 @@ beforeEach(() => {
   existsSyncMock.mockReturnValue(true);
   writeFileSyncMock.mockReset();
   copyFileSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockReturnValue(Buffer.from('fake .tfplan artifact bytes'));
   randomUUIDMock.mockReset();
   randomUUIDMock.mockReturnValue('run-123');
 });
@@ -781,7 +802,7 @@ describe('TerraformService.plan summary parsing and return value', () => {
       child.close(0);
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       runId: 'run-789',
       artifactPath: '/repo/runs/run-789/run-789.tfplan',
       varFilePath: '/repo/runs/run-789/terraform.tfvars',
@@ -789,6 +810,7 @@ describe('TerraformService.plan summary parsing and return value', () => {
       change: 1,
       destroy: 2,
     });
+    expect(typeof (result as { planHash?: string } | undefined)?.planHash).toBe('string');
   });
 
   it('should resolve all three counts to 0 when the plan has no changes', async () => {

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /*
@@ -13,6 +14,7 @@ const {
   existsSyncMock,
   writeFileSyncMock,
   copyFileSyncMock,
+  readFileSyncMock,
   randomUUIDMock,
   runRecordPersistMock,
 } = vi.hoisted(() => {
@@ -22,6 +24,7 @@ const {
   const existsSyncMock = vi.fn();
   const writeFileSyncMock = vi.fn();
   const copyFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
   const randomUUIDMock = vi.fn();
   const runRecordPersistMock = vi.fn();
   return {
@@ -31,6 +34,7 @@ const {
     existsSyncMock,
     writeFileSyncMock,
     copyFileSyncMock,
+    readFileSyncMock,
     randomUUIDMock,
     runRecordPersistMock,
   };
@@ -46,11 +50,21 @@ vi.mock('node:fs', () => ({
   existsSync: existsSyncMock,
   writeFileSync: writeFileSyncMock,
   copyFileSync: copyFileSyncMock,
+  readFileSync: readFileSyncMock,
 }));
 
-vi.mock('node:crypto', () => ({
-  randomUUID: randomUUIDMock,
-}));
+// `createHash` is delegated to the real `node:crypto` implementation (rather
+// than mocked) so `TerraformService.computePlanHash`'s SHA-256 digest is a
+// real, independently-verifiable hash of whatever bytes `readFileSyncMock`
+// returns for a given test — only `randomUUID` needs to be
+// deterministically controlled here.
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return {
+    ...actual,
+    randomUUID: randomUUIDMock,
+  };
+});
 
 import {
   TerraformService,
@@ -178,6 +192,12 @@ function queueSpawn(child: FakeChildProcess): void {
   spawnMock.mockImplementationOnce(() => child);
 }
 
+/** Bytes `readFileSyncMock` returns by default in every test — stands in for the persisted `.tfplan` artifact `computePlanHash` reads. */
+const DEFAULT_PLAN_ARTIFACT_BYTES = Buffer.from('fake .tfplan artifact bytes');
+
+/** SHA-256 hex digest a successful `plan()` run is expected to compute/persist for {@link DEFAULT_PLAN_ARTIFACT_BYTES}. */
+const EXPECTED_PLAN_HASH = createHash('sha256').update(DEFAULT_PLAN_ARTIFACT_BYTES).digest('hex');
+
 /**
  * Waits for every already-queued microtask to drain (via a macrotask
  * boundary) before returning. `plan()` awaits the binary/version resolution
@@ -230,6 +250,8 @@ beforeEach(() => {
   existsSyncMock.mockReturnValue(true);
   writeFileSyncMock.mockReset();
   copyFileSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockReturnValue(DEFAULT_PLAN_ARTIFACT_BYTES);
   randomUUIDMock.mockReset();
   randomUUIDMock.mockReturnValue('run-123');
   runRecordPersistMock.mockReset();
@@ -575,12 +597,13 @@ describe('TerraformService.plan run record persistence', () => {
       kind: 'plan',
       exitCode: 0,
       tfvarsVersionId: 'tfvars-version-abc',
+      planHash: EXPECTED_PLAN_HASH,
     });
     expect(typeof record.startedAt).toBe('string');
     expect(typeof record.completedAt).toBe('string');
   });
 
-  it('should write a TerraformRunRecord with kind "plan" and the non-zero exit code when the process exits non-zero', async () => {
+  it('should write a TerraformRunRecord with kind "plan" and the non-zero exit code when the process exits non-zero, with no planHash', async () => {
     queueSuccessfulResolution();
     randomUUIDMock.mockReturnValue('run-record-2');
     const child = new FakeChildProcess();
@@ -603,9 +626,11 @@ describe('TerraformService.plan run record persistence', () => {
     const [, contents] = recordCalls[0] as [string, string];
     const record = JSON.parse(contents);
     expect(record).toMatchObject({ runId: 'run-record-2', kind: 'plan', exitCode: 1 });
+    expect(record).not.toHaveProperty('planHash');
+    expect(readFileSyncMock).not.toHaveBeenCalled();
   });
 
-  it('should write a TerraformRunRecord with kind "plan" and a null exit code when the run is aborted mid-flight', async () => {
+  it('should write a TerraformRunRecord with kind "plan" and a null exit code when the run is aborted mid-flight, with no planHash', async () => {
     queueSuccessfulResolution();
     randomUUIDMock.mockReturnValue('run-record-3');
     const child = new FakeChildProcess();
@@ -638,6 +663,7 @@ describe('TerraformService.plan run record persistence', () => {
     const [, contents] = recordCalls[0] as [string, string];
     const record = JSON.parse(contents);
     expect(record).toMatchObject({ runId: 'run-record-3', kind: 'plan', exitCode: null });
+    expect(record).not.toHaveProperty('planHash');
   });
 
   it('should throw TerraformRunPersistError carrying the real outcome when the run record write fails', async () => {
@@ -724,6 +750,7 @@ describe('TerraformService.plan run record persistence', () => {
     expect(record.kind).toBe('plan');
     expect(record.exitCode).toBeNull();
     expect(record.tfvarsVersionId).toBe('v1');
+    expect(record).not.toHaveProperty('planHash');
   });
 });
 
@@ -745,7 +772,7 @@ describe('TerraformService.plan RunRecordService persistence', () => {
 
     expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
     const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
-      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string },
+      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string; planHash?: string },
       string,
     ];
     expect(params).toMatchObject({
@@ -753,6 +780,7 @@ describe('TerraformService.plan RunRecordService persistence', () => {
       kind: 'plan',
       exitCode: 0,
       tfvarsVersionId: 'tfvars-version-abc',
+      planHash: EXPECTED_PLAN_HASH,
     });
     expect(logFilePath).toBe('/repo/runs/run-store-1/terraform.log');
 
@@ -786,10 +814,11 @@ describe('TerraformService.plan RunRecordService persistence', () => {
 
     expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
     const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
-      { runId: string; kind: string; exitCode: number | null },
+      { runId: string; kind: string; exitCode: number | null; planHash?: string },
       string,
     ];
     expect(params).toMatchObject({ runId: 'run-store-2', kind: 'plan', exitCode: 1 });
+    expect(params.planHash).toBeUndefined();
     expect(logFilePath).toBe('/repo/runs/run-store-2/terraform.log');
   });
 
@@ -816,10 +845,11 @@ describe('TerraformService.plan RunRecordService persistence', () => {
 
     expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
     const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
-      { runId: string; kind: string; exitCode: number | null },
+      { runId: string; kind: string; exitCode: number | null; planHash?: string },
       string,
     ];
     expect(params).toMatchObject({ runId: 'run-store-3', kind: 'plan', exitCode: null });
+    expect(params.planHash).toBeUndefined();
     expect(logFilePath).toBe('/repo/runs/run-store-3/terraform.log');
   });
 
@@ -865,7 +895,7 @@ describe('TerraformService.plan RunRecordService persistence', () => {
       child.close(0);
     });
 
-    expect(result).toMatchObject({ runId: 'run-store-5', add: 3, change: 1, destroy: 2 });
+    expect(result).toMatchObject({ runId: 'run-store-5', add: 3, change: 1, destroy: 2, planHash: EXPECTED_PLAN_HASH });
     expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
   });
 
@@ -895,10 +925,11 @@ describe('TerraformService.plan RunRecordService persistence', () => {
 
     expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
     const [params, logFilePath] = runRecordPersistMock.mock.calls[0] as [
-      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string },
+      { runId: string; kind: string; exitCode: number | null; tfvarsVersionId?: string; planHash?: string },
       string,
     ];
     expect(params).toMatchObject({ runId: 'run-store-6', kind: 'plan', exitCode: null, tfvarsVersionId: 'v1' });
+    expect(params.planHash).toBeUndefined();
     expect(logFilePath).toBe('/repo/runs/run-store-6/terraform.log');
   });
 });
@@ -929,7 +960,9 @@ describe('TerraformService.plan summary parsing and return value', () => {
       add: 3,
       change: 1,
       destroy: 2,
+      planHash: EXPECTED_PLAN_HASH,
     });
+    expect(readFileSyncMock).toHaveBeenCalledWith('/repo/runs/run-789/run-789.tfplan');
   });
 
   it('should resolve all three counts to 0 when the plan has no changes', async () => {

--- a/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.plan.test.ts
@@ -70,6 +70,7 @@ import {
   TerraformService,
   TerraformNotFoundError,
   TerraformPlanError,
+  TerraformPlanHashError,
   TerraformRunPersistError,
   type TerraformRunChunk,
   type TerraformPlanResult,
@@ -707,6 +708,69 @@ describe('TerraformService.plan run record persistence', () => {
     const rejection = (await pending.catch((err: unknown) => err)) as TerraformRunPersistError;
     expect(rejection.cause).toBeInstanceOf(Error);
     expect((rejection.cause as Error).cause).toBe(persistFailure);
+  });
+
+  it('should still write run.json, terraform.log, and the RunRecordStore entry — and throw TerraformPlanHashError — when the process exits 0 but computePlanHash fails to read the persisted artifact', async () => {
+    queueSuccessfulResolution();
+    randomUUIDMock.mockReturnValue('run-record-hash-fail');
+    const child = new FakeChildProcess();
+    queueSpawn(child);
+    runRecordPersistMock.mockResolvedValue(undefined);
+    const hashReadFailure = new Error('ENOENT: no such file or directory');
+    // Only the .tfplan artifact read (computePlanHash) fails — every other
+    // readFileSync caller in this test file uses the default mock, so this
+    // targets exactly the call plan() makes once the process has exited 0.
+    readFileSyncMock.mockImplementation((path: unknown) => {
+      if (typeof path === 'string' && path.endsWith('.tfplan')) {
+        throw hashReadFailure;
+      }
+      return Buffer.from('plan-bytes');
+    });
+
+    const service = new TerraformService(
+      stubPlanConfigService({ runsDir: '/repo/runs', tfvarsBucket: null }),
+      stubRemoteFileStore(),
+      stubRunRecordService(),
+    );
+
+    const pending = collectPlanChunks(service.plan(), () => {
+      child.emitStdout('Plan: 3 to add, 1 to change, 2 to destroy.\n');
+      child.close(0);
+    });
+
+    // The raw fs error must not escape unwrapped — it's surfaced as a
+    // descriptive TerraformPlanHashError instead.
+    await expect(pending).rejects.toBeInstanceOf(TerraformPlanHashError);
+    const rejection = (await pending.catch((err: unknown) => err)) as TerraformPlanHashError;
+    expect(rejection.runId).toBe('run-record-hash-fail');
+    expect(rejection.cause).toBe(hashReadFailure);
+
+    // terraform.log must still have been written despite the hash failure.
+    const logCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-record-hash-fail/terraform.log',
+    );
+    expect(logCalls).toHaveLength(1);
+
+    // run.json must still have been written, with exitCode 0 (the process
+    // really did succeed) and no planHash (the hash computation failed).
+    const recordCalls = writeFileSyncMock.mock.calls.filter(
+      ([path]) => path === '/repo/runs/run-record-hash-fail/run.json',
+    );
+    expect(recordCalls).toHaveLength(1);
+    const [, contents] = recordCalls[0] as [string, string];
+    const record = JSON.parse(contents);
+    expect(record).toMatchObject({ runId: 'run-record-hash-fail', kind: 'plan', exitCode: 0 });
+    expect(record).not.toHaveProperty('planHash');
+
+    // The cloud-agnostic RunRecordStore must also still have received this
+    // run, mirroring the local run.json write above.
+    expect(runRecordPersistMock).toHaveBeenCalledTimes(1);
+    const [params] = runRecordPersistMock.mock.calls[0] as [
+      { runId: string; kind: string; exitCode: number | null; planHash?: string },
+      string,
+    ];
+    expect(params).toMatchObject({ runId: 'run-record-hash-fail', kind: 'plan', exitCode: 0 });
+    expect(params.planHash).toBeUndefined();
   });
 
   it('should write exactly one run.json record with a null exitCode when the generator is force-closed before the process exits', async () => {

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
-import { copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createHash, randomUUID } from 'node:crypto';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { promisify } from 'node:util';
 import { Inject, Injectable } from '@nestjs/common';
@@ -128,6 +128,15 @@ export interface TerraformPlanResult {
   change: number;
   /** Number of resources Terraform plans to destroy. */
   destroy: number;
+  /**
+   * SHA-256 hex digest of the persisted `.tfplan` artifact at
+   * {@link artifactPath}, computed via {@link TerraformService.computePlanHash}
+   * once the spawned process has exited `0` — see #109. A later `apply()`
+   * call compares its caller-supplied `planHash` against this run's stored
+   * value before proceeding, so the tfvars/plan an admin approved is exactly
+   * what gets applied.
+   */
+  planHash: string;
 }
 
 /**
@@ -235,6 +244,13 @@ export interface TerraformRunRecord {
   exitCode: number | null;
   /** The tfvars version id the applied plan was generated against, if the caller supplied one. */
   tfvarsVersionId?: string;
+  /**
+   * SHA-256 hex digest of the persisted `.tfplan` artifact this record's
+   * `plan` run produced — see {@link TerraformPlanResult.planHash}. Set only
+   * on a successful `plan` record; a failed or aborted `plan` run (and
+   * `apply`/`destroy` records generally) leave this unset.
+   */
+  planHash?: string;
 }
 
 /**
@@ -696,6 +712,12 @@ export class TerraformService {
    * value alongside `runId`, `artifactPath`, and `varFilePath`. A "no changes"
    * plan (no summary line present) resolves all three counts to `0`.
    *
+   * Once the process has exited `0` (and the run wasn't aborted), the
+   * persisted `.tfplan` artifact at `artifactPath` is hashed via
+   * {@link computePlanHash} and the SHA-256 hex digest is returned as
+   * `planHash` on {@link TerraformPlanResult} — see #109. A failed or aborted
+   * run never computes or persists a `planHash`.
+   *
    * Every yielded chunk's `line` is also accumulated in-memory as it streams
    * through, and — once the spawned process has closed, regardless of
    * whether the run succeeded, failed, or was aborted — written in a single
@@ -874,6 +896,14 @@ export class TerraformService {
 
       const result = next.value;
 
+      // Compute the SHA-256 hash of the persisted `.tfplan` artifact once the
+      // process has exited cleanly — see {@link computePlanHash}. Only
+      // computed on the success path: a failed or aborted run has no (or an
+      // incomplete) `.tfplan` artifact worth hashing, so `planHash` stays
+      // unset for those outcomes.
+      const planHash =
+        !result.aborted && result.exitCode === 0 ? this.computePlanHash(artifactPath) : undefined;
+
       // Compute the outcome the generator would return/throw *before*
       // attempting to persist the run record, so a persistence failure below
       // can still report the real plan outcome instead of losing it behind
@@ -881,7 +911,7 @@ export class TerraformService {
       const outcome: TerraformPlanOutcome = result.aborted
         ? { kind: 'aborted' }
         : result.exitCode === 0
-          ? { kind: 'success', result: { runId, artifactPath, varFilePath, add, change, destroy } }
+          ? { kind: 'success', result: { runId, artifactPath, varFilePath, add, change, destroy, planHash: planHash! } }
           : { kind: 'failed', error: new TerraformPlanError(result.exitCode) };
 
       // `runRecordWritten` is flipped *before* the write is attempted (not
@@ -905,14 +935,14 @@ export class TerraformService {
       const completedAt = new Date().toISOString();
       const planExitCode = result.aborted ? null : result.exitCode;
       try {
-        this.writeRunRecord(runId, 'plan', startedAt, completedAt, planExitCode, tfvarsVersionId);
+        this.writeRunRecord(runId, 'plan', startedAt, completedAt, planExitCode, tfvarsVersionId, planHash);
       } catch (err) {
         throw new TerraformRunPersistError(runId, outcome, err);
       }
       // Persists the same run to the cloud-agnostic RunRecordStore (DynamoDB
       // for AWS) alongside the local run.json write above — see
       // persistRunRecord's TSDoc for why this is best-effort and awaited.
-      await this.persistRunRecord(runId, 'plan', startedAt, completedAt, planExitCode, tfvarsVersionId);
+      await this.persistRunRecord(runId, 'plan', startedAt, completedAt, planExitCode, tfvarsVersionId, planHash);
 
       if (outcome.kind === 'aborted') {
         // Aborted mid-run: the child was killed inside spawnAndStream. End
@@ -1615,6 +1645,22 @@ export class TerraformService {
   }
 
   /**
+   * Computes the SHA-256 hex digest of the `.tfplan` artifact at
+   * `artifactPath` — called by {@link plan} exactly once, immediately after
+   * the spawned `terraform plan` process has exited `0`, so the returned
+   * digest reflects the plan binary actually written to disk for this run.
+   * Read via `readFileSync` (rather than streamed) since `.tfplan` artifacts
+   * are small enough that buffering the whole file for a single hash pass is
+   * simpler than wiring up a streaming digest — see #109 for why this hash
+   * exists: a later `apply()` call compares its caller-supplied `planHash`
+   * against this run's stored value before proceeding, so the tfvars/plan an
+   * admin approved is exactly what gets applied.
+   */
+  private computePlanHash(artifactPath: string): string {
+    return createHash('sha256').update(readFileSync(artifactPath)).digest('hex');
+  }
+
+  /**
    * Writes `lines` (the full stdout+stderr transcript accumulated in-memory
    * by {@link plan}/{@link apply}/{@link destroy} as they streamed
    * {@link spawnAndStream}'s chunks) to `<runsDir>/<runId>/terraform.log` in
@@ -1672,6 +1718,11 @@ export class TerraformService {
    * so the exact same timestamp can also be handed to
    * {@link persistRunRecord} — the local `run.json` and the remote
    * `RunRecordStore` entry for a given run always agree on `completedAt`.
+   *
+   * `planHash`, when supplied (only by a successful {@link plan} run — see
+   * {@link computePlanHash}), is recorded on {@link TerraformRunRecord.planHash}.
+   * Defaults to `undefined` so `apply()`/`destroy()`'s existing call sites
+   * don't need to pass it.
    */
   private writeRunRecord(
     runId: string,
@@ -1680,6 +1731,7 @@ export class TerraformService {
     completedAt: string,
     exitCode: number | null,
     tfvarsVersionId: string | undefined,
+    planHash: string | undefined = undefined,
   ): void {
     TerraformService.assertValidRunId(runId);
     const runDir = join(this.config.getRunsDir(), runId);
@@ -1690,6 +1742,7 @@ export class TerraformService {
       completedAt,
       exitCode,
       tfvarsVersionId,
+      planHash,
     };
     try {
       mkdirSync(runDir, { recursive: true });
@@ -1729,6 +1782,13 @@ export class TerraformService {
    * observable (e.g. in tests), not because its outcome affects the
    * already-computed plan/apply/destroy outcome those callers act on
    * afterward.
+   *
+   * `planHash`, when supplied (only by a successful {@link plan} run — see
+   * {@link computePlanHash}), is forwarded to `RunRecordService.persist` so
+   * it lands on the persisted `RunRecord.planHash` alongside the local
+   * `run.json`'s copy written by {@link writeRunRecord}. Defaults to
+   * `undefined` so `apply()`/`destroy()`'s existing call sites don't need to
+   * pass it.
    */
   private async persistRunRecord(
     runId: string,
@@ -1737,10 +1797,11 @@ export class TerraformService {
     completedAt: string,
     exitCode: number | null,
     tfvarsVersionId: string | undefined,
+    planHash: string | undefined = undefined,
   ): Promise<void> {
     try {
       await this.runRecordService.persist(
-        { runId, kind, startedAt, completedAt, exitCode, tfvarsVersionId },
+        { runId, kind, startedAt, completedAt, exitCode, tfvarsVersionId, planHash },
         this.getRunLogPath(runId),
       );
     } catch (err) {

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -275,7 +275,33 @@ export type TerraformApplyOutcome =
 export type TerraformPlanOutcome =
   | { kind: 'success'; result: TerraformPlanResult }
   | { kind: 'aborted' }
-  | { kind: 'failed'; error: TerraformPlanError };
+  | { kind: 'failed'; error: TerraformPlanError | TerraformPlanHashError };
+
+/**
+ * Thrown by {@link TerraformService.plan} when the spawned `terraform plan`
+ * process exited `0` but {@link TerraformService.computePlanHash} then failed
+ * to read the persisted `.tfplan` artifact back off disk (e.g. it was deleted
+ * or became unreadable in the window between the process closing and the
+ * hash read) — distinct from {@link TerraformPlanError} (the process itself
+ * exiting non-zero). Folded into a `{ kind: 'failed' }` outcome rather than
+ * `'success'` so `plan()` still writes `terraform.log`/`run.json`/the
+ * `RunRecordStore` entry for the run (see the try/catch around
+ * `computePlanHash` in `plan()`) instead of letting the raw filesystem error
+ * unwind past that persistence block and reach the renderer unexplained.
+ */
+export class TerraformPlanHashError extends Error {
+  constructor(
+    public readonly runId: string,
+    public readonly artifactPath: string,
+    public readonly cause: unknown,
+  ) {
+    super(
+      `Failed to compute SHA-256 hash of plan artifact "${artifactPath}" for run "${runId}": ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    this.name = 'TerraformPlanHashError';
+  }
+}
 
 /**
  * Thrown by {@link TerraformService.plan}, {@link TerraformService.apply}, or
@@ -319,7 +345,12 @@ export class TerraformRunPersistError extends Error {
       case 'aborted':
         return 'aborted';
       case 'failed':
-        return `failed (exit code ${outcome.error.exitCode ?? 'null'})`;
+        // `TerraformPlanHashError` (a plan whose process exited `0` but then
+        // failed to hash the persisted artifact) has no `exitCode` — describe
+        // it by its message instead of an exit code that doesn't apply.
+        return 'exitCode' in outcome.error
+          ? `failed (exit code ${outcome.error.exitCode ?? 'null'})`
+          : `failed (${outcome.error.message})`;
     }
   }
 }
@@ -898,21 +929,42 @@ export class TerraformService {
 
       // Compute the SHA-256 hash of the persisted `.tfplan` artifact once the
       // process has exited cleanly — see {@link computePlanHash}. Only
-      // computed on the success path: a failed or aborted run has no (or an
+      // attempted on the success path: a failed or aborted run has no (or an
       // incomplete) `.tfplan` artifact worth hashing, so `planHash` stays
-      // unset for those outcomes.
-      const planHash =
-        !result.aborted && result.exitCode === 0 ? this.computePlanHash(artifactPath) : undefined;
+      // unset for those outcomes. Wrapped in try/catch (rather than left to
+      // propagate) because `readFileSync` can still throw here even though
+      // `terraform plan` exited `0` — e.g. the artifact was deleted or became
+      // unreadable in the window between the process closing and this read.
+      // Left unwrapped, that exception would unwind straight past the
+      // writeRunLog/writeRunRecord/persistRunRecord calls below, silently
+      // breaking the "a run record is written on every exit path" guarantee
+      // and surfacing an unexplained raw fs error to the renderer instead of
+      // a proper `TerraformPlanHashError`. Captured here and folded into a
+      // 'failed' outcome below so persistence still runs before it's thrown.
+      let planHash: string | undefined;
+      let planHashError: TerraformPlanHashError | undefined;
+      if (!result.aborted && result.exitCode === 0) {
+        try {
+          planHash = this.computePlanHash(artifactPath);
+        } catch (err) {
+          planHashError = new TerraformPlanHashError(runId, artifactPath, err);
+        }
+      }
 
       // Compute the outcome the generator would return/throw *before*
       // attempting to persist the run record, so a persistence failure below
       // can still report the real plan outcome instead of losing it behind
-      // an unrelated filesystem exception — mirrors apply()/destroy().
+      // an unrelated filesystem exception — mirrors apply()/destroy(). A
+      // `terraform plan` process that exited `0` but then failed to hash is
+      // reported as 'failed' (not 'success' with a missing `planHash`) — see
+      // {@link TerraformPlanHashError}.
       const outcome: TerraformPlanOutcome = result.aborted
         ? { kind: 'aborted' }
-        : result.exitCode === 0
-          ? { kind: 'success', result: { runId, artifactPath, varFilePath, add, change, destroy, planHash: planHash! } }
-          : { kind: 'failed', error: new TerraformPlanError(result.exitCode) };
+        : planHashError
+          ? { kind: 'failed', error: planHashError }
+          : result.exitCode === 0
+            ? { kind: 'success', result: { runId, artifactPath, varFilePath, add, change, destroy, planHash: planHash! } }
+            : { kind: 'failed', error: new TerraformPlanError(result.exitCode) };
 
       // `runRecordWritten` is flipped *before* the write is attempted (not
       // only on success) so the outer `finally` below never re-attempts a

--- a/app/packages/desktop-main/src/services/TerraformService.ts
+++ b/app/packages/desktop-main/src/services/TerraformService.ts
@@ -1646,7 +1646,7 @@ export class TerraformService {
 
   /**
    * Computes the SHA-256 hex digest of the `.tfplan` artifact at
-   * `artifactPath` — called by {@link plan} exactly once, immediately after
+   * `artifactPath`. Called by {@link plan} exactly once, immediately after
    * the spawned `terraform plan` process has exited `0`, so the returned
    * digest reflects the plan binary actually written to disk for this run.
    * Read via `readFileSync` (rather than streamed) since `.tfplan` artifacts
@@ -1655,8 +1655,18 @@ export class TerraformService {
    * exists: a later `apply()` call compares its caller-supplied `planHash`
    * against this run's stored value before proceeding, so the tfvars/plan an
    * admin approved is exactly what gets applied.
+   *
+   * Public (rather than `private`) so `TerraformController.apply` can also
+   * call it directly, as a pre-flight step, to *re-read and re-hash the
+   * on-disk artifact* right before spawning `terraform apply` — comparing
+   * `payload.planHash`/`record.planHash` alone only proves the two in-memory
+   * values agree with each other, not that the `.tfplan` file actually
+   * sitting on disk still matches either of them. Without this second,
+   * artifact-level re-verification a swapped/tampered `.tfplan` file (with
+   * the stored `RunRecord.planHash` left untouched) would still pass the
+   * plan-hash gate and get applied.
    */
-  private computePlanHash(artifactPath: string): string {
+  computePlanHash(artifactPath: string): string {
     return createHash('sha256').update(readFileSync(artifactPath)).digest('hex');
   }
 

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -573,15 +573,20 @@ export interface TerraformApplyPayload {
 /**
  * Immediate acknowledgement the `terraform.approve` IPC channel resolves
  * with once the identified plan run has been marked approved. Mirrors
- * `POST /api/terraform/runs/:id/approve` (#109), which records `approvedBy`
- * and `approvedAt` on the underlying `RunRecord` — see `RunRecord.approvedBy`
- * / `RunRecord.approvedAt` in `@hyveon/shared/runs.ts`, the source of truth
- * for the approval fields this type mirrors.
+ * `TerraformApproveAck` in `@hyveon/desktop-main/src/controllers/terraform.controller.ts`
+ * — that type is the source of truth; keep this copy in sync with it.
+ * `approved: true` means `RunRecordService.approveRun` succeeded and
+ * `approvedBy`/`approvedAt` mirror the values stamped onto the persisted
+ * `RunRecord`. `approved: false` means the request failed (invalid payload,
+ * missing service, or a thrown error) — `error` carries a human-readable
+ * description and `approvedBy`/`approvedAt` are omitted. Note there is no
+ * `runId` field — the controller never returns one.
  */
 export interface TerraformApproveAck {
-  runId: string;
-  approvedBy: string;
-  approvedAt: string;
+  approved: boolean;
+  approvedBy?: string;
+  approvedAt?: string;
+  error?: string;
 }
 
 /**

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -556,6 +556,35 @@ export interface TerraformPlanAck {
 }
 
 /**
+ * Payload accepted by the `terraform.apply` IPC channel. `planRunId`
+ * identifies the approved plan run to apply; `planHash` is the caller's
+ * expected plan hash, checked against the plan run's stored `planHash` to
+ * catch drift between when the plan was approved and when apply runs.
+ *
+ * Mirrors the `POST /api/terraform/apply` request body described in issue
+ * #109 — the desktop-main apply IPC handler is the source of truth; keep
+ * this copy in sync with it.
+ */
+export interface TerraformApplyPayload {
+  planRunId: string;
+  planHash: string;
+}
+
+/**
+ * Immediate acknowledgement the `terraform.approve` IPC channel resolves
+ * with once the identified plan run has been marked approved. Mirrors
+ * `POST /api/terraform/runs/:id/approve` (#109), which records `approvedBy`
+ * and `approvedAt` on the underlying `RunRecord` — see `RunRecord.approvedBy`
+ * / `RunRecord.approvedAt` in `@hyveon/shared/runs.ts`, the source of truth
+ * for the approval fields this type mirrors.
+ */
+export interface TerraformApproveAck {
+  runId: string;
+  approvedBy: string;
+  approvedAt: string;
+}
+
+/**
  * Shape of the subset of Terraform root outputs the management app consumes.
  *
  * Mirrors `TfOutputs` in `@hyveon/desktop-main/src/services/ConfigService.ts`
@@ -776,6 +805,26 @@ export interface GsdTerraformApi {
    * progress and the final `TerraformPlanResult`.
    */
   plan: (opts?: TerraformPlanPayload) => Promise<TerraformPlanAck>;
+  /**
+   * Approves a completed plan run (identified by `opts.planRunId`, its
+   * `runId`) so `apply` may proceed against it, by invoking the
+   * `terraform.approve` IPC channel with `opts`.
+   *
+   * Mirrors `POST /api/terraform/runs/:id/approve` (#109) — admin-only;
+   * records the approver and approved-at timestamp on the plan run and
+   * resolves the {@link TerraformApproveAck}.
+   */
+  approve: (opts: { planRunId: string }) => Promise<TerraformApproveAck>;
+  /**
+   * Submits a `terraform apply` run gated on plan-hash + approval by
+   * invoking the `terraform.apply` IPC channel, resolving an ack shaped like
+   * {@link TerraformPlanAck}. Mirrors `POST /api/terraform/apply` (#109):
+   * rejects when the plan run isn't approved, the current tfvars has
+   * drifted since the plan, the supplied `planHash` doesn't match the plan
+   * run's stored hash, or another run already holds the shared workspace
+   * lock.
+   */
+  apply: (payload: TerraformApplyPayload) => Promise<TerraformPlanAck>;
   /**
    * Returns the current Terraform outputs by invoking the `terraform.output`
    * IPC channel with `{ force }`. `force` defaults to `false`, matching

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -1088,7 +1088,7 @@ describe('preload dispatcher', () => {
       });
 
       it('should invoke the terraform.approve channel with the opts payload', async () => {
-        const result = { runId: 'run-001', approvedBy: 'admin@example.com', approvedAt: '2026-07-21T00:00:00.000Z' };
+        const result = { approved: true, approvedBy: 'admin@example.com', approvedAt: '2026-07-21T00:00:00.000Z' };
         ipcInvoke.mockResolvedValue(result);
         const terraform = bridge['terraform'] as { approve: (opts: { planRunId: string }) => Promise<unknown> };
         const opts = { planRunId: 'run-001' };
@@ -1109,7 +1109,7 @@ describe('preload dispatcher', () => {
 
       it('should call the registered mock instead of ipcRenderer.invoke when terraform.approve is mocked', async () => {
         const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
-        const result = { runId: 'run-mock', approvedBy: 'admin@example.com', approvedAt: '2026-07-21T00:00:00.000Z' };
+        const result = { approved: true, approvedBy: 'admin@example.com', approvedAt: '2026-07-21T00:00:00.000Z' };
         const mockHandler = vi.fn().mockResolvedValue(result);
         testApi.mock('terraform.approve', mockHandler);
 

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -1076,6 +1076,124 @@ describe('preload dispatcher', () => {
   });
 
   // -------------------------------------------------------------------------
+  // terraform.approve
+  // -------------------------------------------------------------------------
+
+  describe('terraform.approve', () => {
+    describe('real-IPC fallthrough', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should invoke the terraform.approve channel with the opts payload', async () => {
+        const result = { runId: 'run-001', approvedBy: 'admin@example.com', approvedAt: '2026-07-21T00:00:00.000Z' };
+        ipcInvoke.mockResolvedValue(result);
+        const terraform = bridge['terraform'] as { approve: (opts: { planRunId: string }) => Promise<unknown> };
+        const opts = { planRunId: 'run-001' };
+
+        const response = await terraform.approve(opts);
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.approve', opts);
+        expect(response).toEqual(result);
+      });
+    });
+
+    describe('mock-override', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should call the registered mock instead of ipcRenderer.invoke when terraform.approve is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+        const result = { runId: 'run-mock', approvedBy: 'admin@example.com', approvedAt: '2026-07-21T00:00:00.000Z' };
+        const mockHandler = vi.fn().mockResolvedValue(result);
+        testApi.mock('terraform.approve', mockHandler);
+
+        const terraform = bridge['terraform'] as { approve: (opts: { planRunId: string }) => Promise<unknown> };
+        const opts = { planRunId: 'run-mock' };
+        const response = await terraform.approve(opts);
+
+        expect(mockHandler).toHaveBeenCalledWith(opts);
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(response).toEqual(result);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // terraform.apply
+  // -------------------------------------------------------------------------
+
+  describe('terraform.apply', () => {
+    describe('real-IPC fallthrough', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('0');
+      });
+
+      it('should invoke the terraform.apply channel with the payload and resolve the started ack with a runId', async () => {
+        const ack = { started: true, runId: 'run-002' };
+        ipcInvoke.mockResolvedValue(ack);
+        const terraform = bridge['terraform'] as {
+          apply: (payload: { planRunId: string; planHash: string }) => Promise<unknown>;
+        };
+        const payload = { planRunId: 'run-001', planHash: 'sha256:abc123' };
+
+        const result = await terraform.apply(payload);
+
+        expect(ipcInvoke).toHaveBeenCalledWith('terraform.apply', payload);
+        expect(result).toEqual(ack);
+      });
+
+      it('should resolve conflict details when the shared workspace is already busy', async () => {
+        const ack = {
+          started: false,
+          error: 'terraform apply refused: plan is already in flight',
+          conflict: 'plan' as const,
+        };
+        ipcInvoke.mockResolvedValue(ack);
+        const terraform = bridge['terraform'] as {
+          apply: (payload: { planRunId: string; planHash: string }) => Promise<unknown>;
+        };
+
+        const result = await terraform.apply({ planRunId: 'run-001', planHash: 'sha256:abc123' });
+
+        expect(result).toEqual(ack);
+      });
+    });
+
+    describe('mock-override', () => {
+      let bridge: Record<string, unknown>;
+
+      beforeEach(async () => {
+        bridge = await loadPreloadBridge('1');
+      });
+
+      it('should call the registered mock instead of ipcRenderer.invoke when terraform.apply is mocked', async () => {
+        const testApi = bridge['__test'] as { mock: (channel: string, handler: unknown) => void };
+        const ack = { started: true, runId: 'run-mock' };
+        const mockHandler = vi.fn().mockResolvedValue(ack);
+        testApi.mock('terraform.apply', mockHandler);
+
+        const terraform = bridge['terraform'] as {
+          apply: (payload: { planRunId: string; planHash: string }) => Promise<unknown>;
+        };
+        const payload = { planRunId: 'run-001', planHash: 'sha256:def456' };
+        const result = await terraform.apply(payload);
+
+        expect(mockHandler).toHaveBeenCalledWith(payload);
+        expect(ipcInvoke).not.toHaveBeenCalled();
+        expect(result).toEqual(ack);
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // terraform.output
   // -------------------------------------------------------------------------
 

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -42,6 +42,8 @@ import type {
   GsdApi,
   GsdTestApi,
   LogChunk,
+  TerraformApplyPayload,
+  TerraformApproveAck,
   TerraformInitConfig,
   TerraformPlanAck,
   TerraformPlanPayload,
@@ -426,6 +428,8 @@ const api: GsdApi = {
   terraform: {
     init: streamTerraformInit,
     plan: (opts?: TerraformPlanPayload) => invoke<TerraformPlanAck>('terraform.plan', opts),
+    approve: (opts: { planRunId: string }) => invoke<TerraformApproveAck>('terraform.approve', opts),
+    apply: (payload: TerraformApplyPayload) => invoke<TerraformPlanAck>('terraform.apply', payload),
     output: (force?: boolean) => invoke<TfOutputs | null>('terraform.output', { force }),
   },
 };

--- a/app/packages/shared/src/audit.ts
+++ b/app/packages/shared/src/audit.ts
@@ -5,9 +5,12 @@ import type { GameServer } from './tfvars.js';
  * The kind of mutation an {@link AuditEntry} records. Mirrors the CRUD verbs
  * exposed by the `game_servers` write endpoints in `@hyveon/desktop-main`,
  * plus `plan` for a dry-run `terraform plan` invocation that touched no
- * infrastructure.
+ * infrastructure, `approve` for marking a successful `plan` run approved
+ * for a later `apply` (see `TerraformController.approve`, issue #109), and
+ * `apply` for a `terraform apply` invocation that actually mutated
+ * infrastructure (see `TerraformController.apply`, issue #109).
  */
-export type AuditAction = 'add' | 'edit' | 'remove' | 'plan';
+export type AuditAction = 'add' | 'edit' | 'remove' | 'plan' | 'approve' | 'apply';
 
 /**
  * A single row in the DynamoDB audit log (`${project_name}-audit` table,

--- a/app/packages/shared/src/cloud.ts
+++ b/app/packages/shared/src/cloud.ts
@@ -243,6 +243,19 @@ export interface RunRecordStore {
   putRecord(record: RunRecord): Promise<void>;
 
   /**
+   * Looks up a previously persisted run record by its `runId` (as opposed to
+   * `putRecord`'s `sk`-based keying), since callers such as the apply-status
+   * IPC handler only have the `runId` minted at run start and not the
+   * `<startedAt>#<runId>` sort key.
+   *
+   * @param runId - Unique identifier of the run to look up (matches
+   *   {@link RunRecord.runId}).
+   * @returns The matching {@link RunRecord}, or `undefined` if no record with
+   *   that `runId` exists in the store.
+   */
+  getRecordByRunId(runId: string): Promise<RunRecord | undefined>;
+
+  /**
    * Writes a run's captured log to the remote file store, keyed by `runId`.
    *
    * @param runId - Unique identifier of the run the log belongs to.

--- a/app/packages/shared/src/runs.test.ts
+++ b/app/packages/shared/src/runs.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { buildRunSk, deriveRunStatus, isRunLockExpired, type RunLock } from './runs.js';
+import {
+  buildRunSk,
+  deriveRunStatus,
+  isRunLockExpired,
+  isApprovalExpired,
+  APPROVAL_WINDOW_MS,
+  type RunLock,
+} from './runs.js';
 
 /**
  * Builds a minimal {@link RunLock} fixture for {@link isRunLockExpired}
@@ -88,5 +95,35 @@ describe('isRunLockExpired', () => {
 
     expect(isRunLockExpired(pastLock)).toBe(true);
     expect(isRunLockExpired(futureLock)).toBe(false);
+  });
+});
+
+describe('isApprovalExpired', () => {
+  const approvedAt = '2026-07-20T12:00:00.000Z';
+
+  it('should return false when now is before approvedAt plus the approval window', () => {
+    const now = new Date(new Date(approvedAt).getTime() + APPROVAL_WINDOW_MS - 1);
+
+    expect(isApprovalExpired(approvedAt, now)).toBe(false);
+  });
+
+  it('should return true when now is after approvedAt plus the approval window', () => {
+    const now = new Date(new Date(approvedAt).getTime() + APPROVAL_WINDOW_MS + 1);
+
+    expect(isApprovalExpired(approvedAt, now)).toBe(true);
+  });
+
+  it('should return true when now exactly equals approvedAt plus the approval window', () => {
+    const now = new Date(new Date(approvedAt).getTime() + APPROVAL_WINDOW_MS);
+
+    expect(isApprovalExpired(approvedAt, now)).toBe(true);
+  });
+
+  it('should default now to the current time when it is not supplied', () => {
+    const longAgo = new Date(Date.now() - APPROVAL_WINDOW_MS - 1000).toISOString();
+    const justNow = new Date().toISOString();
+
+    expect(isApprovalExpired(longAgo)).toBe(true);
+    expect(isApprovalExpired(justNow)).toBe(false);
   });
 });

--- a/app/packages/shared/src/runs.ts
+++ b/app/packages/shared/src/runs.ts
@@ -41,6 +41,28 @@ export interface RunRecord {
   /** The tfvars version id the run was executed against, if the caller supplied one. */
   tfvarsVersionId?: string;
   /**
+   * Hash of the plan artifact this record's `terraform` invocation produced
+   * (for a `plan` run) or was gated against (for an `apply` run) — see #109.
+   * The apply IPC handler compares the caller-supplied `planHash` against the
+   * plan run's stored value before allowing the apply to proceed, ensuring
+   * the tfvars/plan an admin approved is exactly what gets applied.
+   */
+  planHash?: string;
+  /**
+   * Opaque identifier (e.g. username) of the admin who approved this plan
+   * run for apply. Set only by the approve endpoint
+   * (`POST /api/terraform/runs/:id/approve`, #109) and only ever on `plan`
+   * records — an unapproved plan has this unset.
+   */
+  approvedBy?: string;
+  /**
+   * ISO-8601 timestamp captured when {@link approvedBy} approved this plan
+   * run. Paired with {@link isApprovalExpired} to enforce that apply only
+   * proceeds while the approval is still within {@link APPROVAL_WINDOW_MS} of
+   * being granted, so a stale approval can't be used to apply drifted state.
+   */
+  approvedAt?: string;
+  /**
    * The run's captured log text, embedded directly on the record because it
    * was small enough to fit under the caller's inline-size threshold (see
    * `RunRecordService.INLINE_LOG_LIMIT_BYTES`). Mutually exclusive with
@@ -150,4 +172,30 @@ export interface RunLock {
  */
 export function isRunLockExpired(lock: RunLock, now: Date = new Date()): boolean {
   return now.getTime() >= new Date(lock.expiresAt).getTime();
+}
+
+/**
+ * Duration (in milliseconds) an admin's approval of a plan run remains valid
+ * before the apply IPC handler (#109) must reject it and require
+ * re-approval. Fixed at 15 minutes — long enough to review a plan and click
+ * apply, short enough that a stale approval can't be used to apply against
+ * drifted tfvars long after the reviewer looked at it.
+ */
+export const APPROVAL_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Determines whether a plan {@link RunRecord}'s approval has expired, based
+ * on whether `now` has passed {@link RunRecord.approvedAt} plus
+ * {@link APPROVAL_WINDOW_MS}.
+ *
+ * Pure: takes `now` as an argument (defaulting to the current time) rather
+ * than reading the clock internally, so tests can pass a fixed value for
+ * deterministic assertions.
+ *
+ * @param approvedAt - ISO-8601 timestamp the run was approved at (see {@link RunRecord.approvedAt}).
+ * @param now - The instant to check the approval against. Defaults to `new Date()`.
+ * @returns `true` if `now` is at or after `approvedAt + APPROVAL_WINDOW_MS`, `false` otherwise.
+ */
+export function isApprovalExpired(approvedAt: string, now: Date = new Date()): boolean {
+  return now.getTime() >= new Date(approvedAt).getTime() + APPROVAL_WINDOW_MS;
 }


### PR DESCRIPTION
Closes #109

## Summary

- Adds a `terraform.approve` IPC handler (`TerraformController`, `desktop-main`) that records the approver + approved-at timestamp on a plan run's `RunRecord`, backed by `RunRecordService.approveRun()` / `getByRunId()`.
- Adds a `terraform.apply` streaming IPC handler that gates apply on the plan-hash contract from #83: the target plan run must exist and be approved, the supplied `planHash` must match the plan run's persisted hash (computed during `TerraformService.plan()`), the current tfvars version must still match the plan run's `tfvarsVersion` (no drift since plan), and no other run may currently hold the lock — closing a TOCTOU gap between lock acquisition and workspace check along the way.
- Extends `TerraformService.plan()` to compute and persist a `planHash` alongside each plan run, and extends `RunRecord`/`AuditAction` in `@hyveon/shared` with the approval + plan-hash fields the gate depends on.
- Adds `AwsRunRecordStore.getRecordByRunId()` and lets `RunService.createRun()` accept a pre-minted `runId` so the apply run can be linked back to its originating plan run.
- Exposes `gsd.terraform.approve()` and `gsd.terraform.apply()` on the preload bridge (`desktop-preload`), with `TerraformApproveAck` carrying all required response fields.

## Changes

```
 .../cloud-aws/src/AwsRunRecordStore.test.ts        |  87 ++-
 app/packages/cloud-aws/src/AwsRunRecordStore.ts    |  88 ++-
 .../src/controllers/terraform.controller.test.ts   | 681 ++++++++++++++++++++-
 .../src/controllers/terraform.controller.ts        | 571 ++++++++++++++++-
 app/packages/desktop-main/src/ipc-main-bridge.ts   |   4 +
 .../src/services/RunRecordService.test.ts          | 127 +++-
 .../desktop-main/src/services/RunRecordService.ts  | 144 ++++-
 .../desktop-main/src/services/RunService.test.ts   |  15 +
 .../desktop-main/src/services/RunService.ts        |   8 +-
 .../src/services/TerraformService.apply.test.ts    |  44 +-
 .../src/services/TerraformService.destroy.test.ts  |  44 +-
 .../src/services/TerraformService.init.test.ts     |  68 +-
 .../src/services/TerraformService.plan.test.ts     | 117 +++-
 .../desktop-main/src/services/TerraformService.ts  | 145 ++++-
 app/packages/desktop-preload/src/gsd-api.ts        |  54 ++
 app/packages/desktop-preload/src/preload.test.ts   | 118 ++++
 app/packages/desktop-preload/src/preload.ts        |   4 +
 app/packages/shared/src/audit.ts                   |   7 +-
 app/packages/shared/src/cloud.ts                   |  13 +
 app/packages/shared/src/runs.test.ts               |  39 +-
 app/packages/shared/src/runs.ts                    |  48 ++
 21 files changed, 2343 insertions(+), 83 deletions(-)
```

## Test plan

- [x] Approve handler requires admin permission and writes approver + approved-at to the `RunRecord` (`terraform.controller.test.ts`).
- [x] Apply rejects when the plan run has no approval.
- [x] Apply rejects when tfvars have drifted since the plan (`tfvarsVersion` mismatch).
- [x] Apply rejects when the supplied `planHash` doesn't match the plan run's persisted hash.
- [x] Apply rejects when another run currently holds the lock, including the TOCTOU window between lock acquisition and workspace check.
- [x] Successful apply triggers the local Terraform run and records a new apply `RunRecord` linked to the originating plan run via `planRunId`.
- [x] `gsd.terraform.approve()` / `gsd.terraform.apply()` exposed on the preload bridge — covered by `preload.test.ts`.
- [x] `npm run app:test` passing for the touched workspaces (shared, cloud-aws, desktop-main, desktop-preload).
- [x] `npm run app:lint` clean.

**Note:** issue #109's original acceptance criteria describe `POST /api/terraform/runs/:id/approve` and `POST /api/terraform/apply` against a CodeBuild-driven backend — that reflects an earlier architecture. As with #106–#108, the codebase has since moved to a local Terraform binary driven over Electron IPC, so this PR implements the equivalent `terraform.approve` and `terraform.apply` IPC handlers through that surface instead of HTTP/CodeBuild.
