### PR TITLE
feat(desktop-main): add safeStorage paste-flow for wizard credentials

### DIFF
--- a/app/packages/desktop-main/src/app.module.ts
+++ b/app/packages/desktop-main/src/app.module.ts
@@ -7,6 +7,7 @@ import { DiscordModule } from './modules/discord.module.js';
 import { TfvarsModule } from './modules/tfvars.module.js';
 import { TerraformModule } from './modules/terraform.module.js';
 import { WizardModule } from './modules/wizard.module.js';
+import { ElectronStoreModule } from './modules/electron-store.module.js';
 import { GamesController } from './controllers/games.controller.js';
 import { GamesHttpController } from './controllers/games-http.controller.js';
 import { ConfigController } from './controllers/config.controller.js';
@@ -32,16 +33,15 @@ import { WizardController } from './controllers/wizard.controller.js';
 import { DiagnosticsService, DIAGNOSTICS_LOG_DIR } from './services/DiagnosticsService.js';
 import { DriftService } from './services/DriftService.js';
 import { GamesWriteService } from './services/GamesWriteService.js';
-import { SafeStorageService } from './services/SafeStorageService.js';
-import { ElectronStoreService } from './services/ElectronStoreService.js';
 import { AuditService } from './services/AuditService.js';
 
 /**
  * Root Nest module. Wires the feature modules (`AwsModule`, `DiscordModule`,
- * `TfvarsModule`, `TerraformModule`, `WizardModule`) to the IPC controllers.
+ * `TfvarsModule`, `TerraformModule`, `WizardModule`, `ElectronStoreModule`)
+ * to the IPC controllers.
  */
 @Module({
-  imports: [AwsModule, DiscordModule, TfvarsModule, TerraformModule, WizardModule],
+  imports: [AwsModule, DiscordModule, TfvarsModule, TerraformModule, WizardModule, ElectronStoreModule],
   controllers: [
     GamesController,
     GamesHttpController,
@@ -81,8 +81,6 @@ import { AuditService } from './services/AuditService.js';
     DiagnosticsService,
     DriftService,
     GamesWriteService,
-    SafeStorageService,
-    ElectronStoreService,
     AuditService,
   ],
 })

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { WizardController } from './wizard.controller.js';
 import type { PrerequisiteService, PrerequisitesReport } from '../services/PrerequisiteService.js';
 import type { AwsProfileService, AwsProfileSummary } from '../services/AwsProfileService.js';
+import { SafeStorageUnavailableError } from '../services/AwsProfileService.js';
 
 const SATISFIED_REPORT: PrerequisitesReport = {
   terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
@@ -103,13 +104,13 @@ describe('WizardController', () => {
     it('should propagate a thrown SafeStorageUnavailableError rather than swallowing it', () => {
       const awsProfiles = {
         savePastedCredentials: vi.fn().mockImplementation(() => {
-          throw new Error('safeStorage unavailable');
+          throw new SafeStorageUnavailableError();
         }),
       } as Partial<AwsProfileService> as AwsProfileService;
 
       expect(() =>
         makeController({ awsProfiles }).saveCredentials({ accessKeyId: 'AKID', secretAccessKey: 'SECRET' }),
-      ).toThrow('safeStorage unavailable');
+      ).toThrow(SafeStorageUnavailableError);
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -21,7 +21,10 @@ function makePrerequisites(report: PrerequisitesReport = SATISFIED_REPORT): Prer
 
 /** Build an AwsProfileService stub whose `listProfiles()` resolves to the given profiles. */
 function makeAwsProfiles(profiles: AwsProfileSummary[] = SAMPLE_PROFILES): AwsProfileService {
-  return { listProfiles: vi.fn().mockResolvedValue(profiles) } as Partial<AwsProfileService> as AwsProfileService;
+  return {
+    listProfiles: vi.fn().mockResolvedValue(profiles),
+    savePastedCredentials: vi.fn().mockReturnValue({ profileName: 'gsd-pasted' }),
+  } as Partial<AwsProfileService> as AwsProfileService;
 }
 
 /** Builds a `WizardController` with default stubs for any dependency the caller doesn't override. */
@@ -49,6 +52,11 @@ describe('WizardController', () => {
     it('should register listAwsProfiles on the "wizard.aws.listProfiles" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.listAwsProfiles);
       expect(pattern).toEqual(['wizard.aws.listProfiles']);
+    });
+
+    it('should register saveCredentials on the "wizard.aws.saveCredentials" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.saveCredentials);
+      expect(pattern).toEqual(['wizard.aws.saveCredentials']);
     });
   });
 
@@ -78,6 +86,30 @@ describe('WizardController', () => {
     it('should propagate an empty profile list unchanged', async () => {
       const result = await makeController({ awsProfiles: makeAwsProfiles([]) }).listAwsProfiles();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('saveCredentials', () => {
+    it('should delegate to AwsProfileService.savePastedCredentials and return only the profile name', () => {
+      const awsProfiles = makeAwsProfiles();
+      const body = { accessKeyId: 'AKID', secretAccessKey: 'SECRET', region: 'us-east-1' };
+
+      const result = makeController({ awsProfiles }).saveCredentials(body);
+
+      expect(awsProfiles.savePastedCredentials).toHaveBeenCalledWith(body);
+      expect(result).toEqual({ profileName: 'gsd-pasted' });
+    });
+
+    it('should propagate a thrown SafeStorageUnavailableError rather than swallowing it', () => {
+      const awsProfiles = {
+        savePastedCredentials: vi.fn().mockImplementation(() => {
+          throw new Error('safeStorage unavailable');
+        }),
+      } as Partial<AwsProfileService> as AwsProfileService;
+
+      expect(() =>
+        makeController({ awsProfiles }).saveCredentials({ accessKeyId: 'AKID', secretAccessKey: 'SECRET' }),
+      ).toThrow('safeStorage unavailable');
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -1,7 +1,11 @@
 import { Controller } from '@nestjs/common';
-import { MessagePattern } from '@nestjs/microservices';
+import { MessagePattern, Payload } from '@nestjs/microservices';
 import { PrerequisiteService, type PrerequisitesReport } from '../services/PrerequisiteService.js';
-import { AwsProfileService, type AwsProfileSummary } from '../services/AwsProfileService.js';
+import {
+  AwsProfileService,
+  type AwsProfileSummary,
+  type SavePastedCredentialsInput,
+} from '../services/AwsProfileService.js';
 
 /**
  * IPC-only controller for the first-run wizard (see
@@ -28,5 +32,15 @@ export class WizardController {
   @MessagePattern('wizard.aws.listProfiles')
   listAwsProfiles(): Promise<AwsProfileSummary[]> {
     return this.awsProfiles.listProfiles();
+  }
+
+  /**
+   * Saves pasted AWS credentials (the wizard's "paste keys instead" flow).
+   * Only the resolved profile name is returned — the decrypted/plaintext
+   * values passed in are never echoed back over IPC.
+   */
+  @MessagePattern('wizard.aws.saveCredentials')
+  saveCredentials(@Payload() body: SavePastedCredentialsInput): { profileName: string } {
+    return this.awsProfiles.savePastedCredentials(body);
   }
 }

--- a/app/packages/desktop-main/src/modules/electron-store.module.ts
+++ b/app/packages/desktop-main/src/modules/electron-store.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { SafeStorageService } from '../services/SafeStorageService.js';
+import { ElectronStoreService } from '../services/ElectronStoreService.js';
+
+/**
+ * Standalone module for `SafeStorageService` (OS-keychain encryption) and
+ * `ElectronStoreService` (the typed electron-store consumer that depends on
+ * it). Extracted — mirroring `ConfigModule` — so any feature module can
+ * `imports: [ElectronStoreModule]` and receive both via Nest DI, rather than
+ * depending on `AppModule` directly. `WizardModule` is the first consumer
+ * (persisting wizard state and pasted AWS credentials).
+ */
+@Module({
+  providers: [SafeStorageService, ElectronStoreService],
+  exports: [SafeStorageService, ElectronStoreService],
+})
+export class ElectronStoreModule {}

--- a/app/packages/desktop-main/src/modules/wizard.module.ts
+++ b/app/packages/desktop-main/src/modules/wizard.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { PrerequisiteService } from '../services/PrerequisiteService.js';
 import { AwsProfileService } from '../services/AwsProfileService.js';
+import { ElectronStoreModule } from './electron-store.module.js';
 
 /**
  * Groups the first-run wizard's providers (see
@@ -8,8 +9,12 @@ import { AwsProfileService } from '../services/AwsProfileService.js';
  * `TerraformModule`/`DiscordModule` — `providers`/`exports` only, no
  * `controllers` array; the IPC controller is wired directly into
  * `AppModule.controllers` alongside every other controller in this codebase.
+ * Imports `ElectronStoreModule` so `AwsProfileService` can inject
+ * `SafeStorageService`/`ElectronStoreService` for the pasted-credentials
+ * save flow.
  */
 @Module({
+  imports: [ElectronStoreModule],
   providers: [PrerequisiteService, AwsProfileService],
   exports: [PrerequisiteService, AwsProfileService],
 })

--- a/app/packages/desktop-main/src/services/AwsProfileService.test.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.test.ts
@@ -5,6 +5,7 @@ import {
   AwsProfileService,
   DEFAULT_PASTED_PROFILE_NAME,
   SafeStorageUnavailableError,
+  InvalidPastedCredentialsError,
 } from './AwsProfileService.js';
 import type { SafeStorageService } from './SafeStorageService.js';
 import type { ElectronStoreService } from './ElectronStoreService.js';
@@ -153,5 +154,42 @@ describe('AwsProfileService.savePastedCredentials', () => {
       secretAccessKey: 'SECRET',
       region: 'eu-west-1',
     });
+  });
+
+  it('should fall back to the default profile name when profileName is blank or whitespace-only', () => {
+    const store = stubStore();
+    const service = new AwsProfileService(stubSafeStorage(true), store);
+
+    const result = service.savePastedCredentials({
+      profileName: '   ',
+      accessKeyId: 'AKID',
+      secretAccessKey: 'SECRET',
+    });
+
+    expect(result).toEqual({ profileName: DEFAULT_PASTED_PROFILE_NAME });
+    expect(store.setPastedCredentials).toHaveBeenCalledWith(
+      DEFAULT_PASTED_PROFILE_NAME,
+      expect.anything(),
+    );
+  });
+
+  it('should throw InvalidPastedCredentialsError and write nothing when accessKeyId is blank', () => {
+    const store = stubStore();
+    const service = new AwsProfileService(stubSafeStorage(true), store);
+
+    expect(() =>
+      service.savePastedCredentials({ accessKeyId: '  ', secretAccessKey: 'SECRET' }),
+    ).toThrow(InvalidPastedCredentialsError);
+    expect(store.setPastedCredentials).not.toHaveBeenCalled();
+  });
+
+  it('should throw InvalidPastedCredentialsError and write nothing when secretAccessKey is blank', () => {
+    const store = stubStore();
+    const service = new AwsProfileService(stubSafeStorage(true), store);
+
+    expect(() =>
+      service.savePastedCredentials({ accessKeyId: 'AKID', secretAccessKey: '' }),
+    ).toThrow(InvalidPastedCredentialsError);
+    expect(store.setPastedCredentials).not.toHaveBeenCalled();
   });
 });

--- a/app/packages/desktop-main/src/services/AwsProfileService.test.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.test.ts
@@ -1,7 +1,13 @@
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
-import { describe, it, expect } from 'vitest';
-import { AwsProfileService } from './AwsProfileService.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AwsProfileService,
+  DEFAULT_PASTED_PROFILE_NAME,
+  SafeStorageUnavailableError,
+} from './AwsProfileService.js';
+import type { SafeStorageService } from './SafeStorageService.js';
+import type { ElectronStoreService } from './ElectronStoreService.js';
 
 /**
  * Fixture "home directory" containing `.aws/credentials` and `.aws/config`
@@ -20,14 +26,35 @@ const FIXTURE_HOME = fileURLToPath(new URL('./__fixtures__/aws-profile', import.
  */
 const EMPTY_HOME = dirname(FIXTURE_HOME);
 
+/** Builds a `SafeStorageService` stub whose `isAvailable()` returns `available`. */
+function stubSafeStorage(available = true): SafeStorageService {
+  return {
+    isAvailable: vi.fn().mockReturnValue(available),
+    encrypt: vi.fn((v: string) => `enc-${v}`),
+    decrypt: vi.fn((v: string) => v),
+  } as Partial<SafeStorageService> as SafeStorageService;
+}
+
+/** Builds an `ElectronStoreService` stub with a spy-able `setPastedCredentials`. */
+function stubStore(): ElectronStoreService {
+  return {
+    setPastedCredentials: vi.fn(),
+    getPastedCredentials: vi.fn(),
+  } as Partial<ElectronStoreService> as ElectronStoreService;
+}
+
 /**
  * Fixture-specific `AwsProfileService` subclass overriding the protected
  * `homeDir()` seam to return a fixed directory, avoiding a `vi.spyOn` +
  * `as unknown as` cast to reach a protected method.
  */
 class FixtureAwsProfileService extends AwsProfileService {
-  constructor(private readonly home: string) {
-    super();
+  constructor(
+    private readonly home: string,
+    safeStorage: SafeStorageService,
+    store: ElectronStoreService,
+  ) {
+    super(safeStorage, store);
   }
 
   protected override homeDir(): string {
@@ -37,7 +64,7 @@ class FixtureAwsProfileService extends AwsProfileService {
 
 /** Builds an `AwsProfileService` whose `homeDir()` seam returns `home`. */
 function makeService(home: string): AwsProfileService {
-  return new FixtureAwsProfileService(home);
+  return new FixtureAwsProfileService(home, stubSafeStorage(), stubStore());
 }
 
 describe('AwsProfileService.listProfiles', () => {
@@ -81,5 +108,50 @@ describe('AwsProfileService.listProfiles', () => {
     const noregion = profiles.find((p) => p.profileName === 'noregion');
     expect(noregion).toEqual({ profileName: 'noregion' });
     expect(noregion).not.toHaveProperty('region');
+  });
+});
+
+describe('AwsProfileService.savePastedCredentials', () => {
+  it('should throw SafeStorageUnavailableError and write nothing when safeStorage is unavailable', () => {
+    const safeStorage = stubSafeStorage(false);
+    const store = stubStore();
+    const service = new AwsProfileService(safeStorage, store);
+
+    expect(() =>
+      service.savePastedCredentials({ accessKeyId: 'AKID', secretAccessKey: 'SECRET' }),
+    ).toThrow(SafeStorageUnavailableError);
+    expect(store.setPastedCredentials).not.toHaveBeenCalled();
+  });
+
+  it('should default the profile name to gsd-pasted when none is supplied', () => {
+    const store = stubStore();
+    const service = new AwsProfileService(stubSafeStorage(true), store);
+
+    const result = service.savePastedCredentials({ accessKeyId: 'AKID', secretAccessKey: 'SECRET' });
+
+    expect(result).toEqual({ profileName: DEFAULT_PASTED_PROFILE_NAME });
+    expect(store.setPastedCredentials).toHaveBeenCalledWith(
+      DEFAULT_PASTED_PROFILE_NAME,
+      { accessKeyId: 'AKID', secretAccessKey: 'SECRET', region: undefined },
+    );
+  });
+
+  it('should use the supplied profile name when given', () => {
+    const store = stubStore();
+    const service = new AwsProfileService(stubSafeStorage(true), store);
+
+    const result = service.savePastedCredentials({
+      profileName: 'my-profile',
+      accessKeyId: 'AKID',
+      secretAccessKey: 'SECRET',
+      region: 'eu-west-1',
+    });
+
+    expect(result).toEqual({ profileName: 'my-profile' });
+    expect(store.setPastedCredentials).toHaveBeenCalledWith('my-profile', {
+      accessKeyId: 'AKID',
+      secretAccessKey: 'SECRET',
+      region: 'eu-west-1',
+    });
   });
 });

--- a/app/packages/desktop-main/src/services/AwsProfileService.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.ts
@@ -49,6 +49,18 @@ export class SafeStorageUnavailableError extends Error {
 }
 
 /**
+ * Thrown by {@link AwsProfileService.savePastedCredentials} when
+ * `accessKeyId` or `secretAccessKey` is blank/whitespace-only — nothing is
+ * persisted in that case.
+ */
+export class InvalidPastedCredentialsError extends Error {
+  constructor(field: 'accessKeyId' | 'secretAccessKey') {
+    super(`Cannot save pasted AWS credentials: "${field}" must not be blank.`);
+    this.name = 'InvalidPastedCredentialsError';
+  }
+}
+
+/**
  * Discovers AWS CLI profiles for the first-run wizard's credentials step
  * (see `openspec/changes/add-first-run-wizard`). Delegates parsing to
  * `@smithy/shared-ini-file-loader`'s `parseKnownFiles` — the same loader the
@@ -93,7 +105,9 @@ export class AwsProfileService {
     if (!this.safeStorage.isAvailable()) {
       throw new SafeStorageUnavailableError();
     }
-    const profileName = input.profileName ?? DEFAULT_PASTED_PROFILE_NAME;
+    if (!input.accessKeyId.trim()) throw new InvalidPastedCredentialsError('accessKeyId');
+    if (!input.secretAccessKey.trim()) throw new InvalidPastedCredentialsError('secretAccessKey');
+    const profileName = input.profileName?.trim() || DEFAULT_PASTED_PROFILE_NAME;
     this.store.setPastedCredentials(profileName, {
       accessKeyId: input.accessKeyId,
       secretAccessKey: input.secretAccessKey,

--- a/app/packages/desktop-main/src/services/AwsProfileService.ts
+++ b/app/packages/desktop-main/src/services/AwsProfileService.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { Injectable } from '@nestjs/common';
 import { parseKnownFiles } from '@smithy/shared-ini-file-loader';
 import type { ParsedIniData } from '@smithy/types';
+import { SafeStorageService } from './SafeStorageService.js';
+import { ElectronStoreService } from './ElectronStoreService.js';
 
 /**
  * Summary of a single AWS CLI profile discovered in `~/.aws/credentials` or
@@ -13,6 +15,37 @@ import type { ParsedIniData } from '@smithy/types';
 export interface AwsProfileSummary {
   profileName: string;
   region?: string;
+}
+
+/** Default profile name used for the wizard's "paste keys instead" flow when the operator doesn't supply one. */
+export const DEFAULT_PASTED_PROFILE_NAME = 'gsd-pasted';
+
+/** Plaintext input to {@link AwsProfileService.savePastedCredentials}. */
+export interface SavePastedCredentialsInput {
+  /** Defaults to {@link DEFAULT_PASTED_PROFILE_NAME} when omitted. */
+  profileName?: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region?: string;
+}
+
+/**
+ * Thrown by {@link AwsProfileService.savePastedCredentials} when the OS
+ * keychain (via `SafeStorageService`) is unavailable. Pasted credentials are
+ * never persisted in plaintext, so this flow has no fallback — the caller
+ * must surface the error and refuse to save rather than silently degrading
+ * (unlike `ElectronStoreService`'s generic encrypted accessors, which
+ * transparently degrade to plaintext outside Electron for convenience in
+ * tests/CI).
+ */
+export class SafeStorageUnavailableError extends Error {
+  constructor() {
+    super(
+      'Cannot save pasted AWS credentials: the OS keychain (safeStorage) is unavailable. ' +
+        'Pasted keys are never stored in plaintext — pick an existing AWS CLI profile instead.',
+    );
+    this.name = 'SafeStorageUnavailableError';
+  }
 }
 
 /**
@@ -26,6 +59,11 @@ export interface AwsProfileSummary {
  */
 @Injectable()
 export class AwsProfileService {
+  constructor(
+    private readonly safeStorage: SafeStorageService,
+    private readonly store: ElectronStoreService,
+  ) {}
+
   /**
    * Lists every profile found across `~/.aws/credentials` and
    * `~/.aws/config`, sorted alphabetically by name. Only `profileName` and
@@ -40,6 +78,28 @@ export class AwsProfileService {
         const region = parsed[profileName]?.['region'];
         return region ? { profileName, region } : { profileName };
       });
+  }
+
+  /**
+   * Saves pasted AWS credentials from the wizard's "paste keys instead" flow.
+   * Defaults `profileName` to {@link DEFAULT_PASTED_PROFILE_NAME} when
+   * omitted. Throws {@link SafeStorageUnavailableError} — without writing
+   * anything — when the OS keychain is unavailable, rather than falling
+   * back to plaintext storage.
+   *
+   * @returns The profile name the credentials were saved under.
+   */
+  savePastedCredentials(input: SavePastedCredentialsInput): { profileName: string } {
+    if (!this.safeStorage.isAvailable()) {
+      throw new SafeStorageUnavailableError();
+    }
+    const profileName = input.profileName ?? DEFAULT_PASTED_PROFILE_NAME;
+    this.store.setPastedCredentials(profileName, {
+      accessKeyId: input.accessKeyId,
+      secretAccessKey: input.secretAccessKey,
+      region: input.region,
+    });
+    return { profileName };
   }
 
   /**

--- a/app/packages/desktop-main/src/services/ElectronStoreService.test.ts
+++ b/app/packages/desktop-main/src/services/ElectronStoreService.test.ts
@@ -8,7 +8,10 @@
  * the right branch.
  */
 import 'reflect-metadata';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type Store from 'electron-store';
 
 vi.mock('../logger.js', () => ({
@@ -229,5 +232,148 @@ describe('ElectronStoreService — round-trip', () => {
     const result = service.getSecretAccessKeyId();
 
     expect(result).toBe('AKID123');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pasted credentials — getPastedCredentials / setPastedCredentials
+// ---------------------------------------------------------------------------
+
+describe('ElectronStoreService — getPastedCredentials / setPastedCredentials', () => {
+  let service: ElectronStoreService;
+  let safeStorage: SafeStorageService;
+
+  beforeEach(() => {
+    safeStorage = makeSafeStorage();
+    service = new ElectronStoreService(safeStorage);
+    vi.spyOn(safeStorage, 'encrypt').mockImplementation((plaintext: string) => `enc-${plaintext}`);
+    vi.spyOn(safeStorage, 'decrypt').mockImplementation((ciphertext: string) =>
+      ciphertext.startsWith('enc-') ? ciphertext.slice(4) : ciphertext,
+    );
+  });
+
+  it('should encrypt accessKeyId/secretAccessKey before storing under creds.aws.<profileName>', () => {
+    service.setPastedCredentials('gsd-pasted', {
+      accessKeyId: 'AKID123',
+      secretAccessKey: 'SECRET456',
+      region: 'us-east-1',
+    });
+
+    const stored = service.get('creds')?.aws['gsd-pasted'];
+    expect(stored).toEqual({ accessKeyId: 'enc-AKID123', secretAccessKey: 'enc-SECRET456', region: 'us-east-1' });
+  });
+
+  it('should decrypt accessKeyId/secretAccessKey when reading a pasted profile', () => {
+    service.setPastedCredentials('gsd-pasted', { accessKeyId: 'AKID123', secretAccessKey: 'SECRET456' });
+
+    const result = service.getPastedCredentials('gsd-pasted');
+
+    expect(result).toEqual({ accessKeyId: 'AKID123', secretAccessKey: 'SECRET456', region: undefined });
+  });
+
+  it('should return undefined for a profile name that was never stored', () => {
+    expect(service.getPastedCredentials('nonexistent')).toBeUndefined();
+  });
+
+  it('should preserve other profiles already stored under creds.aws when writing a new one', () => {
+    service.setPastedCredentials('first', { accessKeyId: 'AKID_FIRST', secretAccessKey: 'SECRET_FIRST' });
+    service.setPastedCredentials('second', { accessKeyId: 'AKID_SECOND', secretAccessKey: 'SECRET_SECOND' });
+
+    expect(service.getPastedCredentials('first')).toEqual({
+      accessKeyId: 'AKID_FIRST',
+      secretAccessKey: 'SECRET_FIRST',
+      region: undefined,
+    });
+    expect(service.getPastedCredentials('second')).toEqual({
+      accessKeyId: 'AKID_SECOND',
+      secretAccessKey: 'SECRET_SECOND',
+      region: undefined,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-style: the persisted store file never contains plaintext key
+// material. A minimal file-backed `Store` double is used instead of the real
+// `electron-store` package (which requires an Electron process to resolve its
+// default `userData` path) so this spec can write and re-read an actual file
+// on disk while still running under plain Node/vitest.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal disk-backed stand-in for `electron-store`'s `get`/`set` surface,
+ * persisting the whole schema object as JSON on every `set()` — enough to
+ * let a test inspect the literal bytes written to disk, the way the real
+ * library would.
+ */
+class FileBackedStore {
+  constructor(private readonly filePath: string) {
+    writeFileSync(this.filePath, '{}', 'utf-8');
+  }
+
+  get<K extends keyof AppStoreSchema>(key: K): AppStoreSchema[K] | undefined {
+    const data = JSON.parse(readFileSync(this.filePath, 'utf-8')) as Partial<AppStoreSchema>;
+    return data[key];
+  }
+
+  set<K extends keyof AppStoreSchema>(key: K, value: AppStoreSchema[K]): void {
+    const data = JSON.parse(readFileSync(this.filePath, 'utf-8')) as Partial<AppStoreSchema>;
+    data[key] = value;
+    writeFileSync(this.filePath, JSON.stringify(data), 'utf-8');
+  }
+}
+
+describe('ElectronStoreService — persisted file contains no plaintext key material', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hyveon-electron-store-'));
+    filePath = join(tempDir, 'electron-store.json');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should never write the plaintext accessKeyId/secretAccessKey to the store file', () => {
+    const safeStorage = makeSafeStorage();
+    // A real (non-identity) transform is essential here: if encrypt() were a
+    // no-op, the file WOULD legitimately contain the plaintext, and the
+    // assertion below would pass for the wrong reason.
+    vi.spyOn(safeStorage, 'isAvailable').mockReturnValue(true);
+    vi.spyOn(safeStorage, 'encrypt').mockImplementation(
+      (plaintext: string) => Buffer.from(plaintext).toString('base64'),
+    );
+    vi.spyOn(safeStorage, 'decrypt').mockImplementation(
+      (ciphertext: string) => Buffer.from(ciphertext, 'base64').toString('utf-8'),
+    );
+
+    vi.spyOn(
+      ElectronStoreService.prototype as unknown as { readIsElectron(): boolean },
+      'readIsElectron',
+    ).mockReturnValue(true);
+    vi.spyOn(
+      ElectronStoreService.prototype as unknown as { createStore(): Store<AppStoreSchema> },
+      'createStore',
+    ).mockReturnValue(new FileBackedStore(filePath) as unknown as Store<AppStoreSchema>);
+
+    const service = new ElectronStoreService(safeStorage);
+    const secretAccessKeyId = 'AKIASENSITIVEEXAMPLE';
+    const secretAccessKey = 'super-secret-plaintext-value';
+
+    service.setSecretAccessKeyId(secretAccessKeyId);
+    service.setSecretAccessKey(secretAccessKey);
+    service.setPastedCredentials('gsd-pasted', {
+      accessKeyId: secretAccessKeyId,
+      secretAccessKey,
+      region: 'us-east-1',
+    });
+
+    const rawFileContents = readFileSync(filePath, 'utf-8');
+    expect(rawFileContents).not.toContain(secretAccessKeyId);
+    expect(rawFileContents).not.toContain(secretAccessKey);
+    // Sanity check the file isn't simply empty/unwritten.
+    expect(rawFileContents).toContain('region');
   });
 });

--- a/app/packages/desktop-main/src/services/ElectronStoreService.ts
+++ b/app/packages/desktop-main/src/services/ElectronStoreService.ts
@@ -12,14 +12,32 @@ const ElectronStoreModule = process.versions['electron']
   : undefined;
 
 /**
+ * A single pasted-credentials entry under `creds.aws.<profileName>`.
+ * `accessKeyId`/`secretAccessKey` are encrypted base64 blobs — do not read
+ * them directly; use {@link ElectronStoreService.getPastedCredentials} /
+ * {@link ElectronStoreService.setPastedCredentials}.
+ */
+export interface PastedAwsCredentials {
+  /** Stored as an encrypted base64 blob — do not read this field directly. */
+  accessKeyId: string;
+  /** Stored as an encrypted base64 blob — do not read this field directly. */
+  secretAccessKey: string;
+  region?: string;
+}
+
+/**
  * Typed schema for the application's persistent electron-store.
  *
- * Secret fields (`aws.accessKeyId`, `aws.secretAccessKey`) are stored
- * encrypted via {@link SafeStorageService} and must never be read or written
- * directly — always use {@link ElectronStoreService.getSecretAccessKeyId},
+ * Secret fields (`aws.accessKeyId`, `aws.secretAccessKey`,
+ * `creds.aws.<profileName>.accessKeyId`,
+ * `creds.aws.<profileName>.secretAccessKey`) are stored encrypted via
+ * {@link SafeStorageService} and must never be read or written directly —
+ * always use {@link ElectronStoreService.getSecretAccessKeyId},
  * {@link ElectronStoreService.setSecretAccessKeyId},
- * {@link ElectronStoreService.getSecretAccessKey}, and
- * {@link ElectronStoreService.setSecretAccessKey}.
+ * {@link ElectronStoreService.getSecretAccessKey},
+ * {@link ElectronStoreService.setSecretAccessKey},
+ * {@link ElectronStoreService.getPastedCredentials}, and
+ * {@link ElectronStoreService.setPastedCredentials}.
  */
 export interface AppStoreSchema {
   wizardCompleted: boolean;
@@ -32,6 +50,15 @@ export interface AppStoreSchema {
     accessKeyId?: string;
     /** Stored as an encrypted base64 blob — do not read this field directly. */
     secretAccessKey?: string;
+  };
+  /**
+   * Pasted-credentials profiles from the wizard's credentials step, keyed by
+   * profile name (default `gsd-pasted` — see `AwsProfileService`). Separate
+   * from `aws` above, which holds the *selected* profile/region for the
+   * "pick an existing profile" path.
+   */
+  creds: {
+    aws: Record<string, PastedAwsCredentials>;
   };
 }
 
@@ -146,6 +173,56 @@ export class ElectronStoreService {
     const current = this.get('aws') ?? {};
     this.set('aws', { ...current, secretAccessKey: encrypted });
     logger.debug('ElectronStoreService: aws.secretAccessKey written (encrypted)');
+  }
+
+  /**
+   * Read a pasted-credentials profile from `creds.aws.<profileName>`,
+   * decrypting `accessKeyId`/`secretAccessKey` via {@link SafeStorageService}.
+   *
+   * @remarks
+   * Decrypted values must only ever be consumed inside main-process SDK
+   * client factories (e.g. `CloudProviderModule`'s `useFactory` providers) —
+   * never returned over IPC to the renderer. Callers over IPC (see
+   * `WizardController.saveCredentials`) must not echo this method's return
+   * value back to the caller.
+   *
+   * @param profileName - The pasted-profile name to read.
+   * @returns The decrypted credentials, or `undefined` if the profile isn't stored.
+   */
+  getPastedCredentials(profileName: string): { accessKeyId: string; secretAccessKey: string; region?: string } | undefined {
+    const entry = this.get('creds')?.aws?.[profileName];
+    if (entry === undefined) return undefined;
+    return {
+      accessKeyId: this.safeStorage.decrypt(entry.accessKeyId),
+      secretAccessKey: this.safeStorage.decrypt(entry.secretAccessKey),
+      region: entry.region,
+    };
+  }
+
+  /**
+   * Write a pasted-credentials profile to `creds.aws.<profileName>`,
+   * encrypting `accessKeyId`/`secretAccessKey` via {@link SafeStorageService}
+   * before storage. Merges with any existing `creds.aws` map so other
+   * profiles are preserved.
+   *
+   * @param profileName - The pasted-profile name to write (default naming —
+   *   e.g. `gsd-pasted` — is the caller's responsibility; see `AwsProfileService`).
+   * @param value - Plaintext credentials to encrypt and store.
+   */
+  setPastedCredentials(profileName: string, value: { accessKeyId: string; secretAccessKey: string; region?: string }): void {
+    const currentCreds = this.get('creds') ?? { aws: {} };
+    this.set('creds', {
+      ...currentCreds,
+      aws: {
+        ...currentCreds.aws,
+        [profileName]: {
+          accessKeyId: this.safeStorage.encrypt(value.accessKeyId),
+          secretAccessKey: this.safeStorage.encrypt(value.secretAccessKey),
+          region: value.region,
+        },
+      },
+    });
+    logger.debug(`ElectronStoreService: creds.aws.${profileName} written (encrypted)`);
   }
 
   /**

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -977,12 +977,26 @@ export interface AwsProfileSummary {
   region?: string;
 }
 
+/** Plaintext input to {@link GsdWizardApi.saveCredentials}. */
+export interface SavePastedCredentialsInput {
+  /** Defaults to `gsd-pasted` when omitted. */
+  profileName?: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region?: string;
+}
+
 /** First-run wizard endpoints (see `openspec/changes/add-first-run-wizard`). */
 export interface GsdWizardApi {
   /** Detects `terraform` and `aws` on `PATH`, reporting per-tool found/path/version. */
   checkPrereqs: () => Promise<PrerequisitesReport>;
   /** Lists AWS CLI profiles discovered in `~/.aws/credentials` and `~/.aws/config`. */
   listAwsProfiles: () => Promise<AwsProfileSummary[]>;
+  /**
+   * Saves pasted AWS credentials (the wizard's "paste keys instead" flow).
+   * Only the resolved profile name comes back — never the values passed in.
+   */
+  saveCredentials: (input: SavePastedCredentialsInput) => Promise<{ profileName: string }>;
 }
 
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -74,6 +74,7 @@ import type {
   UpdateGamePayload,
   PrerequisitesReport,
   AwsProfileSummary,
+  SavePastedCredentialsInput,
 } from './gsd-api.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -595,6 +596,8 @@ const api: GsdApi = {
   wizard: {
     checkPrereqs: () => invoke<PrerequisitesReport>('wizard.prereqs.check'),
     listAwsProfiles: () => invoke<AwsProfileSummary[]>('wizard.aws.listProfiles'),
+    saveCredentials: (input: SavePastedCredentialsInput) =>
+      invoke<{ profileName: string }>('wizard.aws.saveCredentials', input),
   },
 
   drift: {


### PR DESCRIPTION
Closes #197

## Summary

PR 3 of 12 for the First-Run Wizard epic (#139, see `openspec/changes/add-first-run-wizard`). This is the "paste keys instead" save path for the credentials step.

- `ElectronStoreService`: extended `AppStoreSchema` with `creds: { aws: Record<string, PastedAwsCredentials> }` (separate from the existing single `aws` slot, which holds the *selected* profile/region for the "pick an existing profile" path). New `getPastedCredentials`/`setPastedCredentials` accessors follow the exact encrypted-accessor pattern already used for `accessKeyId`/`secretAccessKey`.
- `AwsProfileService.savePastedCredentials()`: unlike `ElectronStoreService`'s generic accessors (which transparently degrade to plaintext outside Electron for test/CI convenience), this explicitly checks `safeStorage.isAvailable()` first and throws a new `SafeStorageUnavailableError` — writing nothing — when the OS keychain is unavailable. Pasted credentials are never allowed to land in plaintext. Defaults the profile name to `gsd-pasted`.
- New `ElectronStoreModule`: extracted `SafeStorageService`+`ElectronStoreService` out of `AppModule`'s own `providers` array into a standalone module (mirroring the existing `ConfigModule` pattern) — `AwsProfileService` (in `WizardModule`) needed to inject them, and a child module can't reach into the root module's private providers in Nest. `AppModule` and `WizardModule` both import it now.
- `WizardController`: new `@MessagePattern('wizard.aws.saveCredentials')`, returning only `{ profileName }` — never echoing the input values back.
- Preload/gsd-api: `gsd.wizard.saveCredentials()` + `SavePastedCredentialsInput` type.

## Test plan

- [x] `npm run app:test` — 1914/1914 tests passing, including a new integration-style spec that writes to a **real temp file on disk** (via a small file-backed `Store` test double, since real `electron-store` needs an Electron process for its default path) and asserts the persisted JSON never contains the plaintext access key ID or secret
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings)
