### PR TITLE
feat(desktop-main): detect terraform/aws prerequisites

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -6,6 +6,7 @@ import { AwsModule } from './modules/aws.module.js';
 import { DiscordModule } from './modules/discord.module.js';
 import { TfvarsModule } from './modules/tfvars.module.js';
 import { TerraformModule } from './modules/terraform.module.js';
+import { WizardModule } from './modules/wizard.module.js';
 import { GamesController } from './controllers/games.controller.js';
 import { GamesHttpController } from './controllers/games-http.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
@@ -27,6 +28,7 @@ import { AuditController } from './controllers/audit.controller.js';
 import { AuditHttpController } from './controllers/audit-http.controller.js';
 import { TerraformController } from './controllers/terraform.controller.js';
 import { TerraformRunsController } from './controllers/terraform-runs.controller.js';
+import { WizardController } from './controllers/wizard.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
 import { DriftService } from './services/DriftService.js';
 import { GamesWriteService } from './services/GamesWriteService.js';
@@ -36,10 +38,10 @@ import { AuditService } from './services/AuditService.js';
 
 /**
  * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`,
- * `TfvarsModule`, `TerraformModule`) to the IPC controllers.
+ * `TfvarsModule`, `TerraformModule`, `WizardModule`) to the IPC controllers.
  */
 @Module({
-  imports: [AwsModule, DiscordModule, TfvarsModule, TerraformModule],
+  imports: [AwsModule, DiscordModule, TfvarsModule, TerraformModule, WizardModule],
   controllers: [
     GamesController,
     GamesHttpController,
@@ -62,6 +64,7 @@ import { AuditService } from './services/AuditService.js';
     AuditHttpController,
     TerraformController,
     TerraformRunsController,
+    WizardController,
   ],
   providers: [
     {

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+import { WizardController } from './wizard.controller.js';
+import type { PrerequisiteService, PrerequisitesReport } from '../services/PrerequisiteService.js';
+
+const SATISFIED_REPORT: PrerequisitesReport = {
+  terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
+  aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
+};
+
+/** Build a PrerequisiteService stub whose `check()` resolves to the given report. */
+function makePrerequisites(report: PrerequisitesReport = SATISFIED_REPORT): PrerequisiteService {
+  return { check: vi.fn().mockResolvedValue(report) } as Partial<PrerequisiteService> as PrerequisiteService;
+}
+
+/**
+ * The metadata key NestJS stores on each method decorated with
+ * `@MessagePattern`. Asserting this value is the only automated guard
+ * that prevents a typo in the controller from silently breaking IPC.
+ */
+const PATTERN_METADATA_KEY = 'microservices:pattern';
+
+describe('WizardController', () => {
+  describe('@MessagePattern channel names', () => {
+    it('should register checkPrereqs on the "wizard.prereqs.check" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.checkPrereqs);
+      expect(pattern).toEqual(['wizard.prereqs.check']);
+    });
+  });
+
+  describe('checkPrereqs', () => {
+    it('should return the report produced by PrerequisiteService.check', async () => {
+      const prerequisites = makePrerequisites();
+      const result = await new WizardController(prerequisites).checkPrereqs();
+      expect(result).toEqual(SATISFIED_REPORT);
+      expect(prerequisites.check).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate a report with a missing tool unchanged', async () => {
+      const report: PrerequisitesReport = { terraform: { found: false }, aws: { found: false } };
+      const result = await new WizardController(makePrerequisites(report)).checkPrereqs();
+      expect(result).toEqual(report);
+    });
+  });
+});

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@nestjs/common';
+import { MessagePattern } from '@nestjs/microservices';
+import { PrerequisiteService, type PrerequisitesReport } from '../services/PrerequisiteService.js';
+
+/**
+ * IPC-only controller for the first-run wizard (see
+ * `openspec/changes/add-first-run-wizard`). Every handler is a plain
+ * request/response `@MessagePattern` — no HTTP routes, and no streaming
+ * side-channels of its own (the wizard's one streaming step reuses the
+ * already-shipped `terraform.init` channel instead of adding a second one
+ * here).
+ */
+@Controller()
+export class WizardController {
+  constructor(private readonly prerequisites: PrerequisiteService) {}
+
+  /** Detects `terraform` and `aws` on `PATH`, reporting per-tool found/path/version. */
+  @MessagePattern('wizard.prereqs.check')
+  checkPrereqs(): Promise<PrerequisitesReport> {
+    return this.prerequisites.check();
+  }
+}

--- a/app/packages/desktop-main/src/modules/wizard.module.ts
+++ b/app/packages/desktop-main/src/modules/wizard.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { PrerequisiteService } from '../services/PrerequisiteService.js';
+
+/**
+ * Groups the first-run wizard's providers (see
+ * `openspec/changes/add-first-run-wizard`). Follows the same shape as
+ * `TerraformModule`/`DiscordModule` — `providers`/`exports` only, no
+ * `controllers` array; the IPC controller is wired directly into
+ * `AppModule.controllers` alongside every other controller in this codebase.
+ */
+@Module({
+  providers: [PrerequisiteService],
+  exports: [PrerequisiteService],
+})
+export class WizardModule {}

--- a/app/packages/desktop-main/src/services/PrerequisiteService.test.ts
+++ b/app/packages/desktop-main/src/services/PrerequisiteService.test.ts
@@ -48,13 +48,20 @@ function routeExecFile(handler: (file: string, args: string[]) => RouteResult): 
   });
 }
 
-/** Builds a `PrerequisiteService` with `readPlatform` stubbed to `linux` (so `which` is used). */
+/**
+ * Test-only subclass overriding the protected `readPlatform` seam to always
+ * report `linux` (so `which`, not `where.exe`, is used), avoiding a double
+ * `as unknown as` cast to reach a protected method from a plain spy.
+ */
+class LinuxPrerequisiteService extends PrerequisiteService {
+  protected override readPlatform(): NodeJS.Platform {
+    return 'linux';
+  }
+}
+
+/** Builds a `PrerequisiteService` that resolves the platform as `linux`. */
 function makeService(): PrerequisiteService {
-  const service = new PrerequisiteService();
-  vi.spyOn(service as unknown as { readPlatform(): NodeJS.Platform }, 'readPlatform').mockReturnValue(
-    'linux',
-  );
-  return service;
+  return new LinuxPrerequisiteService();
 }
 
 const TERRAFORM_PATH = '/usr/local/bin/terraform';
@@ -77,8 +84,12 @@ describe('PrerequisiteService.isVersionAtLeast', () => {
     expect(PrerequisiteService.isVersionAtLeast('1.4.9', '1.5.0')).toBe(false);
   });
 
-  it('should ignore a pre-release suffix on the version being compared', () => {
-    expect(PrerequisiteService.isVersionAtLeast('1.5.0-beta1', '1.5.0')).toBe(true);
+  it('should treat an equal-core pre-release as below the stable minimum', () => {
+    expect(PrerequisiteService.isVersionAtLeast('1.5.0-beta1', '1.5.0')).toBe(false);
+  });
+
+  it('should still allow a pre-release to satisfy a lower minimum via the numeric core', () => {
+    expect(PrerequisiteService.isVersionAtLeast('1.9.0-beta1', '1.5.0')).toBe(true);
   });
 
   it('should compare minor and patch components independently of major', () => {

--- a/app/packages/desktop-main/src/services/PrerequisiteService.test.ts
+++ b/app/packages/desktop-main/src/services/PrerequisiteService.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * Spy variable must be hoisted before vi.mock() factories run, because
+ * vi.mock() calls are lifted to the top of the compiled output above regular
+ * declarations.
+ */
+const { execFileMock } = vi.hoisted(() => {
+  const execFileMock = vi.fn();
+  return { execFileMock };
+});
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+import { PrerequisiteService } from './PrerequisiteService.js';
+
+/** Error-first callback shape `util.promisify` invokes the mocked `execFile` with. */
+type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+/** Extracts the error-first callback from an `execFile` call's arguments. */
+function lastArgAsCallback(args: unknown[]): ExecFileCallback {
+  return args[args.length - 1] as ExecFileCallback;
+}
+
+/** Either a successful stdout (stderr defaults to empty) or a failure sentinel. */
+type RouteResult = { stdout: string; stderr?: string } | 'fail';
+
+/**
+ * Installs an `execFile` mock that dispatches on the actual `(file, args)`
+ * being invoked rather than call order — required because
+ * `PrerequisiteService.check()` runs the `terraform` and `aws` probes
+ * concurrently via `Promise.all`, so a strict FIFO queue of responses can't
+ * reliably tell which branch a given `execFile` call belongs to.
+ */
+function routeExecFile(handler: (file: string, args: string[]) => RouteResult): void {
+  execFileMock.mockImplementation((...callArgs: unknown[]) => {
+    const file = callArgs[0] as string;
+    const argv = (callArgs[1] as string[] | undefined) ?? [];
+    const callback = lastArgAsCallback(callArgs);
+    const result = handler(file, argv);
+    if (result === 'fail') {
+      callback(new Error('spawn ENOENT'));
+    } else {
+      callback(null, { stdout: result.stdout, stderr: result.stderr ?? '' });
+    }
+  });
+}
+
+/** Builds a `PrerequisiteService` with `readPlatform` stubbed to `linux` (so `which` is used). */
+function makeService(): PrerequisiteService {
+  const service = new PrerequisiteService();
+  vi.spyOn(service as unknown as { readPlatform(): NodeJS.Platform }, 'readPlatform').mockReturnValue(
+    'linux',
+  );
+  return service;
+}
+
+const TERRAFORM_PATH = '/usr/local/bin/terraform';
+const AWS_PATH = '/usr/local/bin/aws';
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+describe('PrerequisiteService.isVersionAtLeast', () => {
+  it('should return true when the version exactly equals the minimum', () => {
+    expect(PrerequisiteService.isVersionAtLeast('1.5.0', '1.5.0')).toBe(true);
+  });
+
+  it('should return true when the version is greater than the minimum', () => {
+    expect(PrerequisiteService.isVersionAtLeast('1.9.0', '1.5.0')).toBe(true);
+  });
+
+  it('should return false when the version is less than the minimum', () => {
+    expect(PrerequisiteService.isVersionAtLeast('1.4.9', '1.5.0')).toBe(false);
+  });
+
+  it('should ignore a pre-release suffix on the version being compared', () => {
+    expect(PrerequisiteService.isVersionAtLeast('1.5.0-beta1', '1.5.0')).toBe(true);
+  });
+
+  it('should compare minor and patch components independently of major', () => {
+    expect(PrerequisiteService.isVersionAtLeast('2.0.0', '1.99.99')).toBe(true);
+    expect(PrerequisiteService.isVersionAtLeast('1.5.1', '1.5.10')).toBe(false);
+  });
+});
+
+describe('PrerequisiteService.check: terraform', () => {
+  it('should report not found when the lookup command fails', async () => {
+    const service = makeService();
+    routeExecFile(() => 'fail');
+
+    const report = await service.check();
+
+    expect(report.terraform).toEqual({ found: false });
+  });
+
+  it('should report found with version and minimumVersionSatisfied when -json output parses', async () => {
+    const service = makeService();
+    routeExecFile((file, argv) => {
+      if (file === 'which' && argv[0] === 'terraform') return { stdout: `${TERRAFORM_PATH}\n` };
+      if (file === 'which' && argv[0] === 'aws') return 'fail';
+      if (file === TERRAFORM_PATH && argv[0] === 'version' && argv[1] === '-json') {
+        return { stdout: JSON.stringify({ terraform_version: '1.9.0' }) };
+      }
+      return 'fail';
+    });
+
+    const report = await service.check();
+
+    expect(report.terraform).toEqual({
+      found: true,
+      path: TERRAFORM_PATH,
+      version: '1.9.0',
+      minimumVersionSatisfied: true,
+    });
+  });
+
+  it('should flag minimumVersionSatisfied as false when the resolved version is below the minimum', async () => {
+    const service = makeService();
+    routeExecFile((file, argv) => {
+      if (file === 'which' && argv[0] === 'terraform') return { stdout: `${TERRAFORM_PATH}\n` };
+      if (file === 'which' && argv[0] === 'aws') return 'fail';
+      if (file === TERRAFORM_PATH && argv[0] === 'version' && argv[1] === '-json') {
+        return { stdout: JSON.stringify({ terraform_version: '1.2.0' }) };
+      }
+      return 'fail';
+    });
+
+    const report = await service.check();
+
+    expect(report.terraform.minimumVersionSatisfied).toBe(false);
+  });
+
+  it('should fall back to plain-text version parsing when -json output is unparseable', async () => {
+    const service = makeService();
+    routeExecFile((file, argv) => {
+      if (file === 'which' && argv[0] === 'terraform') return { stdout: `${TERRAFORM_PATH}\n` };
+      if (file === 'which' && argv[0] === 'aws') return 'fail';
+      if (file === TERRAFORM_PATH && argv[0] === 'version' && argv[1] === '-json') return { stdout: 'not json' };
+      if (file === TERRAFORM_PATH && argv[0] === 'version' && argv.length === 1) {
+        return { stdout: 'Terraform v1.6.3\non linux_amd64\n' };
+      }
+      return 'fail';
+    });
+
+    const report = await service.check();
+
+    expect(report.terraform).toMatchObject({ found: true, version: '1.6.3' });
+  });
+
+  it('should report found with version undefined when neither version form parses', async () => {
+    const service = makeService();
+    routeExecFile((file, argv) => {
+      if (file === 'which' && argv[0] === 'terraform') return { stdout: `${TERRAFORM_PATH}\n` };
+      if (file === 'which' && argv[0] === 'aws') return 'fail';
+      if (file === TERRAFORM_PATH && argv[0] === 'version' && argv[1] === '-json') return { stdout: 'not json' };
+      if (file === TERRAFORM_PATH && argv[0] === 'version' && argv.length === 1) {
+        return { stdout: 'unrecognized output' };
+      }
+      return 'fail';
+    });
+
+    const report = await service.check();
+
+    expect(report.terraform).toEqual({ found: true, path: TERRAFORM_PATH });
+  });
+});
+
+describe('PrerequisiteService.check: aws', () => {
+  it('should report not found when the lookup command fails', async () => {
+    const service = makeService();
+    routeExecFile(() => 'fail');
+
+    const report = await service.check();
+
+    expect(report.aws).toEqual({ found: false });
+  });
+
+  it('should report found with a parsed version from the aws-cli/X.Y.Z banner', async () => {
+    const service = makeService();
+    routeExecFile((file, argv) => {
+      if (file === 'which' && argv[0] === 'aws') return { stdout: `${AWS_PATH}\n` };
+      if (file === 'which' && argv[0] === 'terraform') return 'fail';
+      if (file === AWS_PATH && argv[0] === '--version') {
+        return { stdout: 'aws-cli/2.15.30 Python/3.11.6 Linux/5.15.0 exe/x86_64.ubuntu.22 prompt/off\n' };
+      }
+      return 'fail';
+    });
+
+    const report = await service.check();
+
+    expect(report.aws).toEqual({ found: true, path: AWS_PATH, version: '2.15.30' });
+  });
+
+  it('should report found with version undefined when the banner is unparseable', async () => {
+    const service = makeService();
+    routeExecFile((file, argv) => {
+      if (file === 'which' && argv[0] === 'aws') return { stdout: `${AWS_PATH}\n` };
+      if (file === 'which' && argv[0] === 'terraform') return 'fail';
+      if (file === AWS_PATH && argv[0] === '--version') return { stdout: 'unrecognized banner' };
+      return 'fail';
+    });
+
+    const report = await service.check();
+
+    expect(report.aws).toEqual({ found: true, path: AWS_PATH });
+  });
+});

--- a/app/packages/desktop-main/src/services/PrerequisiteService.ts
+++ b/app/packages/desktop-main/src/services/PrerequisiteService.ts
@@ -6,6 +6,14 @@ import { lookupCommandFor } from './TerraformService.js';
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Timeout applied to every CLI probe (`which`/`where.exe` lookups and
+ * `terraform`/`aws` version invocations). Without one, a hung subprocess
+ * would leave {@link PrerequisiteService.check} pending indefinitely instead
+ * of degrading to a reported status.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
+
 /** Detection result for a single prerequisite binary. */
 export interface PrerequisiteCheckResult {
   /** Whether the binary was located on `PATH`. */
@@ -80,7 +88,7 @@ export class PrerequisiteService {
   protected async locate(binary: string): Promise<string | null> {
     const lookupCommand = lookupCommandFor(this.readPlatform());
     try {
-      const { stdout } = await execFileAsync(lookupCommand, [binary]);
+      const { stdout } = await execFileAsync(lookupCommand, [binary], { timeout: PROBE_TIMEOUT_MS });
       const firstLine = stdout
         .split(/\r?\n/)
         .map((line) => line.trim())
@@ -101,7 +109,7 @@ export class PrerequisiteService {
    */
   protected async readTerraformVersion(binaryPath: string): Promise<string | undefined> {
     try {
-      const { stdout } = await execFileAsync(binaryPath, ['version', '-json']);
+      const { stdout } = await execFileAsync(binaryPath, ['version', '-json'], { timeout: PROBE_TIMEOUT_MS });
       const parsed = JSON.parse(stdout) as { terraform_version?: unknown };
       if (typeof parsed.terraform_version === 'string' && parsed.terraform_version.length > 0) {
         return parsed.terraform_version;
@@ -110,7 +118,7 @@ export class PrerequisiteService {
       // `-json` output missing/unparseable — fall back to plain-text parsing below.
     }
     try {
-      const { stdout } = await execFileAsync(binaryPath, ['version']);
+      const { stdout } = await execFileAsync(binaryPath, ['version'], { timeout: PROBE_TIMEOUT_MS });
       const match = /Terraform\s+v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/.exec(stdout);
       return match?.[1];
     } catch {
@@ -127,7 +135,7 @@ export class PrerequisiteService {
    */
   protected async readAwsVersion(binaryPath: string): Promise<string | undefined> {
     try {
-      const { stdout, stderr } = await execFileAsync(binaryPath, ['--version']);
+      const { stdout, stderr } = await execFileAsync(binaryPath, ['--version'], { timeout: PROBE_TIMEOUT_MS });
       const match = /aws-cli\/(\d+\.\d+\.\d+)/.exec(`${stdout}${stderr}`);
       return match?.[1];
     } catch {
@@ -145,9 +153,11 @@ export class PrerequisiteService {
 
   /**
    * Lightweight `major.minor.patch` comparison — `true` when `version` is
-   * greater than or equal to `minimum`. Pre-release suffixes on `version`
-   * (e.g. `1.9.0-beta1`) are ignored for the comparison; `minimum` is always
-   * a plain `X.Y.Z` constant.
+   * greater than or equal to `minimum`. `minimum` is always a plain `X.Y.Z`
+   * constant. When the numeric core is equal, a pre-release suffix on
+   * `version` (e.g. `1.5.0-beta1`) does *not* satisfy the minimum — matching
+   * SemVer precedence, where a pre-release sorts below the corresponding
+   * stable release (`1.5.0-beta1 < 1.5.0`).
    */
   static isVersionAtLeast(version: string, minimum: string): boolean {
     const a = (version.split('-')[0] ?? '').split('.').map((n) => Number(n) || 0);
@@ -157,6 +167,6 @@ export class PrerequisiteService {
       const bv = b[i] ?? 0;
       if (av !== bv) return av > bv;
     }
-    return true;
+    return !version.includes('-');
   }
 }

--- a/app/packages/desktop-main/src/services/PrerequisiteService.ts
+++ b/app/packages/desktop-main/src/services/PrerequisiteService.ts
@@ -1,0 +1,162 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { Injectable } from '@nestjs/common';
+import { MINIMUM_TERRAFORM_VERSION } from '@hyveon/shared';
+import { lookupCommandFor } from './TerraformService.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Detection result for a single prerequisite binary. */
+export interface PrerequisiteCheckResult {
+  /** Whether the binary was located on `PATH`. */
+  found: boolean;
+  /** Absolute path to the binary, present only when `found` is `true`. */
+  path?: string;
+  /** Parsed semver string, present only when the version output was parseable. */
+  version?: string;
+}
+
+/** Detection result for `terraform`, extending the base shape with a minimum-version flag. */
+export interface TerraformPrerequisiteCheckResult extends PrerequisiteCheckResult {
+  /**
+   * Whether `version` satisfies {@link MINIMUM_TERRAFORM_VERSION}. `undefined`
+   * when `version` itself could not be parsed, since there's nothing to
+   * compare.
+   */
+  minimumVersionSatisfied?: boolean;
+}
+
+/** Combined report returned by {@link PrerequisiteService.check}. */
+export interface PrerequisitesReport {
+  terraform: TerraformPrerequisiteCheckResult;
+  aws: PrerequisiteCheckResult;
+}
+
+/**
+ * Probes for the `terraform` and `aws` CLI binaries on `PATH`, used by the
+ * first-run wizard's blocking prerequisite-detection step (see
+ * `openspec/changes/add-first-run-wizard`). Never attempts to install
+ * anything — a missing or under-minimum-version binary is reported back to
+ * the caller, which surfaces per-OS install instructions and a "Re-check"
+ * action.
+ *
+ * Platform access is extracted into a `protected` seam so tests can
+ * `vi.spyOn` it instead of stubbing the real `process.platform` global.
+ */
+@Injectable()
+export class PrerequisiteService {
+  /** Detects both `terraform` and `aws` in parallel and returns a combined report. */
+  async check(): Promise<PrerequisitesReport> {
+    const [terraform, aws] = await Promise.all([this.checkTerraform(), this.checkAws()]);
+    return { terraform, aws };
+  }
+
+  private async checkTerraform(): Promise<TerraformPrerequisiteCheckResult> {
+    const path = await this.locate('terraform');
+    if (!path) return { found: false };
+    const version = await this.readTerraformVersion(path);
+    if (!version) return { found: true, path };
+    return {
+      found: true,
+      path,
+      version,
+      minimumVersionSatisfied: PrerequisiteService.isVersionAtLeast(version, MINIMUM_TERRAFORM_VERSION),
+    };
+  }
+
+  private async checkAws(): Promise<PrerequisiteCheckResult> {
+    const path = await this.locate('aws');
+    if (!path) return { found: false };
+    const version = await this.readAwsVersion(path);
+    return version ? { found: true, path, version } : { found: true, path };
+  }
+
+  /**
+   * Locates `binary` on `PATH` via the platform's lookup command
+   * (`which`/`where.exe`, from {@link lookupCommandFor}). Returns the first
+   * non-empty stdout line, or `null` when the lookup command fails (binary
+   * missing, lookup command itself missing, empty output).
+   */
+  protected async locate(binary: string): Promise<string | null> {
+    const lookupCommand = lookupCommandFor(this.readPlatform());
+    try {
+      const { stdout } = await execFileAsync(lookupCommand, [binary]);
+      const firstLine = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+      return firstLine ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Runs `terraform version -json` and extracts `terraform_version`, falling
+   * back to parsing the plain-text `Terraform vX.Y.Z` line when `-json`
+   * output is missing/unparseable (older Terraform releases). Returns
+   * `undefined` — never throws — when neither form parses, since an
+   * unparseable version is a degrade-gracefully case for the wizard, not a
+   * hard failure.
+   */
+  protected async readTerraformVersion(binaryPath: string): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFileAsync(binaryPath, ['version', '-json']);
+      const parsed = JSON.parse(stdout) as { terraform_version?: unknown };
+      if (typeof parsed.terraform_version === 'string' && parsed.terraform_version.length > 0) {
+        return parsed.terraform_version;
+      }
+    } catch {
+      // `-json` output missing/unparseable — fall back to plain-text parsing below.
+    }
+    try {
+      const { stdout } = await execFileAsync(binaryPath, ['version']);
+      const match = /Terraform\s+v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?)/.exec(stdout);
+      return match?.[1];
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Runs `aws --version` and extracts the semver from the `aws-cli/X.Y.Z ...`
+   * banner (AWS CLI v1 and v2 both emit this prefix). Returns `undefined`
+   * — never throws — when the output doesn't match, so an unrecognized
+   * banner shape degrades to "found, version unknown" rather than failing
+   * the whole prerequisite check.
+   */
+  protected async readAwsVersion(binaryPath: string): Promise<string | undefined> {
+    try {
+      const { stdout, stderr } = await execFileAsync(binaryPath, ['--version']);
+      const match = /aws-cli\/(\d+\.\d+\.\d+)/.exec(`${stdout}${stderr}`);
+      return match?.[1];
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns `process.platform`. Extracted as a protected seam so tests can
+   * `vi.spyOn` it instead of stubbing the real global.
+   */
+  protected readPlatform(): NodeJS.Platform {
+    return process.platform;
+  }
+
+  /**
+   * Lightweight `major.minor.patch` comparison — `true` when `version` is
+   * greater than or equal to `minimum`. Pre-release suffixes on `version`
+   * (e.g. `1.9.0-beta1`) are ignored for the comparison; `minimum` is always
+   * a plain `X.Y.Z` constant.
+   */
+  static isVersionAtLeast(version: string, minimum: string): boolean {
+    const a = (version.split('-')[0] ?? '').split('.').map((n) => Number(n) || 0);
+    const b = minimum.split('.').map((n) => Number(n) || 0);
+    for (let i = 0; i < 3; i++) {
+      const av = a[i] ?? 0;
+      const bv = b[i] ?? 0;
+      if (av !== bv) return av > bv;
+    }
+    return true;
+  }
+}

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -948,6 +948,34 @@ export interface GsdConfigApi {
   }) => Promise<WatchdogConfigResult>;
 }
 
+/** Detection result for a single first-run-wizard prerequisite binary. */
+export interface PrerequisiteCheckResult {
+  /** Whether the binary was located on `PATH`. */
+  found: boolean;
+  /** Absolute path to the binary, present only when `found` is `true`. */
+  path?: string;
+  /** Parsed semver string, present only when the version output was parseable. */
+  version?: string;
+}
+
+/** Detection result for `terraform`, extending the base shape with a minimum-version flag. */
+export interface TerraformPrerequisiteCheckResult extends PrerequisiteCheckResult {
+  /** Whether `version` satisfies the app's minimum supported Terraform version. */
+  minimumVersionSatisfied?: boolean;
+}
+
+/** Combined report returned by the first-run wizard's prerequisite-detection step. */
+export interface PrerequisitesReport {
+  terraform: TerraformPrerequisiteCheckResult;
+  aws: PrerequisiteCheckResult;
+}
+
+/** First-run wizard endpoints (see `openspec/changes/add-first-run-wizard`). */
+export interface GsdWizardApi {
+  /** Detects `terraform` and `aws` on `PATH`, reporting per-tool found/path/version. */
+  checkPrereqs: () => Promise<PrerequisitesReport>;
+}
+
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */
 export interface GsdDriftApi {
   /** Returns the current drift report — games out of sync between declared and deployed state. */
@@ -1259,6 +1287,8 @@ export interface GsdApi {
   env: GsdEnvApi;
   /** Watchdog configuration stored in server_config.json. */
   config: GsdConfigApi;
+  /** First-run wizard endpoints: prerequisite detection, credentials, cloud bootstrap. */
+  wizard: GsdWizardApi;
   /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */
   drift: GsdDriftApi;
   /** Local application log diagnostics: tail recent lines or retrieve the log file path. */

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -72,6 +72,7 @@ import type {
   RunHistoryPageResult,
   TfOutputs,
   UpdateGamePayload,
+  PrerequisitesReport,
 } from './gsd-api.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -588,6 +589,10 @@ const api: GsdApi = {
       watchdog_idle_checks?: number;
       watchdog_min_packets?: number;
     }) => invoke('config.update', body),
+  },
+
+  wizard: {
+    checkPrereqs: () => invoke<PrerequisitesReport>('wizard.prereqs.check'),
   },
 
   drift: {

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './errors.js';
+export * from './terraformVersion.js';
 export * from './tfvars.js';
 export * from './gameServerValidator.js';
 export * from './gamesWrite.js';

--- a/app/packages/shared/src/terraformVersion.ts
+++ b/app/packages/shared/src/terraformVersion.ts
@@ -1,0 +1,9 @@
+/**
+ * Minimum Terraform version the app supports, matching the `required_version`
+ * constraint declared in both `terraform/main.tf` and
+ * `terraform/aws/versions.tf`. Kept in `@hyveon/shared` (rather than
+ * `@hyveon/desktop-main`) so the first-run wizard's prerequisite check and
+ * Settings' "resolved vs. minimum" display can both import a single source
+ * of truth.
+ */
+export const MINIMUM_TERRAFORM_VERSION = '1.5.0';


### PR DESCRIPTION
Closes #182

## Summary

PR 1 of 12 for the First-Run Wizard epic (#139, see `openspec/changes/add-first-run-wizard`). This PR is the prerequisite-detection service — the wizard's blocking first step, which checks for `terraform`/`aws` on `PATH` before anything else can run.

- New `MINIMUM_TERRAFORM_VERSION` constant in `@hyveon/shared` (`1.5.0`, matching the `required_version` constraint already in `terraform/main.tf`/`terraform/aws/versions.tf`).
- New `PrerequisiteService` (`desktop-main/src/services/PrerequisiteService.ts`): probes for `terraform` and `aws` on `PATH` (reusing the existing `lookupCommandFor` helper from `TerraformService`), parses Terraform's `-json`/plain-text version output and the AWS CLI's `aws-cli/X.Y.Z` banner, and flags whether the resolved Terraform version meets the minimum. Never throws — a missing or unparseable tool degrades to a reported status (`{ found: false }` or `{ found: true, version: undefined }`) rather than an error, since the wizard's job is to show install instructions, not crash.
- New `WizardModule` + `WizardController` (`@MessagePattern('wizard.prereqs.check')`), wired into `AppModule` — the first of several `wizard.*` IPC channels this epic will add.
- New preload surface: `gsd.wizard.checkPrereqs()`, mirrored as `GsdWizardApi`/`PrerequisitesReport` in `gsd-api.ts`.

No Electron-only APIs are touched here (plain `execFile`), so there's nothing to gate on `process.versions.electron` in this PR.

## Test plan

- [x] `npm run app:test` — 1892/1892 tests passing (new: prerequisite-detection + version-parsing + minimum-version-flagging specs for both tools, concurrent-probe-safe via a request-routing `execFile` mock since `terraform`/`aws` are checked in parallel; controller `@MessagePattern` dispatch specs)
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings)
