### PR TITLE
chore: add OpenSpec proposal to rename Gsd to Hyveon

### DIFF
--- a/openspec/changes/rename-gsd-to-hyveon/.openspec.yaml
+++ b/openspec/changes/rename-gsd-to-hyveon/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/rename-gsd-to-hyveon/design.md
+++ b/openspec/changes/rename-gsd-to-hyveon/design.md
@@ -1,0 +1,63 @@
+## Context
+
+`Gsd`/`gsd`/`GSD` appears across ~50 files in three unrelated tiers:
+
+1. **The desktop-preload IPC surface** — `GsdApi`, `GsdTestApi`, `GsdMockNamespaces`, and eleven per-domain `Gsd*Api` interfaces in `app/packages/desktop-preload/src/gsd-api.ts`, exposed at runtime via `contextBridge.exposeInMainWorld('gsd', ...)` in `preload.ts` and consumed everywhere as `window.gsd`.
+2. **Test infrastructure** — `applyGsdMocks()`, `installGsdHttpBridge()`, and the `gsd-http-bridge.ts`/`gsd-api.ts` filenames in the e2e fixtures/specs/page-objects.
+3. **An unrelated local dev-tooling marker** — `.gsd/tfvars-bucket` (a gitignored local marker file) and the `GSD_TFVARS_BACKEND` env var, used by `setup.sh`, `scripts/tfvars-sync.ts`, `scripts/init-parent.ts`, and `ConfigService.ts` to track the S3 tfvars-backend bootstrap state. This has no relationship to the preload API — it predates it — but carries the same stale name.
+
+The repo already completed a `project_name` rebrand to `hyveon` for AWS-provisioned resources (#213, see `docs/docs/guides/project-name-migration.md`). This change is the same rebrand applied to the parts of the codebase Terraform doesn't touch.
+
+Two matches found during research are **not** real occurrences and must not be touched:
+
+- `package-lock.json` / `docs/package-lock.json`: `gsd` appears only as a substring inside base64 `integrity` hashes (e.g. `...CGsdzS7d...`) — coincidental, not the acronym.
+- `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md`: a dated, already-implemented architecture design doc. It documents what was decided on 2026-05-10 under the name in effect at the time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every live identifier, runtime global, filename, directory, env var, and doc reference that means "Gsd"/"gsd"/"GSD" reads as "Hyveon"/"hyveon"/"HYVEON" instead, with zero behavior change.
+- The workspace builds, lints, and passes its full test suite (unit, e2e electron, e2e chromium, integration) after the rename, with no `Gsd`/`gsd`/`GSD` residue outside the two excluded cases above.
+- Git history is preserved for renamed files (`git mv`, not delete+recreate).
+
+**Non-Goals:**
+- Not touching AWS-provisioned resource names or `terraform/variables.tf`'s `project_name` — that rebrand is already done (#213) and out of scope here.
+- Not rewriting the dated historical design doc (`docs/superpowers/specs/2026-05-10-*`) — it's a historical record, not live documentation.
+- Not adding a backwards-compatibility shim for the renamed `window.gsd` global or `.gsd/` marker path — per repo convention, this is a clean rename, not a versioned migration.
+
+## Decisions
+
+**Case-tier mapping.** Apply three parallel substitutions, chosen by the casing already in use at each site — never mix tiers:
+- `Gsd` → `Hyveon` (PascalCase: interface/type names like `GsdApi`)
+- `gsd` → `hyveon` (camelCase/lowercase: `window.gsd`, `applyGsdMocks`, `.gsd/`, filenames)
+- `GSD` → `HYVEON` (all-caps: `GSD_TFVARS_BACKEND`, the `# GSD bootstrap metadata` comment in `.gitignore`)
+
+**Sequencing follows the npm workspace dependency order**, so each stage leaves a compilable state and TypeScript errors surface immediately at their source rather than cascading:
+1. `@hyveon/desktop-preload` (`gsd-api.ts` → `hyveon-api.ts` via `git mv`, then `index.ts`, `preload.ts`, their `.test.ts` files)
+2. `@hyveon/web` (`api.service.ts`, `globals.d.ts`, `window.d.ts`, every component/page importing `Gsd*` types or reading `window.gsd`)
+3. `app/packages/web/e2e/**` (fixtures, page-objects, specs — including the `gsd-http-bridge.ts` → `hyveon-http-bridge.ts` file rename)
+4. `@hyveon/desktop-main` (`ConfigService.ts`, `TerraformService.ts`, controllers referencing `.gsd/`) + `scripts/**` + `setup.sh` + `.gitignore` + `electron-builder.yml`
+5. Docs (`CLAUDE.md`, `docs/docs/**` except the historical design doc, `scripts/README.md`)
+6. Final repo-wide verification grep to confirm zero residual matches outside the two excluded files.
+
+**`window.gsd` → `window.hyveon` lands as one atomic change**, not a dual-exposed transition period. This is an internal renderer↔main IPC bridge shipped as a single Electron app version — there's no external consumer or older-client compatibility concern the way there would be for a public API, so exposing both names temporarily would just be dead code.
+
+**`.gsd/tfvars-bucket` gets a clean rename, not a fallback read path.** Per repo convention (no compatibility shims for internal tooling), `ConfigService`/`tfvars-sync.ts` will only look for `.hyveon/tfvars-bucket` after this change. Developers with an existing local `.gsd/tfvars-bucket` marker need a one-time manual `mv .gsd .hyveon`. `setup.sh` gets a short one-time check: if `.gsd/` exists and `.hyveon/` doesn't, print a hint to rename it manually before continuing (a warning, not an automatic migration, so we don't silently move files a developer might not expect touched).
+
+**`electron-builder.yml`'s `appId: dev.gsd.desktop` → `dev.hyveon.desktop` is included**, per explicit scope confirmation, but is called out separately in Risks below — it's the one change in this set with a real (if small) external-facing consequence rather than being purely cosmetic.
+
+## Risks / Trade-offs
+
+- **[Risk]** Changing `appId` affects OS-level app identity for anyone with an already-packaged install (macOS keychain-linked entries, Windows uninstall registry keys are keyed by `appId`) → **Mitigation**: this app has no broad external distribution yet (internal/early-stage per CLAUDE.md); no auto-migration is provided, but this is worth a one-line release note if/when a build goes out to existing testers.
+- **[Risk]** A case-tier mismatch (e.g. a mid-word match like `desktopGsdBridge` needing `Hyveon` even though it's not a standalone identifier) causes a partial rename that still compiles but reads inconsistently → **Mitigation**: tasks.md's final step is a repo-wide case-insensitive `gsd` grep (excluding the two known-excluded files) that must return zero hits before the change is considered done.
+- **[Risk]** `.gsd/tfvars-bucket` silently "disappears" for an existing developer, making `tfvars-sync.ts` behave as if no backend has been bootstrapped yet → **Mitigation**: `setup.sh`'s new one-time hint (see Decisions) surfaces this before it causes confusing downstream errors.
+- **[Trade-off]** Doing this as one larger PR (vs. one PR per workspace) means a bigger diff to review, but avoids an intermediate state where `@hyveon/web` still imports `Gsd*` types from a `@hyveon/desktop-preload` that has already renamed them — splitting by workspace would break the build between PRs.
+
+## Migration Plan
+
+Single PR with sequenced, working-tree-clean commits following the order in Decisions. No deploy-time migration: this is dev-tooling and desktop-app source, not provisioned infrastructure. Rollback is a plain revert of the PR; the only irreversible-feeling artifact is a developer's local `.gsd/` → `.hyveon/` manual rename, which is trivially reversible (`mv .hyveon .gsd`) if the PR is reverted.
+
+## Open Questions
+
+- Confirmed with the user: the historical design doc (`docs/superpowers/specs/2026-05-10-*`) is left untouched as a historical record — flagged explicitly in tasks.md so it isn't mistaken for a missed occurrence during the final verification grep.
+- `electron-builder.yml` appId change is in scope per explicit user confirmation (all four scope tiers selected, including "remove all GSD references") — no further sign-off is being sought here, but it's called out above so it isn't buried in an otherwise-cosmetic diff.

--- a/openspec/changes/rename-gsd-to-hyveon/proposal.md
+++ b/openspec/changes/rename-gsd-to-hyveon/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The desktop preload API, its TypeScript types, the renderer's runtime global, e2e test helpers, and an unrelated Terraform tfvars-bucket marker all carry the name `Gsd`/`gsd`/`GSD` — a leftover from the project's pre-rebrand name. The app and repo are now called Hyveon (see the `project_name` rebrand tracked in #213), but the code, the `window.gsd` bridge, test fixtures, scripts, and docs still say `gsd` in various cases. This is confusing for anyone reading the code fresh: `GsdApi`, `window.gsd`, `.gsd/tfvars-bucket`, and `GSD_TFVARS_BACKEND` don't explain what they are the way `HyveonApi`, `window.hyveon`, `.hyveon/tfvars-bucket`, and `HYVEON_TFVARS_BACKEND` would.
+
+## What Changes
+
+- Rename every `Gsd*` TypeScript interface/type in `@hyveon/desktop-preload` (`GsdApi`, `GsdTestApi`, `GsdMockNamespaces`, `GsdGamesApi`, `GsdCostsApi`, `GsdLogsApi`, `GsdFilesApi`, `GsdDiscordApi`, `GsdEnvApi`, `GsdConfigApi`, `GsdDriftApi`, `GsdDiagnosticsApi`, `GsdAuditApi`, `GsdTerraformRunsApi`, `GsdTerraformApi`, `GsdTerraformRollbackApi`) to their `Hyveon*` equivalents.
+- Rename e2e test helper functions and fixtures: `applyGsdMocks()` → `applyHyveonMocks()`, `installGsdHttpBridge()` → `installHyveonHttpBridge()`, and the `gsd-http-bridge.ts`/`gsd-api.ts` filenames.
+- **BREAKING**: rename the renderer's runtime IPC bridge global from `window.gsd` to `window.hyveon` — the `contextBridge.exposeInMainWorld('gsd', ...)` call in `preload.ts` becomes `exposeInMainWorld('hyveon', ...)`. Every consumer of `window.gsd` (production `api.service.ts`, all e2e specs/page-objects/fixtures, `globals.d.ts`/`window.d.ts` augmentations, and this repo's `CLAUDE.md` documentation of the `window.gsd.__test.mock()` test seam) moves in the same change so nothing is left calling a global that no longer exists.
+- **BREAKING**: rename the unrelated local tfvars-bucket marker directory `.gsd/` to `.hyveon/` and the `GSD_TFVARS_BACKEND` env var to `HYVEON_TFVARS_BACKEND`, used by `setup.sh`, `scripts/tfvars-sync.ts`, `scripts/init-parent.ts`, and `ConfigService.ts`. Anyone with an existing local `.gsd/tfvars-bucket` marker file needs a one-time manual rename (or re-run of the relevant setup step) after pulling this change — see design.md for the migration note.
+- Update every doc reference (`docs/docs/setup.md`, `docs/docs/guides/s3-tfvars.md`, `docs/docs/guides/submodule.md`, `docs/docs/guides/project-name-migration.md`, `scripts/README.md`, `CLAUDE.md`) so none of them still say `gsd`/`GSD`/`Gsd`.
+- No behavior changes: this is a pure identifier rename. Every renamed function, type, global, directory, and env var keeps its existing signature and semantics — only the name changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `preload-bridge-naming`: the desktop preload IPC bridge's public name — the runtime `window.*` global the renderer talks to, and the TypeScript type names describing it — is `hyveon`/`Hyveon*`, not `gsd`/`Gsd*`. This is the one part of the rename with an externally-observable contract (the renderer must call `window.hyveon`, not `window.gsd`), so it gets a spec even though the underlying IPC behavior is unchanged.
+
+### Modified Capabilities
+
+None — no other spec-level requirements change. Every other renamed file, helper, directory, or env var keeps its current behavior; only its name changes, and none of those areas has an existing `openspec/specs/` capability to delta.
+
+## Impact
+
+- **Code**: `app/packages/desktop-preload/src/*` (gsd-api.ts, index.ts, preload.ts + their `.test.ts` files), `app/packages/web/src/*` (api.service.ts, globals.d.ts, window.d.ts, and every page/component that references `window.gsd` or imports `Gsd*` types), `app/packages/web/e2e/**` (fixtures, page-objects, specs), `app/packages/desktop-main/src/**` (ConfigService.ts, TerraformService.ts, controllers referencing `.gsd/`), `scripts/**` (init-parent.ts + tests, tfvars-sync.ts), `setup.sh`, `electron-builder.yml`.
+- **Docs**: `CLAUDE.md`, `docs/docs/setup.md`, `docs/docs/guides/s3-tfvars.md`, `docs/docs/guides/submodule.md`, `docs/docs/guides/project-name-migration.md`, `scripts/README.md`, `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md`.
+- **Local developer state**: anyone with an existing `.gsd/tfvars-bucket` marker file on disk needs a one-time manual migration step (documented in design.md) after this change lands — the marker path itself is renamed, it isn't backwards-compatible by default.
+- **No AWS infrastructure impact**: this does not touch `terraform/variables.tf`'s `project_name` (already `hyveon` per #213) or any provisioned AWS resource name — it's local repo/dev-workflow naming only.

--- a/openspec/changes/rename-gsd-to-hyveon/specs/preload-bridge-naming/spec.md
+++ b/openspec/changes/rename-gsd-to-hyveon/specs/preload-bridge-naming/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Preload bridge is exposed as `window.hyveon`
+The desktop preload script SHALL expose the renderer-facing IPC bridge object as `window.hyveon` via `contextBridge.exposeInMainWorld('hyveon', ...)`. It SHALL NOT expose the same object as `window.gsd`.
+
+#### Scenario: Renderer reads the bridge after preload initializes
+- **WHEN** the Electron renderer process loads and the preload script has run
+- **THEN** `window.hyveon` is defined and exposes the `games`, `costs`, `logs`, `files`, `discord`, `env`, `config`, `drift`, `diagnostics`, `audit`, and `terraform` namespaces
+- **AND** `window.gsd` is `undefined`
+
+### Requirement: Bridge TypeScript types are named `Hyveon*`
+The TypeScript types describing the preload bridge and its test-mock surface (the top-level bridge type, the test-mode API, and the mock-namespace bag type) SHALL be named `HyveonApi`, `HyveonTestApi`, and `HyveonMockNamespaces` respectively, matching the runtime global's name. No `Gsd`-prefixed type SHALL remain in `@hyveon/desktop-preload`'s public exports.
+
+#### Scenario: Web package imports the bridge type
+- **WHEN** `@hyveon/web`'s `globals.d.ts` augments the `Window` interface for the preload bridge
+- **THEN** it declares `interface Window { hyveon?: HyveonApi }`, importing `HyveonApi` from `@hyveon/desktop-preload`
+
+### Requirement: Test-mode mock seam uses the same bridge name
+The Playwright Electron test seam (gated on `HYVEON_TEST_MODE=1`) SHALL attach its `__test` mock registry under `window.hyveon.__test`, not `window.gsd.__test`, and e2e helper functions that seed it SHALL be named to match (e.g. `applyHyveonMocks`, not `applyGsdMocks`).
+
+#### Scenario: Electron e2e spec seeds a mock IPC response
+- **WHEN** a Playwright Electron spec calls the mock-seeding helper to stub an IPC channel
+- **THEN** the helper calls `window.hyveon.__test.mock(channel, handler)` inside the page, and the production build (without the test-mode env var) never exposes `window.hyveon.__test` at all

--- a/openspec/changes/rename-gsd-to-hyveon/tasks.md
+++ b/openspec/changes/rename-gsd-to-hyveon/tasks.md
@@ -1,0 +1,49 @@
+## 1. `@hyveon/desktop-preload` package
+
+- [ ] 1.1 `git mv app/packages/desktop-preload/src/gsd-api.ts app/packages/desktop-preload/src/hyveon-api.ts` and rename every `Gsd*` interface inside it (`GsdApi` → `HyveonApi`, `GsdTestApi` → `HyveonTestApi`, `GsdMockNamespaces` → `HyveonMockNamespaces`, `GsdGamesApi`, `GsdCostsApi`, `GsdLogsApi`, `GsdFilesApi`, `GsdDiscordApi`, `GsdEnvApi`, `GsdConfigApi`, `GsdDriftApi`, `GsdDiagnosticsApi`, `GsdAuditApi`, `GsdTerraformRunsApi`, `GsdTerraformApi`, `GsdTerraformRollbackApi` → `Hyveon*` equivalents), plus doc comments referencing `GsdApi`/`window.gsd`.
+- [ ] 1.2 Update `app/packages/desktop-preload/src/index.ts`: import path to `./hyveon-api.js`, `Gsd*` type imports/re-exports → `Hyveon*`, and the `Window.gsd` global augmentation → `Window.hyveon`.
+- [ ] 1.3 Update `app/packages/desktop-preload/src/preload.ts`: `Gsd*` type imports, the `const api: GsdApi` → `HyveonApi` annotation, and `contextBridge.exposeInMainWorld('gsd', gsdBridge)` → `exposeInMainWorld('hyveon', hyveonBridge)` (rename the local `gsdBridge` variable too).
+- [ ] 1.4 Update `app/packages/desktop-preload/src/preload.test.ts` for the renamed types/global.
+- [ ] 1.5 Update `app/packages/desktop-preload/src/test-mock-registry.ts` and `test-mock-registry.test.ts` for the renamed mock-namespace type and any `gsd`-named identifiers.
+- [ ] 1.6 Run `npm run app:build` (or a scoped `tsc --noEmit` for `@hyveon/desktop-preload`) to confirm this package compiles clean before moving to its consumers.
+
+## 2. `@hyveon/web` package
+
+- [ ] 2.1 Update `app/packages/web/src/globals.d.ts` and `app/packages/web/src/window.d.ts`: `window.gsd` → `window.hyveon`, `GsdApi` import → `HyveonApi`, doc comments.
+- [ ] 2.2 Update `app/packages/web/src/api.service.ts` and `api.service.test.ts`: every `window.gsd.*` call site → `window.hyveon.*`.
+- [ ] 2.3 Update `app/packages/web/src/components/rollback-action.component.tsx` and its `.test.tsx`.
+- [ ] 2.4 Update the terraform page family: `terraform.page.tsx`/`.test.tsx`, `terraform-history.page.tsx`/`.test.tsx`, `terraform-run-detail.page.tsx`/`.test.tsx`.
+- [ ] 2.5 Update `app/packages/web/src/pages/logs.page.tsx` and `logs.page.test.tsx`.
+- [ ] 2.6 Run `npm run app:test` scoped to `@hyveon/web` (or the full suite) to confirm no `window.gsd`/`GsdApi` references remain in production or unit-test code.
+
+## 3. E2E test infrastructure
+
+- [ ] 3.1 `git mv app/packages/web/e2e/fixtures/gsd-http-bridge.ts app/packages/web/e2e/fixtures/hyveon-http-bridge.ts`; rename `installGsdHttpBridge()` → `installHyveonHttpBridge()` inside it.
+- [ ] 3.2 Update `app/packages/web/e2e/fixtures/electron-launch.ts`: rename `applyGsdMocks()` → `applyHyveonMocks()` and any `window.gsd` references inside `win.evaluate(...)` calls.
+- [ ] 3.3 Update `app/packages/web/e2e/fixtures/electron-mock.ts` and `app/packages/web/e2e/fixtures/index.ts` (import path to `./hyveon-http-bridge.js`, re-exported helper names).
+- [ ] 3.4 Update page objects: `app/packages/web/e2e/pages/DashboardPage.ts`, `app/packages/web/e2e/pages/TerraformPage.ts`.
+- [ ] 3.5 Update specs calling the renamed helpers: `costs.spec.ts`, `dashboard.spec.ts`, `discord.spec.ts`, `electron-ipc-roundtrip.spec.ts`, `electron-smoke.spec.ts`, `ipc-mock.spec.ts`, `logs.spec.ts`, `terraform.spec.ts`.
+- [ ] 3.6 Run `npm run app:test:e2e` (electron + chromium projects) to confirm the renamed fixtures/helpers work end-to-end.
+
+## 4. `@hyveon/desktop-main`, scripts, and local dev tooling
+
+- [ ] 4.1 Update `app/packages/desktop-main/src/services/ConfigService.ts` and `ConfigService.test.ts`: `.gsd/tfvars-bucket` path → `.hyveon/tfvars-bucket`, any `GSD_TFVARS_BACKEND` reference → `HYVEON_TFVARS_BACKEND`.
+- [ ] 4.2 Update `app/packages/desktop-main/src/services/TerraformService.ts` and controllers `diagnostics.controller.ts`, `terraform.controller.ts` for any `gsd`-named references.
+- [ ] 4.3 Update `scripts/init-parent.ts` (+ `init-parent.test.ts`, `init-parent.cli.test.ts`) and `scripts/tfvars-sync.ts`: `.gsd/` path and `GSD_TFVARS_BACKEND` env var → `.hyveon/` / `HYVEON_TFVARS_BACKEND`.
+- [ ] 4.4 Update `setup.sh`: env var name, `.gsd/tfvars-bucket` path, and add the one-time hint described in design.md (if `.gsd/` exists and `.hyveon/` doesn't, print a manual-rename hint before continuing).
+- [ ] 4.5 Update `.gitignore`: `.gsd/` entry and its `# GSD bootstrap metadata` comment → `.hyveon/` / `# Hyveon bootstrap metadata`.
+- [ ] 4.6 Update `electron-builder.yml`: `appId: dev.gsd.desktop` → `dev.hyveon.desktop` (see design.md's Risks section on `appId` impact for already-packaged installs).
+- [ ] 4.7 Run `npm run app:test` (full suite) and `npm run app:lint` to confirm this group compiles, lints, and passes.
+
+## 5. Documentation
+
+- [ ] 5.1 Update `CLAUDE.md`: every `window.gsd`/`Gsd*` reference in the Electron e2e IPC mock seam section and elsewhere.
+- [ ] 5.2 Update `docs/docs/setup.md`, `docs/docs/guides/s3-tfvars.md`, `docs/docs/guides/submodule.md`, `docs/docs/guides/project-name-migration.md` for `.gsd/`/`GSD_TFVARS_BACKEND`/`gsd` references.
+- [ ] 5.3 Update `scripts/README.md`.
+- [ ] 5.4 Leave `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md` untouched — it's a dated historical design record (see design.md Context/Open Questions); do not rename its `gsd` references.
+
+## 6. Final verification
+
+- [ ] 6.1 Run a repo-wide case-insensitive `gsd` grep excluding `node_modules`, `.git`, build output dirs, `package-lock.json`, `docs/package-lock.json` (false-positive hash substrings), and `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md` (intentionally-excluded historical doc) — confirm zero remaining hits.
+- [ ] 6.2 Run `npm run app:build`, `npm run app:lint`, `npm run app:test`, and `npm run app:test:e2e` (both projects) end to end; confirm all green.
+- [ ] 6.3 Manually smoke-test the packaged/dev Electron app once (`npm run app:dev`) and confirm `window.hyveon` is populated in the renderer devtools console, with `window.gsd` undefined.


### PR DESCRIPTION
## Summary
- Adds the OpenSpec change `rename-gsd-to-hyveon`: proposal, design, a new `preload-bridge-naming` delta spec, and an implementation task list.
- Proposes renaming every `Gsd`/`gsd`/`GSD` identifier repo-wide to `Hyveon`/`hyveon`/`HYVEON` — TypeScript interfaces in `@hyveon/desktop-preload`, the runtime `window.gsd` IPC bridge global (→ `window.hyveon`, **BREAKING**), e2e test helper names, and the unrelated local dev-tooling `.gsd/tfvars-bucket` marker + `GSD_TFVARS_BACKEND` env var (**BREAKING** for existing local dev state).
- Planning artifacts only — no implementation code changes in this PR. `design.md` explicitly excludes two false leads found during research: `gsd` substrings inside `package-lock.json` integrity hashes (coincidental, not real matches), and the dated historical doc `docs/superpowers/specs/2026-05-10-electron-desktop-pivot-design.md` (left as a historical record).

## Test plan
- [ ] `openspec validate rename-gsd-to-hyveon` passes (already verified locally: "Change 'rename-gsd-to-hyveon' is valid")
- [ ] `openspec status --change rename-gsd-to-hyveon` shows all 4 artifacts complete (already verified locally)
- No code changes in this PR, so no build/lint/test run applies yet — implementation follows via `/opsx:apply` in a follow-up PR per `tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
