### PR TITLE
feat(desktop-main): SDK bootstrap of DynamoDB lock table

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -47,9 +47,12 @@ function makeStore(
   } as Partial<ElectronStoreService> as ElectronStoreService;
 }
 
-/** Build a BootstrapService stub whose `ensureStateBucket()` resolves to the given result. */
+/** Build a BootstrapService stub whose `ensureStateBucket()`/`ensureLockTable()` resolve to the given result. */
 function makeBootstrap(result: BootstrapResult = { status: 'created' }): BootstrapService {
-  return { ensureStateBucket: vi.fn().mockResolvedValue(result) } as Partial<BootstrapService> as BootstrapService;
+  return {
+    ensureStateBucket: vi.fn().mockResolvedValue(result),
+    ensureLockTable: vi.fn().mockResolvedValue(result),
+  } as Partial<BootstrapService> as BootstrapService;
 }
 
 /** Builds a `WizardController` with default stubs for any dependency the caller doesn't override. */
@@ -104,6 +107,11 @@ describe('WizardController', () => {
     it('should register bootstrapStateBucket on the "wizard.bootstrap.stateBucket" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.bootstrapStateBucket);
       expect(pattern).toEqual(['wizard.bootstrap.stateBucket']);
+    });
+
+    it('should register bootstrapLockTable on the "wizard.bootstrap.lockTable" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.bootstrapLockTable);
+      expect(pattern).toEqual(['wizard.bootstrap.lockTable']);
     });
   });
 
@@ -283,6 +291,25 @@ describe('WizardController', () => {
       const result = await makeController({ bootstrap }).bootstrapStateBucket({ bucketName: 'taken' });
 
       expect(result).toEqual({ status: 'failed', message: 'bucket taken' });
+    });
+  });
+
+  describe('bootstrapLockTable', () => {
+    it('should delegate to BootstrapService.ensureLockTable with the given table name', async () => {
+      const bootstrap = makeBootstrap({ status: 'created' });
+
+      const result = await makeController({ bootstrap }).bootstrapLockTable({ tableName: 'my-lock-table' });
+
+      expect(bootstrap.ensureLockTable).toHaveBeenCalledWith('my-lock-table');
+      expect(result).toEqual({ status: 'created' });
+    });
+
+    it('should propagate a failed result unchanged rather than throwing', async () => {
+      const bootstrap = makeBootstrap({ status: 'failed', message: 'access denied' });
+
+      const result = await makeController({ bootstrap }).bootstrapLockTable({ tableName: 'my-lock-table' });
+
+      expect(result).toEqual({ status: 'failed', message: 'access denied' });
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -14,6 +14,11 @@ export interface BootstrapStateBucketInput {
   bucketName: string;
 }
 
+/** Payload accepted by {@link WizardController.bootstrapLockTable}. */
+export interface BootstrapLockTableInput {
+  tableName: string;
+}
+
 /**
  * The credentials step's chosen source, as persisted to `ElectronStoreService.aws`.
  * `profile` names either a real `~/.aws` profile (the "pick an existing
@@ -154,5 +159,14 @@ export class WizardController {
   @MessagePattern('wizard.bootstrap.stateBucket')
   bootstrapStateBucket(@Payload() body: BootstrapStateBucketInput): Promise<BootstrapResult> {
     return this.bootstrap.ensureStateBucket(body.bucketName);
+  }
+
+  /**
+   * Idempotently creates/ensures the Terraform state-lock DynamoDB table.
+   * See `BootstrapService.ensureLockTable` for the full idempotency mapping.
+   */
+  @MessagePattern('wizard.bootstrap.lockTable')
+  bootstrapLockTable(@Payload() body: BootstrapLockTableInput): Promise<BootstrapResult> {
+    return this.bootstrap.ensureLockTable(body.tableName);
   }
 }

--- a/app/packages/desktop-main/src/services/BootstrapService.test.ts
+++ b/app/packages/desktop-main/src/services/BootstrapService.test.ts
@@ -8,11 +8,15 @@ import {
   PutBucketVersioningCommand,
   PutBucketEncryptionCommand,
 } from '@aws-sdk/client-s3';
+import { DynamoDBClient, CreateTableCommand, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { BootstrapService, BootstrapCredentialsNotConfiguredError } from './BootstrapService.js';
 import type { ElectronStoreService } from './ElectronStoreService.js';
 
 /** Typed stand-in for the AWS S3 SDK client, shared across the tests below. */
 const s3Mock = mockClient(S3Client);
+
+/** Typed stand-in for the AWS DynamoDB SDK client, shared across the tests below. */
+const dynamoMock = mockClient(DynamoDBClient);
 
 /** Build an `ElectronStoreService` stub whose `get('aws')` resolves to the given choice. */
 function makeStore(
@@ -34,6 +38,7 @@ function awsError(name: string): Error {
 
 beforeEach(() => {
   s3Mock.reset();
+  dynamoMock.reset();
 });
 
 describe('BootstrapService', () => {
@@ -180,6 +185,52 @@ describe('BootstrapService', () => {
       await service.ensureStateBucket('my-state-bucket');
 
       expect(store.getPastedCredentials).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ensureLockTable', () => {
+    it('should create the lock table with a LockID string hash key and wait for it to become ACTIVE', async () => {
+      dynamoMock.on(CreateTableCommand).resolves({});
+      dynamoMock.on(DescribeTableCommand).resolves({ Table: { TableStatus: 'ACTIVE' } });
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureLockTable('my-lock-table');
+
+      expect(result).toEqual({ status: 'created' });
+      expect(dynamoMock.commandCalls(CreateTableCommand)[0]!.args[0].input).toEqual({
+        TableName: 'my-lock-table',
+        AttributeDefinitions: [{ AttributeName: 'LockID', AttributeType: 'S' }],
+        KeySchema: [{ AttributeName: 'LockID', KeyType: 'HASH' }],
+        BillingMode: 'PAY_PER_REQUEST',
+      });
+      expect(dynamoMock.commandCalls(DescribeTableCommand)).toHaveLength(1);
+    });
+
+    it('should treat ResourceInUseException as a success no-op without waiting', async () => {
+      dynamoMock.on(CreateTableCommand).rejects(awsError('ResourceInUseException'));
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureLockTable('my-lock-table');
+
+      expect(result).toEqual({ status: 'exists' });
+      expect(dynamoMock.commandCalls(DescribeTableCommand)).toHaveLength(0);
+    });
+
+    it('should report failure with the error message for an unexpected CreateTable error', async () => {
+      dynamoMock.on(CreateTableCommand).rejects(new Error('access denied'));
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureLockTable('my-lock-table');
+
+      expect(result).toEqual({ status: 'failed', message: 'access denied' });
+    });
+
+    it('should throw BootstrapCredentialsNotConfiguredError when no region is stored', async () => {
+      const service = new BootstrapService(makeStore(undefined));
+
+      await expect(service.ensureLockTable('my-lock-table')).rejects.toThrow(
+        BootstrapCredentialsNotConfiguredError,
+      );
     });
   });
 });

--- a/app/packages/desktop-main/src/services/BootstrapService.ts
+++ b/app/packages/desktop-main/src/services/BootstrapService.ts
@@ -8,8 +8,23 @@ import {
   type BucketLocationConstraint,
   type S3ClientConfig,
 } from '@aws-sdk/client-s3';
+import { DynamoDBClient, CreateTableCommand, waitUntilTableExists } from '@aws-sdk/client-dynamodb';
 import { fromIni } from '@aws-sdk/credential-providers';
 import { ElectronStoreService } from './ElectronStoreService.js';
+
+/**
+ * How long `ensureLockTable` waits for a freshly-created lock table to reach
+ * `ACTIVE` before giving up and reporting `failed`.
+ */
+const LOCK_TABLE_ACTIVE_WAIT_SECONDS = 60;
+
+/**
+ * The credentials/region shape shared by every wizard-bootstrap SDK client
+ * (`S3Client`, `DynamoDBClient`, ...). `region` and `credentials` are
+ * structurally identical across `@aws-sdk/client-*` config types, so a
+ * single resolved value can construct any of them without a per-service cast.
+ */
+type WizardAwsClientConfig = Pick<S3ClientConfig, 'region' | 'credentials'>;
 
 /** Per-resource outcome returned by a `BootstrapService` operation over IPC. */
 export type BootstrapResourceStatus = 'created' | 'exists' | 'failed';
@@ -96,6 +111,52 @@ export class BootstrapService {
   }
 
   /**
+   * Idempotently ensures the Terraform state-lock DynamoDB table exists,
+   * with the `LockID` string hash key the S3 backend's native locking
+   * requires, waiting until the table reaches `ACTIVE` before reporting
+   * success on a fresh create.
+   *
+   * @param tableName - Name of the lock table to create/ensure.
+   */
+  async ensureLockTable(tableName: string): Promise<BootstrapResult> {
+    const client = this.createDynamoDbClient();
+    try {
+      const created = await this.createTable(client, tableName);
+      return { status: created ? 'created' : 'exists' };
+    } catch (err) {
+      return { status: 'failed', message: this.describeError(err) };
+    }
+  }
+
+  /**
+   * Creates the lock table and waits for it to become `ACTIVE`, returning
+   * `true` if this call created it and `false` if it already existed
+   * (`ResourceInUseException`) — both are success paths.
+   */
+  private async createTable(client: DynamoDBClient, tableName: string): Promise<boolean> {
+    try {
+      await client.send(
+        new CreateTableCommand({
+          TableName: tableName,
+          AttributeDefinitions: [{ AttributeName: 'LockID', AttributeType: 'S' }],
+          KeySchema: [{ AttributeName: 'LockID', KeyType: 'HASH' }],
+          BillingMode: 'PAY_PER_REQUEST',
+        }),
+      );
+      await waitUntilTableExists(
+        { client, maxWaitTime: LOCK_TABLE_ACTIVE_WAIT_SECONDS },
+        { TableName: tableName },
+      );
+      return true;
+    } catch (err) {
+      if (this.isAwsErrorCode(err, 'ResourceInUseException')) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Creates the bucket, returning `true` if this call created it and
    * `false` if it already existed under the caller's own account
    * (`BucketAlreadyOwnedByYou`) — both are success paths. Re-throws for
@@ -175,7 +236,16 @@ export class BootstrapService {
     return new S3Client(this.resolveClientConfig());
   }
 
-  private resolveClientConfig(): S3ClientConfig {
+  /**
+   * Builds a DynamoDB client from the same wizard-chosen credentials/region
+   * as {@link createS3Client}. Extracted as a protected seam so tests can
+   * stub it without touching real credentials.
+   */
+  protected createDynamoDbClient(): DynamoDBClient {
+    return new DynamoDBClient(this.resolveClientConfig());
+  }
+
+  private resolveClientConfig(): WizardAwsClientConfig {
     const aws = this.store.get('aws');
     if (!aws?.region) {
       throw new BootstrapCredentialsNotConfiguredError();

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -991,6 +991,11 @@ export interface BootstrapStateBucketInput {
   bucketName: string;
 }
 
+/** Payload accepted by {@link GsdWizardApi.bootstrapLockTable}. */
+export interface BootstrapLockTableInput {
+  tableName: string;
+}
+
 /** Per-resource outcome of a `wizard.bootstrap.*` call. */
 export type BootstrapResourceStatus = 'created' | 'exists' | 'failed';
 
@@ -1026,6 +1031,12 @@ export interface GsdWizardApi {
    * credentials step.
    */
   bootstrapStateBucket: (input: BootstrapStateBucketInput) => Promise<BootstrapResult>;
+  /**
+   * Idempotently creates/ensures the Terraform state-lock DynamoDB table
+   * (`LockID` string hash key) using the credentials/region chosen in the
+   * credentials step.
+   */
+  bootstrapLockTable: (input: BootstrapLockTableInput) => Promise<BootstrapResult>;
 }
 
 /**

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -78,6 +78,7 @@ import type {
   WizardState,
   SaveWizardStateInput,
   BootstrapStateBucketInput,
+  BootstrapLockTableInput,
   BootstrapResult,
 } from './gsd-api.js';
 
@@ -606,6 +607,8 @@ const api: GsdApi = {
     saveState: (input: SaveWizardStateInput) => invoke<WizardState>('wizard.state.save', input),
     bootstrapStateBucket: (input: BootstrapStateBucketInput) =>
       invoke<BootstrapResult>('wizard.bootstrap.stateBucket', input),
+    bootstrapLockTable: (input: BootstrapLockTableInput) =>
+      invoke<BootstrapResult>('wizard.bootstrap.lockTable', input),
   },
 
   drift: {

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -78,7 +78,7 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 - [x] 8.3 Add `@MessagePattern('wizard.bootstrap.lockTable')` + preload/`gsd-api.ts` mirror with per-resource status
 - [x] 8.4 Vitest specs with `aws-sdk-client-mock`: fresh create + ACTIVE wait, already-exists no-op, failure surfaces `failed` status; assert key schema matches Terraform S3-backend locking requirements
 - [x] 8.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 8.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #203`
+- [x] 8.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #203` — [PR #326](https://github.com/CoderCoco/Hyveon/pull/326)
 
 ## 9. Issue #205 — SDK bootstrap: versioned S3 tfvars bucket (desktop-main)
 

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -73,11 +73,11 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 8. Issue #203 — SDK bootstrap: DynamoDB lock table (desktop-main)
 
-- [ ] 8.1 Create worktree: `git worktree add .worktrees/claude/issue-203-bootstrap-lock-table -b claude/issue-203-bootstrap-lock-table`
-- [ ] 8.2 Implement `BootstrapService.ensureLockTable()` with `@aws-sdk/client-dynamodb`: `CreateTable` with `LockID` string hash key, waiter until `ACTIVE`; idempotent (`ResourceInUseException` ⇒ success)
-- [ ] 8.3 Add `@MessagePattern('wizard.bootstrap.lockTable')` + preload/`gsd-api.ts` mirror with per-resource status
-- [ ] 8.4 Vitest specs with `aws-sdk-client-mock`: fresh create + ACTIVE wait, already-exists no-op, failure surfaces `failed` status; assert key schema matches Terraform S3-backend locking requirements
-- [ ] 8.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 8.1 Create worktree: `git worktree add .worktrees/claude/issue-203-bootstrap-lock-table -b claude/issue-203-bootstrap-lock-table`
+- [x] 8.2 Implement `BootstrapService.ensureLockTable()` with `@aws-sdk/client-dynamodb`: `CreateTable` with `LockID` string hash key, waiter until `ACTIVE`; idempotent (`ResourceInUseException` ⇒ success)
+- [x] 8.3 Add `@MessagePattern('wizard.bootstrap.lockTable')` + preload/`gsd-api.ts` mirror with per-resource status
+- [x] 8.4 Vitest specs with `aws-sdk-client-mock`: fresh create + ACTIVE wait, already-exists no-op, failure surfaces `failed` status; assert key schema matches Terraform S3-backend locking requirements
+- [x] 8.5 Verify `npm run app:test` and `npm run app:lint` pass
 - [ ] 8.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #203`
 
 ## 9. Issue #205 — SDK bootstrap: versioned S3 tfvars bucket (desktop-main)


### PR DESCRIPTION
Closes #203

## Summary
- Add `BootstrapService.ensureLockTable()`, idempotently creating the Terraform state-lock DynamoDB table (`LockID` string hash key, `PAY_PER_REQUEST` billing) via `@aws-sdk/client-dynamodb`, waiting until the table reaches `ACTIVE` on a fresh create. `ResourceInUseException` is treated as a success no-op.
- Wire `wizard.bootstrap.lockTable` as a `@MessagePattern` on `WizardController`, with a preload/`gsd-api.ts` mirror (`bootstrapLockTable`) returning the same `created`/`exists`/`failed` per-resource status shape as the state-bucket bootstrap step (#200).
- Sync `openspec/changes/add-first-run-wizard/tasks.md` for groups 1-7 (#182, #189, #197, #184, #186, #192, #200), which merged without their checklist items being marked complete in those PRs.

## Test plan
- [x] `npm run app:test` — 2009/2009 tests pass, including new `BootstrapService.ensureLockTable` and `WizardController.bootstrapLockTable` specs
- [x] `npm run app:lint` — clean (3 pre-existing unrelated warnings in `ConfigService.ts`)
- [x] `npm run app:build` — shared/cloud-aws/desktop-main/web all build clean
