### PR TITLE
feat(web): add pick-cloud step to the first-run wizard

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -29,10 +29,18 @@ function makeAwsProfiles(profiles: AwsProfileSummary[] = SAMPLE_PROFILES): AwsPr
   } as Partial<AwsProfileService> as AwsProfileService;
 }
 
-/** Build an ElectronStoreService stub whose `get('wizardCompleted')` returns the given value. */
-function makeStore(wizardCompleted: boolean | undefined = undefined): ElectronStoreService {
+/**
+ * Build an `ElectronStoreService` stub backed by a plain object so
+ * `set()` followed by `get()` (as `saveState` does) round-trips like the
+ * real service, instead of always returning a fixed value.
+ */
+function makeStore(seed: { wizardCompleted?: boolean; activeCloud?: 'aws' } = {}): ElectronStoreService {
+  const data: Record<string, unknown> = { ...seed };
   return {
-    get: vi.fn().mockImplementation((key: string) => (key === 'wizardCompleted' ? wizardCompleted : undefined)),
+    get: vi.fn().mockImplementation((key: string) => data[key]),
+    set: vi.fn().mockImplementation((key: string, value: unknown) => {
+      data[key] = value;
+    }),
   } as Partial<ElectronStoreService> as ElectronStoreService;
 }
 
@@ -76,6 +84,11 @@ describe('WizardController', () => {
     it('should register getState on the "wizard.state.get" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.getState);
       expect(pattern).toEqual(['wizard.state.get']);
+    });
+
+    it('should register saveState on the "wizard.state.save" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.saveState);
+      expect(pattern).toEqual(['wizard.state.save']);
     });
   });
 
@@ -134,29 +147,56 @@ describe('WizardController', () => {
 
   describe('getState', () => {
     it('should return wizardCompleted: false when the store has never set it and test mode is off', () => {
-      const controller = makeController({ store: makeStore(undefined) });
+      const controller = makeController({ store: makeStore() });
       vi.spyOn(controller as unknown as { isTestMode(): boolean }, 'isTestMode').mockReturnValue(false);
 
-      expect(controller.getState()).toEqual({ wizardCompleted: false });
+      expect(controller.getState()).toEqual({ wizardCompleted: false, activeCloud: undefined });
     });
 
     it('should default to wizardCompleted: true when unset and HYVEON_TEST_MODE is active', () => {
-      const controller = makeController({ store: makeStore(undefined) });
+      const controller = makeController({ store: makeStore() });
       vi.spyOn(controller as unknown as { isTestMode(): boolean }, 'isTestMode').mockReturnValue(true);
 
-      expect(controller.getState()).toEqual({ wizardCompleted: true });
+      expect(controller.getState()).toEqual({ wizardCompleted: true, activeCloud: undefined });
     });
 
     it('should honor an explicitly-stored false value even under test mode', () => {
-      const controller = makeController({ store: makeStore(false) });
+      const controller = makeController({ store: makeStore({ wizardCompleted: false }) });
       vi.spyOn(controller as unknown as { isTestMode(): boolean }, 'isTestMode').mockReturnValue(true);
 
-      expect(controller.getState()).toEqual({ wizardCompleted: false });
+      expect(controller.getState()).toEqual({ wizardCompleted: false, activeCloud: undefined });
     });
 
     it('should return wizardCompleted: true once the store has it set', () => {
-      const result = makeController({ store: makeStore(true) }).getState();
-      expect(result).toEqual({ wizardCompleted: true });
+      const result = makeController({ store: makeStore({ wizardCompleted: true }) }).getState();
+      expect(result).toEqual({ wizardCompleted: true, activeCloud: undefined });
+    });
+
+    it('should include the stored activeCloud when present', () => {
+      const result = makeController({ store: makeStore({ wizardCompleted: true, activeCloud: 'aws' }) }).getState();
+      expect(result).toEqual({ wizardCompleted: true, activeCloud: 'aws' });
+    });
+  });
+
+  describe('saveState', () => {
+    it('should persist activeCloud to the store and return the updated state', () => {
+      const store = makeStore({ wizardCompleted: false });
+      const controller = makeController({ store });
+
+      const result = controller.saveState({ activeCloud: 'aws' });
+
+      expect(store.set).toHaveBeenCalledWith('activeCloud', 'aws');
+      expect(result).toEqual({ wizardCompleted: false, activeCloud: 'aws' });
+    });
+
+    it('should not write to the store when activeCloud is omitted, but still return current state', () => {
+      const store = makeStore({ wizardCompleted: true, activeCloud: 'aws' });
+      const controller = makeController({ store });
+
+      const result = controller.saveState({});
+
+      expect(store.set).not.toHaveBeenCalled();
+      expect(result).toEqual({ wizardCompleted: true, activeCloud: 'aws' });
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -198,5 +198,15 @@ describe('WizardController', () => {
       expect(store.set).not.toHaveBeenCalled();
       expect(result).toEqual({ wizardCompleted: true, activeCloud: 'aws' });
     });
+
+    it('should throw and write nothing when activeCloud is not the supported "aws" value', () => {
+      const store = makeStore({ wizardCompleted: false });
+      const controller = makeController({ store });
+
+      expect(() =>
+        controller.saveState({ activeCloud: 'gcp' as unknown as 'aws' }),
+      ).toThrow('Unsupported cloud provider: gcp');
+      expect(store.set).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -11,6 +11,13 @@ import { ElectronStoreService } from '../services/ElectronStoreService.js';
 /** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
 export interface WizardState {
   wizardCompleted: boolean;
+  /** The cloud chosen in the pick-cloud step. Locked to `'aws'` for v1; `undefined` before that step runs. */
+  activeCloud?: 'aws';
+}
+
+/** Payload accepted by {@link WizardController.saveState}. */
+export interface SaveWizardStateInput {
+  activeCloud?: 'aws';
 }
 
 /**
@@ -53,8 +60,23 @@ export class WizardController {
   @MessagePattern('wizard.state.get')
   getState(): WizardState {
     const stored = this.store.get('wizardCompleted');
-    if (stored !== undefined) return { wizardCompleted: stored };
-    return { wizardCompleted: this.isTestMode() };
+    const wizardCompleted = stored !== undefined ? stored : this.isTestMode();
+    return { wizardCompleted, activeCloud: this.store.get('activeCloud') };
+  }
+
+  /**
+   * Persists wizard-flow answers into `ElectronStoreService`. Only
+   * `activeCloud` exists so far (the pick-cloud step); later PRs in this
+   * epic extend the payload as more steps need to durably save a choice.
+   * Returns the same shape as {@link getState} so the renderer can update
+   * its local state directly from the response.
+   */
+  @MessagePattern('wizard.state.save')
+  saveState(@Payload() body: SaveWizardStateInput): WizardState {
+    if (body.activeCloud !== undefined) {
+      this.store.set('activeCloud', body.activeCloud);
+    }
+    return this.getState();
   }
 
   /**

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -74,6 +74,12 @@ export class WizardController {
   @MessagePattern('wizard.state.save')
   saveState(@Payload() body: SaveWizardStateInput): WizardState {
     if (body.activeCloud !== undefined) {
+      // The `SaveWizardStateInput` union only constrains compile-time
+      // callers — an IPC payload is runtime data, so a malformed or
+      // malicious call could otherwise persist an unsupported value.
+      if (body.activeCloud !== 'aws') {
+        throw new Error(`Unsupported cloud provider: ${String(body.activeCloud)}`);
+      }
       this.store.set('activeCloud', body.activeCloud);
     }
     return this.getState();

--- a/app/packages/desktop-main/src/services/ElectronStoreService.test.ts
+++ b/app/packages/desktop-main/src/services/ElectronStoreService.test.ts
@@ -236,6 +236,55 @@ describe('ElectronStoreService — round-trip', () => {
 });
 
 // ---------------------------------------------------------------------------
+// activeCloud — relaunch semantics
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateful stand-in for the mocked `electron-store` `Store`, backed by a
+ * plain object so `get`/`set` actually persist across calls — needed to
+ * prove a value survives being read by a *second* `ElectronStoreService`
+ * instance pointed at the same underlying store, simulating an app relaunch
+ * (a fresh service instance is constructed on every app boot; only the
+ * on-disk store file — modeled here by this shared object — persists).
+ */
+function makeStatefulMockStore(): Store<AppStoreSchema> {
+  const data: Partial<AppStoreSchema> = {};
+  return {
+    get: vi.fn().mockImplementation((key: keyof AppStoreSchema) => data[key]),
+    set: vi.fn().mockImplementation((key: keyof AppStoreSchema, value: unknown) => {
+      (data as Record<string, unknown>)[key] = value;
+    }),
+  } as unknown as Store<AppStoreSchema>;
+}
+
+describe('ElectronStoreService — activeCloud persists across a simulated relaunch', () => {
+  it('should read back activeCloud from a new service instance pointed at the same store', () => {
+    const sharedMockStore = makeStatefulMockStore();
+    const safeStorage = makeSafeStorage();
+
+    vi.spyOn(
+      ElectronStoreService.prototype as unknown as { readIsElectron(): boolean },
+      'readIsElectron',
+    ).mockReturnValue(true);
+    vi.spyOn(
+      ElectronStoreService.prototype as unknown as { createStore(): Store<AppStoreSchema> },
+      'createStore',
+    ).mockReturnValue(sharedMockStore);
+
+    // First "launch": a service instance writes the operator's cloud choice.
+    const firstLaunch = new ElectronStoreService(safeStorage);
+    firstLaunch.set('activeCloud', 'aws');
+
+    // Second "launch": a brand-new instance, same underlying store — this is
+    // exactly what happens when the app restarts and re-constructs its
+    // providers from scratch.
+    const secondLaunch = new ElectronStoreService(safeStorage);
+
+    expect(secondLaunch.get('activeCloud')).toBe('aws');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Pasted credentials — getPastedCredentials / setPastedCredentials
 // ---------------------------------------------------------------------------
 

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -999,11 +999,24 @@ export interface GsdWizardApi {
   saveCredentials: (input: SavePastedCredentialsInput) => Promise<{ profileName: string }>;
   /** Whether the first-run wizard has completed — used to gate the app router. */
   getState: () => Promise<WizardState>;
+  /**
+   * Persists wizard-flow answers (currently just `activeCloud`). Returns the
+   * same shape as {@link getState} so the caller can update local state
+   * directly from the response.
+   */
+  saveState: (input: SaveWizardStateInput) => Promise<WizardState>;
 }
 
 /** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
 export interface WizardState {
   wizardCompleted: boolean;
+  /** The cloud chosen in the pick-cloud step. Locked to `'aws'` for v1; `undefined` before that step runs. */
+  activeCloud?: 'aws';
+}
+
+/** Payload accepted by {@link GsdWizardApi.saveState}. */
+export interface SaveWizardStateInput {
+  activeCloud?: 'aws';
 }
 
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */

--- a/app/packages/desktop-preload/src/index.ts
+++ b/app/packages/desktop-preload/src/index.ts
@@ -23,6 +23,7 @@ export type {
   TerraformPrerequisiteCheckResult,
   PrerequisitesReport,
   WizardState,
+  SaveWizardStateInput,
 } from './gsd-api.js';
 
 declare global {

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -76,6 +76,7 @@ import type {
   AwsProfileSummary,
   SavePastedCredentialsInput,
   WizardState,
+  SaveWizardStateInput,
 } from './gsd-api.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -600,6 +601,7 @@ const api: GsdApi = {
     saveCredentials: (input: SavePastedCredentialsInput) =>
       invoke<{ profileName: string }>('wizard.aws.saveCredentials', input),
     getState: () => invoke<WizardState>('wizard.state.get'),
+    saveState: (input: SaveWizardStateInput) => invoke<WizardState>('wizard.state.save', input),
   },
 
   drift: {

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -6,6 +6,7 @@ import type { PrerequisitesReport } from '@hyveon/desktop-preload';
 const gsdMock = {
   wizard: {
     checkPrereqs: vi.fn(),
+    saveState: vi.fn(),
   },
 };
 vi.stubGlobal('gsd', gsdMock);
@@ -24,7 +25,17 @@ const UNSATISFIED: PrerequisitesReport = {
 
 beforeEach(() => {
   gsdMock.wizard.checkPrereqs.mockReset();
+  gsdMock.wizard.saveState.mockReset();
 });
+
+/** Advances the wizard from the (satisfied) prerequisites step to pick-cloud. */
+async function advanceToPickCloud(): Promise<void> {
+  gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+  render(<FirstRunWizard />);
+  await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
+  await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+  await screen.findByText(/choose the cloud provider/i);
+}
 
 afterEach(() => {
   cleanup();
@@ -70,11 +81,44 @@ describe('FirstRunWizard', () => {
     expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
   });
 
-  it('should disable Back on the first (and currently only) step', async () => {
+  it('should disable Back on the first step', async () => {
     gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
     render(<FirstRunWizard />);
     await waitFor(() => expect(gsdMock.wizard.checkPrereqs).toHaveBeenCalledTimes(1));
 
     expect(screen.getByRole('button', { name: /back/i })).toBeDisabled();
+  });
+
+  it('should advance to the pick-cloud step once prerequisites are satisfied and Next is clicked', async () => {
+    await advanceToPickCloud();
+    expect(screen.getByRole('radio', { name: /Amazon Web Services/i })).toBeInTheDocument();
+  });
+
+  it('should persist the selected cloud via wizard.state.save when advancing past pick-cloud', async () => {
+    gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false, activeCloud: 'aws' });
+    await advanceToPickCloud();
+
+    await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+    await waitFor(() => expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({ activeCloud: 'aws' }));
+  });
+
+  it('should show an error and stay on pick-cloud when saving the cloud choice fails', async () => {
+    gsdMock.wizard.saveState.mockRejectedValue(new Error('disk full'));
+    await advanceToPickCloud();
+
+    await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('disk full');
+    // Still on pick-cloud, not advanced further.
+    expect(screen.getByRole('radio', { name: /Amazon Web Services/i })).toBeInTheDocument();
+  });
+
+  it('should allow going back from pick-cloud to prerequisites', async () => {
+    await advanceToPickCloud();
+
+    await userEvent.click(screen.getByRole('button', { name: /back/i }));
+
+    expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
   });
 });

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -121,4 +121,21 @@ describe('FirstRunWizard', () => {
 
     expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
   });
+
+  it('should disable Back while the cloud choice save is pending, to avoid a race with the step transition', async () => {
+    let resolveSave!: (value: { wizardCompleted: boolean; activeCloud: 'aws' }) => void;
+    gsdMock.wizard.saveState.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    await advanceToPickCloud();
+
+    await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /back/i })).toBeDisabled());
+
+    resolveSave({ wizardCompleted: false, activeCloud: 'aws' });
+    await waitFor(() => expect(screen.getByRole('button', { name: /back/i })).not.toBeDisabled());
+  });
 });

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -6,30 +6,35 @@
  * before the dashboard is usable, so `app.component.tsx` renders it in place
  * of the normal routed layout while `wizardCompleted` is `false`.
  *
- * Only the prerequisites step exists so far; later PRs in this epic append
- * more steps to `WIZARD_STEPS` and this shell's render body.
+ * Only prerequisites and pick-cloud exist so far; later PRs in this epic
+ * append more steps to `WIZARD_STEPS` and this shell's render body.
  */
 import { useCallback, useEffect, useState } from 'react';
 import type { PrerequisitesReport } from '@hyveon/desktop-preload';
 import { Button } from '@/components/ui/button.component';
 import { PrerequisitesStep } from './prerequisites-step.component.js';
+import { PickCloudStep, type CloudOption } from './pick-cloud-step.component.js';
 import { WIZARD_STEPS, arePrerequisitesSatisfied, type WizardStep } from './wizard.utils.js';
 
 /** Human-readable heading for each {@link WizardStep}. */
 const STEP_LABELS: Record<WizardStep, string> = {
   prerequisites: 'Install prerequisites',
+  'pick-cloud': 'Choose your cloud',
 };
 
 /**
- * Self-contained first-run wizard: owns its own step index and the
- * prerequisites-check state (report/checking/error), and fetches an initial
- * check on mount.
+ * Self-contained first-run wizard: owns its own step index, the
+ * prerequisites-check state (report/checking/error), and the pick-cloud
+ * selection. Fetches an initial prerequisites check on mount.
  */
 export function FirstRunWizard() {
   const [stepIndex, setStepIndex] = useState(0);
   const [report, setReport] = useState<PrerequisitesReport | null>(null);
   const [checking, setChecking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectedCloud, setSelectedCloud] = useState<CloudOption>('aws');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const step = WIZARD_STEPS[stepIndex];
 
@@ -56,7 +61,28 @@ export function FirstRunWizard() {
 
   const advanceDisabled = step === 'prerequisites' ? !arePrerequisitesSatisfied(report) : false;
 
-  function goNext() {
+  /**
+   * Advances past the current step. When leaving `pick-cloud`, persists the
+   * selection via `wizard.state.save` first and stays put if that fails —
+   * every other step advances immediately (nothing to persist yet).
+   */
+  async function goNext() {
+    if (step === 'pick-cloud') {
+      if (!window.gsd) {
+        setSaveError('IPC bridge (window.gsd) is not available in this context.');
+        return;
+      }
+      setSaving(true);
+      setSaveError(null);
+      try {
+        await window.gsd.wizard.saveState({ activeCloud: selectedCloud });
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : 'Failed to save your cloud choice.');
+        setSaving(false);
+        return;
+      }
+      setSaving(false);
+    }
     setStepIndex((index) => Math.min(index + 1, WIZARD_STEPS.length - 1));
   }
 
@@ -77,12 +103,22 @@ export function FirstRunWizard() {
         {step === 'prerequisites' && (
           <PrerequisitesStep report={report} checking={checking} error={error} onRecheck={checkPrereqs} />
         )}
+        {step === 'pick-cloud' && (
+          <>
+            <PickCloudStep selectedCloud={selectedCloud} onSelect={setSelectedCloud} />
+            {saveError && (
+              <p role="alert" className="text-sm text-[var(--color-red)]">
+                {saveError}
+              </p>
+            )}
+          </>
+        )}
 
         <div className="flex justify-between">
           <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0}>
             Back
           </Button>
-          <Button type="button" onClick={goNext} disabled={advanceDisabled}>
+          <Button type="button" onClick={goNext} disabled={advanceDisabled || saving}>
             Next
           </Button>
         </div>

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -115,7 +115,7 @@ export function FirstRunWizard() {
         )}
 
         <div className="flex justify-between">
-          <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0}>
+          <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0 || saving}>
             Back
           </Button>
           <Button type="button" onClick={goNext} disabled={advanceDisabled || saving}>

--- a/app/packages/web/src/components/first-run-wizard/pick-cloud-step.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/pick-cloud-step.component.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PickCloudStep } from './pick-cloud-step.component.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PickCloudStep', () => {
+  it('should render the single AWS option', () => {
+    render(<PickCloudStep selectedCloud="aws" onSelect={vi.fn()} />);
+    expect(screen.getByRole('radio', { name: /Amazon Web Services \(AWS\)/i })).toBeInTheDocument();
+  });
+
+  it('should mark the AWS option as checked since it is the only choice', () => {
+    render(<PickCloudStep selectedCloud="aws" onSelect={vi.fn()} />);
+    expect(screen.getByRole('radio', { name: /Amazon Web Services/i })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('should render the "more clouds coming" footer', () => {
+    render(<PickCloudStep selectedCloud="aws" onSelect={vi.fn()} />);
+    expect(screen.getByText(/more clouds are coming/i)).toBeInTheDocument();
+  });
+
+  it('should call onSelect with "aws" when the option is clicked', async () => {
+    const onSelect = vi.fn();
+    render(<PickCloudStep selectedCloud="aws" onSelect={onSelect} />);
+
+    await userEvent.click(screen.getByRole('radio', { name: /Amazon Web Services/i }));
+
+    expect(onSelect).toHaveBeenCalledWith('aws');
+  });
+});

--- a/app/packages/web/src/components/first-run-wizard/pick-cloud-step.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/pick-cloud-step.component.tsx
@@ -1,0 +1,60 @@
+import { CheckCircle2 } from 'lucide-react';
+
+/** A cloud option the pick-cloud step can offer. Only `'aws'` exists for v1. */
+export type CloudOption = 'aws';
+
+/** Props for {@link PickCloudStep}. */
+export interface PickCloudStepProps {
+  /** Currently selected cloud. Locked to `'aws'` for v1. */
+  selectedCloud: CloudOption;
+  /** Called with the clicked option's id. */
+  onSelect: (cloud: CloudOption) => void;
+}
+
+/** Static list of selectable cloud options, driving the rendered cards. Only one entry exists in v1. */
+const CLOUD_OPTIONS: { id: CloudOption; label: string; description: string }[] = [
+  { id: 'aws', label: 'Amazon Web Services (AWS)', description: 'ECS Fargate, EFS, Route 53, DynamoDB, Secrets Manager.' },
+];
+
+/**
+ * Second step of the first-run wizard (#186): the operator picks which
+ * cloud to deploy to. AWS is the only option in v1 — the list-driven
+ * rendering and `onSelect` callback keep the step structurally ready for
+ * more clouds later without an early redesign.
+ */
+export function PickCloudStep({ selectedCloud, onSelect }: PickCloudStepProps) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">Choose the cloud provider Hyveon will deploy your game servers to.</p>
+
+      <div className="space-y-3" role="radiogroup" aria-label="Cloud provider">
+        {CLOUD_OPTIONS.map((option) => {
+          const selected = option.id === selectedCloud;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => onSelect(option.id)}
+              className="w-full flex items-center gap-3 rounded-[var(--radius-md)] border border-[var(--color-border)] p-4 text-left transition-colors data-[selected=true]:border-[var(--color-primary)] data-[selected=true]:bg-[var(--color-surface-2)]"
+              data-selected={selected}
+            >
+              {selected ? (
+                <CheckCircle2 className="size-5 shrink-0 text-[var(--color-primary)]" />
+              ) : (
+                <span className="size-5 shrink-0 rounded-full border border-[var(--color-border)]" />
+              )}
+              <span>
+                <span className="block font-medium">{option.label}</span>
+                <span className="block text-xs text-muted-foreground">{option.description}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="text-xs text-muted-foreground">More clouds are coming in a future release.</p>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
@@ -7,11 +7,11 @@
 import type { PrerequisitesReport } from '@hyveon/desktop-preload';
 
 /**
- * Ordered wizard steps. Only `prerequisites` exists so far — later PRs in
- * this epic (#186 pick-cloud, #192 credentials, #200/#203/#205 bootstrap,
- * #208 IAM check, #210 terraform-init) append to this array.
+ * Ordered wizard steps. Later PRs in this epic (#192 credentials,
+ * #200/#203/#205 bootstrap, #208 IAM check, #210 terraform-init) append to
+ * this array.
  */
-export const WIZARD_STEPS = ['prerequisites'] as const;
+export const WIZARD_STEPS = ['prerequisites', 'pick-cloud'] as const;
 
 /** A single step in {@link WIZARD_STEPS}. */
 export type WizardStep = (typeof WIZARD_STEPS)[number];


### PR DESCRIPTION
Closes #186

## Summary

PR 5 of 12 for the First-Run Wizard epic (#139, see `openspec/changes/add-first-run-wizard`). Adds the wizard's second step: pick cloud.

- New `pick-cloud-step.component.tsx`: list-driven radiogroup (only `'aws'` exists in v1) with a "more clouds are coming" footer — presentational, `selectedCloud`/`onSelect` props.
- `wizard.utils.ts`: extended `WIZARD_STEPS` to `['prerequisites', 'pick-cloud']`.
- `first-run-wizard.component.tsx`: added the step to the render body; `goNext()` is now async — when advancing past pick-cloud specifically, it persists via `window.gsd.wizard.saveState({ activeCloud })` and only advances on success, showing an inline error and staying put on failure.
- Backend: `WizardController` gained `@MessagePattern('wizard.state.save')`, writing `activeCloud` into `ElectronStoreService` (plain field, no new accessors needed) and returning the same `WizardState` shape as `getState` (which now also includes `activeCloud`).
- Preload/gsd-api: mirrored `saveState` + the extended types, re-exported from `desktop-preload/src/index.ts`.

## Test plan

- [x] `npm run app:test` — 1958/1958 tests passing (67 new): pick-cloud step rendering/selection, shell advance/persist/error/back flows, controller channel + behavior specs, and an `ElectronStoreService` "relaunch semantics" spec (two service instances sharing one underlying mocked store, proving a value written by one is read by the other)
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings)
