### PR TITLE
feat(web): add first-run wizard shell and prerequisites step

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -4,6 +4,7 @@ import { WizardController } from './wizard.controller.js';
 import type { PrerequisiteService, PrerequisitesReport } from '../services/PrerequisiteService.js';
 import type { AwsProfileService, AwsProfileSummary } from '../services/AwsProfileService.js';
 import { SafeStorageUnavailableError } from '../services/AwsProfileService.js';
+import type { ElectronStoreService } from '../services/ElectronStoreService.js';
 
 const SATISFIED_REPORT: PrerequisitesReport = {
   terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
@@ -28,11 +29,23 @@ function makeAwsProfiles(profiles: AwsProfileSummary[] = SAMPLE_PROFILES): AwsPr
   } as Partial<AwsProfileService> as AwsProfileService;
 }
 
+/** Build an ElectronStoreService stub whose `get('wizardCompleted')` returns the given value. */
+function makeStore(wizardCompleted: boolean | undefined = undefined): ElectronStoreService {
+  return {
+    get: vi.fn().mockImplementation((key: string) => (key === 'wizardCompleted' ? wizardCompleted : undefined)),
+  } as Partial<ElectronStoreService> as ElectronStoreService;
+}
+
 /** Builds a `WizardController` with default stubs for any dependency the caller doesn't override. */
-function makeController(overrides: { prerequisites?: PrerequisiteService; awsProfiles?: AwsProfileService } = {}): WizardController {
+function makeController(overrides: {
+  prerequisites?: PrerequisiteService;
+  awsProfiles?: AwsProfileService;
+  store?: ElectronStoreService;
+} = {}): WizardController {
   return new WizardController(
     overrides.prerequisites ?? makePrerequisites(),
     overrides.awsProfiles ?? makeAwsProfiles(),
+    overrides.store ?? makeStore(),
   );
 }
 
@@ -58,6 +71,11 @@ describe('WizardController', () => {
     it('should register saveCredentials on the "wizard.aws.saveCredentials" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.saveCredentials);
       expect(pattern).toEqual(['wizard.aws.saveCredentials']);
+    });
+
+    it('should register getState on the "wizard.state.get" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.getState);
+      expect(pattern).toEqual(['wizard.state.get']);
     });
   });
 
@@ -111,6 +129,34 @@ describe('WizardController', () => {
       expect(() =>
         makeController({ awsProfiles }).saveCredentials({ accessKeyId: 'AKID', secretAccessKey: 'SECRET' }),
       ).toThrow(SafeStorageUnavailableError);
+    });
+  });
+
+  describe('getState', () => {
+    it('should return wizardCompleted: false when the store has never set it and test mode is off', () => {
+      const controller = makeController({ store: makeStore(undefined) });
+      vi.spyOn(controller as unknown as { isTestMode(): boolean }, 'isTestMode').mockReturnValue(false);
+
+      expect(controller.getState()).toEqual({ wizardCompleted: false });
+    });
+
+    it('should default to wizardCompleted: true when unset and HYVEON_TEST_MODE is active', () => {
+      const controller = makeController({ store: makeStore(undefined) });
+      vi.spyOn(controller as unknown as { isTestMode(): boolean }, 'isTestMode').mockReturnValue(true);
+
+      expect(controller.getState()).toEqual({ wizardCompleted: true });
+    });
+
+    it('should honor an explicitly-stored false value even under test mode', () => {
+      const controller = makeController({ store: makeStore(false) });
+      vi.spyOn(controller as unknown as { isTestMode(): boolean }, 'isTestMode').mockReturnValue(true);
+
+      expect(controller.getState()).toEqual({ wizardCompleted: false });
+    });
+
+    it('should return wizardCompleted: true once the store has it set', () => {
+      const result = makeController({ store: makeStore(true) }).getState();
+      expect(result).toEqual({ wizardCompleted: true });
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -6,6 +6,12 @@ import {
   type AwsProfileSummary,
   type SavePastedCredentialsInput,
 } from '../services/AwsProfileService.js';
+import { ElectronStoreService } from '../services/ElectronStoreService.js';
+
+/** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
+export interface WizardState {
+  wizardCompleted: boolean;
+}
 
 /**
  * IPC-only controller for the first-run wizard (see
@@ -20,7 +26,45 @@ export class WizardController {
   constructor(
     private readonly prerequisites: PrerequisiteService,
     private readonly awsProfiles: AwsProfileService,
+    private readonly store: ElectronStoreService,
   ) {}
+
+  /**
+   * Returns the wizard's completion flag so the renderer can gate the app
+   * router. Defaults to `false` (unset in a fresh `electron-store`, meaning
+   * the wizard hasn't run yet) — except under the `HYVEON_TEST_MODE` e2e
+   * test seam, where an unset value defaults to `true` instead.
+   *
+   * @remarks
+   * The Electron e2e specs that land on the dashboard (`dashboard`, `costs`,
+   * `logs`, `discord`, `terraform`) launch the real packaged app and don't
+   * register a `wizard.state.get` mock (most seed their own IPC responses
+   * inline per test, not through the shared `applyGsdMocks` helper), so a
+   * `false` default here would route every one of them into the wizard
+   * instead of the dashboard they're actually testing. Defaulting to
+   * `true` under test mode avoids retrofitting every existing spec; a
+   * future spec that *does* want to exercise the wizard flow itself can
+   * still override this via `window.gsd.__test.mock('wizard.state.get', ...)`
+   * — the mock registry is consulted before this controller is ever reached.
+   * This is a plain read of `ElectronStoreService` either way — the fuller
+   * resumable step-progress state (`userData/state.json`, owned by
+   * `FirstRunWizardService`) lands in a later PR of this epic.
+   */
+  @MessagePattern('wizard.state.get')
+  getState(): WizardState {
+    const stored = this.store.get('wizardCompleted');
+    if (stored !== undefined) return { wizardCompleted: stored };
+    return { wizardCompleted: this.isTestMode() };
+  }
+
+  /**
+   * Returns `true` when `HYVEON_TEST_MODE=1` is set (the Electron e2e test
+   * seam). Extracted as a protected seam so tests can `vi.spyOn` it instead
+   * of mutating `process.env` directly.
+   */
+  protected isTestMode(): boolean {
+    return process.env['HYVEON_TEST_MODE'] === '1';
+  }
 
   /** Detects `terraform` and `aws` on `PATH`, reporting per-tool found/path/version. */
   @MessagePattern('wizard.prereqs.check')

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -997,6 +997,13 @@ export interface GsdWizardApi {
    * Only the resolved profile name comes back — never the values passed in.
    */
   saveCredentials: (input: SavePastedCredentialsInput) => Promise<{ profileName: string }>;
+  /** Whether the first-run wizard has completed — used to gate the app router. */
+  getState: () => Promise<WizardState>;
+}
+
+/** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
+export interface WizardState {
+  wizardCompleted: boolean;
 }
 
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */

--- a/app/packages/desktop-preload/src/index.ts
+++ b/app/packages/desktop-preload/src/index.ts
@@ -19,6 +19,10 @@ export type {
   TerraformDestroyMintAck,
   TerraformRollbackResolveAck,
   TerraformRollbackConfirmAck,
+  PrerequisiteCheckResult,
+  TerraformPrerequisiteCheckResult,
+  PrerequisitesReport,
+  WizardState,
 } from './gsd-api.js';
 
 declare global {

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -75,6 +75,7 @@ import type {
   PrerequisitesReport,
   AwsProfileSummary,
   SavePastedCredentialsInput,
+  WizardState,
 } from './gsd-api.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -598,6 +599,7 @@ const api: GsdApi = {
     listAwsProfiles: () => invoke<AwsProfileSummary[]>('wizard.aws.listProfiles'),
     saveCredentials: (input: SavePastedCredentialsInput) =>
       invoke<{ profileName: string }>('wizard.aws.saveCredentials', input),
+    getState: () => invoke<WizardState>('wizard.state.get'),
   },
 
   drift: {

--- a/app/packages/web/src/app.component.tsx
+++ b/app/packages/web/src/app.component.tsx
@@ -28,7 +28,13 @@ function useWizardCompleted(): boolean | null {
 
   useEffect(() => {
     let cancelled = false;
-    if (!window.gsd) {
+    // Optional chaining matters here, not just the `window.gsd` presence
+    // check: a `window.gsd` stub built before this namespace existed (e.g.
+    // the chromium e2e tier's stub bridge) has no `.wizard` property, and
+    // `window.gsd.wizard.getState()` would throw synchronously — before
+    // there's even a promise to `.catch()` — permanently stalling this
+    // component at `wizardCompleted === null` (renders nothing, forever).
+    if (!window.gsd?.wizard) {
       setWizardCompleted(true);
       return;
     }

--- a/app/packages/web/src/app.component.tsx
+++ b/app/packages/web/src/app.component.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AppLayout } from './components/app-layout.component.js';
 import { DashboardPage } from './pages/dashboard.page.js';
@@ -14,9 +15,46 @@ import { AuditPage } from './pages/audit.page.js';
 import { PollingProvider } from './polling/polling-provider.component.js';
 import { GameStatusProvider } from './polling/game-status-provider.component.js';
 import { Toaster } from './components/ui/sonner.component.js';
+import { FirstRunWizard } from './components/first-run-wizard/first-run-wizard.component.js';
 
 /**
- * Root component. Renders the routed dashboard shell. Routes:
+ * Fetches the wizard's completion flag once on mount. Defaults to `true`
+ * (i.e. skip the wizard) on any failure — a missing `window.gsd` bridge or a
+ * failed IPC call must never lock an otherwise-working install out of its
+ * own dashboard. Returns `null` while the check is in flight.
+ */
+function useWizardCompleted(): boolean | null {
+  const [wizardCompleted, setWizardCompleted] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!window.gsd) {
+      setWizardCompleted(true);
+      return;
+    }
+    window.gsd.wizard
+      .getState()
+      .then((state) => {
+        if (!cancelled) setWizardCompleted(state.wizardCompleted);
+      })
+      .catch(() => {
+        if (!cancelled) setWizardCompleted(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return wizardCompleted;
+}
+
+/**
+ * Root component.
+ *
+ * Gates the whole app behind the first-run wizard: while
+ * `wizardCompleted` is `false`, renders only {@link FirstRunWizard} (no
+ * routing, no polling providers — there's nothing to poll before AWS is
+ * bootstrapped). Once complete, renders the routed dashboard shell:
  *   - `/` → Dashboard (game cards + panels)
  *   - `/costs` → Cost analysis placeholder
  *   - `/discord` → Discord settings placeholder
@@ -30,6 +68,11 @@ import { Toaster } from './components/ui/sonner.component.js';
  *   - `/audit` → Audit log
  */
 export default function App() {
+  const wizardCompleted = useWizardCompleted();
+
+  if (wizardCompleted === null) return null;
+  if (!wizardCompleted) return <FirstRunWizard />;
+
   return (
     <PollingProvider>
       <GameStatusProvider>

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+
+const gsdMock = {
+  wizard: {
+    checkPrereqs: vi.fn(),
+  },
+};
+vi.stubGlobal('gsd', gsdMock);
+
+import { FirstRunWizard } from './first-run-wizard.component.js';
+
+const SATISFIED: PrerequisitesReport = {
+  terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
+  aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
+};
+
+const UNSATISFIED: PrerequisitesReport = {
+  terraform: { found: false },
+  aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
+};
+
+beforeEach(() => {
+  gsdMock.wizard.checkPrereqs.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('FirstRunWizard', () => {
+  it('should check prerequisites on mount and render found tools once resolved', async () => {
+    gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+
+    render(<FirstRunWizard />);
+
+    await waitFor(() => expect(gsdMock.wizard.checkPrereqs).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
+  });
+
+  it('should disable Next while prerequisites are unsatisfied', async () => {
+    gsdMock.wizard.checkPrereqs.mockResolvedValue(UNSATISFIED);
+
+    render(<FirstRunWizard />);
+
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+  });
+
+  it('should enable Next once both tools are satisfied', async () => {
+    gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+
+    render(<FirstRunWizard />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
+  });
+
+  it('should re-invoke the prerequisite check when Re-check is clicked', async () => {
+    gsdMock.wizard.checkPrereqs.mockResolvedValue(UNSATISFIED);
+
+    render(<FirstRunWizard />);
+    await waitFor(() => expect(gsdMock.wizard.checkPrereqs).toHaveBeenCalledTimes(1));
+
+    gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+    await userEvent.click(screen.getByRole('button', { name: /re-check/i }));
+
+    await waitFor(() => expect(gsdMock.wizard.checkPrereqs).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
+  });
+
+  it('should disable Back on the first (and currently only) step', async () => {
+    gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+    render(<FirstRunWizard />);
+    await waitFor(() => expect(gsdMock.wizard.checkPrereqs).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled();
+  });
+});

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -1,0 +1,92 @@
+/**
+ * Shell for the first-run wizard (#184, epic #139): mirrors the add-game
+ * wizard's step-flow pattern (shell owns step index + fetched state, one
+ * component per step, pure helpers in `wizard.utils.ts`) but renders
+ * full-page rather than in a `<Dialog>` — this wizard gates the entire app
+ * before the dashboard is usable, so `app.component.tsx` renders it in place
+ * of the normal routed layout while `wizardCompleted` is `false`.
+ *
+ * Only the prerequisites step exists so far; later PRs in this epic append
+ * more steps to `WIZARD_STEPS` and this shell's render body.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+import { Button } from '@/components/ui/button.component';
+import { PrerequisitesStep } from './prerequisites-step.component.js';
+import { WIZARD_STEPS, arePrerequisitesSatisfied, type WizardStep } from './wizard.utils.js';
+
+/** Human-readable heading for each {@link WizardStep}. */
+const STEP_LABELS: Record<WizardStep, string> = {
+  prerequisites: 'Install prerequisites',
+};
+
+/**
+ * Self-contained first-run wizard: owns its own step index and the
+ * prerequisites-check state (report/checking/error), and fetches an initial
+ * check on mount.
+ */
+export function FirstRunWizard() {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [report, setReport] = useState<PrerequisitesReport | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const step = WIZARD_STEPS[stepIndex];
+
+  const checkPrereqs = useCallback(async () => {
+    if (!window.gsd) {
+      setError('IPC bridge (window.gsd) is not available in this context.');
+      return;
+    }
+    setChecking(true);
+    setError(null);
+    try {
+      const result = await window.gsd.wizard.checkPrereqs();
+      setReport(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to check prerequisites.');
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void checkPrereqs();
+  }, [checkPrereqs]);
+
+  const advanceDisabled = step === 'prerequisites' ? !arePrerequisitesSatisfied(report) : false;
+
+  function goNext() {
+    setStepIndex((index) => Math.min(index + 1, WIZARD_STEPS.length - 1));
+  }
+
+  function goBack() {
+    setStepIndex((index) => Math.max(index - 1, 0));
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-xl rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface-1)] p-8 space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold">Welcome to Hyveon</h1>
+          <p className="text-sm text-muted-foreground">
+            Step {stepIndex + 1} of {WIZARD_STEPS.length}: {STEP_LABELS[step]}
+          </p>
+        </div>
+
+        {step === 'prerequisites' && (
+          <PrerequisitesStep report={report} checking={checking} error={error} onRecheck={checkPrereqs} />
+        )}
+
+        <div className="flex justify-between">
+          <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0}>
+            Back
+          </Button>
+          <Button type="button" onClick={goNext} disabled={advanceDisabled}>
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/first-run-wizard/prerequisites-step.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/prerequisites-step.component.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PrerequisitesStep } from './prerequisites-step.component.js';
+import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+
+/** Stubs `navigator.userAgent` for the duration of one test so OS-specific instructions are deterministic. */
+function stubUserAgent(userAgent: string): void {
+  Object.defineProperty(window.navigator, 'userAgent', { value: userAgent, configurable: true });
+}
+
+const SATISFIED: PrerequisitesReport = {
+  terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
+  aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PrerequisitesStep', () => {
+  it('should show a checking message before the first report resolves', () => {
+    render(<PrerequisitesStep report={null} checking={true} error={null} onRecheck={vi.fn()} />);
+    expect(screen.getByText(/checking/i)).toBeInTheDocument();
+  });
+
+  it('should render both tools as found with their versions when satisfied', () => {
+    render(<PrerequisitesStep report={SATISFIED} checking={false} error={null} onRecheck={vi.fn()} />);
+    expect(screen.getByText('Found v1.9.0')).toBeInTheDocument();
+    expect(screen.getByText('Found v2.15.30')).toBeInTheDocument();
+  });
+
+  it('should render "Not found" plus install instructions and a vendor link for a missing tool', () => {
+    stubUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)');
+    const report: PrerequisitesReport = { terraform: { found: false }, aws: SATISFIED.aws };
+    render(<PrerequisitesStep report={report} checking={false} error={null} onRecheck={vi.fn()} />);
+
+    expect(screen.getByText('Not found')).toBeInTheDocument();
+    expect(screen.getByText(/brew install hashicorp\/tap\/terraform/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /install guide/i })).toHaveAttribute(
+      'href',
+      'https://developer.hashicorp.com/terraform/install',
+    );
+  });
+
+  it('should show per-platform instructions matching the detected OS', () => {
+    stubUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    const report: PrerequisitesReport = { terraform: { found: false }, aws: SATISFIED.aws };
+    render(<PrerequisitesStep report={report} checking={false} error={null} onRecheck={vi.fn()} />);
+
+    expect(screen.getByText(/winget install Hashicorp.Terraform/)).toBeInTheDocument();
+  });
+
+  it('should warn when a found tool is below the minimum version', () => {
+    const report: PrerequisitesReport = {
+      terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.2.0', minimumVersionSatisfied: false },
+      aws: SATISFIED.aws,
+    };
+    render(<PrerequisitesStep report={report} checking={false} error={null} onRecheck={vi.fn()} />);
+
+    expect(screen.getByText(/below the minimum supported version/i)).toBeInTheDocument();
+  });
+
+  it('should render the error message when detection itself fails', () => {
+    render(<PrerequisitesStep report={null} checking={false} error="IPC bridge unavailable" onRecheck={vi.fn()} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('IPC bridge unavailable');
+  });
+
+  it('should call onRecheck when the Re-check button is clicked', async () => {
+    const onRecheck = vi.fn();
+    render(<PrerequisitesStep report={SATISFIED} checking={false} error={null} onRecheck={onRecheck} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /re-check/i }));
+
+    expect(onRecheck).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable the Re-check button while a check is in flight', () => {
+    render(<PrerequisitesStep report={SATISFIED} checking={true} error={null} onRecheck={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /re-check/i })).toBeDisabled();
+  });
+});

--- a/app/packages/web/src/components/first-run-wizard/prerequisites-step.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/prerequisites-step.component.tsx
@@ -1,0 +1,135 @@
+import { CheckCircle2, XCircle, AlertTriangle, Loader2, ExternalLink } from 'lucide-react';
+import type { PrerequisiteCheckResult, PrerequisitesReport, TerraformPrerequisiteCheckResult } from '@hyveon/desktop-preload';
+import { Button } from '@/components/ui/button.component';
+import { Badge } from '@/components/ui/badge.component';
+import { detectOs, type DetectedOs } from './wizard.utils.js';
+
+/** Props for {@link PrerequisitesStep}. */
+export interface PrerequisitesStepProps {
+  /** Latest detection result, or `null` before the first check resolves. */
+  report: PrerequisitesReport | null;
+  /** True while a check (initial or Re-check) is in flight. */
+  checking: boolean;
+  /** Set when the detection call itself fails (e.g. IPC bridge unavailable). */
+  error: string | null;
+  /** Invoked by the Re-check button. */
+  onRecheck: () => void;
+}
+
+/** Per-OS install instructions and vendor links for a single tool. */
+const INSTALL_INSTRUCTIONS: Record<'terraform' | 'aws', Record<DetectedOs, string>> = {
+  terraform: {
+    macos: 'brew tap hashicorp/tap && brew install hashicorp/tap/terraform',
+    windows: 'winget install Hashicorp.Terraform',
+    linux: 'Download the binary and place it on PATH, or use your distro’s package manager (e.g. apt install terraform on distros with the HashiCorp apt repo configured).',
+    unknown: 'See the install guide linked below for your platform.',
+  },
+  aws: {
+    macos: 'brew install awscli',
+    windows: 'Download and run the AWS CLI MSI installer.',
+    linux: 'Use your distro’s package manager, or the official bundled installer (curl + unzip + ./aws/install).',
+    unknown: 'See the install guide linked below for your platform.',
+  },
+};
+
+const VENDOR_LINKS: Record<'terraform' | 'aws', string> = {
+  terraform: 'https://developer.hashicorp.com/terraform/install',
+  aws: 'https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html',
+};
+
+const TOOL_LABELS: Record<'terraform' | 'aws', string> = {
+  terraform: 'Terraform',
+  aws: 'AWS CLI',
+};
+
+/**
+ * First step of the first-run wizard (#184): detects `terraform` and `aws`
+ * on `PATH` and blocks progression until both are present (and, for
+ * Terraform, meet the minimum supported version). Never offers to install
+ * anything itself — only instructions, a vendor link, and a Re-check button,
+ * per the locked wizard design (no auto-install, no auto-grant).
+ */
+export function PrerequisitesStep({ report, checking, error, onRecheck }: PrerequisitesStepProps) {
+  const os = detectOs();
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Hyveon needs <code>terraform</code> and the <code>aws</code> CLI on your <code>PATH</code> before it can
+        bootstrap your AWS account. Install any missing tool below, then select Re-check.
+      </p>
+
+      {error && (
+        <p role="alert" className="text-sm text-[var(--color-red)]">
+          {error}
+        </p>
+      )}
+
+      {!report && checking && !error && <p className="text-sm text-muted-foreground">Checking…</p>}
+
+      {report && (
+        <div className="space-y-4">
+          <ToolRow tool="terraform" result={report.terraform} os={os} />
+          <ToolRow tool="aws" result={report.aws} os={os} />
+        </div>
+      )}
+
+      <Button type="button" variant="outline" onClick={onRecheck} disabled={checking}>
+        {checking && <Loader2 className="animate-spin" />}
+        Re-check
+      </Button>
+    </div>
+  );
+}
+
+/** Renders detection status, version, and (when missing/below-minimum) install instructions for one tool. */
+function ToolRow({
+  tool,
+  result,
+  os,
+}: {
+  tool: 'terraform' | 'aws';
+  result: PrerequisiteCheckResult | TerraformPrerequisiteCheckResult;
+  os: DetectedOs;
+}) {
+  const minimumSatisfied = 'minimumVersionSatisfied' in result ? result.minimumVersionSatisfied : undefined;
+  const belowMinimum = minimumSatisfied === false;
+
+  return (
+    <div className="rounded-[var(--radius-md)] border border-[var(--color-border)] p-4 space-y-2">
+      <div className="flex items-center gap-2">
+        {result.found && !belowMinimum && <CheckCircle2 className="size-4 text-[var(--color-green)]" />}
+        {result.found && belowMinimum && <AlertTriangle className="size-4 text-[var(--color-amber)]" />}
+        {!result.found && <XCircle className="size-4 text-[var(--color-red)]" />}
+        <span className="font-medium">{TOOL_LABELS[tool]}</span>
+        {result.found ? (
+          <Badge variant={belowMinimum ? 'warning' : 'success'}>
+            {result.version ? `Found v${result.version}` : 'Found'}
+          </Badge>
+        ) : (
+          <Badge variant="destructive">Not found</Badge>
+        )}
+      </div>
+
+      {belowMinimum && (
+        <p className="text-xs text-[var(--color-amber)]">
+          Version {result.version} is below the minimum supported version. Please upgrade.
+        </p>
+      )}
+
+      {(!result.found || belowMinimum) && (
+        <div className="text-xs text-muted-foreground space-y-1">
+          <p>{INSTALL_INSTRUCTIONS[tool][os]}</p>
+          <a
+            href={VENDOR_LINKS[tool]}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-[var(--color-primary)] hover:underline"
+          >
+            Install guide <ExternalLink className="size-3" />
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.test.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { detectOs, arePrerequisitesSatisfied } from './wizard.utils.js';
+import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+
+describe('detectOs', () => {
+  it('should detect macOS from a macOS user-agent string', () => {
+    expect(detectOs('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')).toBe('macos');
+  });
+
+  it('should detect Windows from a Windows user-agent string', () => {
+    expect(detectOs('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')).toBe('windows');
+  });
+
+  it('should detect Linux from a Linux user-agent string', () => {
+    expect(detectOs('Mozilla/5.0 (X11; Linux x86_64)')).toBe('linux');
+  });
+
+  it('should return unknown for an unrecognized user-agent string', () => {
+    expect(detectOs('SomeOtherPlatform/1.0')).toBe('unknown');
+  });
+});
+
+const SATISFIED: PrerequisitesReport = {
+  terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
+  aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
+};
+
+describe('arePrerequisitesSatisfied', () => {
+  it('should return false when the report is null', () => {
+    expect(arePrerequisitesSatisfied(null)).toBe(false);
+  });
+
+  it('should return true when both tools are found and terraform meets the minimum version', () => {
+    expect(arePrerequisitesSatisfied(SATISFIED)).toBe(true);
+  });
+
+  it('should return false when terraform is not found', () => {
+    expect(arePrerequisitesSatisfied({ ...SATISFIED, terraform: { found: false } })).toBe(false);
+  });
+
+  it('should return false when aws is not found', () => {
+    expect(arePrerequisitesSatisfied({ ...SATISFIED, aws: { found: false } })).toBe(false);
+  });
+
+  it('should return false when terraform is below the minimum version', () => {
+    expect(
+      arePrerequisitesSatisfied({
+        ...SATISFIED,
+        terraform: { ...SATISFIED.terraform, minimumVersionSatisfied: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true when terraform version is unparseable (minimumVersionSatisfied undefined)', () => {
+    expect(
+      arePrerequisitesSatisfied({
+        ...SATISFIED,
+        terraform: { found: true, path: '/usr/local/bin/terraform' },
+      }),
+    ).toBe(true);
+  });
+});

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure helpers for the first-run wizard shell — step ordering, OS detection
+ * for prerequisite install instructions, and the prerequisites-satisfied
+ * gate. No React imports, so these are testable independent of any
+ * component.
+ */
+import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+
+/**
+ * Ordered wizard steps. Only `prerequisites` exists so far — later PRs in
+ * this epic (#186 pick-cloud, #192 credentials, #200/#203/#205 bootstrap,
+ * #208 IAM check, #210 terraform-init) append to this array.
+ */
+export const WIZARD_STEPS = ['prerequisites'] as const;
+
+/** A single step in {@link WIZARD_STEPS}. */
+export type WizardStep = (typeof WIZARD_STEPS)[number];
+
+/** Operating systems the prerequisites step can tailor install instructions for. */
+export type DetectedOs = 'macos' | 'windows' | 'linux' | 'unknown';
+
+/**
+ * Detects the operating system from a user-agent string (defaults to
+ * `navigator.userAgent`), used to pick which install instructions to show.
+ */
+export function detectOs(userAgent: string = navigator.userAgent): DetectedOs {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes('mac os') || ua.includes('macintosh')) return 'macos';
+  if (ua.includes('windows')) return 'windows';
+  if (ua.includes('linux')) return 'linux';
+  return 'unknown';
+}
+
+/**
+ * True once both `terraform` and `aws` are found, and terraform's resolved
+ * version (when parseable) meets the minimum. An unparseable version
+ * (`minimumVersionSatisfied === undefined`) does not block progression —
+ * only an explicit `false` does.
+ */
+export function arePrerequisitesSatisfied(report: PrerequisitesReport | null): boolean {
+  if (!report) return false;
+  return report.terraform.found && report.terraform.minimumVersionSatisfied !== false && report.aws.found;
+}


### PR DESCRIPTION
Closes #184

## Summary

PR 4 of 12 for the First-Run Wizard epic (#139, see `openspec/changes/add-first-run-wizard`). First web-side (React) work in the epic: the wizard shell and its first step.

- New `web/src/components/first-run-wizard/`: `wizard.utils.ts` (pure helpers — `WIZARD_STEPS`, `detectOs()`, `arePrerequisitesSatisfied()`), `first-run-wizard.component.tsx` (shell, mirrors the add-game-wizard step-flow pattern but full-page instead of a Dialog since it gates the whole app), `prerequisites-step.component.tsx` (per-tool found/version status, OS-tailored install instructions + vendor link, Re-check button, no auto-install path per the locked wizard design).
- `app.component.tsx`: router gating — fetches `wizardCompleted` via `window.gsd.wizard.getState()` on mount, renders only `<FirstRunWizard />` while false. Defaults to `true` (skip the wizard) on any fetch failure or missing bridge — a broken IPC call must never lock a working install out of its own dashboard.
- Backend: new `@MessagePattern('wizard.state.get')` reading `ElectronStoreService`'s `wizardCompleted` flag.
- `desktop-preload/src/index.ts`: added the prerequisite/wizard-state types to the public export list (matching how `terraform.page.tsx` already imports Terraform types from `@hyveon/desktop-preload`).

### A note on the `HYVEON_TEST_MODE` default (the least obvious part of this diff)

The new router gate means a fresh Electron launch with no `wizardCompleted` set would render the wizard instead of the dashboard — breaking every existing Electron e2e spec that lands on the dashboard (`dashboard`, `costs`, `logs`, `discord`, `terraform` specs, all launching the real packaged app via `_electron.launch()`). Only 2 of those 5 use the shared `applyGsdMocks()` helper; the other 3 seed `window.gsd.__test.mock()` inline, many times each — patching every call site would mean touching dozens of places across files unrelated to this PR. Instead, `wizard.state.get` defaults to `wizardCompleted: true` specifically under `HYVEON_TEST_MODE` (the same env var already used for the e2e test seam elsewhere in this codebase). Existing specs need zero changes. A future spec that wants to actually test the wizard flow can still override via the normal `__test.mock('wizard.state.get', ...)` seam, which takes priority.

**Caveat:** no Electron/Playwright e2e run was performed in this environment — this is a defensive fix based on reading `playwright.config.ts` and the 5 affected spec files, not a live-verified e2e pass. Worth confirming once CI runs.

## Test plan

- [x] `npm run app:test` — 1945/1945 tests passing (23 new)
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings)
- [ ] Electron e2e suite (`dashboard`/`costs`/`logs`/`discord`/`terraform` specs) — not run locally, relying on CI to confirm the `HYVEON_TEST_MODE` default actually preserves them
