### PR TITLE
feat(desktop-main): SDK bootstrap of the tfvars S3 bucket

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -47,11 +47,12 @@ function makeStore(
   } as Partial<ElectronStoreService> as ElectronStoreService;
 }
 
-/** Build a BootstrapService stub whose `ensureStateBucket()`/`ensureLockTable()` resolve to the given result. */
+/** Build a BootstrapService stub whose `ensure*` methods resolve to the given result. */
 function makeBootstrap(result: BootstrapResult = { status: 'created' }): BootstrapService {
   return {
     ensureStateBucket: vi.fn().mockResolvedValue(result),
     ensureLockTable: vi.fn().mockResolvedValue(result),
+    ensureTfvarsBucket: vi.fn().mockResolvedValue(result),
   } as Partial<BootstrapService> as BootstrapService;
 }
 
@@ -112,6 +113,11 @@ describe('WizardController', () => {
     it('should register bootstrapLockTable on the "wizard.bootstrap.lockTable" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.bootstrapLockTable);
       expect(pattern).toEqual(['wizard.bootstrap.lockTable']);
+    });
+
+    it('should register bootstrapTfvarsBucket on the "wizard.bootstrap.tfvarsBucket" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.bootstrapTfvarsBucket);
+      expect(pattern).toEqual(['wizard.bootstrap.tfvarsBucket']);
     });
   });
 
@@ -308,6 +314,25 @@ describe('WizardController', () => {
       const bootstrap = makeBootstrap({ status: 'failed', message: 'access denied' });
 
       const result = await makeController({ bootstrap }).bootstrapLockTable({ tableName: 'my-lock-table' });
+
+      expect(result).toEqual({ status: 'failed', message: 'access denied' });
+    });
+  });
+
+  describe('bootstrapTfvarsBucket', () => {
+    it('should delegate to BootstrapService.ensureTfvarsBucket with the given bucket name', async () => {
+      const bootstrap = makeBootstrap({ status: 'created' });
+
+      const result = await makeController({ bootstrap }).bootstrapTfvarsBucket({ bucketName: 'my-tfvars-bucket' });
+
+      expect(bootstrap.ensureTfvarsBucket).toHaveBeenCalledWith('my-tfvars-bucket');
+      expect(result).toEqual({ status: 'created' });
+    });
+
+    it('should propagate a failed result unchanged rather than throwing', async () => {
+      const bootstrap = makeBootstrap({ status: 'failed', message: 'access denied' });
+
+      const result = await makeController({ bootstrap }).bootstrapTfvarsBucket({ bucketName: 'my-tfvars-bucket' });
 
       expect(result).toEqual({ status: 'failed', message: 'access denied' });
     });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -19,6 +19,11 @@ export interface BootstrapLockTableInput {
   tableName: string;
 }
 
+/** Payload accepted by {@link WizardController.bootstrapTfvarsBucket}. */
+export interface BootstrapTfvarsBucketInput {
+  bucketName: string;
+}
+
 /**
  * The credentials step's chosen source, as persisted to `ElectronStoreService.aws`.
  * `profile` names either a real `~/.aws` profile (the "pick an existing
@@ -168,5 +173,15 @@ export class WizardController {
   @MessagePattern('wizard.bootstrap.lockTable')
   bootstrapLockTable(@Payload() body: BootstrapLockTableInput): Promise<BootstrapResult> {
     return this.bootstrap.ensureLockTable(body.tableName);
+  }
+
+  /**
+   * Idempotently creates/ensures the versioned tfvars S3 bucket (versioning +
+   * 90-day noncurrent-version-expiration lifecycle rule). See
+   * `BootstrapService.ensureTfvarsBucket` for the full idempotency mapping.
+   */
+  @MessagePattern('wizard.bootstrap.tfvarsBucket')
+  bootstrapTfvarsBucket(@Payload() body: BootstrapTfvarsBucketInput): Promise<BootstrapResult> {
+    return this.bootstrap.ensureTfvarsBucket(body.bucketName);
   }
 }

--- a/app/packages/desktop-main/src/services/BootstrapService.test.ts
+++ b/app/packages/desktop-main/src/services/BootstrapService.test.ts
@@ -7,6 +7,7 @@ import {
   HeadBucketCommand,
   PutBucketVersioningCommand,
   PutBucketEncryptionCommand,
+  PutBucketLifecycleConfigurationCommand,
 } from '@aws-sdk/client-s3';
 import { DynamoDBClient, CreateTableCommand, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { BootstrapService, BootstrapCredentialsNotConfiguredError } from './BootstrapService.js';
@@ -229,6 +230,95 @@ describe('BootstrapService', () => {
       const service = new BootstrapService(makeStore(undefined));
 
       await expect(service.ensureLockTable('my-lock-table')).rejects.toThrow(
+        BootstrapCredentialsNotConfiguredError,
+      );
+    });
+  });
+
+  describe('ensureTfvarsBucket', () => {
+    it('should create the bucket with versioning and a 90-day noncurrent-version lifecycle rule on a fresh bucket', async () => {
+      s3Mock.on(CreateBucketCommand).resolves({});
+      s3Mock.on(PutBucketVersioningCommand).resolves({});
+      s3Mock.on(PutBucketLifecycleConfigurationCommand).resolves({});
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureTfvarsBucket('my-tfvars-bucket');
+
+      expect(result).toEqual({ status: 'created' });
+      expect(s3Mock.commandCalls(CreateBucketCommand)[0]!.args[0].input).toEqual({
+        Bucket: 'my-tfvars-bucket',
+        CreateBucketConfiguration: { LocationConstraint: 'us-west-2' },
+      });
+      expect(s3Mock.commandCalls(PutBucketVersioningCommand)[0]!.args[0].input).toEqual({
+        Bucket: 'my-tfvars-bucket',
+        VersioningConfiguration: { Status: 'Enabled' },
+      });
+      expect(s3Mock.commandCalls(PutBucketLifecycleConfigurationCommand)[0]!.args[0].input).toEqual({
+        Bucket: 'my-tfvars-bucket',
+        LifecycleConfiguration: {
+          Rules: [
+            {
+              ID: 'expire-noncurrent-versions',
+              Status: 'Enabled',
+              Filter: {},
+              NoncurrentVersionExpiration: { NoncurrentDays: 90 },
+            },
+          ],
+        },
+      });
+    });
+
+    it('should treat BucketAlreadyOwnedByYou as a success no-op and still ensure versioning/lifecycle', async () => {
+      s3Mock.on(CreateBucketCommand).rejects(awsError('BucketAlreadyOwnedByYou'));
+      s3Mock.on(PutBucketVersioningCommand).resolves({});
+      s3Mock.on(PutBucketLifecycleConfigurationCommand).resolves({});
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureTfvarsBucket('my-tfvars-bucket');
+
+      expect(result).toEqual({ status: 'exists' });
+      expect(s3Mock.commandCalls(PutBucketVersioningCommand)).toHaveLength(1);
+      expect(s3Mock.commandCalls(PutBucketLifecycleConfigurationCommand)).toHaveLength(1);
+    });
+
+    it('should skip CreateBucket in us-east-1 when HeadBucket confirms the bucket already exists', async () => {
+      s3Mock.on(HeadBucketCommand).resolves({});
+      s3Mock.on(PutBucketVersioningCommand).resolves({});
+      s3Mock.on(PutBucketLifecycleConfigurationCommand).resolves({});
+      const service = new BootstrapService(makeStore({ region: 'us-east-1' }));
+
+      const result = await service.ensureTfvarsBucket('my-tfvars-bucket');
+
+      expect(result).toEqual({ status: 'exists' });
+      expect(s3Mock.commandCalls(CreateBucketCommand)).toHaveLength(0);
+    });
+
+    it('should report a clear failure when the bucket name is owned by another account', async () => {
+      s3Mock.on(CreateBucketCommand).rejects(awsError('BucketAlreadyExists'));
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureTfvarsBucket('taken-bucket-name');
+
+      expect(result.status).toBe('failed');
+      expect(result.message).toMatch(/already taken by another AWS account/i);
+      expect(s3Mock.commandCalls(PutBucketVersioningCommand)).toHaveLength(0);
+    });
+
+    it('should report failure with the error message when the lifecycle rule cannot be applied after a successful create', async () => {
+      s3Mock.on(CreateBucketCommand).resolves({});
+      s3Mock.on(PutBucketVersioningCommand).resolves({});
+      s3Mock.on(PutBucketLifecycleConfigurationCommand).rejects(new Error('access denied'));
+      const service = new BootstrapService(makeStore({ region: 'us-west-2' }));
+
+      const result = await service.ensureTfvarsBucket('my-tfvars-bucket');
+
+      expect(result).toEqual({ status: 'failed', message: 'access denied' });
+    });
+
+    it('should throw BootstrapCredentialsNotConfiguredError when no region is stored', async () => {
+      const service = new BootstrapService(makeStore(undefined));
+
+      await expect(service.ensureTfvarsBucket('my-tfvars-bucket')).rejects.toThrow(
         BootstrapCredentialsNotConfiguredError,
       );
     });

--- a/app/packages/desktop-main/src/services/BootstrapService.ts
+++ b/app/packages/desktop-main/src/services/BootstrapService.ts
@@ -5,6 +5,7 @@ import {
   HeadBucketCommand,
   PutBucketVersioningCommand,
   PutBucketEncryptionCommand,
+  PutBucketLifecycleConfigurationCommand,
   type BucketLocationConstraint,
   type S3ClientConfig,
 } from '@aws-sdk/client-s3';
@@ -17,6 +18,13 @@ import { ElectronStoreService } from './ElectronStoreService.js';
  * `ACTIVE` before giving up and reporting `failed`.
  */
 const LOCK_TABLE_ACTIVE_WAIT_SECONDS = 60;
+
+/**
+ * How many days a noncurrent tfvars object version is retained before
+ * expiring — matches `terraform/bootstrap/main.tf`'s
+ * `aws_s3_bucket_lifecycle_configuration.tfvars` rule.
+ */
+const TFVARS_NONCURRENT_VERSION_EXPIRATION_DAYS = 90;
 
 /**
  * The credentials/region shape shared by every wizard-bootstrap SDK client
@@ -126,6 +134,58 @@ export class BootstrapService {
     } catch (err) {
       return { status: 'failed', message: this.describeError(err) };
     }
+  }
+
+  /**
+   * Idempotently ensures the versioned tfvars S3 bucket exists with a
+   * lifecycle rule expiring noncurrent object versions after 90 days.
+   *
+   * @remarks
+   * Mirrors `terraform/bootstrap/main.tf`'s `aws_s3_bucket_versioning.tfvars`
+   * / `aws_s3_bucket_lifecycle_configuration.tfvars` resources so the SDK
+   * and HCL provisioning paths stay behaviourally consistent (design.md
+   * decision 6) — the resulting bucket is the canonical `RemoteFileStore`.
+   *
+   * @param bucketName - Name of the tfvars bucket to create/ensure.
+   */
+  async ensureTfvarsBucket(bucketName: string): Promise<BootstrapResult> {
+    const client = this.createS3Client();
+    let created: boolean;
+    try {
+      created = await this.createBucket(client, bucketName);
+    } catch (err) {
+      return { status: 'failed', message: this.describeError(err) };
+    }
+
+    try {
+      await client.send(
+        new PutBucketVersioningCommand({
+          Bucket: bucketName,
+          VersioningConfiguration: { Status: 'Enabled' },
+        }),
+      );
+      await client.send(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: bucketName,
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                ID: 'expire-noncurrent-versions',
+                Status: 'Enabled',
+                Filter: {},
+                NoncurrentVersionExpiration: {
+                  NoncurrentDays: TFVARS_NONCURRENT_VERSION_EXPIRATION_DAYS,
+                },
+              },
+            ],
+          },
+        }),
+      );
+    } catch (err) {
+      return { status: 'failed', message: this.describeError(err) };
+    }
+
+    return { status: created ? 'created' : 'exists' };
   }
 
   /**

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -996,6 +996,11 @@ export interface BootstrapLockTableInput {
   tableName: string;
 }
 
+/** Payload accepted by {@link GsdWizardApi.bootstrapTfvarsBucket}. */
+export interface BootstrapTfvarsBucketInput {
+  bucketName: string;
+}
+
 /** Per-resource outcome of a `wizard.bootstrap.*` call. */
 export type BootstrapResourceStatus = 'created' | 'exists' | 'failed';
 
@@ -1037,6 +1042,12 @@ export interface GsdWizardApi {
    * credentials step.
    */
   bootstrapLockTable: (input: BootstrapLockTableInput) => Promise<BootstrapResult>;
+  /**
+   * Idempotently creates/ensures the versioned tfvars S3 bucket (versioning +
+   * 90-day noncurrent-version-expiration lifecycle rule) using the
+   * credentials/region chosen in the credentials step.
+   */
+  bootstrapTfvarsBucket: (input: BootstrapTfvarsBucketInput) => Promise<BootstrapResult>;
 }
 
 /**

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -79,6 +79,7 @@ import type {
   SaveWizardStateInput,
   BootstrapStateBucketInput,
   BootstrapLockTableInput,
+  BootstrapTfvarsBucketInput,
   BootstrapResult,
 } from './gsd-api.js';
 
@@ -609,6 +610,8 @@ const api: GsdApi = {
       invoke<BootstrapResult>('wizard.bootstrap.stateBucket', input),
     bootstrapLockTable: (input: BootstrapLockTableInput) =>
       invoke<BootstrapResult>('wizard.bootstrap.lockTable', input),
+    bootstrapTfvarsBucket: (input: BootstrapTfvarsBucketInput) =>
+      invoke<BootstrapResult>('wizard.bootstrap.tfvarsBucket', input),
   },
 
   drift: {

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -82,11 +82,11 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 9. Issue #205 — SDK bootstrap: versioned S3 tfvars bucket (desktop-main)
 
-- [ ] 9.1 Create worktree: `git worktree add .worktrees/claude/issue-205-bootstrap-tfvars-bucket -b claude/issue-205-bootstrap-tfvars-bucket`
-- [ ] 9.2 Implement `BootstrapService.ensureTfvarsBucket()`: create-if-missing, `PutBucketVersioning`, `PutBucketLifecycleConfiguration` expiring noncurrent versions after 90 days; idempotent; TSDoc noting behavioral parity with `terraform/bootstrap/`
-- [ ] 9.3 Add `@MessagePattern('wizard.bootstrap.tfvarsBucket')` + preload/`gsd-api.ts` mirror; bucket name feeds the `RemoteFileStore` configuration
-- [ ] 9.4 Vitest specs with `aws-sdk-client-mock`: fresh create with versioning + lifecycle, existing-bucket no-op with settings ensured, failure path
-- [ ] 9.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 9.1 Create worktree: `git worktree add .worktrees/claude/issue-205-bootstrap-tfvars-bucket -b claude/issue-205-bootstrap-tfvars-bucket`
+- [x] 9.2 Implement `BootstrapService.ensureTfvarsBucket()`: create-if-missing, `PutBucketVersioning`, `PutBucketLifecycleConfiguration` expiring noncurrent versions after 90 days; idempotent; TSDoc noting behavioral parity with `terraform/bootstrap/`
+- [x] 9.3 Add `@MessagePattern('wizard.bootstrap.tfvarsBucket')` + preload/`gsd-api.ts` mirror; bucket name feeds the `RemoteFileStore` configuration
+- [x] 9.4 Vitest specs with `aws-sdk-client-mock`: fresh create with versioning + lifecycle, existing-bucket no-op with settings ensured, failure path
+- [x] 9.5 Verify `npm run app:test` and `npm run app:lint` pass
 - [ ] 9.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #205`
 
 ## 10. Issue #208 — IAM SimulatePrincipalPolicy check (desktop-main + web panel)

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -87,7 +87,7 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 - [x] 9.3 Add `@MessagePattern('wizard.bootstrap.tfvarsBucket')` + preload/`gsd-api.ts` mirror; bucket name feeds the `RemoteFileStore` configuration
 - [x] 9.4 Vitest specs with `aws-sdk-client-mock`: fresh create with versioning + lifecycle, existing-bucket no-op with settings ensured, failure path
 - [x] 9.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 9.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #205`
+- [x] 9.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #205` — [PR #327](https://github.com/CoderCoco/Hyveon/pull/327)
 
 ## 10. Issue #208 — IAM SimulatePrincipalPolicy check (desktop-main + web panel)
 


### PR DESCRIPTION
Closes #205

## Summary
- `BootstrapService.ensureTfvarsBucket()` idempotently creates the versioned tfvars S3 bucket and applies a 90-day noncurrent-version-expiration lifecycle rule, mirroring `terraform/bootstrap/main.tf`'s `aws_s3_bucket_versioning.tfvars` / `aws_s3_bucket_lifecycle_configuration.tfvars` resources so the SDK bootstrap path and the HCL provisioning path stay behaviourally consistent.
- Adds the `wizard.bootstrap.tfvarsBucket` `@MessagePattern` to `WizardController`, plus the typed preload/`gsd-api.ts` mirror (`bootstrapTfvarsBucket`).
- Reuses `BootstrapService`'s existing `createBucket`/credentials-resolution seams (`BootstrapCredentialsNotConfiguredError`, pasted-vs-profile credential resolution) — no new client-construction logic needed.

## Test plan
- [x] `npm run app:test` — 2018/2018 passing (9 new: 6 `BootstrapService.ensureTfvarsBucket` specs — fresh create w/ versioning+lifecycle, already-owned no-op, us-east-1 HeadBucket short-circuit, foreign-owner failure, lifecycle-apply failure, missing-credentials error; 3 `WizardController.bootstrapTfvarsBucket` specs — pattern registration + delegation + failure propagation)
- [x] `npm run app:lint` — 0 errors (3 pre-existing warnings in an untouched file)
