### PR TITLE
feat(desktop-main): add AwsProfileService for wizard credentials

### DIFF
--- a/app/packages/desktop-main/package.json
+++ b/app/packages/desktop-main/package.json
@@ -17,6 +17,8 @@
     "@aws-sdk/client-ecs": "^3.600.0",
     "@aws-sdk/client-secrets-manager": "^3.600.0",
     "@aws-sdk/lib-dynamodb": "^3.600.0",
+    "@smithy/shared-ini-file-loader": "^4.0.0",
+    "@smithy/types": "^4.0.0",
     "@cdktf/hcl2json": "^0.21.0",
     "@grpc/proto-loader": "^0.8.1",
     "@hyveon/cloud-aws": "*",

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -2,15 +2,34 @@ import 'reflect-metadata';
 import { describe, it, expect, vi } from 'vitest';
 import { WizardController } from './wizard.controller.js';
 import type { PrerequisiteService, PrerequisitesReport } from '../services/PrerequisiteService.js';
+import type { AwsProfileService, AwsProfileSummary } from '../services/AwsProfileService.js';
 
 const SATISFIED_REPORT: PrerequisitesReport = {
   terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
   aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
 };
 
+const SAMPLE_PROFILES: AwsProfileSummary[] = [
+  { profileName: 'default', region: 'us-east-1' },
+  { profileName: 'dev', region: 'us-west-2' },
+];
+
 /** Build a PrerequisiteService stub whose `check()` resolves to the given report. */
 function makePrerequisites(report: PrerequisitesReport = SATISFIED_REPORT): PrerequisiteService {
   return { check: vi.fn().mockResolvedValue(report) } as Partial<PrerequisiteService> as PrerequisiteService;
+}
+
+/** Build an AwsProfileService stub whose `listProfiles()` resolves to the given profiles. */
+function makeAwsProfiles(profiles: AwsProfileSummary[] = SAMPLE_PROFILES): AwsProfileService {
+  return { listProfiles: vi.fn().mockResolvedValue(profiles) } as Partial<AwsProfileService> as AwsProfileService;
+}
+
+/** Builds a `WizardController` with default stubs for any dependency the caller doesn't override. */
+function makeController(overrides: { prerequisites?: PrerequisiteService; awsProfiles?: AwsProfileService } = {}): WizardController {
+  return new WizardController(
+    overrides.prerequisites ?? makePrerequisites(),
+    overrides.awsProfiles ?? makeAwsProfiles(),
+  );
 }
 
 /**
@@ -26,20 +45,39 @@ describe('WizardController', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.checkPrereqs);
       expect(pattern).toEqual(['wizard.prereqs.check']);
     });
+
+    it('should register listAwsProfiles on the "wizard.aws.listProfiles" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.listAwsProfiles);
+      expect(pattern).toEqual(['wizard.aws.listProfiles']);
+    });
   });
 
   describe('checkPrereqs', () => {
     it('should return the report produced by PrerequisiteService.check', async () => {
       const prerequisites = makePrerequisites();
-      const result = await new WizardController(prerequisites).checkPrereqs();
+      const result = await makeController({ prerequisites }).checkPrereqs();
       expect(result).toEqual(SATISFIED_REPORT);
       expect(prerequisites.check).toHaveBeenCalledTimes(1);
     });
 
     it('should propagate a report with a missing tool unchanged', async () => {
       const report: PrerequisitesReport = { terraform: { found: false }, aws: { found: false } };
-      const result = await new WizardController(makePrerequisites(report)).checkPrereqs();
+      const result = await makeController({ prerequisites: makePrerequisites(report) }).checkPrereqs();
       expect(result).toEqual(report);
+    });
+  });
+
+  describe('listAwsProfiles', () => {
+    it('should return the profiles produced by AwsProfileService.listProfiles', async () => {
+      const awsProfiles = makeAwsProfiles();
+      const result = await makeController({ awsProfiles }).listAwsProfiles();
+      expect(result).toEqual(SAMPLE_PROFILES);
+      expect(awsProfiles.listProfiles).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate an empty profile list unchanged', async () => {
+      const result = await makeController({ awsProfiles: makeAwsProfiles([]) }).listAwsProfiles();
+      expect(result).toEqual([]);
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -1,6 +1,7 @@
 import { Controller } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
 import { PrerequisiteService, type PrerequisitesReport } from '../services/PrerequisiteService.js';
+import { AwsProfileService, type AwsProfileSummary } from '../services/AwsProfileService.js';
 
 /**
  * IPC-only controller for the first-run wizard (see
@@ -12,11 +13,20 @@ import { PrerequisiteService, type PrerequisitesReport } from '../services/Prere
  */
 @Controller()
 export class WizardController {
-  constructor(private readonly prerequisites: PrerequisiteService) {}
+  constructor(
+    private readonly prerequisites: PrerequisiteService,
+    private readonly awsProfiles: AwsProfileService,
+  ) {}
 
   /** Detects `terraform` and `aws` on `PATH`, reporting per-tool found/path/version. */
   @MessagePattern('wizard.prereqs.check')
   checkPrereqs(): Promise<PrerequisitesReport> {
     return this.prerequisites.check();
+  }
+
+  /** Lists AWS CLI profiles discovered in `~/.aws/credentials` and `~/.aws/config`. */
+  @MessagePattern('wizard.aws.listProfiles')
+  listAwsProfiles(): Promise<AwsProfileSummary[]> {
+    return this.awsProfiles.listProfiles();
   }
 }

--- a/app/packages/desktop-main/src/modules/wizard.module.ts
+++ b/app/packages/desktop-main/src/modules/wizard.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PrerequisiteService } from '../services/PrerequisiteService.js';
+import { AwsProfileService } from '../services/AwsProfileService.js';
 
 /**
  * Groups the first-run wizard's providers (see
@@ -9,7 +10,7 @@ import { PrerequisiteService } from '../services/PrerequisiteService.js';
  * `AppModule.controllers` alongside every other controller in this codebase.
  */
 @Module({
-  providers: [PrerequisiteService],
-  exports: [PrerequisiteService],
+  providers: [PrerequisiteService, AwsProfileService],
+  exports: [PrerequisiteService, AwsProfileService],
 })
 export class WizardModule {}

--- a/app/packages/desktop-main/src/services/AwsProfileService.test.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.test.ts
@@ -1,15 +1,15 @@
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { AwsProfileService } from './AwsProfileService.js';
 
 /**
  * Fixture "home directory" containing `.aws/credentials` and `.aws/config`
  * with a mix of profiles: `default` and `dev` in both files (region agrees
- * in both), and `prod` defined only via a config-file `[profile prod]`
- * section (no credentials entry) — this exercises the config-file
- * `profile <name>` → `<name>` normalization real `aws configure list-profiles`
- * output relies on.
+ * in both), `prod` defined only via a config-file `[profile prod]` section
+ * (no credentials entry) — this exercises the config-file `profile <name>` →
+ * `<name>` normalization real `aws configure list-profiles` output relies
+ * on — and `noregion`, a credentials-only profile with no region anywhere.
  */
 const FIXTURE_HOME = fileURLToPath(new URL('./__fixtures__/aws-profile', import.meta.url));
 
@@ -20,20 +20,30 @@ const FIXTURE_HOME = fileURLToPath(new URL('./__fixtures__/aws-profile', import.
  */
 const EMPTY_HOME = dirname(FIXTURE_HOME);
 
+/**
+ * Fixture-specific `AwsProfileService` subclass overriding the protected
+ * `homeDir()` seam to return a fixed directory, avoiding a `vi.spyOn` +
+ * `as unknown as` cast to reach a protected method.
+ */
+class FixtureAwsProfileService extends AwsProfileService {
+  constructor(private readonly home: string) {
+    super();
+  }
+
+  protected override homeDir(): string {
+    return this.home;
+  }
+}
+
 /** Builds an `AwsProfileService` whose `homeDir()` seam returns `home`. */
 function makeService(home: string): AwsProfileService {
-  const service = new AwsProfileService();
-  vi.spyOn(
-    service as unknown as { homeDir(): string },
-    'homeDir',
-  ).mockReturnValue(home);
-  return service;
+  return new FixtureAwsProfileService(home);
 }
 
 describe('AwsProfileService.listProfiles', () => {
   it('should list profiles merged from both credentials and config files, sorted by name', async () => {
     const profiles = await makeService(FIXTURE_HOME).listProfiles();
-    expect(profiles.map((p) => p.profileName)).toEqual(['default', 'dev', 'prod']);
+    expect(profiles.map((p) => p.profileName)).toEqual(['default', 'dev', 'noregion', 'prod']);
   });
 
   it('should pick up region from the merged profile data', async () => {
@@ -57,7 +67,7 @@ describe('AwsProfileService.listProfiles', () => {
   it('should never expose aws_access_key_id/aws_secret_access_key or other non-region fields', async () => {
     const profiles = await makeService(FIXTURE_HOME).listProfiles();
     for (const profile of profiles) {
-      expect(Object.keys(profile).sort()).toEqual(['profileName', 'region'].sort());
+      expect(Object.keys(profile).every((key) => key === 'profileName' || key === 'region')).toBe(true);
     }
   });
 
@@ -66,14 +76,10 @@ describe('AwsProfileService.listProfiles', () => {
     expect(profiles).toEqual([]);
   });
 
-  it('should omit region when a profile has none set', async () => {
-    // The fixture credentials-file `default` entry has no region of its own;
-    // it still ends up with `us-east-1` merged in from the config file, so
-    // this asserts the field is simply absent rather than an empty string
-    // when truly unset — using the same fixture, `output` (config-only,
-    // non-region) never leaks through regardless.
+  it('should omit the region property entirely when a profile has none set', async () => {
     const profiles = await makeService(FIXTURE_HOME).listProfiles();
-    const withoutRegion = profiles.filter((p) => p.region === undefined);
-    expect(withoutRegion).toEqual([]);
+    const noregion = profiles.find((p) => p.profileName === 'noregion');
+    expect(noregion).toEqual({ profileName: 'noregion' });
+    expect(noregion).not.toHaveProperty('region');
   });
 });

--- a/app/packages/desktop-main/src/services/AwsProfileService.test.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.test.ts
@@ -1,0 +1,79 @@
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+import { AwsProfileService } from './AwsProfileService.js';
+
+/**
+ * Fixture "home directory" containing `.aws/credentials` and `.aws/config`
+ * with a mix of profiles: `default` and `dev` in both files (region agrees
+ * in both), and `prod` defined only via a config-file `[profile prod]`
+ * section (no credentials entry) — this exercises the config-file
+ * `profile <name>` → `<name>` normalization real `aws configure list-profiles`
+ * output relies on.
+ */
+const FIXTURE_HOME = fileURLToPath(new URL('./__fixtures__/aws-profile', import.meta.url));
+
+/**
+ * The parent of {@link FIXTURE_HOME} has no `.aws` directory of its own —
+ * used to exercise the missing-files path without needing a second,
+ * otherwise-empty fixture directory.
+ */
+const EMPTY_HOME = dirname(FIXTURE_HOME);
+
+/** Builds an `AwsProfileService` whose `homeDir()` seam returns `home`. */
+function makeService(home: string): AwsProfileService {
+  const service = new AwsProfileService();
+  vi.spyOn(
+    service as unknown as { homeDir(): string },
+    'homeDir',
+  ).mockReturnValue(home);
+  return service;
+}
+
+describe('AwsProfileService.listProfiles', () => {
+  it('should list profiles merged from both credentials and config files, sorted by name', async () => {
+    const profiles = await makeService(FIXTURE_HOME).listProfiles();
+    expect(profiles.map((p) => p.profileName)).toEqual(['default', 'dev', 'prod']);
+  });
+
+  it('should pick up region from the merged profile data', async () => {
+    const profiles = await makeService(FIXTURE_HOME).listProfiles();
+    const byName = Object.fromEntries(profiles.map((p) => [p.profileName, p]));
+    expect(byName['default']?.region).toBe('us-east-1');
+    expect(byName['dev']?.region).toBe('us-west-2');
+  });
+
+  it('should normalize a config-file "[profile <name>]" section to just "<name>"', async () => {
+    const profiles = await makeService(FIXTURE_HOME).listProfiles();
+    const prod = profiles.find((p) => p.profileName === 'prod');
+    expect(prod).toEqual({ profileName: 'prod', region: 'eu-west-1' });
+  });
+
+  it('should include a profile defined only in the config file (no credentials entry)', async () => {
+    const profiles = await makeService(FIXTURE_HOME).listProfiles();
+    expect(profiles.some((p) => p.profileName === 'prod')).toBe(true);
+  });
+
+  it('should never expose aws_access_key_id/aws_secret_access_key or other non-region fields', async () => {
+    const profiles = await makeService(FIXTURE_HOME).listProfiles();
+    for (const profile of profiles) {
+      expect(Object.keys(profile).sort()).toEqual(['profileName', 'region'].sort());
+    }
+  });
+
+  it('should return an empty array when neither credentials nor config files exist', async () => {
+    const profiles = await makeService(EMPTY_HOME).listProfiles();
+    expect(profiles).toEqual([]);
+  });
+
+  it('should omit region when a profile has none set', async () => {
+    // The fixture credentials-file `default` entry has no region of its own;
+    // it still ends up with `us-east-1` merged in from the config file, so
+    // this asserts the field is simply absent rather than an empty string
+    // when truly unset — using the same fixture, `output` (config-only,
+    // non-region) never leaks through regardless.
+    const profiles = await makeService(FIXTURE_HOME).listProfiles();
+    const withoutRegion = profiles.filter((p) => p.region === undefined);
+    expect(withoutRegion).toEqual([]);
+  });
+});

--- a/app/packages/desktop-main/src/services/AwsProfileService.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.ts
@@ -36,10 +36,10 @@ export class AwsProfileService {
     const parsed = await this.parseFiles();
     return Object.keys(parsed)
       .sort((a, b) => a.localeCompare(b))
-      .map((profileName) => ({
-        profileName,
-        region: parsed[profileName]?.['region'],
-      }));
+      .map((profileName) => {
+        const region = parsed[profileName]?.['region'];
+        return region ? { profileName, region } : { profileName };
+      });
   }
 
   /**

--- a/app/packages/desktop-main/src/services/AwsProfileService.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.ts
@@ -1,0 +1,69 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { Injectable } from '@nestjs/common';
+import { parseKnownFiles } from '@smithy/shared-ini-file-loader';
+import type { ParsedIniData } from '@smithy/types';
+
+/**
+ * Summary of a single AWS CLI profile discovered in `~/.aws/credentials` or
+ * `~/.aws/config`. Deliberately minimal — never carries
+ * `aws_access_key_id`/`aws_secret_access_key` or any other sensitive field,
+ * so this shape is safe to send over IPC to the renderer.
+ */
+export interface AwsProfileSummary {
+  profileName: string;
+  region?: string;
+}
+
+/**
+ * Discovers AWS CLI profiles for the first-run wizard's credentials step
+ * (see `openspec/changes/add-first-run-wizard`). Delegates parsing to
+ * `@smithy/shared-ini-file-loader`'s `parseKnownFiles` — the same loader the
+ * AWS SDK for JS itself uses to resolve profiles — rather than hand-rolling
+ * INI parsing, so profile discovery matches `aws configure list-profiles`
+ * semantics (config-file `[profile <name>]` sections normalized to
+ * `<name>`, both files merged into one profile map).
+ */
+@Injectable()
+export class AwsProfileService {
+  /**
+   * Lists every profile found across `~/.aws/credentials` and
+   * `~/.aws/config`, sorted alphabetically by name. Only `profileName` and
+   * `region` are read out of each profile's parsed fields — every other
+   * field (including credential material) is left untouched.
+   */
+  async listProfiles(): Promise<AwsProfileSummary[]> {
+    const parsed = await this.parseFiles();
+    return Object.keys(parsed)
+      .sort((a, b) => a.localeCompare(b))
+      .map((profileName) => ({
+        profileName,
+        region: parsed[profileName]?.['region'],
+      }));
+  }
+
+  /**
+   * Parses `~/.aws/credentials` and `~/.aws/config` (merged the same way the
+   * AWS CLI does). Missing files degrade to an empty map rather than
+   * throwing — `parseKnownFiles` swallows `ENOENT` internally. `ignoreCache`
+   * is always set so a profile added after the app started is picked up on
+   * the next call rather than serving the loader's internal file cache.
+   */
+  protected async parseFiles(): Promise<ParsedIniData> {
+    const home = this.homeDir();
+    return parseKnownFiles({
+      filepath: join(home, '.aws', 'credentials'),
+      configFilepath: join(home, '.aws', 'config'),
+      ignoreCache: true,
+    });
+  }
+
+  /**
+   * Returns the current user's home directory. Extracted as a protected
+   * seam so tests can point at a fixture directory instead of the real
+   * `~/.aws` files.
+   */
+  protected homeDir(): string {
+    return homedir();
+  }
+}

--- a/app/packages/desktop-main/src/services/__fixtures__/aws-profile/.aws/config
+++ b/app/packages/desktop-main/src/services/__fixtures__/aws-profile/.aws/config
@@ -1,0 +1,10 @@
+[default]
+region = us-east-1
+output = json
+
+[profile dev]
+region = us-west-2
+
+[profile prod]
+region = eu-west-1
+sso_session = my-sso

--- a/app/packages/desktop-main/src/services/__fixtures__/aws-profile/.aws/credentials
+++ b/app/packages/desktop-main/src/services/__fixtures__/aws-profile/.aws/credentials
@@ -6,3 +6,7 @@ aws_secret_access_key = defaultSecretExample
 aws_access_key_id = AKIAEXAMPLEDEV
 aws_secret_access_key = devSecretExample
 region = us-west-2
+
+[noregion]
+aws_access_key_id = AKIAEXAMPLENOREGION
+aws_secret_access_key = noregionSecretExample

--- a/app/packages/desktop-main/src/services/__fixtures__/aws-profile/.aws/credentials
+++ b/app/packages/desktop-main/src/services/__fixtures__/aws-profile/.aws/credentials
@@ -1,0 +1,8 @@
+[default]
+aws_access_key_id = AKIAEXAMPLEDEFAULT
+aws_secret_access_key = defaultSecretExample
+
+[dev]
+aws_access_key_id = AKIAEXAMPLEDEV
+aws_secret_access_key = devSecretExample
+region = us-west-2

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -968,10 +968,21 @@ export interface PrerequisitesReport {
   aws: PrerequisiteCheckResult;
 }
 
+/**
+ * Summary of a single AWS CLI profile discovered in `~/.aws/credentials` or
+ * `~/.aws/config`. Never carries key material.
+ */
+export interface AwsProfileSummary {
+  profileName: string;
+  region?: string;
+}
+
 /** First-run wizard endpoints (see `openspec/changes/add-first-run-wizard`). */
 export interface GsdWizardApi {
   /** Detects `terraform` and `aws` on `PATH`, reporting per-tool found/path/version. */
   checkPrereqs: () => Promise<PrerequisitesReport>;
+  /** Lists AWS CLI profiles discovered in `~/.aws/credentials` and `~/.aws/config`. */
+  listAwsProfiles: () => Promise<AwsProfileSummary[]>;
 }
 
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -73,6 +73,7 @@ import type {
   TfOutputs,
   UpdateGamePayload,
   PrerequisitesReport,
+  AwsProfileSummary,
 } from './gsd-api.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -593,6 +594,7 @@ const api: GsdApi = {
 
   wizard: {
     checkPrereqs: () => invoke<PrerequisitesReport>('wizard.prereqs.check'),
+    listAwsProfiles: () => invoke<AwsProfileSummary[]>('wizard.aws.listProfiles'),
   },
 
   drift: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,8 @@
         "@nestjs/core": "^10.4.0",
         "@nestjs/microservices": "^10.4.0",
         "@nestjs/platform-express": "^10.4.0",
+        "@smithy/shared-ini-file-loader": "^4.0.0",
+        "@smithy/types": "^4.0.0",
         "electron-store": "^11.0.2",
         "express": "^4.19.2",
         "fix-path": "^4.0.0",
@@ -4856,9 +4858,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
-      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -5101,6 +5103,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.6.14",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.6.14.tgz",
+      "integrity": "sha512-/rg/ksfMpLzG9fK67n+98OsyFHME7j6jW/3NwIRVTv2C5YAbHQUFxutBnmq7rWFoB2qojDShgTv+i1JeGXJS6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.30.0",
         "tslib": "^2.6.2"
       },
       "engines": {


### PR DESCRIPTION
Closes #189

## Summary

PR 2 of 12 for the First-Run Wizard epic (#139, see `openspec/changes/add-first-run-wizard`). This is the credentials-step's profile-discovery service — lists AWS CLI profiles so the wizard can offer a dropdown instead of asking the operator to type a profile name blind.

- New `AwsProfileService`: discovers AWS CLI profiles from `~/.aws/credentials` and `~/.aws/config` via `@smithy/shared-ini-file-loader`'s `parseKnownFiles` — the same loader the AWS SDK for JS itself uses — so merging and config-file `[profile <name>]` normalization match `aws configure list-profiles` semantics rather than hand-rolled INI parsing drifting from it. `listProfiles()` returns only `{ profileName, region? }`; no credential material is ever read out of the parsed data. Home-directory resolution sits behind a protected `homeDir()` seam so tests point at fixture files instead of the real `~/.aws` directory.
  - Note: the task named `@aws-sdk/shared-ini-file-loader` as the preferred package, but that's deprecated upstream in favor of `@smithy/shared-ini-file-loader` (itself noted as transitioning to `@smithy/core/config`, but still the current actively-published entry point) — used the current package instead.
- Extended the `WizardModule`/`WizardController` (from #182) with `AwsProfileService` as a provider and a new `@MessagePattern('wizard.aws.listProfiles')` handler.
- New preload surface: `gsd.wizard.listAwsProfiles()`, mirrored as `AwsProfileSummary`/`GsdWizardApi.listAwsProfiles` in `gsd-api.ts`.
- New realistic INI fixtures (`desktop-main/src/services/__fixtures__/aws-profile/.aws/{credentials,config}`) exercising real parsing behavior (not mocked): a profile present in both files, a profile defined only via config's `[profile prod]`, and region values.

## Test plan

- [x] `npm run app:test` — 1903/1903 tests passing (new: merged listing, region pickup, profile-only-in-config normalization, no-key-material assertion, missing-files → empty array; updated controller specs for the new IPC method)
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings)
