### PR TITLE
feat(web): add credentials step to the first-run wizard

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -34,7 +34,9 @@ function makeAwsProfiles(profiles: AwsProfileSummary[] = SAMPLE_PROFILES): AwsPr
  * `set()` followed by `get()` (as `saveState` does) round-trips like the
  * real service, instead of always returning a fixed value.
  */
-function makeStore(seed: { wizardCompleted?: boolean; activeCloud?: 'aws' } = {}): ElectronStoreService {
+function makeStore(
+  seed: { wizardCompleted?: boolean; activeCloud?: 'aws'; aws?: { profile?: string; region?: string } } = {},
+): ElectronStoreService {
   const data: Record<string, unknown> = { ...seed };
   return {
     get: vi.fn().mockImplementation((key: string) => data[key]),
@@ -176,6 +178,16 @@ describe('WizardController', () => {
       const result = makeController({ store: makeStore({ wizardCompleted: true, activeCloud: 'aws' }) }).getState();
       expect(result).toEqual({ wizardCompleted: true, activeCloud: 'aws' });
     });
+
+    it('should include the stored aws credential choice when present', () => {
+      const store = makeStore({ wizardCompleted: true, aws: { profile: 'default', region: 'us-east-1' } });
+      const result = makeController({ store }).getState();
+      expect(result).toEqual({
+        wizardCompleted: true,
+        activeCloud: undefined,
+        aws: { profile: 'default', region: 'us-east-1' },
+      });
+    });
   });
 
   describe('saveState', () => {
@@ -206,6 +218,38 @@ describe('WizardController', () => {
       expect(() =>
         controller.saveState({ activeCloud: 'gcp' as unknown as 'aws' }),
       ).toThrow('Unsupported cloud provider: gcp');
+      expect(store.set).not.toHaveBeenCalled();
+    });
+
+    it('should persist the aws credential choice and return the updated state', () => {
+      const store = makeStore({ wizardCompleted: false });
+      const controller = makeController({ store });
+
+      const result = controller.saveState({ aws: { profile: 'default', region: 'us-east-1' } });
+
+      expect(store.set).toHaveBeenCalledWith('aws', { profile: 'default', region: 'us-east-1' });
+      expect(result).toEqual({
+        wizardCompleted: false,
+        activeCloud: undefined,
+        aws: { profile: 'default', region: 'us-east-1' },
+      });
+    });
+
+    it('should merge a partial aws update onto the existing stored value', () => {
+      const store = makeStore({ wizardCompleted: false, aws: { profile: 'default', region: 'us-east-1' } });
+      const controller = makeController({ store });
+
+      controller.saveState({ aws: { region: 'eu-west-1' } });
+
+      expect(store.set).toHaveBeenCalledWith('aws', { profile: 'default', region: 'eu-west-1' });
+    });
+
+    it('should not write to the store when aws is omitted', () => {
+      const store = makeStore({ wizardCompleted: true });
+      const controller = makeController({ store });
+
+      controller.saveState({});
+
       expect(store.set).not.toHaveBeenCalled();
     });
   });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -8,16 +8,32 @@ import {
 } from '../services/AwsProfileService.js';
 import { ElectronStoreService } from '../services/ElectronStoreService.js';
 
+/**
+ * The credentials step's chosen source, as persisted to `ElectronStoreService.aws`.
+ * `profile` names either a real `~/.aws` profile (the "pick an existing
+ * profile" path) or a `creds.aws.<profileName>` pasted-credentials entry
+ * (the "paste keys instead" path, e.g. `gsd-pasted`) — the two are
+ * distinguished later by whether `creds.aws.<profile>` exists, not by a
+ * separate flag here.
+ */
+export interface WizardAwsChoice {
+  profile?: string;
+  region?: string;
+}
+
 /** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
 export interface WizardState {
   wizardCompleted: boolean;
   /** The cloud chosen in the pick-cloud step. Locked to `'aws'` for v1; `undefined` before that step runs. */
   activeCloud?: 'aws';
+  /** The credential source chosen in the credentials step (#192), if any. */
+  aws?: WizardAwsChoice;
 }
 
 /** Payload accepted by {@link WizardController.saveState}. */
 export interface SaveWizardStateInput {
   activeCloud?: 'aws';
+  aws?: WizardAwsChoice;
 }
 
 /**
@@ -61,15 +77,18 @@ export class WizardController {
   getState(): WizardState {
     const stored = this.store.get('wizardCompleted');
     const wizardCompleted = stored !== undefined ? stored : this.isTestMode();
-    return { wizardCompleted, activeCloud: this.store.get('activeCloud') };
+    return { wizardCompleted, activeCloud: this.store.get('activeCloud'), aws: this.store.get('aws') };
   }
 
   /**
-   * Persists wizard-flow answers into `ElectronStoreService`. Only
-   * `activeCloud` exists so far (the pick-cloud step); later PRs in this
-   * epic extend the payload as more steps need to durably save a choice.
-   * Returns the same shape as {@link getState} so the renderer can update
-   * its local state directly from the response.
+   * Persists wizard-flow answers into `ElectronStoreService`. `activeCloud`
+   * (pick-cloud step) and `aws` (credentials step, #192 — the chosen
+   * profile/region) exist so far; later PRs in this epic extend the payload
+   * as more steps need to durably save a choice. `aws` is merged onto any
+   * existing stored value so unrelated fields (e.g. encrypted key material
+   * written by other flows) survive. Returns the same shape as
+   * {@link getState} so the renderer can update its local state directly
+   * from the response.
    */
   @MessagePattern('wizard.state.save')
   saveState(@Payload() body: SaveWizardStateInput): WizardState {
@@ -81,6 +100,10 @@ export class WizardController {
         throw new Error(`Unsupported cloud provider: ${String(body.activeCloud)}`);
       }
       this.store.set('activeCloud', body.activeCloud);
+    }
+    if (body.aws !== undefined) {
+      const current = this.store.get('aws') ?? {};
+      this.store.set('aws', { ...current, ...body.aws });
     }
     return this.getState();
   }

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -1007,16 +1007,29 @@ export interface GsdWizardApi {
   saveState: (input: SaveWizardStateInput) => Promise<WizardState>;
 }
 
+/**
+ * The credentials step's chosen source. `profile` names either a real
+ * `~/.aws` profile (the "pick an existing profile" path) or a pasted-
+ * credentials profile name (the "paste keys instead" path, e.g. `gsd-pasted`).
+ */
+export interface WizardAwsChoice {
+  profile?: string;
+  region?: string;
+}
+
 /** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
 export interface WizardState {
   wizardCompleted: boolean;
   /** The cloud chosen in the pick-cloud step. Locked to `'aws'` for v1; `undefined` before that step runs. */
   activeCloud?: 'aws';
+  /** The credential source chosen in the credentials step (#192), if any. */
+  aws?: WizardAwsChoice;
 }
 
 /** Payload accepted by {@link GsdWizardApi.saveState}. */
 export interface SaveWizardStateInput {
   activeCloud?: 'aws';
+  aws?: WizardAwsChoice;
 }
 
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */

--- a/app/packages/web/src/components/first-run-wizard/credentials-step.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/credentials-step.component.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AwsProfileSummary } from '@hyveon/desktop-preload';
+import { CredentialsStep, type CredentialsStepProps } from './credentials-step.component.js';
+
+afterEach(() => {
+  cleanup();
+});
+
+const SAMPLE_PROFILES: AwsProfileSummary[] = [
+  { profileName: 'default', region: 'us-east-1' },
+  { profileName: 'personal' },
+];
+
+/** Builds default props for {@link CredentialsStep}; overrides merge in per-test. */
+function makeProps(overrides: Partial<CredentialsStepProps> = {}): CredentialsStepProps {
+  return {
+    mode: 'profile',
+    onModeChange: vi.fn(),
+    profiles: SAMPLE_PROFILES,
+    profilesLoading: false,
+    profilesError: null,
+    selectedProfileName: '',
+    onSelectProfile: vi.fn(),
+    region: '',
+    onRegionChange: vi.fn(),
+    pasteAccessKeyId: '',
+    pasteSecretAccessKey: '',
+    pasteRegion: '',
+    onPasteFieldChange: vi.fn(),
+    onSubmitPaste: vi.fn(),
+    pasteSaving: false,
+    pasteError: null,
+    pastedProfileName: null,
+    ...overrides,
+  };
+}
+
+describe('CredentialsStep', () => {
+  describe('profile mode', () => {
+    it('should populate the dropdown with the discovered profiles', () => {
+      render(<CredentialsStep {...makeProps()} />);
+
+      const select = screen.getByLabelText('Profile') as HTMLSelectElement;
+      const optionLabels = Array.from(select.options).map((o) => o.value);
+      expect(optionLabels).toEqual(['', 'default', 'personal']);
+    });
+
+    it('should show a loading message before the initial profile list resolves', () => {
+      render(<CredentialsStep {...makeProps({ profiles: null, profilesLoading: true })} />);
+      expect(screen.getByText(/loading aws profiles/i)).toBeInTheDocument();
+    });
+
+    it('should show a no-profiles message when the list resolves empty', () => {
+      render(<CredentialsStep {...makeProps({ profiles: [] })} />);
+      expect(screen.getByText(/no aws cli profiles found/i)).toBeInTheDocument();
+    });
+
+    it('should surface a profiles-list error', () => {
+      render(<CredentialsStep {...makeProps({ profiles: null, profilesError: 'IPC bridge unavailable' })} />);
+      expect(screen.getByRole('alert')).toHaveTextContent('IPC bridge unavailable');
+    });
+
+    it('should call onSelectProfile when a profile is chosen', async () => {
+      const onSelectProfile = vi.fn();
+      render(<CredentialsStep {...makeProps({ onSelectProfile })} />);
+
+      await userEvent.selectOptions(screen.getByLabelText('Profile'), 'personal');
+
+      expect(onSelectProfile).toHaveBeenCalledWith('personal');
+    });
+
+    it('should default the region field from the selected profile', () => {
+      render(<CredentialsStep {...makeProps({ selectedProfileName: 'default', region: 'us-east-1' })} />);
+      expect(screen.getByLabelText('Region')).toHaveValue('us-east-1');
+    });
+
+    it('should call onRegionChange when the operator edits the region', async () => {
+      const onRegionChange = vi.fn();
+      render(<CredentialsStep {...makeProps({ selectedProfileName: 'default', region: '', onRegionChange })} />);
+
+      await userEvent.type(screen.getByLabelText('Region'), 'e');
+
+      expect(onRegionChange).toHaveBeenCalledWith('e');
+    });
+  });
+
+  describe('mode toggle', () => {
+    it('should call onModeChange with "paste" when "Paste keys instead" is clicked', async () => {
+      const onModeChange = vi.fn();
+      render(<CredentialsStep {...makeProps({ onModeChange })} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
+
+      expect(onModeChange).toHaveBeenCalledWith('paste');
+    });
+
+    it('should mark the active mode button as pressed', () => {
+      render(<CredentialsStep {...makeProps({ mode: 'paste' })} />);
+      expect(screen.getByRole('button', { name: /paste keys instead/i })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByRole('button', { name: /use an existing profile/i })).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
+
+  describe('paste mode', () => {
+    function pasteProps(overrides: Partial<CredentialsStepProps> = {}) {
+      return makeProps({ mode: 'paste', ...overrides });
+    }
+
+    it('should render the paste form fields', () => {
+      render(<CredentialsStep {...pasteProps()} />);
+      expect(screen.getByLabelText('Access key ID')).toBeInTheDocument();
+      expect(screen.getByLabelText('Secret access key')).toBeInTheDocument();
+      expect(screen.getByLabelText('Region')).toBeInTheDocument();
+    });
+
+    it('should call onPasteFieldChange when the access key ID is typed', async () => {
+      const onPasteFieldChange = vi.fn();
+      render(<CredentialsStep {...pasteProps({ onPasteFieldChange })} />);
+
+      await userEvent.type(screen.getByLabelText('Access key ID'), 'A');
+
+      expect(onPasteFieldChange).toHaveBeenCalledWith('accessKeyId', 'A');
+    });
+
+    it('should call onSubmitPaste when "Save credentials" is clicked', async () => {
+      const onSubmitPaste = vi.fn();
+      render(<CredentialsStep {...pasteProps({ onSubmitPaste })} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
+
+      expect(onSubmitPaste).toHaveBeenCalledTimes(1);
+    });
+
+    it('should disable "Save credentials" while a save is in flight', () => {
+      render(<CredentialsStep {...pasteProps({ pasteSaving: true })} />);
+      expect(screen.getByRole('button', { name: /save credentials/i })).toBeDisabled();
+    });
+
+    it('should surface a paste-flow error', () => {
+      render(<CredentialsStep {...pasteProps({ pasteError: 'OS keychain unavailable' })} />);
+      expect(screen.getByRole('alert')).toHaveTextContent('OS keychain unavailable');
+    });
+
+    it('should show a saved confirmation once the paste flow succeeds', () => {
+      render(<CredentialsStep {...pasteProps({ pastedProfileName: 'gsd-pasted' })} />);
+      expect(screen.getByText(/saved as profile "gsd-pasted"/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/packages/web/src/components/first-run-wizard/credentials-step.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/credentials-step.component.tsx
@@ -1,0 +1,196 @@
+import { CheckCircle2, Loader2 } from 'lucide-react';
+import type { AwsProfileSummary } from '@hyveon/desktop-preload';
+import { Button } from '@/components/ui/button.component';
+import { Input } from '@/components/ui/input.component';
+import { Label } from '@/components/ui/label.component';
+
+/** How the operator is supplying AWS credentials in {@link CredentialsStep}. */
+export type CredentialMode = 'profile' | 'paste';
+
+/** A field in the "paste keys instead" form. */
+export type PasteField = 'accessKeyId' | 'secretAccessKey' | 'region';
+
+/** Props for {@link CredentialsStep}. */
+export interface CredentialsStepProps {
+  mode: CredentialMode;
+  onModeChange: (mode: CredentialMode) => void;
+
+  /** Discovered `~/.aws` profiles, or `null` before the initial list resolves. */
+  profiles: AwsProfileSummary[] | null;
+  /** True while the initial list (or a re-list) is in flight. */
+  profilesLoading: boolean;
+  /** Set when listing profiles itself fails (e.g. IPC bridge unavailable). */
+  profilesError: string | null;
+
+  /** Currently selected profile name in `mode: 'profile'`; `''` means none chosen yet. */
+  selectedProfileName: string;
+  onSelectProfile: (profileName: string) => void;
+  /** Region for the selected profile — defaults from the profile's own region, editable. */
+  region: string;
+  onRegionChange: (region: string) => void;
+
+  pasteAccessKeyId: string;
+  pasteSecretAccessKey: string;
+  pasteRegion: string;
+  onPasteFieldChange: (field: PasteField, value: string) => void;
+  onSubmitPaste: () => void;
+  /** True while the paste-flow save is in flight. */
+  pasteSaving: boolean;
+  /** Set when the paste-flow save fails (e.g. safeStorage unavailable). */
+  pasteError: string | null;
+  /** Set once the paste flow has successfully saved — the profile name it saved under. */
+  pastedProfileName: string | null;
+}
+
+/**
+ * Credentials step of the first-run wizard (#192): the operator either picks
+ * a discovered `~/.aws` CLI profile or pastes an access key ID/secret
+ * directly (encrypted via the safeStorage flow from #197). Purely
+ * presentational — the parent wizard shell owns all state, the
+ * `listAwsProfiles`/`saveCredentials` IPC calls, and persisting the final
+ * choice via `wizard.state.save` when the operator advances.
+ */
+export function CredentialsStep({
+  mode,
+  onModeChange,
+  profiles,
+  profilesLoading,
+  profilesError,
+  selectedProfileName,
+  onSelectProfile,
+  region,
+  onRegionChange,
+  pasteAccessKeyId,
+  pasteSecretAccessKey,
+  pasteRegion,
+  onPasteFieldChange,
+  onSubmitPaste,
+  pasteSaving,
+  pasteError,
+  pastedProfileName,
+}: CredentialsStepProps) {
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Choose the AWS credentials Hyveon will use to manage your game servers.
+      </p>
+
+      <div className="flex gap-2" role="group" aria-label="Credential source">
+        <Button
+          type="button"
+          variant={mode === 'profile' ? 'default' : 'outline'}
+          aria-pressed={mode === 'profile'}
+          onClick={() => onModeChange('profile')}
+        >
+          Use an existing profile
+        </Button>
+        <Button
+          type="button"
+          variant={mode === 'paste' ? 'default' : 'outline'}
+          aria-pressed={mode === 'paste'}
+          onClick={() => onModeChange('paste')}
+        >
+          Paste keys instead
+        </Button>
+      </div>
+
+      {mode === 'profile' && (
+        <div className="space-y-4">
+          {profilesError && (
+            <p role="alert" className="text-sm text-[var(--color-red)]">
+              {profilesError}
+            </p>
+          )}
+
+          {!profiles && profilesLoading && !profilesError && (
+            <p className="text-sm text-muted-foreground">Loading AWS profiles…</p>
+          )}
+
+          {profiles && profiles.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No AWS CLI profiles found on this machine. Use &quot;Paste keys instead&quot; below.
+            </p>
+          )}
+
+          {profiles && profiles.length > 0 && (
+            <div className="space-y-2">
+              <Label htmlFor="wizard-credentials-profile">Profile</Label>
+              <select
+                id="wizard-credentials-profile"
+                value={selectedProfileName}
+                onChange={(e) => onSelectProfile(e.target.value)}
+                className="h-9 w-full rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 text-sm text-[var(--color-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+              >
+                <option value="">Select a profile…</option>
+                {profiles.map((profile) => (
+                  <option key={profile.profileName} value={profile.profileName}>
+                    {profile.profileName}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="wizard-credentials-profile-region">Region</Label>
+            <Input
+              id="wizard-credentials-profile-region"
+              value={region}
+              placeholder="us-east-1"
+              onChange={(e) => onRegionChange(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
+
+      {mode === 'paste' && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="wizard-credentials-paste-access-key-id">Access key ID</Label>
+            <Input
+              id="wizard-credentials-paste-access-key-id"
+              value={pasteAccessKeyId}
+              onChange={(e) => onPasteFieldChange('accessKeyId', e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="wizard-credentials-paste-secret-access-key">Secret access key</Label>
+            <Input
+              id="wizard-credentials-paste-secret-access-key"
+              type="password"
+              value={pasteSecretAccessKey}
+              onChange={(e) => onPasteFieldChange('secretAccessKey', e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="wizard-credentials-paste-region">Region</Label>
+            <Input
+              id="wizard-credentials-paste-region"
+              value={pasteRegion}
+              placeholder="us-east-1"
+              onChange={(e) => onPasteFieldChange('region', e.target.value)}
+            />
+          </div>
+
+          {pasteError && (
+            <p role="alert" className="text-sm text-[var(--color-red)]">
+              {pasteError}
+            </p>
+          )}
+
+          {pastedProfileName && (
+            <p className="flex items-center gap-1 text-sm text-[var(--color-green)]">
+              <CheckCircle2 className="size-4" />
+              Saved as profile &quot;{pastedProfileName}&quot;
+            </p>
+          )}
+
+          <Button type="button" variant="outline" onClick={onSubmitPaste} disabled={pasteSaving}>
+            {pasteSaving && <Loader2 className="animate-spin" />}
+            Save credentials
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+import type { AwsProfileSummary, PrerequisitesReport } from '@hyveon/desktop-preload';
 
 const gsdMock = {
   wizard: {
     checkPrereqs: vi.fn(),
     saveState: vi.fn(),
+    listAwsProfiles: vi.fn(),
+    saveCredentials: vi.fn(),
   },
 };
 vi.stubGlobal('gsd', gsdMock);
@@ -23,9 +25,16 @@ const UNSATISFIED: PrerequisitesReport = {
   aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
 };
 
+const SAMPLE_PROFILES: AwsProfileSummary[] = [
+  { profileName: 'default', region: 'us-east-1' },
+  { profileName: 'personal' },
+];
+
 beforeEach(() => {
   gsdMock.wizard.checkPrereqs.mockReset();
   gsdMock.wizard.saveState.mockReset();
+  gsdMock.wizard.listAwsProfiles.mockReset().mockResolvedValue(SAMPLE_PROFILES);
+  gsdMock.wizard.saveCredentials.mockReset();
 });
 
 /** Advances the wizard from the (satisfied) prerequisites step to pick-cloud. */
@@ -35,6 +44,14 @@ async function advanceToPickCloud(): Promise<void> {
   await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
   await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
   await screen.findByText(/choose the cloud provider/i);
+}
+
+/** Advances the wizard from prerequisites through pick-cloud to the credentials step. */
+async function advanceToCredentials(): Promise<void> {
+  gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false, activeCloud: 'aws' });
+  await advanceToPickCloud();
+  await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+  await screen.findByText(/choose the aws credentials/i);
 }
 
 afterEach(() => {
@@ -137,5 +154,113 @@ describe('FirstRunWizard', () => {
 
     resolveSave({ wizardCompleted: false, activeCloud: 'aws' });
     await waitFor(() => expect(screen.getByRole('button', { name: /back/i })).not.toBeDisabled());
+  });
+
+  describe('credentials step', () => {
+    it('should list AWS profiles on mount and populate the dropdown once on the credentials step', async () => {
+      await advanceToCredentials();
+
+      await waitFor(() => expect(gsdMock.wizard.listAwsProfiles).toHaveBeenCalledTimes(1));
+      expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'personal' })).toBeInTheDocument();
+    });
+
+    it('should disable Next until a profile is selected', async () => {
+      await advanceToCredentials();
+      await screen.findByLabelText('Profile');
+
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+    });
+
+    it('should enable Next and default the region once a profile is picked', async () => {
+      await advanceToCredentials();
+      const select = await screen.findByLabelText('Profile');
+
+      await userEvent.selectOptions(select, 'default');
+
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+      expect(screen.getByLabelText('Region')).toHaveValue('us-east-1');
+    });
+
+    it('should persist the selected profile and region via wizard.state.save when advancing', async () => {
+      gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false, aws: { profile: 'default', region: 'us-east-1' } });
+      await advanceToCredentials();
+      const select = await screen.findByLabelText('Profile');
+      await userEvent.selectOptions(select, 'default');
+
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+      await waitFor(() =>
+        expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({ aws: { profile: 'default', region: 'us-east-1' } }),
+      );
+    });
+
+    it('should persist an operator-overridden region instead of the profile default', async () => {
+      gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false, aws: { profile: 'default', region: 'eu-west-1' } });
+      await advanceToCredentials();
+      const select = await screen.findByLabelText('Profile');
+      await userEvent.selectOptions(select, 'default');
+      const regionInput = screen.getByLabelText('Region');
+      await userEvent.clear(regionInput);
+      await userEvent.type(regionInput, 'eu-west-1');
+
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+      await waitFor(() =>
+        expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({ aws: { profile: 'default', region: 'eu-west-1' } }),
+      );
+    });
+
+    it('should switch to the paste form and save pasted credentials via wizard.aws.saveCredentials', async () => {
+      gsdMock.wizard.saveCredentials.mockResolvedValue({ profileName: 'gsd-pasted' });
+      await advanceToCredentials();
+
+      await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
+      await userEvent.type(screen.getByLabelText('Access key ID'), 'AKID');
+      await userEvent.type(screen.getByLabelText('Secret access key'), 'SECRET');
+      await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
+
+      await waitFor(() =>
+        expect(gsdMock.wizard.saveCredentials).toHaveBeenCalledWith({
+          accessKeyId: 'AKID',
+          secretAccessKey: 'SECRET',
+          region: undefined,
+        }),
+      );
+      expect(await screen.findByText(/saved as profile "gsd-pasted"/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+    });
+
+    it('should show a paste error and keep Next disabled when saveCredentials fails', async () => {
+      gsdMock.wizard.saveCredentials.mockRejectedValue(new Error('OS keychain unavailable'));
+      await advanceToCredentials();
+
+      await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
+      await userEvent.type(screen.getByLabelText('Access key ID'), 'AKID');
+      await userEvent.type(screen.getByLabelText('Secret access key'), 'SECRET');
+      await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('OS keychain unavailable');
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+    });
+
+    it('should persist the pasted profile via wizard.state.save when advancing after a successful paste', async () => {
+      gsdMock.wizard.saveCredentials.mockResolvedValue({ profileName: 'gsd-pasted' });
+      gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false, aws: { profile: 'gsd-pasted', region: 'us-west-2' } });
+      await advanceToCredentials();
+
+      await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
+      await userEvent.type(screen.getByLabelText('Access key ID'), 'AKID');
+      await userEvent.type(screen.getByLabelText('Secret access key'), 'SECRET');
+      await userEvent.type(screen.getByLabelText('Region'), 'us-west-2');
+      await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
+      await screen.findByText(/saved as profile/i);
+
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+      await waitFor(() =>
+        expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({ aws: { profile: 'gsd-pasted', region: 'us-west-2' } }),
+      );
+    });
   });
 });

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -231,6 +231,22 @@ describe('FirstRunWizard', () => {
       expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
     });
 
+    it('should invalidate a successful paste save when a field is edited afterward, disabling Next again', async () => {
+      gsdMock.wizard.saveCredentials.mockResolvedValue({ profileName: 'gsd-pasted' });
+      await advanceToCredentials();
+
+      await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
+      await userEvent.type(screen.getByLabelText('Access key ID'), 'AKID');
+      await userEvent.type(screen.getByLabelText('Secret access key'), 'SECRET');
+      await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
+      await screen.findByText(/saved as profile "gsd-pasted"/i);
+
+      await userEvent.type(screen.getByLabelText('Secret access key'), '2');
+
+      expect(screen.queryByText(/saved as profile/i)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+    });
+
     it('should show a paste error and keep Next disabled when saveCredentials fails', async () => {
       gsdMock.wizard.saveCredentials.mockRejectedValue(new Error('OS keychain unavailable'));
       await advanceToCredentials();

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -6,26 +6,30 @@
  * before the dashboard is usable, so `app.component.tsx` renders it in place
  * of the normal routed layout while `wizardCompleted` is `false`.
  *
- * Only prerequisites and pick-cloud exist so far; later PRs in this epic
- * append more steps to `WIZARD_STEPS` and this shell's render body.
+ * Only prerequisites, pick-cloud, and credentials exist so far; later PRs in
+ * this epic append more steps to `WIZARD_STEPS` and this shell's render body.
  */
 import { useCallback, useEffect, useState } from 'react';
-import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+import type { AwsProfileSummary, PrerequisitesReport } from '@hyveon/desktop-preload';
 import { Button } from '@/components/ui/button.component';
 import { PrerequisitesStep } from './prerequisites-step.component.js';
 import { PickCloudStep, type CloudOption } from './pick-cloud-step.component.js';
+import { CredentialsStep, type CredentialMode, type PasteField } from './credentials-step.component.js';
 import { WIZARD_STEPS, arePrerequisitesSatisfied, type WizardStep } from './wizard.utils.js';
 
 /** Human-readable heading for each {@link WizardStep}. */
 const STEP_LABELS: Record<WizardStep, string> = {
   prerequisites: 'Install prerequisites',
   'pick-cloud': 'Choose your cloud',
+  credentials: 'AWS credentials',
 };
 
 /**
  * Self-contained first-run wizard: owns its own step index, the
- * prerequisites-check state (report/checking/error), and the pick-cloud
- * selection. Fetches an initial prerequisites check on mount.
+ * prerequisites-check state (report/checking/error), the pick-cloud
+ * selection, and the credentials-step state (profile list, mode, selection,
+ * paste form). Fetches an initial prerequisites check and AWS profile list
+ * on mount.
  */
 export function FirstRunWizard() {
   const [stepIndex, setStepIndex] = useState(0);
@@ -35,6 +39,19 @@ export function FirstRunWizard() {
   const [selectedCloud, setSelectedCloud] = useState<CloudOption>('aws');
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  const [profiles, setProfiles] = useState<AwsProfileSummary[] | null>(null);
+  const [profilesLoading, setProfilesLoading] = useState(false);
+  const [profilesError, setProfilesError] = useState<string | null>(null);
+  const [credentialMode, setCredentialMode] = useState<CredentialMode>('profile');
+  const [selectedProfileName, setSelectedProfileName] = useState('');
+  const [region, setRegion] = useState('');
+  const [pasteAccessKeyId, setPasteAccessKeyId] = useState('');
+  const [pasteSecretAccessKey, setPasteSecretAccessKey] = useState('');
+  const [pasteRegion, setPasteRegion] = useState('');
+  const [pasteSaving, setPasteSaving] = useState(false);
+  const [pasteError, setPasteError] = useState<string | null>(null);
+  const [pastedProfileName, setPastedProfileName] = useState<string | null>(null);
 
   const step = WIZARD_STEPS[stepIndex];
 
@@ -59,12 +76,76 @@ export function FirstRunWizard() {
     void checkPrereqs();
   }, [checkPrereqs]);
 
-  const advanceDisabled = step === 'prerequisites' ? !arePrerequisitesSatisfied(report) : false;
+  useEffect(() => {
+    async function fetchProfiles() {
+      if (!window.gsd) {
+        setProfilesError('IPC bridge (window.gsd) is not available in this context.');
+        return;
+      }
+      setProfilesLoading(true);
+      setProfilesError(null);
+      try {
+        const result = await window.gsd.wizard.listAwsProfiles();
+        setProfiles(result);
+      } catch (err) {
+        setProfilesError(err instanceof Error ? err.message : 'Failed to list AWS profiles.');
+      } finally {
+        setProfilesLoading(false);
+      }
+    }
+    void fetchProfiles();
+  }, []);
+
+  /** Selecting a profile defaults `region` from that profile's own configured region. */
+  function selectProfile(profileName: string) {
+    setSelectedProfileName(profileName);
+    const region = profiles?.find((p) => p.profileName === profileName)?.region;
+    setRegion(region ?? '');
+  }
+
+  function pasteFieldChange(field: PasteField, value: string) {
+    if (field === 'accessKeyId') setPasteAccessKeyId(value);
+    else if (field === 'secretAccessKey') setPasteSecretAccessKey(value);
+    else setPasteRegion(value);
+  }
+
+  /** Runs the safeStorage paste-flow immediately (not deferred to Next), per the credentials-step spec. */
+  async function submitPaste() {
+    if (!window.gsd) {
+      setPasteError('IPC bridge (window.gsd) is not available in this context.');
+      return;
+    }
+    setPasteSaving(true);
+    setPasteError(null);
+    try {
+      const result = await window.gsd.wizard.saveCredentials({
+        accessKeyId: pasteAccessKeyId,
+        secretAccessKey: pasteSecretAccessKey,
+        region: pasteRegion || undefined,
+      });
+      setPastedProfileName(result.profileName);
+    } catch (err) {
+      setPasteError(err instanceof Error ? err.message : 'Failed to save credentials.');
+    } finally {
+      setPasteSaving(false);
+    }
+  }
+
+  const credentialsChosen =
+    credentialMode === 'profile' ? selectedProfileName !== '' : pastedProfileName !== null;
+
+  const advanceDisabled =
+    step === 'prerequisites'
+      ? !arePrerequisitesSatisfied(report)
+      : step === 'credentials'
+        ? !credentialsChosen
+        : false;
 
   /**
-   * Advances past the current step. When leaving `pick-cloud`, persists the
-   * selection via `wizard.state.save` first and stays put if that fails —
-   * every other step advances immediately (nothing to persist yet).
+   * Advances past the current step. When leaving `pick-cloud` or
+   * `credentials`, persists the choice via `wizard.state.save` first and
+   * stays put if that fails — every other step advances immediately
+   * (nothing to persist yet).
    */
   async function goNext() {
     if (step === 'pick-cloud') {
@@ -78,6 +159,24 @@ export function FirstRunWizard() {
         await window.gsd.wizard.saveState({ activeCloud: selectedCloud });
       } catch (err) {
         setSaveError(err instanceof Error ? err.message : 'Failed to save your cloud choice.');
+        setSaving(false);
+        return;
+      }
+      setSaving(false);
+    }
+    if (step === 'credentials') {
+      if (!window.gsd) {
+        setSaveError('IPC bridge (window.gsd) is not available in this context.');
+        return;
+      }
+      const profile = credentialMode === 'profile' ? selectedProfileName : (pastedProfileName ?? undefined);
+      const chosenRegion = credentialMode === 'profile' ? region : pasteRegion;
+      setSaving(true);
+      setSaveError(null);
+      try {
+        await window.gsd.wizard.saveState({ aws: { profile, region: chosenRegion || undefined } });
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : 'Failed to save your AWS credentials choice.');
         setSaving(false);
         return;
       }
@@ -106,6 +205,34 @@ export function FirstRunWizard() {
         {step === 'pick-cloud' && (
           <>
             <PickCloudStep selectedCloud={selectedCloud} onSelect={setSelectedCloud} />
+            {saveError && (
+              <p role="alert" className="text-sm text-[var(--color-red)]">
+                {saveError}
+              </p>
+            )}
+          </>
+        )}
+        {step === 'credentials' && (
+          <>
+            <CredentialsStep
+              mode={credentialMode}
+              onModeChange={setCredentialMode}
+              profiles={profiles}
+              profilesLoading={profilesLoading}
+              profilesError={profilesError}
+              selectedProfileName={selectedProfileName}
+              onSelectProfile={selectProfile}
+              region={region}
+              onRegionChange={setRegion}
+              pasteAccessKeyId={pasteAccessKeyId}
+              pasteSecretAccessKey={pasteSecretAccessKey}
+              pasteRegion={pasteRegion}
+              onPasteFieldChange={pasteFieldChange}
+              onSubmitPaste={submitPaste}
+              pasteSaving={pasteSaving}
+              pasteError={pasteError}
+              pastedProfileName={pastedProfileName}
+            />
             {saveError && (
               <p role="alert" className="text-sm text-[var(--color-red)]">
                 {saveError}

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -107,6 +107,7 @@ export function FirstRunWizard() {
     if (field === 'accessKeyId') setPasteAccessKeyId(value);
     else if (field === 'secretAccessKey') setPasteSecretAccessKey(value);
     else setPasteRegion(value);
+    setPastedProfileName(null);
   }
 
   /** Runs the safeStorage paste-flow immediately (not deferred to Next), per the credentials-step spec. */

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
@@ -7,11 +7,10 @@
 import type { PrerequisitesReport } from '@hyveon/desktop-preload';
 
 /**
- * Ordered wizard steps. Later PRs in this epic (#192 credentials,
- * #200/#203/#205 bootstrap, #208 IAM check, #210 terraform-init) append to
- * this array.
+ * Ordered wizard steps. Later PRs in this epic (#200/#203/#205 bootstrap,
+ * #208 IAM check, #210 terraform-init) append to this array.
  */
-export const WIZARD_STEPS = ['prerequisites', 'pick-cloud'] as const;
+export const WIZARD_STEPS = ['prerequisites', 'pick-cloud', 'credentials'] as const;
 
 /** A single step in {@link WIZARD_STEPS}. */
 export type WizardStep = (typeof WIZARD_STEPS)[number];

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -54,12 +54,12 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 6. Issue #192 — wizard step: pick or paste credentials (web, after #189 + #197)
 
-- [ ] 6.1 Create worktree: `git worktree add .worktrees/claude/issue-192-wizard-credentials-step -b claude/issue-192-wizard-credentials-step`
-- [ ] 6.2 Implement `credentials-step.component.tsx`: profile dropdown from `gsd.wizard.listAwsProfiles()`, "paste keys instead" toggle opening a key-ID/secret/region form, region selector defaulting from the selected profile with override
-- [ ] 6.3 Wire submission: profile selection persists `{ profileName, region }`; paste form invokes `gsd.wizard.saveCredentials` (safeStorage flow from #197)
-- [ ] 6.4 RTL/jsdom specs: dropdown population, paste toggle, region default + override, both submission paths round-tripping through the mocked `gsd.wizard` namespace
-- [ ] 6.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 6.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #192`
+- [x] 6.1 Create worktree: `git worktree add .worktrees/claude/issue-192-wizard-credentials-step -b claude/issue-192-wizard-credentials-step`
+- [x] 6.2 Implement `credentials-step.component.tsx`: profile dropdown from `gsd.wizard.listAwsProfiles()`, "paste keys instead" toggle opening a key-ID/secret/region form, region selector defaulting from the selected profile with override
+- [x] 6.3 Wire submission: profile selection persists `{ profileName, region }`; paste form invokes `gsd.wizard.saveCredentials` (safeStorage flow from #197)
+- [x] 6.4 RTL/jsdom specs: dropdown population, paste toggle, region default + override, both submission paths round-tripping through the mocked `gsd.wizard` namespace
+- [x] 6.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 6.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #192`
 
 ## 7. Issue #200 — SDK bootstrap: S3 state bucket (desktop-main)
 

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -16,41 +16,41 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 2. Issue #189 — AwsProfileService (desktop-main)
 
-- [ ] 2.1 Create worktree: `git worktree add .worktrees/claude/issue-189-aws-profile-service -b claude/issue-189-aws-profile-service`
-- [ ] 2.2 Implement `AwsProfileService` in `desktop-main/src/services/AwsProfileService.ts` parsing `~/.aws/credentials` + `~/.aws/config` (prefer `@aws-sdk/shared-ini-file-loader`) into `{ profileName, region? }` summaries; home-dir resolution behind a service seam; missing files return `[]`; never expose key material
-- [ ] 2.3 Add `@MessagePattern('wizard.aws.listProfiles')` to the wizard IPC controller (or create it here if #182 has not merged) + preload `gsd.wizard.listAwsProfiles()` + `gsd-api.ts` mirror
-- [ ] 2.4 Co-located vitest specs: profiles from both files with `profile <name>` aliasing, region pickup, missing files, assertion that responses contain no key material; parity with `aws configure list-profiles` semantics via fixtures
-- [ ] 2.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 2.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #189`
+- [x] 2.1 Create worktree: `git worktree add .worktrees/claude/issue-189-aws-profile-service -b claude/issue-189-aws-profile-service`
+- [x] 2.2 Implement `AwsProfileService` in `desktop-main/src/services/AwsProfileService.ts` parsing `~/.aws/credentials` + `~/.aws/config` (prefer `@aws-sdk/shared-ini-file-loader`) into `{ profileName, region? }` summaries; home-dir resolution behind a service seam; missing files return `[]`; never expose key material
+- [x] 2.3 Add `@MessagePattern('wizard.aws.listProfiles')` to the wizard IPC controller (or create it here if #182 has not merged) + preload `gsd.wizard.listAwsProfiles()` + `gsd-api.ts` mirror
+- [x] 2.4 Co-located vitest specs: profiles from both files with `profile <name>` aliasing, region pickup, missing files, assertion that responses contain no key material; parity with `aws configure list-profiles` semantics via fixtures
+- [x] 2.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 2.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #189` — [PR #319](https://github.com/CoderCoco/Hyveon/pull/319)
 
 ## 3. Issue #197 — safeStorage paste-flow (desktop-main)
 
-- [ ] 3.1 Create worktree: `git worktree add .worktrees/claude/issue-197-safestorage-paste-flow -b claude/issue-197-safestorage-paste-flow`
-- [ ] 3.2 Extend `ElectronStoreService` schema with `creds.aws.<profileName>` entries (encrypted accessKeyId/secretAccessKey + region), reusing its existing encrypted-accessor pattern and `SafeStorageService`
-- [ ] 3.3 Implement paste-flow save in the wizard service layer: encrypt via `SafeStorageService`, default profile name `gsd-pasted`; surface an explicit error when safeStorage is unavailable (no plaintext fallback)
-- [ ] 3.4 Add `@MessagePattern('wizard.aws.saveCredentials')` + preload/`gsd-api.ts` mirror; decrypted values never returned over IPC
-- [ ] 3.5 Ensure decryption is consumed only in main-process factories (`CloudProviderModule` / SDK-client factory seam) with TSDoc noting the constraint
-- [ ] 3.6 Vitest specs: round-trip encrypt/decrypt returns original strings, default profile naming, safeStorage-unavailable error; integration-style spec asserting the persisted store file contains no plaintext key material
-- [ ] 3.7 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 3.8 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #197`
+- [x] 3.1 Create worktree: `git worktree add .worktrees/claude/issue-197-safestorage-paste-flow -b claude/issue-197-safestorage-paste-flow`
+- [x] 3.2 Extend `ElectronStoreService` schema with `creds.aws.<profileName>` entries (encrypted accessKeyId/secretAccessKey + region), reusing its existing encrypted-accessor pattern and `SafeStorageService`
+- [x] 3.3 Implement paste-flow save in the wizard service layer: encrypt via `SafeStorageService`, default profile name `gsd-pasted`; surface an explicit error when safeStorage is unavailable (no plaintext fallback)
+- [x] 3.4 Add `@MessagePattern('wizard.aws.saveCredentials')` + preload/`gsd-api.ts` mirror; decrypted values never returned over IPC
+- [x] 3.5 Ensure decryption is consumed only in main-process factories (`CloudProviderModule` / SDK-client factory seam) with TSDoc noting the constraint
+- [x] 3.6 Vitest specs: round-trip encrypt/decrypt returns original strings, default profile naming, safeStorage-unavailable error; integration-style spec asserting the persisted store file contains no plaintext key material
+- [x] 3.7 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 3.8 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #197` — [PR #320](https://github.com/CoderCoco/Hyveon/pull/320)
 
 ## 4. Issue #184 — wizard step: install prerequisites (web, after #182)
 
-- [ ] 4.1 Create worktree: `git worktree add .worktrees/claude/issue-184-wizard-prereq-step -b claude/issue-184-wizard-prereq-step`
-- [ ] 4.2 Scaffold the first-run wizard shell (`web/src/components/first-run-wizard/first-run-wizard.component.tsx`) mirroring the add-game-wizard step-flow pattern (shell + per-step components + pure utils), with router gating on `wizardCompleted`
-- [ ] 4.3 Implement `prerequisites-step.component.tsx`: per-tool detection results, OS-specific install instructions (macOS/Windows/Linux) with vendor links, Re-check button invoking `gsd.wizard.checkPrereqs()`, Next disabled until both tools satisfied, no auto-install path
-- [ ] 4.4 React Testing Library/jsdom specs (co-located, "should …" names, `gsd` stubbed via the test-mock-registry pattern): blocked progression when missing, Re-check re-invocation, per-platform instructions, enable-on-green
-- [ ] 4.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 4.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #184`
+- [x] 4.1 Create worktree: `git worktree add .worktrees/claude/issue-184-wizard-prereq-step -b claude/issue-184-wizard-prereq-step`
+- [x] 4.2 Scaffold the first-run wizard shell (`web/src/components/first-run-wizard/first-run-wizard.component.tsx`) mirroring the add-game-wizard step-flow pattern (shell + per-step components + pure utils), with router gating on `wizardCompleted`
+- [x] 4.3 Implement `prerequisites-step.component.tsx`: per-tool detection results, OS-specific install instructions (macOS/Windows/Linux) with vendor links, Re-check button invoking `gsd.wizard.checkPrereqs()`, Next disabled until both tools satisfied, no auto-install path
+- [x] 4.4 React Testing Library/jsdom specs (co-located, "should …" names, `gsd` stubbed via the test-mock-registry pattern): blocked progression when missing, Re-check re-invocation, per-platform instructions, enable-on-green
+- [x] 4.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 4.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #184` — [PR #321](https://github.com/CoderCoco/Hyveon/pull/321)
 
 ## 5. Issue #186 — wizard step: pick cloud (web)
 
-- [ ] 5.1 Create worktree: `git worktree add .worktrees/claude/issue-186-wizard-pick-cloud -b claude/issue-186-wizard-pick-cloud`
-- [ ] 5.2 Implement `pick-cloud-step.component.tsx`: options driven by a list (AWS only in v1) with "more clouds coming" footer; persist `activeCloud: 'aws'` via a `wizard.state.save`-style IPC into `ElectronStoreService`
-- [ ] 5.3 Add/extend the IPC + preload surface for persisting the cloud choice (`gsd.wizard.*`), with `ElectronStoreService.activeCloud` as the durable store
-- [ ] 5.4 RTL/jsdom specs: single AWS option renders, footer present, confirm persists choice; service spec asserting persistence survives a store reload (relaunch semantics)
-- [ ] 5.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 5.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #186`
+- [x] 5.1 Create worktree: `git worktree add .worktrees/claude/issue-186-wizard-pick-cloud -b claude/issue-186-wizard-pick-cloud`
+- [x] 5.2 Implement `pick-cloud-step.component.tsx`: options driven by a list (AWS only in v1) with "more clouds coming" footer; persist `activeCloud: 'aws'` via a `wizard.state.save`-style IPC into `ElectronStoreService`
+- [x] 5.3 Add/extend the IPC + preload surface for persisting the cloud choice (`gsd.wizard.*`), with `ElectronStoreService.activeCloud` as the durable store
+- [x] 5.4 RTL/jsdom specs: single AWS option renders, footer present, confirm persists choice; service spec asserting persistence survives a store reload (relaunch semantics)
+- [x] 5.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 5.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #186` — [PR #322](https://github.com/CoderCoco/Hyveon/pull/322)
 
 ## 6. Issue #192 — wizard step: pick or paste credentials (web, after #189 + #197)
 

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -4,15 +4,15 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 1. Issue #182 — prerequisite-detection service (desktop-main)
 
-- [ ] 1.1 Create worktree: `git worktree add .worktrees/claude/issue-182-prereq-detection -b claude/issue-182-prereq-detection`
-- [ ] 1.2 Add `MINIMUM_TERRAFORM_VERSION` constant to `@hyveon/shared` with TSDoc
-- [ ] 1.3 Implement `PrerequisiteService` in `desktop-main/src/services/PrerequisiteService.ts`: probe `terraform` and `aws` via `execFile` + existing `lookupCommandFor`; return `{ found, path?, version? }` per tool; environment/platform access behind protected seams for `vi.spyOn` (no raw `process.env`)
-- [ ] 1.4 Implement version parsing for Terraform 1.x (`Terraform vX.Y.Z`) and AWS CLI v2 (`aws-cli/X.Y.Z ...`); unparseable output degrades to `found: true` with undefined version; compare terraform against `MINIMUM_TERRAFORM_VERSION` and flag unsatisfied
-- [ ] 1.5 Add `WizardModule` (`desktop-main/src/modules/wizard.module.ts`) and IPC-only `WizardController` with `@MessagePattern('wizard.prereqs.check')`; wire into `AppModule`; gate any electron imports on `process.versions.electron`
-- [ ] 1.6 Add preload `gsd.wizard.checkPrereqs()` + typed mirror in `gsd-api.ts`
-- [ ] 1.7 Co-located vitest specs ("should …" names, TSDoc'd helpers): found/missing/spawn-failure paths, both version formats, minimum-version flagging, controller dispatch
-- [ ] 1.8 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 1.9 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #182`
+- [x] 1.1 Create worktree: `git worktree add .worktrees/claude/issue-182-prereq-detection -b claude/issue-182-prereq-detection`
+- [x] 1.2 Add `MINIMUM_TERRAFORM_VERSION` constant to `@hyveon/shared` with TSDoc
+- [x] 1.3 Implement `PrerequisiteService` in `desktop-main/src/services/PrerequisiteService.ts`: probe `terraform` and `aws` via `execFile` + existing `lookupCommandFor`; return `{ found, path?, version? }` per tool; environment/platform access behind protected seams for `vi.spyOn` (no raw `process.env`)
+- [x] 1.4 Implement version parsing for Terraform 1.x (`Terraform vX.Y.Z`) and AWS CLI v2 (`aws-cli/X.Y.Z ...`); unparseable output degrades to `found: true` with undefined version; compare terraform against `MINIMUM_TERRAFORM_VERSION` and flag unsatisfied
+- [x] 1.5 Add `WizardModule` (`desktop-main/src/modules/wizard.module.ts`) and IPC-only `WizardController` with `@MessagePattern('wizard.prereqs.check')`; wire into `AppModule`; gate any electron imports on `process.versions.electron`
+- [x] 1.6 Add preload `gsd.wizard.checkPrereqs()` + typed mirror in `gsd-api.ts`
+- [x] 1.7 Co-located vitest specs ("should …" names, TSDoc'd helpers): found/missing/spawn-failure paths, both version formats, minimum-version flagging, controller dispatch
+- [x] 1.8 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 1.9 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #182` — [PR #317](https://github.com/CoderCoco/Hyveon/pull/317)
 
 ## 2. Issue #189 — AwsProfileService (desktop-main)
 


### PR DESCRIPTION
Closes #192

## Summary

PR 6 of 12 for the First-Run Wizard epic (#139, see `openspec/changes/add-first-run-wizard`). This is the wizard's credentials step: the operator either picks a discovered `~/.aws` CLI profile or pastes an access key ID/secret directly via the existing safeStorage paste-flow (#197).

- New `credentials-step.component.tsx` (purely presentational, mirrors `prerequisites-step`/`pick-cloud-step`): a mode toggle ("Use an existing profile" / "Paste keys instead"), a profile dropdown populated from `gsd.wizard.listAwsProfiles()`, a region field defaulting from the selected profile's own configured region (editable), and a paste form (access key ID / secret access key / region) that invokes `gsd.wizard.saveCredentials`.
- `FirstRunWizard` shell now fetches AWS profiles on mount (alongside the existing prerequisites check) and owns all credentials-step state — selection, paste form fields, and the paste-flow's save-in-flight/error/success state. The paste-flow save runs immediately on "Save credentials" (not deferred to Next), per the locked wizard design; the profile-selection path persists on Next, mirroring how pick-cloud persists `activeCloud`.
- Extended `WizardController.saveState`/`getState` (and the mirrored `gsd-api.ts` types) with `aws?: { profile?: string; region?: string }`, merged onto any existing stored value so the chosen credential source (profile name — either a real `~/.aws` profile or a `creds.aws.<profileName>` pasted-credentials entry — plus region) round-trips to the main process and persists for later wizard steps.
- Also flips the #182 (prerequisite-detection) task checkboxes in `tasks.md` to `[x]` in a separate commit — PR #317 shipped that work but the checkboxes were never updated.

## Test plan

- [x] `npm run app:test` — 1987/1987 tests passing (new: `credentials-step.component.test.tsx` covering dropdown population, mode toggle, paste form, error/success states; extended `first-run-wizard.component.test.tsx` covering profile listing on mount, region defaulting, region override, `wizard.state.save`/`wizard.aws.saveCredentials` round-tripping through the mocked `gsd.wizard` namespace; extended `wizard.controller.test.ts` for the `aws` field round-trip and merge-on-partial-update behavior)
- [x] `npm run app:lint` — 0 errors (3 pre-existing, unrelated warnings in `ConfigService.ts`)