### PR TITLE
refactor: remove ALB code paths after Caddy sidecar cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,11 @@ When adding a game, only edit `terraform.tfvars`. Don't hand-write new resources
 
 ### DNS is Lambda-managed, not Terraform-managed
 
-`terraform/aws/route53.tf` creates the zone data source and the updater Lambda, but **no `aws_route53_record` resources**. An EventBridge rule on `ECS Task State Change` fires `@hyveon/lambda-update-dns`, which UPSERTs a record for `{game}.{hosted_zone_name}` on `RUNNING` and DELETEs on `STOPPED`. Terraform would fight the Lambda — keep DNS records out of Terraform.
+`terraform/aws/route53.tf` creates the zone data source and the updater Lambda, but **no `aws_route53_record` resources**. An EventBridge rule on `ECS Task State Change` fires `@hyveon/lambda-update-dns`, which UPSERTs a record for `{game}.{hosted_zone_name}` on `RUNNING` and DELETEs on `STOPPED`. Terraform would fight the Lambda — keep DNS records out of Terraform. This path is uniform for every game, including `https = true` ones (see below) — there's no separate ALB-registration branch.
+
+### HTTPS terminates in-task via a Caddy sidecar, not an ALB
+
+Games flagged `https = true` in the `game_servers` map get a second container in their `aws_ecs_task_definition.game` — an official `caddy` image running `caddy reverse-proxy --from {game}.{hosted_zone_name} --to localhost:{port}`, which handles Let's Encrypt issuance/renewal automatically (HTTP-01/TLS-ALPN-01) and proxies to the game container over `localhost` (both containers share the task's awsvpc ENI). Issued certs persist on a dedicated `{game}-certs` EFS access point mounted at Caddy's `/data` so restarts don't re-trigger issuance and Let's Encrypt rate limits stay out of reach. There is **no ALB, target group, or ACM certificate anywhere in the stack** — the security group opens 443/80 publicly for HTTPS games (the raw game port loses public ingress; only the sidecar reaches it via `localhost`), and the task's single public IP serves both the game port and 443, so `@hyveon/lambda-update-dns` needs no special-casing for HTTPS games.
 
 ### Watchdog state lives in ECS task tags
 

--- a/app/packages/desktop-main/src/services/AuditService.test.ts
+++ b/app/packages/desktop-main/src/services/AuditService.test.ts
@@ -31,8 +31,6 @@ const TF: TfOutputs = {
   efs_access_points: {},
   domain_name: '',
   game_names: [],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
   discord_table_name: '',
   audit_table_name: 'test-audit',
   discord_bot_token_secret_arn: '',

--- a/app/packages/desktop-main/src/services/ConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.test.ts
@@ -101,7 +101,6 @@ describe('ConfigService', () => {
       expect(outputs!.ecs_cluster_name).toBe('my-cluster');
       expect(outputs!.game_names).toEqual(['minecraft', 'factorio']);
       expect(outputs!.subnet_ids).toBe('');
-      expect(outputs!.alb_dns_name).toBeNull();
       expect(outputs!.efs_access_points).toEqual({});
       expect(outputs!.applied_game_servers).toBeNull();
     });

--- a/app/packages/desktop-main/src/services/ConfigService.ts
+++ b/app/packages/desktop-main/src/services/ConfigService.ts
@@ -35,8 +35,6 @@ export interface TfOutputs {
   efs_access_points: Record<string, string>;
   domain_name: string;
   game_names: string[];
-  alb_dns_name: string | null;
-  acm_certificate_arn: string | null;
   discord_table_name: string;
   audit_table_name: string;
   runs_table_name: string;
@@ -96,8 +94,6 @@ export function projectTfOutputs(raw: RawTfState): TfOutputs | null {
     efs_access_points: get('efs_access_points', {}),
     domain_name: get('domain_name', ''),
     game_names: get('game_names', []),
-    alb_dns_name: get('alb_dns_name', null),
-    acm_certificate_arn: get('acm_certificate_arn', null),
     discord_table_name: get('discord_table_name', ''),
     audit_table_name: get('audit_table_name', ''),
     runs_table_name: get('runs_table_name', ''),

--- a/app/packages/desktop-main/src/services/DiscordConfigService.test.ts
+++ b/app/packages/desktop-main/src/services/DiscordConfigService.test.ts
@@ -40,8 +40,6 @@ const TF: TfOutputs = {
   efs_access_points: {},
   domain_name: '',
   game_names: [],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
   discord_table_name: 'test-discord',
   discord_bot_token_secret_arn: 'arn:bot-token',
   discord_public_key_secret_arn: 'arn:public-key',

--- a/app/packages/desktop-main/src/services/EcsService.test.ts
+++ b/app/packages/desktop-main/src/services/EcsService.test.ts
@@ -48,8 +48,6 @@ const DEFAULT_OUTPUTS: TfOutputs = {
   efs_access_points: { minecraft: 'fsap-1' },
   domain_name: 'example.com',
   game_names: ['minecraft'],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
 };
 
 /**

--- a/app/packages/desktop-main/src/services/FileManagerService.test.ts
+++ b/app/packages/desktop-main/src/services/FileManagerService.test.ts
@@ -26,8 +26,6 @@ const DEFAULT_OUTPUTS: TfOutputs = {
   efs_access_points: { minecraft: 'fsap-mc' },
   domain_name: 'example.com',
   game_names: ['minecraft'],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
 };
 
 /**

--- a/app/packages/desktop-main/src/services/LogsService.test.ts
+++ b/app/packages/desktop-main/src/services/LogsService.test.ts
@@ -36,8 +36,6 @@ const TF_OUTPUTS: TfOutputs = {
   efs_access_points: {},
   domain_name: 'example.com',
   game_names: ['minecraft'],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
   discord_table_name: 'discord-table',
   discord_bot_token_secret_arn: 'arn:aws:secretsmanager:us-east-1:123:secret:bot-token',
   discord_public_key_secret_arn: 'arn:aws:secretsmanager:us-east-1:123:secret:public-key',

--- a/app/packages/desktop-main/src/services/RunRecordService.test.ts
+++ b/app/packages/desktop-main/src/services/RunRecordService.test.ts
@@ -36,8 +36,6 @@ const TF: TfOutputs = {
   efs_access_points: {},
   domain_name: '',
   game_names: [],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
   discord_table_name: '',
   audit_table_name: '',
   runs_table_name: 'test-runs',

--- a/app/packages/desktop-main/src/services/RunService.test.ts
+++ b/app/packages/desktop-main/src/services/RunService.test.ts
@@ -29,8 +29,6 @@ const TF: TfOutputs = {
   efs_access_points: {},
   domain_name: '',
   game_names: [],
-  alb_dns_name: null,
-  acm_certificate_arn: null,
   discord_table_name: '',
   audit_table_name: '',
   runs_table_name: 'test-runs',

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -816,8 +816,6 @@ export interface TfOutputs {
   efs_access_points: Record<string, string>;
   domain_name: string;
   game_names: string[];
-  alb_dns_name: string | null;
-  acm_certificate_arn: string | null;
   discord_table_name: string;
   audit_table_name: string;
   discord_bot_token_secret_arn: string;

--- a/app/packages/desktop-preload/src/preload.test.ts
+++ b/app/packages/desktop-preload/src/preload.test.ts
@@ -1389,8 +1389,6 @@ describe('preload dispatcher', () => {
       efs_access_points: { minecraft: 'fsap-1' },
       domain_name: 'example.com',
       game_names: ['minecraft'],
-      alb_dns_name: null,
-      acm_certificate_arn: null,
       discord_table_name: 'hyveon-discord',
       audit_table_name: 'hyveon-audit',
       discord_bot_token_secret_arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:bot-token',

--- a/app/packages/lambda/update-dns/package.json
+++ b/app/packages/lambda/update-dns/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@aws-sdk/client-ec2": "^3.600.0",
     "@aws-sdk/client-ecs": "^3.600.0",
-    "@aws-sdk/client-elastic-load-balancing-v2": "^3.600.0",
     "@aws-sdk/client-route-53": "^3.600.0",
     "@types/aws-lambda": "^8.10.138"
   }

--- a/app/packages/lambda/update-dns/src/handler.test.ts
+++ b/app/packages/lambda/update-dns/src/handler.test.ts
@@ -1,9 +1,10 @@
 /**
  * Tests for the update-dns Lambda — TypeScript port of update_dns.py.
  *
- * Covers DNS upsert/delete, ALB register/deregister for HTTPS games, and
- * the new Discord follow-up that PATCHes the original interaction message
- * when a task reaches RUNNING with a pending row in DynamoDB.
+ * Covers DNS upsert/delete (including HTTPS-flagged games, which now follow
+ * the same plain A-record path since TLS terminates in-task via a Caddy
+ * sidecar) and the Discord follow-up that PATCHes the original interaction
+ * message when a task reaches RUNNING with a pending row in DynamoDB.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -15,11 +16,6 @@ import {
   DescribeNetworkInterfacesCommand,
   EC2Client,
 } from '@aws-sdk/client-ec2';
-import {
-  ElasticLoadBalancingV2Client,
-  RegisterTargetsCommand,
-  DeregisterTargetsCommand,
-} from '@aws-sdk/client-elastic-load-balancing-v2';
 import {
   Route53Client,
   ChangeResourceRecordSetsCommand,
@@ -39,14 +35,11 @@ vi.mock('@hyveon/shared', async () => {
 
 const ecsMock = mockClient(ECSClient);
 const ec2Mock = mockClient(EC2Client);
-const elbv2Mock = mockClient(ElasticLoadBalancingV2Client);
 const route53Mock = mockClient(Route53Client);
 
 process.env['HOSTED_ZONE_ID'] = 'Z123';
 process.env['DOMAIN_NAME'] = 'example.com';
 process.env['GAME_NAMES'] = 'palworld,foundryvtt';
-process.env['HTTPS_GAMES'] = 'foundryvtt';
-process.env['ALB_TARGET_GROUPS'] = JSON.stringify({ foundryvtt: 'arn:tg-foundry' });
 process.env['TABLE_NAME'] = 'test-discord';
 process.env['DNS_TTL'] = '30';
 process.env['AWS_REGION_'] = 'us-east-1';
@@ -90,7 +83,6 @@ function stubTaskWithEni(eniId = 'eni-xyz') {
 beforeEach(() => {
   ecsMock.reset();
   ec2Mock.reset();
-  elbv2Mock.reset();
   route53Mock.reset();
   fetchMock.mockReset();
   getPendingMock.mockReset();
@@ -149,34 +141,35 @@ describe('update-dns handler: direct (non-HTTPS) game', () => {
   });
 });
 
-describe('update-dns handler: HTTPS (ALB) game', () => {
-  it('should register the private IP with the ALB target group on RUNNING', async () => {
+describe('update-dns handler: HTTPS-flagged game', () => {
+  it('should follow the plain A-record path like any other game on RUNNING', async () => {
     stubTaskWithEni();
     ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
-      NetworkInterfaces: [{ PrivateIpAddress: '10.0.0.5' }],
+      NetworkInterfaces: [{ Association: { PublicIp: '5.6.7.8' } }],
     });
-    elbv2Mock.on(RegisterTargetsCommand).resolves({});
+    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({});
 
     const result = await handler(stateChange({ game: 'foundryvtt', lastStatus: 'RUNNING' }));
 
-    expect(result).toMatchObject({ status: 'registered', game: 'foundryvtt', ip: '10.0.0.5' });
-    const regs = elbv2Mock.commandCalls(RegisterTargetsCommand);
-    expect(regs).toHaveLength(1);
-    expect(regs[0]!.args[0]!.input.TargetGroupArn).toBe('arn:tg-foundry');
-    expect(regs[0]!.args[0]!.input.Targets![0]!.Id).toBe('10.0.0.5');
+    expect(result).toMatchObject({ status: 'upserted', game: 'foundryvtt', ip: '5.6.7.8' });
+    const changes = route53Mock.commandCalls(ChangeResourceRecordSetsCommand);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]!.args[0]!.input.ChangeBatch!.Changes![0]!.ResourceRecordSet!.Name).toBe(
+      'foundryvtt.example.com',
+    );
   });
 
-  it('should deregister the private IP from the ALB on STOPPED', async () => {
-    stubTaskWithEni();
-    ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
-      NetworkInterfaces: [{ PrivateIpAddress: '10.0.0.5' }],
+  it('should delete the A record on STOPPED', async () => {
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [
+        { Name: 'foundryvtt.example.com.', Type: 'A', ResourceRecords: [{ Value: '5.6.7.8' }], TTL: 30 },
+      ],
     });
-    elbv2Mock.on(DeregisterTargetsCommand).resolves({});
+    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({});
 
     const result = await handler(stateChange({ game: 'foundryvtt', lastStatus: 'STOPPED' }));
 
-    expect(result).toMatchObject({ status: 'deregistered', game: 'foundryvtt' });
-    expect(elbv2Mock.commandCalls(DeregisterTargetsCommand)).toHaveLength(1);
+    expect(result).toMatchObject({ status: 'deleted', game: 'foundryvtt' });
   });
 });
 

--- a/app/packages/lambda/update-dns/src/handler.ts
+++ b/app/packages/lambda/update-dns/src/handler.ts
@@ -3,16 +3,13 @@
  *
  * Triggered by EventBridge on `ECS Task State Change`.
  *
- * For non-HTTPS games (direct Fargate IP):
+ * For every game (HTTPS games terminate TLS in-task via a Caddy sidecar and
+ * share the task's public IP, so they use the same path as everything else):
  *   - RUNNING → resolve ENI public IP → UPSERT Route 53 A record
  *   - STOPPED → DELETE Route 53 A record
  *
- * For HTTPS games (ALB-fronted):
- *   - RUNNING → resolve private IP → register with ALB target group
- *   - STOPPED → deregister from ALB target group
- *
  * New behaviour added in the serverless-Discord migration: on RUNNING, after
- * the DNS/ALB update, look up a pending Discord interaction by task ARN and
+ * the DNS update, look up a pending Discord interaction by task ARN and
  * PATCH the original message with the resolved hostname/IP, then delete the
  * pending row. The Discord interaction token in the pending row is valid for
  * up to 15 minutes — same window as the ECS provisioning timeline.
@@ -27,11 +24,6 @@ import {
   DescribeNetworkInterfacesCommand,
 } from '@aws-sdk/client-ec2';
 import {
-  ElasticLoadBalancingV2Client,
-  RegisterTargetsCommand,
-  DeregisterTargetsCommand,
-} from '@aws-sdk/client-elastic-load-balancing-v2';
-import {
   Route53Client,
   ChangeResourceRecordSetsCommand,
   ListResourceRecordSetsCommand,
@@ -42,12 +34,6 @@ const HOSTED_ZONE_ID = requireEnv('HOSTED_ZONE_ID');
 const DOMAIN_NAME = requireEnv('DOMAIN_NAME');
 const GAME_NAMES = (process.env['GAME_NAMES'] ?? '').split(',').map((s) => s.trim()).filter(Boolean);
 const DNS_TTL = parseInt(process.env['DNS_TTL'] ?? '30', 10);
-const HTTPS_GAMES = new Set(
-  (process.env['HTTPS_GAMES'] ?? '').split(',').map((s) => s.trim()).filter(Boolean),
-);
-const ALB_TARGET_GROUPS: Record<string, string> = JSON.parse(
-  process.env['ALB_TARGET_GROUPS'] ?? '{}',
-);
 const TABLE_NAME = process.env['TABLE_NAME'] ?? '';
 
 /** Per-game connect message templates from Terraform, keyed by game name. */
@@ -75,7 +61,6 @@ function region(): string {
 
 const ec2 = new EC2Client({ region: region() });
 const ecs = new ECSClient({ region: region() });
-const elbv2 = new ElasticLoadBalancingV2Client({ region: region() });
 const route53 = new Route53Client({});
 
 function extractEniId(task: Task): string | null {
@@ -93,22 +78,13 @@ async function getEniPublicIp(eniId: string): Promise<string | null> {
   return resp.NetworkInterfaces?.[0]?.Association?.PublicIp ?? null;
 }
 
-async function getEniPrivateIp(eniId: string): Promise<string | null> {
-  const resp = await ec2.send(new DescribeNetworkInterfacesCommand({ NetworkInterfaceIds: [eniId] }));
-  return resp.NetworkInterfaces?.[0]?.PrivateIpAddress ?? null;
-}
-
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /**
  * Retry a few times since ENI association can lag behind the RUNNING event.
  * Mirrors the 5-attempt loop with 3s sleeps from update_dns.py.
  */
-async function resolveIp(
-  taskArn: string,
-  clusterArn: string,
-  kind: 'public' | 'private',
-): Promise<string | null> {
+async function resolvePublicIp(taskArn: string, clusterArn: string): Promise<string | null> {
   for (let attempt = 1; attempt <= 5; attempt++) {
     try {
       const resp = await ecs.send(new DescribeTasksCommand({ cluster: clusterArn, tasks: [taskArn] }));
@@ -122,7 +98,7 @@ async function resolveIp(
         await sleep(3000);
         continue;
       }
-      const ip = kind === 'public' ? await getEniPublicIp(eniId) : await getEniPrivateIp(eniId);
+      const ip = await getEniPublicIp(eniId);
       if (ip) return ip;
     } catch (err) {
       console.error(`IP resolution attempt ${attempt} failed`, { err });
@@ -206,18 +182,6 @@ async function deleteDns(dnsName: string): Promise<void> {
   }
 }
 
-async function registerAlb(tgArn: string, ip: string): Promise<void> {
-  await elbv2.send(new RegisterTargetsCommand({ TargetGroupArn: tgArn, Targets: [{ Id: ip }] }));
-}
-
-async function deregisterAlb(tgArn: string, ip: string): Promise<void> {
-  try {
-    await elbv2.send(new DeregisterTargetsCommand({ TargetGroupArn: tgArn, Targets: [{ Id: ip }] }));
-  } catch (err) {
-    console.warn('Could not deregister ALB target', { tgArn, ip, err });
-  }
-}
-
 const DISCORD_API = 'https://discord.com/api/v10';
 
 async function patchOriginal(
@@ -240,14 +204,11 @@ async function patchOriginal(
 /**
  * If a Discord interaction is pending for this task, PATCH it with the
  * resolved hostname/IP and delete the pending row.
- *
- * `publicIp` is omitted for HTTPS games because only the private IP is known
- * at this point — the public entry point is always the ALB hostname.
  */
 async function notifyDiscordIfPending(
   taskArn: string,
   game: string,
-  publicIp?: string,
+  publicIp: string,
 ): Promise<void> {
   if (!TABLE_NAME) return;
   try {
@@ -291,7 +252,7 @@ async function handleDirect(
   lastStatus: string,
 ): Promise<HandlerResult> {
   if (lastStatus === 'RUNNING') {
-    const ip = await resolveIp(taskArn, clusterArn, 'public');
+    const ip = await resolvePublicIp(taskArn, clusterArn);
     if (!ip) {
       console.warn(`Could not resolve public IP for ${taskArn}`);
       return { status: 'error', reason: 'no_ip' };
@@ -307,37 +268,12 @@ async function handleDirect(
   return { status: 'no_action', lastStatus };
 }
 
-async function handleHttps(
-  game: string,
-  taskArn: string,
-  clusterArn: string,
-  lastStatus: string,
-): Promise<HandlerResult> {
-  const tgArn = ALB_TARGET_GROUPS[game];
-  if (!tgArn) {
-    console.error(`No ALB target group configured for HTTPS game ${game}`);
-    return { status: 'error', reason: 'no_target_group' };
-  }
-  if (lastStatus === 'RUNNING') {
-    const ip = await resolveIp(taskArn, clusterArn, 'private');
-    if (!ip) return { status: 'error', reason: 'no_ip' };
-    await registerAlb(tgArn, ip);
-    await notifyDiscordIfPending(taskArn, game); // private IP intentionally omitted — use hostname only
-    return { status: 'registered', game, ip };
-  }
-  if (lastStatus === 'STOPPED') {
-    const ip = await resolveIp(taskArn, clusterArn, 'private');
-    if (ip) await deregisterAlb(tgArn, ip);
-    return { status: 'deregistered', game };
-  }
-  return { status: 'no_action', lastStatus };
-}
-
 /**
  * Fired by an EventBridge rule on `ECS Task State Change`. UPSERTs a Route 53 record
  * for `{game}.{hosted_zone_name}` on RUNNING and DELETEs on STOPPED — DNS is owned by
  * this Lambda rather than Terraform so records follow ephemeral task IPs without
- * fighting state. HTTPS games route through an ALB target group instead, and on
+ * fighting state. HTTPS games terminate TLS in-task via a Caddy sidecar sharing the
+ * task's public IP, so they follow the same A-record path as every other game. On
  * RUNNING this also PATCHes any `PENDING#{taskArn}` Discord interaction in DynamoDB
  * so the user sees the resolved address in the same message they clicked on.
  */
@@ -356,9 +292,6 @@ export const handler = async (event: EcsStateChangeEvent): Promise<HandlerResult
   }
 
   const dnsName = `${game}.${DOMAIN_NAME}`;
-  const isHttps = HTTPS_GAMES.has(game);
 
-  return isHttps
-    ? handleHttps(game, taskArn, clusterArn, lastStatus)
-    : handleDirect(game, dnsName, taskArn, clusterArn, lastStatus);
+  return handleDirect(game, dnsName, taskArn, clusterArn, lastStatus);
 };

--- a/app/packages/lambda/watchdog/package.json
+++ b/app/packages/lambda/watchdog/package.json
@@ -10,9 +10,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-cloudwatch": "^3.600.0",
-    "@aws-sdk/client-ec2": "^3.600.0",
     "@aws-sdk/client-ecs": "^3.600.0",
-    "@aws-sdk/client-elastic-load-balancing-v2": "^3.600.0",
     "@aws-sdk/client-route-53": "^3.600.0",
     "@types/aws-lambda": "^8.10.138"
   }

--- a/app/packages/lambda/watchdog/src/handler.test.ts
+++ b/app/packages/lambda/watchdog/src/handler.test.ts
@@ -2,8 +2,9 @@
  * Tests for the watchdog Lambda — TypeScript port of watchdog.py.
  *
  * Covers: idle counter increment via ECS task tags, threshold-based shutdown
- * (with DNS delete for direct games and ALB deregister for HTTPS games), and
- * counter reset when activity is detected.
+ * with DNS delete (uniform for every game, including HTTPS-flagged ones now
+ * that TLS terminates in-task via a Caddy sidecar), and counter reset when
+ * activity is detected.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -16,14 +17,6 @@ import {
   TagResourceCommand,
 } from '@aws-sdk/client-ecs';
 import {
-  DescribeNetworkInterfacesCommand,
-  EC2Client,
-} from '@aws-sdk/client-ec2';
-import {
-  ElasticLoadBalancingV2Client,
-  DeregisterTargetsCommand,
-} from '@aws-sdk/client-elastic-load-balancing-v2';
-import {
   Route53Client,
   ChangeResourceRecordSetsCommand,
   ListResourceRecordSetsCommand,
@@ -34,8 +27,6 @@ import {
 } from '@aws-sdk/client-cloudwatch';
 
 const ecsMock = mockClient(ECSClient);
-const ec2Mock = mockClient(EC2Client);
-const elbv2Mock = mockClient(ElasticLoadBalancingV2Client);
 const route53Mock = mockClient(Route53Client);
 const cwMock = mockClient(CloudWatchClient);
 
@@ -46,8 +37,6 @@ process.env['GAME_NAMES'] = 'palworld,foundryvtt';
 process.env['IDLE_CHECKS'] = '4';
 process.env['MIN_PACKETS'] = '100';
 process.env['CHECK_WINDOW_MINUTES'] = '15';
-process.env['HTTPS_GAMES'] = 'foundryvtt';
-process.env['ALB_TARGET_GROUPS'] = JSON.stringify({ foundryvtt: 'arn:tg-foundry' });
 process.env['AWS_REGION_'] = 'us-east-1';
 
 const { handler } = await import('./handler.js');
@@ -68,8 +57,6 @@ function runningTask(opts: { taskArn: string; game: string; eniId?: string }) {
 
 beforeEach(() => {
   ecsMock.reset();
-  ec2Mock.reset();
-  elbv2Mock.reset();
   route53Mock.reset();
   cwMock.reset();
 });
@@ -169,10 +156,9 @@ describe('watchdog handler: shutdown threshold', () => {
 
     expect(ecsMock.commandCalls(StopTaskCommand)).toHaveLength(1);
     expect(route53Mock.commandCalls(ChangeResourceRecordSetsCommand)).toHaveLength(1);
-    expect(elbv2Mock.commandCalls(DeregisterTargetsCommand)).toHaveLength(0);
   });
 
-  it('should stop the task and deregister the ALB target for HTTPS games at the threshold', async () => {
+  it('should stop the task and delete its DNS record for an HTTPS-flagged game at the threshold, same as any other game', async () => {
     const taskArn = 'arn:task/dead';
     ecsMock.on(ListTasksCommand).resolves({ taskArns: [taskArn] });
     ecsMock.on(DescribeTasksCommand).resolves({
@@ -181,16 +167,15 @@ describe('watchdog handler: shutdown threshold', () => {
     cwMock.on(GetMetricStatisticsCommand).resolves({ Datapoints: [{ Sum: 0 }] });
     ecsMock.on(ListTagsForResourceCommand).resolves({ tags: [{ key: 'idle_checks', value: '3' }] });
     ecsMock.on(StopTaskCommand).resolves({});
-    ec2Mock.on(DescribeNetworkInterfacesCommand).resolves({
-      NetworkInterfaces: [{ PrivateIpAddress: '10.0.0.5' }],
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [{ Name: 'foundryvtt.example.com.', Type: 'A', ResourceRecords: [{ Value: '5.6.7.8' }] }],
     });
-    elbv2Mock.on(DeregisterTargetsCommand).resolves({});
+    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({});
 
     await handler();
 
     expect(ecsMock.commandCalls(StopTaskCommand)).toHaveLength(1);
-    expect(elbv2Mock.commandCalls(DeregisterTargetsCommand)).toHaveLength(1);
-    expect(route53Mock.commandCalls(ChangeResourceRecordSetsCommand)).toHaveLength(0);
+    expect(route53Mock.commandCalls(ChangeResourceRecordSetsCommand)).toHaveLength(1);
   });
 
   it('should treat missing CloudWatch datapoints as active (no shutdown of brand-new tasks)', async () => {

--- a/app/packages/lambda/watchdog/src/handler.test.ts
+++ b/app/packages/lambda/watchdog/src/handler.test.ts
@@ -2,9 +2,11 @@
  * Tests for the watchdog Lambda — TypeScript port of watchdog.py.
  *
  * Covers: idle counter increment via ECS task tags, threshold-based shutdown
- * with DNS delete (uniform for every game, including HTTPS-flagged ones now
- * that TLS terminates in-task via a Caddy sidecar), and counter reset when
- * activity is detected.
+ * (uniform for every game, including HTTPS-flagged ones now that TLS
+ * terminates in-task via a Caddy sidecar), and counter reset when activity is
+ * detected. DNS deletion is owned by `@hyveon/lambda-update-dns` reacting to
+ * the `STOPPED` state-change event `StopTask` produces, so it isn't asserted
+ * here.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -17,22 +19,14 @@ import {
   TagResourceCommand,
 } from '@aws-sdk/client-ecs';
 import {
-  Route53Client,
-  ChangeResourceRecordSetsCommand,
-  ListResourceRecordSetsCommand,
-} from '@aws-sdk/client-route-53';
-import {
   CloudWatchClient,
   GetMetricStatisticsCommand,
 } from '@aws-sdk/client-cloudwatch';
 
 const ecsMock = mockClient(ECSClient);
-const route53Mock = mockClient(Route53Client);
 const cwMock = mockClient(CloudWatchClient);
 
 process.env['ECS_CLUSTER'] = 'test-cluster';
-process.env['HOSTED_ZONE_ID'] = 'Z123';
-process.env['DOMAIN_NAME'] = 'example.com';
 process.env['GAME_NAMES'] = 'palworld,foundryvtt';
 process.env['IDLE_CHECKS'] = '4';
 process.env['MIN_PACKETS'] = '100';
@@ -57,7 +51,6 @@ function runningTask(opts: { taskArn: string; game: string; eniId?: string }) {
 
 beforeEach(() => {
   ecsMock.reset();
-  route53Mock.reset();
   cwMock.reset();
 });
 
@@ -138,7 +131,7 @@ describe('watchdog handler: idle counter', () => {
 });
 
 describe('watchdog handler: shutdown threshold', () => {
-  it('should stop the task and delete its DNS record after IDLE_CHECKS consecutive idle windows (direct game)', async () => {
+  it('should stop the task after IDLE_CHECKS consecutive idle windows (direct game)', async () => {
     const taskArn = 'arn:task/dead';
     ecsMock.on(ListTasksCommand).resolves({ taskArns: [taskArn] });
     ecsMock.on(DescribeTasksCommand).resolves({
@@ -147,18 +140,13 @@ describe('watchdog handler: shutdown threshold', () => {
     cwMock.on(GetMetricStatisticsCommand).resolves({ Datapoints: [{ Sum: 0 }] });
     ecsMock.on(ListTagsForResourceCommand).resolves({ tags: [{ key: 'idle_checks', value: '3' }] });
     ecsMock.on(StopTaskCommand).resolves({});
-    route53Mock.on(ListResourceRecordSetsCommand).resolves({
-      ResourceRecordSets: [{ Name: 'palworld.example.com.', Type: 'A', ResourceRecords: [{ Value: '1.2.3.4' }] }],
-    });
-    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({});
 
     await handler();
 
     expect(ecsMock.commandCalls(StopTaskCommand)).toHaveLength(1);
-    expect(route53Mock.commandCalls(ChangeResourceRecordSetsCommand)).toHaveLength(1);
   });
 
-  it('should stop the task and delete its DNS record for an HTTPS-flagged game at the threshold, same as any other game', async () => {
+  it('should stop an HTTPS-flagged game at the threshold, same as any other game', async () => {
     const taskArn = 'arn:task/dead';
     ecsMock.on(ListTasksCommand).resolves({ taskArns: [taskArn] });
     ecsMock.on(DescribeTasksCommand).resolves({
@@ -167,15 +155,10 @@ describe('watchdog handler: shutdown threshold', () => {
     cwMock.on(GetMetricStatisticsCommand).resolves({ Datapoints: [{ Sum: 0 }] });
     ecsMock.on(ListTagsForResourceCommand).resolves({ tags: [{ key: 'idle_checks', value: '3' }] });
     ecsMock.on(StopTaskCommand).resolves({});
-    route53Mock.on(ListResourceRecordSetsCommand).resolves({
-      ResourceRecordSets: [{ Name: 'foundryvtt.example.com.', Type: 'A', ResourceRecords: [{ Value: '5.6.7.8' }] }],
-    });
-    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({});
 
     await handler();
 
     expect(ecsMock.commandCalls(StopTaskCommand)).toHaveLength(1);
-    expect(route53Mock.commandCalls(ChangeResourceRecordSetsCommand)).toHaveLength(1);
   });
 
   it('should treat missing CloudWatch datapoints as active (no shutdown of brand-new tasks)', async () => {

--- a/app/packages/lambda/watchdog/src/handler.ts
+++ b/app/packages/lambda/watchdog/src/handler.ts
@@ -6,9 +6,12 @@
  *     `CHECK_WINDOW_MINUTES` window.
  *   - If packets &lt; `MIN_PACKETS`, increments the per-task `idle_checks` ECS
  *     resource tag. After `IDLE_CHECKS` consecutive idle windows, the task is
- *     stopped (which triggers the DNS cleanup via the update-dns Lambda).
- *   - We delete the Route 53 record directly here so the DNS removal isn't
- *     racy with task teardown.
+ *     stopped.
+ *   - DNS cleanup is NOT done here: stopping the task emits an
+ *     `ECS Task State Change` event that the update-dns Lambda reacts to,
+ *     deleting the record on its `STOPPED` path. Deleting it here first
+ *     would leave a dangling task with no DNS record if `StopTask` then
+ *     failed.
  */
 import {
   ECSClient,
@@ -20,18 +23,11 @@ import {
   type Task,
 } from '@aws-sdk/client-ecs';
 import {
-  Route53Client,
-  ChangeResourceRecordSetsCommand,
-  ListResourceRecordSetsCommand,
-} from '@aws-sdk/client-route-53';
-import {
   CloudWatchClient,
   GetMetricStatisticsCommand,
 } from '@aws-sdk/client-cloudwatch';
 
 const ECS_CLUSTER = requireEnv('ECS_CLUSTER');
-const HOSTED_ZONE_ID = process.env['HOSTED_ZONE_ID'] ?? '';
-const DOMAIN_NAME = process.env['DOMAIN_NAME'] ?? '';
 const GAME_NAMES = (process.env['GAME_NAMES'] ?? '').split(',').map((s) => s.trim()).filter(Boolean);
 const IDLE_CHECKS = parseInt(process.env['IDLE_CHECKS'] ?? '4', 10);
 const MIN_PACKETS = parseInt(process.env['MIN_PACKETS'] ?? '100', 10);
@@ -55,7 +51,6 @@ function region(): string {
 }
 
 const ecs = new ECSClient({ region: region() });
-const route53 = new Route53Client({});
 const cloudwatch = new CloudWatchClient({ region: region() });
 
 function getEniId(task: Task): string | null {
@@ -122,39 +117,6 @@ async function setIdleCount(taskArn: string, count: number): Promise<void> {
   }
 }
 
-async function deleteDns(game: string): Promise<void> {
-  if (!HOSTED_ZONE_ID || !DOMAIN_NAME) return;
-  const dnsName = `${game}.${DOMAIN_NAME}`;
-  try {
-    const resp = await route53.send(
-      new ListResourceRecordSetsCommand({
-        HostedZoneId: HOSTED_ZONE_ID,
-        StartRecordName: dnsName,
-        StartRecordType: 'A',
-        MaxItems: 1,
-      }),
-    );
-    for (const rrs of resp.ResourceRecordSets ?? []) {
-      if (rrs.Name?.replace(/\.$/, '') === dnsName && rrs.Type === 'A') {
-        await route53.send(
-          new ChangeResourceRecordSetsCommand({
-            HostedZoneId: HOSTED_ZONE_ID,
-            ChangeBatch: {
-              Comment: `Watchdog auto-shutdown: ${game}`,
-              Changes: [{ Action: 'DELETE', ResourceRecordSet: rrs }],
-            },
-          }),
-        );
-        console.log(`Deleted DNS record: ${dnsName}`);
-        return;
-      }
-    }
-    console.log(`No DNS record found for ${dnsName}`);
-  } catch (err) {
-    console.warn(`DNS cleanup failed for ${game}`, { err });
-  }
-}
-
 async function listAllRunningTaskArns(): Promise<string[]> {
   const arns: string[] = [];
   let nextToken: string | undefined;
@@ -174,7 +136,7 @@ async function listAllRunningTaskArns(): Promise<string[]> {
  * `NetworkPacketsIn` on its ENI via CloudWatch and bumps a consecutive-idle counter
  * stored as an ECS task tag (no DynamoDB/SSM state). After `watchdog_idle_checks`
  * consecutive idle intervals, the task is stopped — which triggers the DNS-delete
- * path in `@hyveon/lambda-update-dns`.
+ * path in `@hyveon/lambda-update-dns` via the resulting `STOPPED` state-change event.
  */
 export const handler = async (): Promise<{ checked: number }> => {
   console.log(`Watchdog running — cluster: ${ECS_CLUSTER}, games: ${GAME_NAMES.join(',')}`);
@@ -210,7 +172,6 @@ export const handler = async (): Promise<{ checked: number }> => {
         console.log(
           `${game}: shutting down after ${idleCount} idle checks (${idleCount * CHECK_WINDOW_MINUTES} minutes idle)`,
         );
-        await deleteDns(game);
         await ecs.send(
           new StopTaskCommand({
             cluster: ECS_CLUSTER,

--- a/app/packages/lambda/watchdog/src/handler.ts
+++ b/app/packages/lambda/watchdog/src/handler.ts
@@ -6,11 +6,9 @@
  *     `CHECK_WINDOW_MINUTES` window.
  *   - If packets &lt; `MIN_PACKETS`, increments the per-task `idle_checks` ECS
  *     resource tag. After `IDLE_CHECKS` consecutive idle windows, the task is
- *     stopped (which triggers the DNS/ALB cleanup via the update-dns Lambda).
- *   - For HTTPS games we also deregister the ALB target before stopping so
- *     the LB doesn't keep healthchecking a dying task.
- *   - For non-HTTPS games we delete the Route 53 record directly here so the
- *     DNS removal isn't racy with task teardown.
+ *     stopped (which triggers the DNS cleanup via the update-dns Lambda).
+ *   - We delete the Route 53 record directly here so the DNS removal isn't
+ *     racy with task teardown.
  */
 import {
   ECSClient,
@@ -21,14 +19,6 @@ import {
   ListTagsForResourceCommand,
   type Task,
 } from '@aws-sdk/client-ecs';
-import {
-  EC2Client,
-  DescribeNetworkInterfacesCommand,
-} from '@aws-sdk/client-ec2';
-import {
-  ElasticLoadBalancingV2Client,
-  DeregisterTargetsCommand,
-} from '@aws-sdk/client-elastic-load-balancing-v2';
 import {
   Route53Client,
   ChangeResourceRecordSetsCommand,
@@ -46,12 +36,6 @@ const GAME_NAMES = (process.env['GAME_NAMES'] ?? '').split(',').map((s) => s.tri
 const IDLE_CHECKS = parseInt(process.env['IDLE_CHECKS'] ?? '4', 10);
 const MIN_PACKETS = parseInt(process.env['MIN_PACKETS'] ?? '100', 10);
 const CHECK_WINDOW_MINUTES = parseInt(process.env['CHECK_WINDOW_MINUTES'] ?? '15', 10);
-const HTTPS_GAMES = new Set(
-  (process.env['HTTPS_GAMES'] ?? '').split(',').map((s) => s.trim()).filter(Boolean),
-);
-const ALB_TARGET_GROUPS: Record<string, string> = JSON.parse(
-  process.env['ALB_TARGET_GROUPS'] ?? '{}',
-);
 
 const FAMILY_TO_GAME = new Map<string, string>(GAME_NAMES.map((g) => [`${g}-server`, g]));
 
@@ -71,8 +55,6 @@ function region(): string {
 }
 
 const ecs = new ECSClient({ region: region() });
-const ec2 = new EC2Client({ region: region() });
-const elbv2 = new ElasticLoadBalancingV2Client({ region: region() });
 const route53 = new Route53Client({});
 const cloudwatch = new CloudWatchClient({ region: region() });
 
@@ -173,27 +155,6 @@ async function deleteDns(game: string): Promise<void> {
   }
 }
 
-async function deregisterAlbTarget(game: string, task: Task): Promise<void> {
-  const tgArn = ALB_TARGET_GROUPS[game];
-  if (!tgArn) {
-    console.log(`No ALB target group configured for ${game}`);
-    return;
-  }
-  const eniId = getEniId(task);
-  if (!eniId) return;
-  try {
-    const resp = await ec2.send(new DescribeNetworkInterfacesCommand({ NetworkInterfaceIds: [eniId] }));
-    const privateIp = resp.NetworkInterfaces?.[0]?.PrivateIpAddress;
-    if (!privateIp) return;
-    await elbv2.send(
-      new DeregisterTargetsCommand({ TargetGroupArn: tgArn, Targets: [{ Id: privateIp }] }),
-    );
-    console.log(`Deregistered ALB target ${privateIp} for ${game}`);
-  } catch (err) {
-    console.warn(`ALB deregistration failed for ${game}`, { err });
-  }
-}
-
 async function listAllRunningTaskArns(): Promise<string[]> {
   const arns: string[] = [];
   let nextToken: string | undefined;
@@ -249,11 +210,7 @@ export const handler = async (): Promise<{ checked: number }> => {
         console.log(
           `${game}: shutting down after ${idleCount} idle checks (${idleCount * CHECK_WINDOW_MINUTES} minutes idle)`,
         );
-        if (HTTPS_GAMES.has(game)) {
-          await deregisterAlbTarget(game, task);
-        } else {
-          await deleteDns(game);
-        }
+        await deleteDns(game);
         await ecs.send(
           new StopTaskCommand({
             cluster: ECS_CLUSTER,

--- a/app/packages/web/e2e/fixtures/tfstate.fixture.json
+++ b/app/packages/web/e2e/fixtures/tfstate.fixture.json
@@ -15,8 +15,6 @@
     },
     "domain_name":                    { "value": "test.example.com",   "type": "string" },
     "game_names":                     { "value": ["minecraft", "valheim"], "type": ["tuple", ["string", "string"]] },
-    "alb_dns_name":                   { "value": null,                  "type": "string" },
-    "acm_certificate_arn":            { "value": null,                  "type": "string" },
     "discord_table_name":             { "value": "test-discord-table",  "type": "string" },
     "audit_table_name":               { "value": "test-audit-table",    "type": "string" },
     "runs_table_name":                { "value": "test-runs-table",     "type": "string" },

--- a/docs/docs/components/lambdas.md
+++ b/docs/docs/components/lambdas.md
@@ -149,8 +149,10 @@ Event shape (simplified):
 
 Failure modes:
 
-- IP not available after 5 retries → log warning, skip. Next state change
-  will retry; meanwhile the task is up but unreachable by DNS.
+- IP not available after 5 retries → log warning, skip; the handler returns
+  `{status: 'error', reason: 'no_ip'}`. No retry is scheduled — the task stays
+  up but unreachable by DNS until another `RUNNING`/`STOPPED` state-change
+  event fires for it (e.g. the task is stopped and started again).
 - Route 53 call fails → log, continue. The STOPPED path is eventually
   consistent because the watchdog cleans up too.
 - Pending row missing (expired / never written / `stop` flow) → skip the
@@ -164,8 +166,8 @@ Failure modes:
 | **Package** | `@hyveon/lambda-watchdog` |
 | **Trigger** | EventBridge schedule at `rate(${watchdog_interval_minutes} minute(s))`. No event payload. |
 | **Terraform** | `terraform/aws/watchdog.tf`. |
-| **IAM** | `ecs:ListTasks` / `DescribeTasks` / `StopTask` / `TagResource` / `ListTagsForResource`, `cloudwatch:GetMetricStatistics`, `route53:ChangeResourceRecordSets` / `ListResourceRecordSets`. |
-| **Env vars** | `ECS_CLUSTER`, `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `IDLE_CHECKS`, `MIN_PACKETS`, `CHECK_WINDOW_MINUTES`, `AWS_REGION_`. |
+| **IAM** | `ecs:ListTasks` / `DescribeTasks` / `StopTask` / `TagResource` / `ListTagsForResource`, `cloudwatch:GetMetricStatistics`. |
+| **Env vars** | `ECS_CLUSTER`, `GAME_NAMES`, `IDLE_CHECKS`, `MIN_PACKETS`, `CHECK_WINDOW_MINUTES`, `AWS_REGION_`. |
 
 ### Behaviour
 
@@ -179,8 +181,11 @@ Failure modes:
    - If `packets < MIN_PACKETS`:
      - Increment the `idle_checks` tag.
      - If the counter reaches `IDLE_CHECKS`:
-       - Delete the Route 53 record.
-       - `StopTask` with reason `Watchdog: idle for {N} minutes`.
+       - `StopTask` with reason `Watchdog: idle for {N} minutes`. This Lambda
+         does not touch DNS directly — the resulting `STOPPED` state-change
+         event is what triggers update-dns's record deletion. Deleting the
+         record here first would risk leaving a running task unreachable by
+         DNS if `StopTask` then failed.
      - Otherwise persist the incremented counter via `TagResource`.
    - Else (active), if the counter is non-zero, reset it to 0.
 

--- a/docs/docs/components/lambdas.md
+++ b/docs/docs/components/lambdas.md
@@ -116,8 +116,8 @@ Failure modes:
 | **Package** | `@hyveon/lambda-update-dns` |
 | **Trigger** | EventBridge rule on `source: aws.ecs`, `detail-type: 'ECS Task State Change'`, `lastStatus` in `['RUNNING', 'STOPPED']`. |
 | **Terraform** | `terraform/aws/route53.tf`. |
-| **IAM** | `route53:ChangeResourceRecordSets`, `route53:ListResourceRecordSets`, `ecs:DescribeTasks`, `ec2:DescribeNetworkInterfaces`, `elasticloadbalancing:RegisterTargets` / `DeregisterTargets`, `dynamodb:GetItem` / `DeleteItem`. |
-| **Env vars** | `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `DNS_TTL`, `AWS_REGION_`, `HTTPS_GAMES`, `ALB_TARGET_GROUPS` (JSON map game → target group ARN), `TABLE_NAME`. |
+| **IAM** | `route53:ChangeResourceRecordSets`, `route53:ListResourceRecordSets`, `ecs:DescribeTasks`, `ec2:DescribeNetworkInterfaces`, `dynamodb:GetItem` / `DeleteItem`. |
+| **Env vars** | `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `DNS_TTL`, `AWS_REGION_`, `TABLE_NAME`. |
 
 ### Behaviour
 
@@ -135,29 +135,24 @@ Event shape (simplified):
 ```
 
 1. Parse the task family from `detail.group`, map to a game via
-   `FAMILY_TO_GAME`. Skip unknown families.
-2. Determine whether the game is **HTTPS** (present in `HTTPS_GAMES`) or
-   **direct**.
-3. **Direct games**:
-   - On `RUNNING`: `resolveIp('public')` — retries up to 5 times with
-     3-second sleeps to survive ENI attach lag; then `upsertDns()` writes
-     an A record `{game}.{domain}` → IP with `DNS_TTL`.
-   - On `STOPPED`: read the current record, verify its IP, `deleteDns()`.
-4. **HTTPS games**:
-   - On `RUNNING`: resolve the **private** IP, `registerAlb()` (adds it to
-     the target group).
-   - On `STOPPED`: `deregisterAlb()`.
-5. On `RUNNING`, regardless of game type: call `notifyDiscordIfPending()`
-   — look up `PENDING#{taskArn}` in DynamoDB, format a final status
-   message, PATCH the original Discord interaction, delete the pending
-   row.
+   `FAMILY_TO_GAME`. Skip unknown families. Every game — including
+   `https = true` ones, which terminate TLS in-task via a Caddy sidecar and
+   share the task's public IP — follows the same path below.
+2. On `RUNNING`: `resolvePublicIp()` — retries up to 5 times with
+   3-second sleeps to survive ENI attach lag; then `upsertDns()` writes
+   an A record `{game}.{domain}` → IP with `DNS_TTL`.
+3. On `STOPPED`: read the current record, verify its IP, `deleteDns()`.
+4. On `RUNNING`: call `notifyDiscordIfPending()` — look up
+   `PENDING#{taskArn}` in DynamoDB, format a final status message
+   (including the resolved public IP), PATCH the original Discord
+   interaction, delete the pending row.
 
 Failure modes:
 
 - IP not available after 5 retries → log warning, skip. Next state change
   will retry; meanwhile the task is up but unreachable by DNS.
-- Route 53 / ALB call fails → log, continue. The STOPPED path is
-  eventually consistent because the watchdog cleans up too.
+- Route 53 call fails → log, continue. The STOPPED path is eventually
+  consistent because the watchdog cleans up too.
 - Pending row missing (expired / never written / `stop` flow) → skip the
   Discord PATCH; no user-visible issue.
 - Discord PATCH fails (stale token) → log, continue.
@@ -169,8 +164,8 @@ Failure modes:
 | **Package** | `@hyveon/lambda-watchdog` |
 | **Trigger** | EventBridge schedule at `rate(${watchdog_interval_minutes} minute(s))`. No event payload. |
 | **Terraform** | `terraform/aws/watchdog.tf`. |
-| **IAM** | `ecs:ListTasks` / `DescribeTasks` / `StopTask` / `TagResource` / `ListTagsForResource`, `cloudwatch:GetMetricStatistics`, `route53:ChangeResourceRecordSets` / `ListResourceRecordSets`, `elasticloadbalancing:DeregisterTargets`, `ec2:DescribeNetworkInterfaces`. |
-| **Env vars** | `ECS_CLUSTER`, `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `IDLE_CHECKS`, `MIN_PACKETS`, `CHECK_WINDOW_MINUTES`, `AWS_REGION_`, `HTTPS_GAMES`, `ALB_TARGET_GROUPS`. |
+| **IAM** | `ecs:ListTasks` / `DescribeTasks` / `StopTask` / `TagResource` / `ListTagsForResource`, `cloudwatch:GetMetricStatistics`, `route53:ChangeResourceRecordSets` / `ListResourceRecordSets`. |
+| **Env vars** | `ECS_CLUSTER`, `HOSTED_ZONE_ID`, `DOMAIN_NAME`, `GAME_NAMES`, `IDLE_CHECKS`, `MIN_PACKETS`, `CHECK_WINDOW_MINUTES`, `AWS_REGION_`. |
 
 ### Behaviour
 
@@ -184,8 +179,7 @@ Failure modes:
    - If `packets < MIN_PACKETS`:
      - Increment the `idle_checks` tag.
      - If the counter reaches `IDLE_CHECKS`:
-       - HTTPS game → `DeregisterTargets`.
-       - Direct game → delete the Route 53 record.
+       - Delete the Route 53 record.
        - `StopTask` with reason `Watchdog: idle for {N} minutes`.
      - Otherwise persist the incremented counter via `TagResource`.
    - Else (active), if the counter is non-zero, reset it to 0.

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -65,8 +65,6 @@ On the AWS side you need:
         "events:*",
         "route53:*",
         "ce:*",
-        "elasticloadbalancing:*",
-        "acm:*",
         "dynamodb:*",
         "secretsmanager:*",
         "s3:*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
       "devDependencies": {
         "@aws-sdk/client-ec2": "^3.600.0",
         "@aws-sdk/client-ecs": "^3.600.0",
-        "@aws-sdk/client-elastic-load-balancing-v2": "^3.600.0",
         "@aws-sdk/client-route-53": "^3.600.0",
         "@types/aws-lambda": "^8.10.138"
       }
@@ -153,9 +152,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@aws-sdk/client-cloudwatch": "^3.600.0",
-        "@aws-sdk/client-ec2": "^3.600.0",
         "@aws-sdk/client-ecs": "^3.600.0",
-        "@aws-sdk/client-elastic-load-balancing-v2": "^3.600.0",
         "@aws-sdk/client-route-53": "^3.600.0",
         "@types/aws-lambda": "^8.10.138"
       }
@@ -603,58 +600,6 @@
       "version": "3.1045.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.1045.0.tgz",
       "integrity": "sha512-yZxL5/BSrUyYsJldPzKRPlizsq3v33INgZtUZQVZ4aHV/xselVPxIF2BxCJMmltl7zR+TJX6l/uN5WJHJnHoAA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-node": "^3.972.39",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elastic-load-balancing-v2": {
-      "version": "3.1045.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elastic-load-balancing-v2/-/client-elastic-load-balancing-v2-3.1045.0.tgz",
-      "integrity": "sha512-tyhEmOUj6xEkqfWHooJs0IlOD5Ltry8fnY/ePyIU9d2k6zj0bTSROLAb2pXGxWeDYyLZJYnQvccowbz1LCj0wQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",

--- a/terraform/aws/watchdog.tf
+++ b/terraform/aws/watchdog.tf
@@ -6,10 +6,11 @@
 # task it:
 #   1. Reads CloudWatch NetworkPacketsIn on the task's ENI.
 #   2. If packets < watchdog_min_packets → increments idle_checks ECS task tag.
-#   3. After watchdog_idle_checks consecutive idle checks → stops the task and
-#      removes the Route 53 record (same path for every game — HTTPS games'
-#      TLS terminates in-task via a Caddy sidecar, no load balancer target to
-#      deregister).
+#   3. After watchdog_idle_checks consecutive idle checks → stops the task
+#      (same path for every game — HTTPS games' TLS terminates in-task via a
+#      Caddy sidecar, no load balancer target to deregister). DNS cleanup is
+#      handled by the update-dns Lambda reacting to the resulting STOPPED
+#      state-change event, not by this Lambda directly.
 #
 # Total idle grace period = watchdog_interval_minutes × watchdog_idle_checks.
 # ──────────────────────────────────────────────────────────────────────────────
@@ -66,17 +67,6 @@ resource "aws_iam_role_policy" "watchdog_lambda" {
         Action   = ["cloudwatch:GetMetricStatistics"]
         Resource = "*"
       },
-      {
-        Effect = "Allow"
-        Action = [
-          "route53:ChangeResourceRecordSets",
-          "route53:ListResourceRecordSets",
-        ]
-        Resource = [
-          "arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}",
-          "arn:aws:route53:::change/*",
-        ]
-      },
     ]
   })
 }
@@ -93,8 +83,6 @@ resource "aws_lambda_function" "watchdog" {
   environment {
     variables = {
       ECS_CLUSTER          = aws_ecs_cluster.main.name
-      HOSTED_ZONE_ID       = data.aws_route53_zone.main.zone_id
-      DOMAIN_NAME          = var.hosted_zone_name
       GAME_NAMES           = join(",", keys(var.game_servers))
       IDLE_CHECKS          = tostring(var.watchdog_idle_checks)
       MIN_PACKETS          = tostring(var.watchdog_min_packets)


### PR DESCRIPTION
Closes #292

## Summary

PR 2 of 2 for the ALB → in-task Caddy sidecar migration (PR 1: #315). Removes the dead ALB code paths left behind after the Caddy sidecar cutover.

- `app/packages/lambda/update-dns`: deleted `handleHttps`, `registerAlb`/`deregisterAlb`, the ELBv2 client, and `ALB_TARGET_GROUPS`/`HTTPS_GAMES` env parsing. All games (including HTTPS-flagged ones) now route through the plain `handleDirect` A-record path, and the Discord follow-up notification always includes the resolved public IP.
- `app/packages/lambda/watchdog`: deleted the ALB deregistration step and the same env parsing — DNS cleanup is now uniform for every game.
- Removed the `@aws-sdk/client-elastic-load-balancing-v2` dependency from both Lambda packages.
- Removed `alb_dns_name`/`acm_certificate_arn` from `TfOutputs` (`ConfigService.ts`), the `gsd-api.ts` preload mirror, and all associated test fixtures / the e2e `tfstate.fixture.json`.
- Trimmed `elasticloadbalancing:*` and `acm:*` from the `GameServerDeployAll` IAM policy JSON in `docs/docs/setup.md` — safe now that the ALB/ACM resources are confirmed torn down (verified live in AWS: no load balancers, target groups, or ACM certs in the account).
- Updated `docs/docs/components/lambdas.md` (stale IAM/env-var tables and behaviour descriptions for both Lambdas) and `CLAUDE.md` (new architecture note: HTTPS terminates in-task via a Caddy sidecar, no ALB, DNS path uniform for every game).

## Test plan

- [x] `npm run app:test` — 1876/1876 tests passing
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings confirmed via stash-diff against `main`)
- [x] `terraform fmt -check -recursive`, `terraform validate`, `tflint` — clean (no Terraform files touched in this PR)
- [x] Grepped the full tree post-change for `ALB`/`elastic-load-balancing`/`ElasticLoadBalancing` — no remaining references outside this PR's own commit message
