### PR TITLE
feat(web): terraform-init wizard step and completion flow

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -65,11 +65,12 @@ function makeIamCheck(result: IamCheckResult = { status: 'passed' }): IamCheckSe
 
 /** Build a FirstRunWizardService stub whose `getProgress()` resolves to the given progress. */
 function makeFirstRunWizard(progress: WizardProgress = { step: 'prerequisites' }): FirstRunWizardService {
-  return {
+  const service: Partial<FirstRunWizardService> = {
     getProgress: vi.fn().mockResolvedValue(progress),
     recordStep: vi.fn().mockResolvedValue(undefined),
     complete: vi.fn().mockResolvedValue(undefined),
-  } as Partial<FirstRunWizardService> as FirstRunWizardService;
+  };
+  return service as FirstRunWizardService;
 }
 
 /** Builds a `WizardController` with default stubs for any dependency the caller doesn't override. */

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -68,7 +68,7 @@ function makeFirstRunWizard(progress: WizardProgress = { step: 'prerequisites' }
   return {
     getProgress: vi.fn().mockResolvedValue(progress),
     recordStep: vi.fn().mockResolvedValue(undefined),
-    complete: vi.fn(),
+    complete: vi.fn().mockResolvedValue(undefined),
   } as Partial<FirstRunWizardService> as FirstRunWizardService;
 }
 

--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -7,6 +7,7 @@ import { SafeStorageUnavailableError } from '../services/AwsProfileService.js';
 import type { ElectronStoreService } from '../services/ElectronStoreService.js';
 import type { BootstrapService, BootstrapResult } from '../services/BootstrapService.js';
 import type { IamCheckService, IamCheckResult } from '../services/IamCheckService.js';
+import type { FirstRunWizardService, WizardProgress } from '../services/FirstRunWizardService.js';
 
 const SATISFIED_REPORT: PrerequisitesReport = {
   terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
@@ -62,6 +63,15 @@ function makeIamCheck(result: IamCheckResult = { status: 'passed' }): IamCheckSe
   return { checkPermissions: vi.fn().mockResolvedValue(result) } as Partial<IamCheckService> as IamCheckService;
 }
 
+/** Build a FirstRunWizardService stub whose `getProgress()` resolves to the given progress. */
+function makeFirstRunWizard(progress: WizardProgress = { step: 'prerequisites' }): FirstRunWizardService {
+  return {
+    getProgress: vi.fn().mockResolvedValue(progress),
+    recordStep: vi.fn().mockResolvedValue(undefined),
+    complete: vi.fn(),
+  } as Partial<FirstRunWizardService> as FirstRunWizardService;
+}
+
 /** Builds a `WizardController` with default stubs for any dependency the caller doesn't override. */
 function makeController(overrides: {
   prerequisites?: PrerequisiteService;
@@ -69,6 +79,7 @@ function makeController(overrides: {
   store?: ElectronStoreService;
   bootstrap?: BootstrapService;
   iamCheck?: IamCheckService;
+  firstRunWizard?: FirstRunWizardService;
 } = {}): WizardController {
   return new WizardController(
     overrides.prerequisites ?? makePrerequisites(),
@@ -76,6 +87,7 @@ function makeController(overrides: {
     overrides.store ?? makeStore(),
     overrides.bootstrap ?? makeBootstrap(),
     overrides.iamCheck ?? makeIamCheck(),
+    overrides.firstRunWizard ?? makeFirstRunWizard(),
   );
 }
 
@@ -131,6 +143,21 @@ describe('WizardController', () => {
     it('should register simulateIamPermissions on the "wizard.iam.simulate" IPC channel', () => {
       const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.simulateIamPermissions);
       expect(pattern).toEqual(['wizard.iam.simulate']);
+    });
+
+    it('should register getProgress on the "wizard.progress.get" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.getProgress);
+      expect(pattern).toEqual(['wizard.progress.get']);
+    });
+
+    it('should register saveProgress on the "wizard.progress.save" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.saveProgress);
+      expect(pattern).toEqual(['wizard.progress.save']);
+    });
+
+    it('should register complete on the "wizard.complete" IPC channel', () => {
+      const pattern = Reflect.getMetadata(PATTERN_METADATA_KEY, WizardController.prototype.complete);
+      expect(pattern).toEqual(['wizard.complete']);
     });
   });
 
@@ -375,6 +402,38 @@ describe('WizardController', () => {
       const result = await makeController({ iamCheck }).simulateIamPermissions();
 
       expect(result).toEqual({ status: 'warning', message: 'access denied' });
+    });
+  });
+
+  describe('getProgress', () => {
+    it('should return the progress produced by FirstRunWizardService.getProgress', async () => {
+      const firstRunWizard = makeFirstRunWizard({ step: 'bootstrap' });
+
+      const result = await makeController({ firstRunWizard }).getProgress();
+
+      expect(result).toEqual({ step: 'bootstrap' });
+    });
+  });
+
+  describe('saveProgress', () => {
+    it('should delegate to FirstRunWizardService.recordStep with the given step', async () => {
+      const firstRunWizard = makeFirstRunWizard();
+
+      await makeController({ firstRunWizard }).saveProgress({ step: 'credentials' });
+
+      expect(firstRunWizard.recordStep).toHaveBeenCalledWith('credentials');
+    });
+  });
+
+  describe('complete', () => {
+    it('should call FirstRunWizardService.complete and return the resulting wizard state', async () => {
+      const firstRunWizard = makeFirstRunWizard();
+      const store = makeStore({ wizardCompleted: true, activeCloud: 'aws' });
+
+      const result = await makeController({ firstRunWizard, store }).complete();
+
+      expect(firstRunWizard.complete).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ wizardCompleted: true, activeCloud: 'aws', aws: undefined });
     });
   });
 });

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '../services/AwsProfileService.js';
 import { BootstrapService, type BootstrapResult } from '../services/BootstrapService.js';
 import { IamCheckService, type IamCheckResult } from '../services/IamCheckService.js';
+import { FirstRunWizardService, type WizardProgress, type WizardStepName } from '../services/FirstRunWizardService.js';
 import { ElectronStoreService } from '../services/ElectronStoreService.js';
 
 /** Payload accepted by {@link WizardController.bootstrapStateBucket}. */
@@ -23,6 +24,11 @@ export interface BootstrapLockTableInput {
 /** Payload accepted by {@link WizardController.bootstrapTfvarsBucket}. */
 export interface BootstrapTfvarsBucketInput {
   bucketName: string;
+}
+
+/** Payload accepted by {@link WizardController.saveProgress}. */
+export interface SaveWizardProgressInput {
+  step: WizardStepName;
 }
 
 /**
@@ -69,6 +75,7 @@ export class WizardController {
     private readonly store: ElectronStoreService,
     private readonly bootstrap: BootstrapService,
     private readonly iamCheck: IamCheckService,
+    private readonly firstRunWizard: FirstRunWizardService,
   ) {}
 
   /**
@@ -89,8 +96,8 @@ export class WizardController {
    * still override this via `window.gsd.__test.mock('wizard.state.get', ...)`
    * — the mock registry is consulted before this controller is ever reached.
    * This is a plain read of `ElectronStoreService` either way — the fuller
-   * resumable step-progress state (`userData/state.json`, owned by
-   * `FirstRunWizardService`) lands in a later PR of this epic.
+   * resumable step-progress state (`userData/wizard-state.json`, owned by
+   * `FirstRunWizardService`) is exposed separately via `wizard.progress.get`.
    */
   @MessagePattern('wizard.state.get')
   getState(): WizardState {
@@ -195,5 +202,28 @@ export class WizardController {
   @MessagePattern('wizard.iam.simulate')
   simulateIamPermissions(): Promise<IamCheckResult> {
     return this.iamCheck.checkPermissions();
+  }
+
+  /** Returns the last-recorded resumable step, defaulting to `prerequisites` if unset/corrupt. */
+  @MessagePattern('wizard.progress.get')
+  getProgress(): Promise<WizardProgress> {
+    return this.firstRunWizard.getProgress();
+  }
+
+  /** Persists the current step so the wizard resumes here if the app closes before completion. */
+  @MessagePattern('wizard.progress.save')
+  saveProgress(@Payload() body: SaveWizardProgressInput): Promise<void> {
+    return this.firstRunWizard.recordStep(body.step);
+  }
+
+  /**
+   * Marks the wizard complete (`wizardCompleted: true`), which is what
+   * actually gates the app router past the wizard. Returns the same shape as
+   * {@link getState} so the renderer can update its local state directly.
+   */
+  @MessagePattern('wizard.complete')
+  complete(): WizardState {
+    this.firstRunWizard.complete();
+    return this.getState();
   }
 }

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -222,8 +222,8 @@ export class WizardController {
    * {@link getState} so the renderer can update its local state directly.
    */
   @MessagePattern('wizard.complete')
-  complete(): WizardState {
-    this.firstRunWizard.complete();
+  async complete(): Promise<WizardState> {
+    await this.firstRunWizard.complete();
     return this.getState();
   }
 }

--- a/app/packages/desktop-main/src/modules/wizard.module.ts
+++ b/app/packages/desktop-main/src/modules/wizard.module.ts
@@ -3,6 +3,7 @@ import { PrerequisiteService } from '../services/PrerequisiteService.js';
 import { AwsProfileService } from '../services/AwsProfileService.js';
 import { BootstrapService } from '../services/BootstrapService.js';
 import { IamCheckService } from '../services/IamCheckService.js';
+import { FirstRunWizardService } from '../services/FirstRunWizardService.js';
 import { ElectronStoreModule } from './electron-store.module.js';
 
 /**
@@ -12,12 +13,13 @@ import { ElectronStoreModule } from './electron-store.module.js';
  * `controllers` array; the IPC controller is wired directly into
  * `AppModule.controllers` alongside every other controller in this codebase.
  * Imports `ElectronStoreModule` so `AwsProfileService`/`BootstrapService`/
- * `IamCheckService` can inject `SafeStorageService`/`ElectronStoreService`
- * for the pasted-credentials and credential-resolution flows.
+ * `IamCheckService`/`FirstRunWizardService` can inject
+ * `SafeStorageService`/`ElectronStoreService` for the pasted-credentials,
+ * credential-resolution, and wizard-completion flows.
  */
 @Module({
   imports: [ElectronStoreModule],
-  providers: [PrerequisiteService, AwsProfileService, BootstrapService, IamCheckService],
-  exports: [PrerequisiteService, AwsProfileService, BootstrapService, IamCheckService],
+  providers: [PrerequisiteService, AwsProfileService, BootstrapService, IamCheckService, FirstRunWizardService],
+  exports: [PrerequisiteService, AwsProfileService, BootstrapService, IamCheckService, FirstRunWizardService],
 })
 export class WizardModule {}

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.test.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.test.ts
@@ -1,0 +1,96 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { FirstRunWizardService } from './FirstRunWizardService.js';
+import type { ElectronStoreService } from './ElectronStoreService.js';
+
+/** Test-only subclass exposing the protected `stateFilePath` seam so tests can point it at a real scratch directory. */
+class TestableFirstRunWizardService extends FirstRunWizardService {
+  public override stateFilePath(): string {
+    return super.stateFilePath();
+  }
+}
+
+/** Build an `ElectronStoreService` stub whose `set()` calls are observable. */
+function makeStore(): ElectronStoreService {
+  return { set: vi.fn() } as Partial<ElectronStoreService> as ElectronStoreService;
+}
+
+describe('FirstRunWizardService', () => {
+  let scratchDir: string;
+  let statePath: string;
+  let service: TestableFirstRunWizardService;
+  let store: ElectronStoreService;
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), 'wizard-state-test-'));
+    statePath = join(scratchDir, 'nested', 'wizard-state.json');
+    mkdirSync(join(scratchDir, 'nested'));
+    store = makeStore();
+    service = new TestableFirstRunWizardService(store);
+    vi.spyOn(service, 'stateFilePath').mockReturnValue(statePath);
+  });
+
+  afterEach(() => {
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  describe('getProgress', () => {
+    it('should default to the prerequisites step when the state file does not exist', async () => {
+      const progress = await service.getProgress();
+      expect(progress).toEqual({ step: 'prerequisites' });
+    });
+
+    it('should return the persisted step when the state file holds a recognized step name', async () => {
+      writeFileSync(statePath, JSON.stringify({ step: 'bootstrap' }), 'utf-8');
+      const progress = await service.getProgress();
+      expect(progress).toEqual({ step: 'bootstrap' });
+    });
+
+    it('should default to the prerequisites step when the file contains invalid JSON', async () => {
+      writeFileSync(statePath, 'not valid json{{{', 'utf-8');
+      const progress = await service.getProgress();
+      expect(progress).toEqual({ step: 'prerequisites' });
+    });
+
+    it('should default to the prerequisites step when the file holds an unrecognized step name', async () => {
+      writeFileSync(statePath, JSON.stringify({ step: 'some-future-step' }), 'utf-8');
+      const progress = await service.getProgress();
+      expect(progress).toEqual({ step: 'prerequisites' });
+    });
+  });
+
+  describe('recordStep', () => {
+    it('should write the given step to the state file, creating parent directories as needed', async () => {
+      expect(existsSync(statePath)).toBe(false);
+
+      await service.recordStep('credentials');
+
+      expect(JSON.parse(readFileSync(statePath, 'utf-8'))).toEqual({ step: 'credentials' });
+    });
+
+    it('should be resumable: a later getProgress reflects the step recorded by an earlier recordStep', async () => {
+      await service.recordStep('terraform-init');
+
+      const progress = await service.getProgress();
+
+      expect(progress).toEqual({ step: 'terraform-init' });
+    });
+
+    it('should overwrite a previously recorded step', async () => {
+      await service.recordStep('pick-cloud');
+      await service.recordStep('bootstrap');
+
+      expect(await service.getProgress()).toEqual({ step: 'bootstrap' });
+    });
+  });
+
+  describe('complete', () => {
+    it('should set wizardCompleted to true in ElectronStoreService', () => {
+      service.complete();
+      expect(store.set).toHaveBeenCalledWith('wizardCompleted', true);
+    });
+  });
+});

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.test.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.test.ts
@@ -18,7 +18,8 @@ class TestableFirstRunWizardService extends FirstRunWizardService {
 
 /** Build an `ElectronStoreService` stub whose `set()` calls are observable. */
 function makeStore(): ElectronStoreService {
-  return { set: vi.fn() } as Partial<ElectronStoreService> as ElectronStoreService;
+  const store: Partial<ElectronStoreService> = { set: vi.fn() };
+  return store as ElectronStoreService;
 }
 
 describe('FirstRunWizardService', () => {
@@ -72,6 +73,14 @@ describe('FirstRunWizardService', () => {
       await service.recordStep('credentials');
 
       expect(JSON.parse(readFileSync(statePath, 'utf-8'))).toEqual({ step: 'credentials' });
+    });
+
+    it('should reject a step name outside WIZARD_STEPS rather than writing it', async () => {
+      // The IPC boundary erases WizardStepName's compile-time guarantee, so a
+      // malformed/unexpected value must be rejected explicitly at runtime.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberately bypassing the compile-time type to exercise the runtime guard
+      await expect(service.recordStep('not-a-real-step' as any)).rejects.toThrow('Unsupported wizard step');
+      expect(existsSync(statePath)).toBe(false);
     });
 
     it('should be resumable: a later getProgress reflects the step recorded by an earlier recordStep', async () => {

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.test.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.test.ts
@@ -6,10 +6,13 @@ import { tmpdir } from 'os';
 import { FirstRunWizardService } from './FirstRunWizardService.js';
 import type { ElectronStoreService } from './ElectronStoreService.js';
 
-/** Test-only subclass exposing the protected `stateFilePath` seam so tests can point it at a real scratch directory. */
+/** Test-only subclass exposing the protected `stateFilePath`/`userDataPath` seams so tests can point them at a real scratch directory or assert their composition directly. */
 class TestableFirstRunWizardService extends FirstRunWizardService {
   public override stateFilePath(): string {
     return super.stateFilePath();
+  }
+  public override userDataPath(): string {
+    return super.userDataPath();
   }
 }
 
@@ -88,9 +91,38 @@ describe('FirstRunWizardService', () => {
   });
 
   describe('complete', () => {
-    it('should set wizardCompleted to true in ElectronStoreService', () => {
-      service.complete();
+    it('should set wizardCompleted to true in ElectronStoreService', async () => {
+      await service.complete();
       expect(store.set).toHaveBeenCalledWith('wizardCompleted', true);
+    });
+
+    it('should clear the resume file, so a future re-entry (e.g. Settings Reconfigure) starts clean', async () => {
+      await service.recordStep('terraform-init');
+      expect(existsSync(statePath)).toBe(true);
+
+      await service.complete();
+
+      expect(existsSync(statePath)).toBe(false);
+      expect(await service.getProgress()).toEqual({ step: 'prerequisites' });
+    });
+
+    it('should not throw when the resume file never existed', async () => {
+      await expect(service.complete()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('userDataPath', () => {
+    it('should compose stateFilePath from userDataPath and the fixed filename', () => {
+      const unspiedService = new TestableFirstRunWizardService(makeStore());
+      vi.spyOn(unspiedService, 'userDataPath').mockReturnValue('/fake/userData');
+
+      expect(unspiedService.stateFilePath()).toBe(join('/fake/userData', 'wizard-state.json'));
+    });
+
+    it('should fall back to a hyveon-wizard-namespaced OS temp directory outside Electron', () => {
+      const unspiedService = new TestableFirstRunWizardService(makeStore());
+
+      expect(unspiedService.userDataPath()).toBe(join(tmpdir(), 'hyveon-wizard'));
     });
   });
 });

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.ts
@@ -46,8 +46,18 @@ export class FirstRunWizardService {
     }
   }
 
-  /** Persists `step` so the wizard resumes here if the app is closed and reopened before completion. */
+  /**
+   * Persists `step` so the wizard resumes here if the app is closed and
+   * reopened before completion. `step`'s compile-time type is erased at the
+   * IPC boundary — the caller in `WizardController.saveProgress` is only as
+   * trustworthy as the renderer process — so this validates against
+   * {@link WIZARD_STEPS} before writing, rather than silently persisting an
+   * unsupported value that `getProgress` would later discard anyway.
+   */
   async recordStep(step: WizardStepName): Promise<void> {
+    if (!WIZARD_STEPS.includes(step)) {
+      throw new Error(`Unsupported wizard step: ${String(step)}`);
+    }
     const path = this.stateFilePath();
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, JSON.stringify({ step } satisfies WizardProgress), 'utf-8');
@@ -61,10 +71,19 @@ export class FirstRunWizardService {
    * "Reconfigure" flow) would call `getProgress()` and jump straight back
    * to whatever step was last recorded (often `terraform-init`), skipping
    * every earlier step with none of their answers rehydrated.
+   *
+   * @remarks
+   * The resume file is removed *before* setting the completion flag, not
+   * after: if `rm` were to throw with the flag already set, the caller
+   * would see `complete()` reject (a failure) while the store already says
+   * the wizard is done — a future launch would then skip the wizard
+   * entirely despite the IPC call having reported failure, with the stale
+   * resume file still lingering. Removing first means any failure here
+   * leaves the wizard genuinely incomplete, matching what the caller was told.
    */
   async complete(): Promise<void> {
-    this.store.set('wizardCompleted', true);
     await rm(this.stateFilePath(), { force: true });
+    this.store.set('wizardCompleted', true);
   }
 
   /** Absolute path to the resumable state file. Extracted as a seam so tests can `vi.spyOn` it. */

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { createRequire } from 'module';
@@ -56,11 +56,15 @@ export class FirstRunWizardService {
   /**
    * Marks the wizard complete. Setting `wizardCompleted: true` in
    * `ElectronStoreService` is what actually gates the app router past the
-   * wizard (`WizardController.getState`) — the resume file is left in place
-   * but becomes irrelevant once this flag is set.
+   * wizard (`WizardController.getState`). Also clears the resume file —
+   * without this, a future re-entry into the wizard (e.g. #211's Settings
+   * "Reconfigure" flow) would call `getProgress()` and jump straight back
+   * to whatever step was last recorded (often `terraform-init`), skipping
+   * every earlier step with none of their answers rehydrated.
    */
-  complete(): void {
+  async complete(): Promise<void> {
     this.store.set('wizardCompleted', true);
+    await rm(this.stateFilePath(), { force: true });
   }
 
   /** Absolute path to the resumable state file. Extracted as a seam so tests can `vi.spyOn` it. */
@@ -70,10 +74,17 @@ export class FirstRunWizardService {
 
   /**
    * Resolves a writable per-user directory: the Electron `userData` path
-   * when running inside Electron, or the OS temp directory in
+   * when running inside Electron, or a namespaced OS temp subdirectory in
    * plain-Node/test contexts. Mirrors `ConfigService.readUserDataPath`'s
    * dynamic-require seam so this module has no static `electron` import
    * (which would fail to resolve outside an Electron process).
+   *
+   * @remarks
+   * The tmpdir fallback is namespaced under `hyveon-wizard` (mirroring
+   * `ConfigService.getRunsDir`'s `hyveon-runs` prefix) rather than writing
+   * directly into the bare, world-writable `tmpdir()` root — an unnamespaced
+   * path there is guessable and poses a symlink-pre-creation risk, since
+   * `writeFile` follows symlinks.
    */
   protected userDataPath(): string {
     if (process.versions['electron']) {
@@ -85,6 +96,6 @@ export class FirstRunWizardService {
         // Fall through to the tmpdir fallback below.
       }
     }
-    return tmpdir();
+    return join(tmpdir(), 'hyveon-wizard');
   }
 }

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.ts
@@ -3,18 +3,11 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { createRequire } from 'module';
+import { WIZARD_STEPS, type WizardStep } from '@hyveon/shared';
 import { ElectronStoreService } from './ElectronStoreService.js';
 
-/**
- * Ordered first-run wizard steps whose progress is resumable via
- * `userData/wizard-state.json`. Mirrors `WIZARD_STEPS` in
- * `@hyveon/web`'s `wizard.utils.ts` — that file is the renderer's source of
- * truth for step ordering; keep this list in sync with it.
- */
-export const WIZARD_STEP_NAMES = ['prerequisites', 'pick-cloud', 'credentials', 'bootstrap', 'terraform-init'] as const;
-
-/** A single first-run wizard step name (see {@link WIZARD_STEP_NAMES}). */
-export type WizardStepName = (typeof WIZARD_STEP_NAMES)[number];
+/** A single first-run wizard step name (see {@link WIZARD_STEPS} in `@hyveon/shared`, the single source of truth for step ordering). */
+export type WizardStepName = WizardStep;
 
 /** Resumable wizard progress persisted to `userData/wizard-state.json`. */
 export interface WizardProgress {
@@ -44,7 +37,7 @@ export class FirstRunWizardService {
     try {
       const raw = await readFile(this.stateFilePath(), 'utf-8');
       const parsed = JSON.parse(raw) as Partial<WizardProgress>;
-      if (parsed.step && (WIZARD_STEP_NAMES as readonly string[]).includes(parsed.step)) {
+      if (parsed.step && WIZARD_STEPS.includes(parsed.step)) {
         return { step: parsed.step };
       }
       return DEFAULT_PROGRESS;

--- a/app/packages/desktop-main/src/services/FirstRunWizardService.ts
+++ b/app/packages/desktop-main/src/services/FirstRunWizardService.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@nestjs/common';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { createRequire } from 'module';
+import { ElectronStoreService } from './ElectronStoreService.js';
+
+/**
+ * Ordered first-run wizard steps whose progress is resumable via
+ * `userData/wizard-state.json`. Mirrors `WIZARD_STEPS` in
+ * `@hyveon/web`'s `wizard.utils.ts` — that file is the renderer's source of
+ * truth for step ordering; keep this list in sync with it.
+ */
+export const WIZARD_STEP_NAMES = ['prerequisites', 'pick-cloud', 'credentials', 'bootstrap', 'terraform-init'] as const;
+
+/** A single first-run wizard step name (see {@link WIZARD_STEP_NAMES}). */
+export type WizardStepName = (typeof WIZARD_STEP_NAMES)[number];
+
+/** Resumable wizard progress persisted to `userData/wizard-state.json`. */
+export interface WizardProgress {
+  step: WizardStepName;
+}
+
+/** Progress returned when the state file is missing, unreadable, or holds an unrecognized step name. */
+const DEFAULT_PROGRESS: WizardProgress = { step: 'prerequisites' };
+
+/**
+ * Owns the first-run wizard's resumable step-progress file (see
+ * `openspec/changes/add-first-run-wizard/design.md` decision 4 —
+ * `userData/state.json`, corrupt/missing state starts at step 1). Durable
+ * *answers* (`activeCloud`, `aws`, `wizardCompleted`) live in
+ * `ElectronStoreService`; this service only tracks *which step* the
+ * operator was on, so a wizard interrupted mid-flow resumes there instead of
+ * restarting from scratch. A broken or missing resume file must never lock
+ * an operator out of the wizard — every read degrades to
+ * {@link DEFAULT_PROGRESS} rather than throwing.
+ */
+@Injectable()
+export class FirstRunWizardService {
+  constructor(private readonly store: ElectronStoreService) {}
+
+  /** Reads the last-recorded step, defaulting to `prerequisites` when the file is missing, unreadable, or corrupt. */
+  async getProgress(): Promise<WizardProgress> {
+    try {
+      const raw = await readFile(this.stateFilePath(), 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<WizardProgress>;
+      if (parsed.step && (WIZARD_STEP_NAMES as readonly string[]).includes(parsed.step)) {
+        return { step: parsed.step };
+      }
+      return DEFAULT_PROGRESS;
+    } catch {
+      return DEFAULT_PROGRESS;
+    }
+  }
+
+  /** Persists `step` so the wizard resumes here if the app is closed and reopened before completion. */
+  async recordStep(step: WizardStepName): Promise<void> {
+    const path = this.stateFilePath();
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify({ step } satisfies WizardProgress), 'utf-8');
+  }
+
+  /**
+   * Marks the wizard complete. Setting `wizardCompleted: true` in
+   * `ElectronStoreService` is what actually gates the app router past the
+   * wizard (`WizardController.getState`) — the resume file is left in place
+   * but becomes irrelevant once this flag is set.
+   */
+  complete(): void {
+    this.store.set('wizardCompleted', true);
+  }
+
+  /** Absolute path to the resumable state file. Extracted as a seam so tests can `vi.spyOn` it. */
+  protected stateFilePath(): string {
+    return join(this.userDataPath(), 'wizard-state.json');
+  }
+
+  /**
+   * Resolves a writable per-user directory: the Electron `userData` path
+   * when running inside Electron, or the OS temp directory in
+   * plain-Node/test contexts. Mirrors `ConfigService.readUserDataPath`'s
+   * dynamic-require seam so this module has no static `electron` import
+   * (which would fail to resolve outside an Electron process).
+   */
+  protected userDataPath(): string {
+    if (process.versions['electron']) {
+      try {
+        const require = createRequire(import.meta.url);
+        const electron = require('electron') as { app: { getPath(name: string): string } };
+        return electron.app.getPath('userData');
+      } catch {
+        // Fall through to the tmpdir fallback below.
+      }
+    }
+    return tmpdir();
+  }
+}

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -1019,6 +1019,19 @@ export interface IamCheckResult {
   message?: string;
 }
 
+/** A single first-run wizard step name, in wizard order. Mirrors `WIZARD_STEPS` in `@hyveon/web`'s `wizard.utils.ts`. */
+export type WizardStepName = 'prerequisites' | 'pick-cloud' | 'credentials' | 'bootstrap' | 'terraform-init';
+
+/** Resumable wizard progress persisted to `userData/wizard-state.json`. */
+export interface WizardProgress {
+  step: WizardStepName;
+}
+
+/** Payload accepted by {@link GsdWizardApi.saveProgress}. */
+export interface SaveWizardProgressInput {
+  step: WizardStepName;
+}
+
 /** Per-resource outcome of a `wizard.bootstrap.*` call. */
 export type BootstrapResourceStatus = 'created' | 'exists' | 'failed';
 
@@ -1072,6 +1085,15 @@ export interface GsdWizardApi {
    * `iam:SimulatePrincipalPolicy`, batched). Never grants permissions.
    */
   simulateIamPermissions: () => Promise<IamCheckResult>;
+  /** Returns the last-recorded resumable step, defaulting to `prerequisites` if unset/corrupt. */
+  getProgress: () => Promise<WizardProgress>;
+  /** Persists the current step so the wizard resumes here if the app closes before completion. */
+  saveProgress: (input: SaveWizardProgressInput) => Promise<void>;
+  /**
+   * Marks the wizard complete (`wizardCompleted: true`), gating the app
+   * router past the wizard. Returns the same shape as {@link getState}.
+   */
+  complete: () => Promise<WizardState>;
 }
 
 /**

--- a/app/packages/desktop-preload/src/preload.ts
+++ b/app/packages/desktop-preload/src/preload.ts
@@ -82,6 +82,8 @@ import type {
   BootstrapTfvarsBucketInput,
   BootstrapResult,
   IamCheckResult,
+  WizardProgress,
+  SaveWizardProgressInput,
 } from './gsd-api.js';
 
 /** Fixed side-channel `TerraformController.init` pushes streamed output on. */
@@ -614,6 +616,9 @@ const api: GsdApi = {
     bootstrapTfvarsBucket: (input: BootstrapTfvarsBucketInput) =>
       invoke<BootstrapResult>('wizard.bootstrap.tfvarsBucket', input),
     simulateIamPermissions: () => invoke<IamCheckResult>('wizard.iam.simulate'),
+    getProgress: () => invoke<WizardProgress>('wizard.progress.get'),
+    saveProgress: (input: SaveWizardProgressInput) => invoke<void>('wizard.progress.save', input),
+    complete: () => invoke<WizardState>('wizard.complete'),
   },
 
   drift: {

--- a/app/packages/shared/src/index.ts
+++ b/app/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from './types.js';
 export * from './errors.js';
 export * from './terraformVersion.js';
 export * from './iamPolicy.js';
+export * from './wizardSteps.js';
 export * from './tfvars.js';
 export * from './gameServerValidator.js';
 export * from './gamesWrite.js';

--- a/app/packages/shared/src/wizardSteps.ts
+++ b/app/packages/shared/src/wizardSteps.ts
@@ -1,0 +1,12 @@
+/**
+ * Ordered first-run wizard steps — the single source of truth for step
+ * ordering, shared between the renderer (`@hyveon/web`'s `wizard.utils.ts`,
+ * which needs the runtime array for step-index navigation) and the main
+ * process (`FirstRunWizardService`, which needs it to validate a step name
+ * resumed from `userData/wizard-state.json`). Keeping one copy here avoids
+ * the two packages drifting out of sync.
+ */
+export const WIZARD_STEPS = ['prerequisites', 'pick-cloud', 'credentials', 'bootstrap', 'terraform-init'] as const;
+
+/** A single step in {@link WIZARD_STEPS}. */
+export type WizardStep = (typeof WIZARD_STEPS)[number];

--- a/app/packages/web/src/app.component.tsx
+++ b/app/packages/web/src/app.component.tsx
@@ -60,7 +60,10 @@ function useWizardCompleted(): boolean | null {
  * Gates the whole app behind the first-run wizard: while
  * `wizardCompleted` is `false`, renders only {@link FirstRunWizard} (no
  * routing, no polling providers — there's nothing to poll before AWS is
- * bootstrapped). Once complete, renders the routed dashboard shell:
+ * bootstrapped). The wizard's terraform-init step calls `onComplete` once
+ * `wizard.complete` succeeds, which flips this component straight to the
+ * routed dashboard shell below without waiting on another `wizard.state.get`
+ * round-trip. Once complete, renders the routed dashboard shell:
  *   - `/` → Dashboard (game cards + panels)
  *   - `/costs` → Cost analysis placeholder
  *   - `/discord` → Discord settings placeholder
@@ -74,10 +77,15 @@ function useWizardCompleted(): boolean | null {
  *   - `/audit` → Audit log
  */
 export default function App() {
-  const wizardCompleted = useWizardCompleted();
+  const fetchedWizardCompleted = useWizardCompleted();
+  // Set directly once the wizard's Finish step succeeds, rather than
+  // re-fetching `wizard.state.get` — the wizard already knows the outcome,
+  // and this avoids a redundant IPC round-trip on the completion path.
+  const [wizardJustCompleted, setWizardJustCompleted] = useState(false);
+  const wizardCompleted = wizardJustCompleted ? true : fetchedWizardCompleted;
 
   if (wizardCompleted === null) return null;
-  if (!wizardCompleted) return <FirstRunWizard />;
+  if (!wizardCompleted) return <FirstRunWizard onComplete={() => setWizardJustCompleted(true)} />;
 
   return (
     <PollingProvider>

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -13,6 +13,12 @@ const gsdMock = {
     bootstrapLockTable: vi.fn(),
     bootstrapTfvarsBucket: vi.fn(),
     simulateIamPermissions: vi.fn(),
+    getProgress: vi.fn(),
+    saveProgress: vi.fn(),
+    complete: vi.fn(),
+  },
+  terraform: {
+    init: vi.fn(),
   },
 };
 vi.stubGlobal('gsd', gsdMock);
@@ -43,6 +49,13 @@ beforeEach(() => {
   gsdMock.wizard.bootstrapLockTable.mockReset();
   gsdMock.wizard.bootstrapTfvarsBucket.mockReset();
   gsdMock.wizard.simulateIamPermissions.mockReset();
+  // Defaulted (not just reset) so the shell's resume-on-mount/per-step-save
+  // effects — present on every render regardless of which step a test cares
+  // about — never throw on an unmocked call.
+  gsdMock.wizard.getProgress.mockReset().mockResolvedValue({ step: 'prerequisites' });
+  gsdMock.wizard.saveProgress.mockReset().mockResolvedValue(undefined);
+  gsdMock.wizard.complete.mockReset();
+  gsdMock.terraform.init.mockReset();
 });
 
 /** Advances the wizard from the (satisfied) prerequisites step to pick-cloud. */
@@ -70,6 +83,21 @@ async function advanceToBootstrap(): Promise<void> {
   await userEvent.selectOptions(select, 'default');
   await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
   await screen.findByLabelText('Terraform state bucket name');
+}
+
+/** Advances the wizard all the way to the terraform-init step, with all three bootstrap resources succeeding. */
+async function advanceToTerraformInit(): Promise<void> {
+  gsdMock.wizard.bootstrapStateBucket.mockResolvedValue({ status: 'created' });
+  gsdMock.wizard.bootstrapLockTable.mockResolvedValue({ status: 'created' });
+  gsdMock.wizard.bootstrapTfvarsBucket.mockResolvedValue({ status: 'created' });
+  gsdMock.terraform.init.mockImplementation(async function* () {
+    // No chunks needed by default — individual tests override this.
+  });
+  await advanceToBootstrap();
+  await userEvent.click(screen.getByRole('button', { name: /bootstrap aws resources/i }));
+  await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
+  await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+  await screen.findByRole('button', { name: /finish setup/i });
 }
 
 afterEach(() => {
@@ -365,6 +393,80 @@ describe('FirstRunWizard', () => {
 
       expect(await screen.findByText(/some permissions are missing/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+    });
+  });
+
+  describe('terraform-init step', () => {
+    it('should hide the shared Next button once on the terraform-init step', async () => {
+      await advanceToTerraformInit();
+
+      expect(screen.queryByRole('button', { name: /^next$/i })).not.toBeInTheDocument();
+    });
+
+    it('should call wizard.complete and invoke onComplete when Finish setup succeeds', async () => {
+      gsdMock.terraform.init.mockImplementation(async function* () {
+        yield { stream: 'stdout', line: 'Terraform has been successfully initialized!' };
+      });
+      gsdMock.wizard.complete.mockResolvedValue({ wizardCompleted: true });
+      gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+      const onComplete = vi.fn();
+      render(<FirstRunWizard onComplete={onComplete} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/choose the cloud provider/i);
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/choose the aws credentials/i);
+      await userEvent.selectOptions(await screen.findByLabelText('Profile'), 'default');
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByLabelText('Terraform state bucket name');
+      gsdMock.wizard.bootstrapStateBucket.mockResolvedValue({ status: 'created' });
+      gsdMock.wizard.bootstrapLockTable.mockResolvedValue({ status: 'created' });
+      gsdMock.wizard.bootstrapTfvarsBucket.mockResolvedValue({ status: 'created' });
+      await userEvent.click(screen.getByRole('button', { name: /bootstrap aws resources/i }));
+      await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+
+      await userEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+      await waitFor(() => expect(gsdMock.wizard.complete).toHaveBeenCalledTimes(1));
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should persist each step via wizard.progress.save as the wizard advances', async () => {
+      await advanceToBootstrap();
+
+      await waitFor(() => expect(gsdMock.wizard.saveProgress).toHaveBeenCalledWith({ step: 'bootstrap' }));
+    });
+  });
+
+  describe('resume-on-mount', () => {
+    it('should start at prerequisites when wizard.progress.get resolves to the prerequisites step', async () => {
+      gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+      gsdMock.wizard.getProgress.mockResolvedValue({ step: 'prerequisites' });
+
+      render(<FirstRunWizard />);
+
+      expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
+    });
+
+    it('should jump straight to the recorded step when wizard.progress.get resolves to a later step', async () => {
+      gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+      gsdMock.wizard.listAwsProfiles.mockResolvedValue(SAMPLE_PROFILES);
+      gsdMock.wizard.getProgress.mockResolvedValue({ step: 'credentials' });
+
+      render(<FirstRunWizard />);
+
+      expect(await screen.findByText(/choose the aws credentials/i)).toBeInTheDocument();
+    });
+
+    it('should stay on prerequisites when wizard.progress.get rejects', async () => {
+      gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+      gsdMock.wizard.getProgress.mockRejectedValue(new Error('state file corrupt'));
+
+      render(<FirstRunWizard />);
+
+      expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
     });
   });
 });

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -228,6 +228,26 @@ describe('FirstRunWizard', () => {
       expect(screen.getByLabelText('Region')).toHaveValue('us-east-1');
     });
 
+    it('should keep Next disabled when the selected profile has no region configured', async () => {
+      await advanceToCredentials();
+      const select = await screen.findByLabelText('Profile');
+
+      await userEvent.selectOptions(select, 'personal');
+
+      expect(screen.getByLabelText('Region')).toHaveValue('');
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+    });
+
+    it('should enable Next once an operator fills in a region for a profile that had none', async () => {
+      await advanceToCredentials();
+      const select = await screen.findByLabelText('Profile');
+      await userEvent.selectOptions(select, 'personal');
+
+      await userEvent.type(screen.getByLabelText('Region'), 'eu-central-1');
+
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+    });
+
     it('should persist the selected profile and region via wizard.state.save when advancing', async () => {
       gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false, aws: { profile: 'default', region: 'us-east-1' } });
       await advanceToCredentials();
@@ -264,17 +284,31 @@ describe('FirstRunWizard', () => {
       await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
       await userEvent.type(screen.getByLabelText('Access key ID'), 'AKID');
       await userEvent.type(screen.getByLabelText('Secret access key'), 'SECRET');
+      await userEvent.type(screen.getByLabelText('Region'), 'us-west-2');
       await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
 
       await waitFor(() =>
         expect(gsdMock.wizard.saveCredentials).toHaveBeenCalledWith({
           accessKeyId: 'AKID',
           secretAccessKey: 'SECRET',
-          region: undefined,
+          region: 'us-west-2',
         }),
       );
       expect(await screen.findByText(/saved as profile "gsd-pasted"/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+    });
+
+    it('should keep Next disabled after a successful paste save when no region was entered', async () => {
+      gsdMock.wizard.saveCredentials.mockResolvedValue({ profileName: 'gsd-pasted' });
+      await advanceToCredentials();
+
+      await userEvent.click(screen.getByRole('button', { name: /paste keys instead/i }));
+      await userEvent.type(screen.getByLabelText('Access key ID'), 'AKID');
+      await userEvent.type(screen.getByLabelText('Secret access key'), 'SECRET');
+      await userEvent.click(screen.getByRole('button', { name: /save credentials/i }));
+
+      expect(await screen.findByText(/saved as profile "gsd-pasted"/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
     });
 
     it('should invalidate a successful paste save when a field is edited afterward, disabling Next again', async () => {
@@ -467,6 +501,36 @@ describe('FirstRunWizard', () => {
       render(<FirstRunWizard />);
 
       expect(await screen.findByText('Found v1.9.0')).toBeInTheDocument();
+    });
+
+    it('should clamp a recorded terraform-init step down to bootstrap, rather than auto-running terraform init on mount', async () => {
+      gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+      gsdMock.wizard.getProgress.mockResolvedValue({ step: 'terraform-init' });
+
+      render(<FirstRunWizard />);
+
+      expect(await screen.findByLabelText('Terraform state bucket name')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /finish setup/i })).not.toBeInTheDocument();
+      expect(gsdMock.terraform.init).not.toHaveBeenCalled();
+    });
+
+    it('should not save progress before the resume check has settled, so a fast render never clobbers a resumed step', async () => {
+      gsdMock.wizard.checkPrereqs.mockResolvedValue(SATISFIED);
+      let resolveProgress!: (value: { step: 'credentials' }) => void;
+      gsdMock.wizard.getProgress.mockReturnValue(
+        new Promise((resolve) => {
+          resolveProgress = resolve;
+        }),
+      );
+
+      render(<FirstRunWizard />);
+      // The mount-time synchronous pass must not have persisted anything yet —
+      // resume hasn't settled, so writing here could race the pending read.
+      expect(gsdMock.wizard.saveProgress).not.toHaveBeenCalled();
+
+      resolveProgress({ step: 'credentials' });
+
+      await waitFor(() => expect(gsdMock.wizard.saveProgress).toHaveBeenCalledWith({ step: 'credentials' }));
     });
   });
 });

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -6,10 +6,11 @@
  * before the dashboard is usable, so `app.component.tsx` renders it in place
  * of the normal routed layout while `wizardCompleted` is `false`.
  *
- * Prerequisites, pick-cloud, credentials, and bootstrap exist so far; a
- * later PR in this epic (#210) appends the terraform-init step.
+ * Five steps: prerequisites, pick-cloud, credentials, bootstrap, and
+ * terraform-init (the last of which runs `terraform init` and finishes the
+ * wizard).
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { AwsProfileSummary, IamCheckResult, PrerequisitesReport, TerraformInitConfig } from '@hyveon/desktop-preload';
 import { Button } from '@/components/ui/button.component';
 import { PrerequisitesStep } from './prerequisites-step.component.js';
@@ -84,20 +85,45 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
 
   const step = WIZARD_STEPS[stepIndex];
 
+  // Guards the save-progress effect below until the resume-on-mount effect
+  // has settled (resolved or rejected) — otherwise the two effects race to
+  // read/write the same file, and if the save ever won that race it would
+  // clobber a real resumed step back down to `prerequisites`. Also used to
+  // clamp how far resume is allowed to jump (see the resume effect).
+  const resumeSettledRef = useRef(false);
+
   // Resume-on-mount: jump straight to the last-recorded step instead of
   // always restarting at `prerequisites`, so closing and reopening the app
   // mid-flow doesn't lose progress. Any failure (including a missing IPC
-  // bridge) leaves `stepIndex` at its default of 0.
+  // bridge) leaves `stepIndex` at its default of 0. Clamped to at most the
+  // `bootstrap` step: none of this component's answer state (region,
+  // selected profile, bootstrap resource names) is itself persisted or
+  // rehydrated here, only which step the operator was on — jumping straight
+  // into `terraform-init` would run `terraform init` on mount against a
+  // `backendConfig` built from blank defaults. Resuming to `bootstrap` is
+  // safe by comparison: its IPC calls read the region from the credentials
+  // step's already-persisted `wizard.state.save` call, and worst case the
+  // operator just has to re-click "Bootstrap AWS resources".
   useEffect(() => {
-    if (!window.gsd) return;
+    if (!window.gsd) {
+      resumeSettledRef.current = true;
+      return;
+    }
     window.gsd.wizard
       .getProgress()
       .then((progress) => {
         const index = WIZARD_STEPS.indexOf(progress.step);
-        if (index > 0) setStepIndex(index);
+        const maxResumableIndex = WIZARD_STEPS.indexOf('bootstrap');
+        if (index > 0) setStepIndex(Math.min(index, maxResumableIndex));
+        // Set in the same microtask as the `setStepIndex` call above (rather
+        // than a subsequent `.finally()`), so this is guaranteed true before
+        // React processes that batched update — the save effect's re-run
+        // must never observe `resumeSettledRef.current` still `false`.
+        resumeSettledRef.current = true;
       })
       .catch(() => {
         // Best-effort — starting over at step 1 is always a safe fallback.
+        resumeSettledRef.current = true;
       });
   }, []);
 
@@ -105,8 +131,10 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
   // jump above) so `userData/wizard-state.json` stays in sync with what the
   // operator is actually looking at. Fire-and-forget: a failed write here
   // shouldn't block the wizard, only degrade resume on the next launch.
+  // Gated on `resumeSettledRef` so this can never race the resume effect's
+  // own read of the same file (see that effect's comment).
   useEffect(() => {
-    if (!window.gsd) return;
+    if (!window.gsd || !resumeSettledRef.current) return;
     window.gsd.wizard.saveProgress({ step }).catch(() => {});
   }, [step]);
 
@@ -268,8 +296,14 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
     (resource) => resourceStatuses[resource] === 'created' || resourceStatuses[resource] === 'exists',
   );
 
+  // Requires a non-empty region in both modes — `backendConfig.region` (fed
+  // to `terraform init` on the final step) is computed straight from
+  // `region`/`pasteRegion` with no other fallback, so an empty region here
+  // would otherwise silently reach `terraform init` as `-backend-config=region=`.
   const credentialsChosen =
-    credentialMode === 'profile' ? selectedProfileName !== '' : pastedProfileName !== null;
+    credentialMode === 'profile'
+      ? selectedProfileName !== '' && region !== ''
+      : pastedProfileName !== null && pasteRegion !== '';
 
   const advanceDisabled =
     step === 'prerequisites'

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -9,13 +9,14 @@
  * Prerequisites, pick-cloud, credentials, and bootstrap exist so far; a
  * later PR in this epic (#210) appends the terraform-init step.
  */
-import { useCallback, useEffect, useState } from 'react';
-import type { AwsProfileSummary, IamCheckResult, PrerequisitesReport } from '@hyveon/desktop-preload';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AwsProfileSummary, IamCheckResult, PrerequisitesReport, TerraformInitConfig } from '@hyveon/desktop-preload';
 import { Button } from '@/components/ui/button.component';
 import { PrerequisitesStep } from './prerequisites-step.component.js';
 import { PickCloudStep, type CloudOption } from './pick-cloud-step.component.js';
 import { CredentialsStep, type CredentialMode, type PasteField } from './credentials-step.component.js';
 import { BootstrapStep } from './bootstrap-step.component.js';
+import { TerraformInitStep } from './terraform-init-step.component.js';
 import {
   WIZARD_STEPS,
   arePrerequisitesSatisfied,
@@ -31,7 +32,14 @@ const STEP_LABELS: Record<WizardStep, string> = {
   'pick-cloud': 'Choose your cloud',
   credentials: 'AWS credentials',
   bootstrap: 'Bootstrap AWS resources',
+  'terraform-init': 'Finish setup',
 };
+
+/** Props for {@link FirstRunWizard}. */
+export interface FirstRunWizardProps {
+  /** Invoked once the terraform-init step's `wizard.complete` call succeeds. */
+  onComplete?: () => void;
+}
 
 /**
  * Self-contained first-run wizard: owns its own step index, the
@@ -40,7 +48,7 @@ const STEP_LABELS: Record<WizardStep, string> = {
  * paste form). Fetches an initial prerequisites check and AWS profile list
  * on mount.
  */
-export function FirstRunWizard() {
+export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
   const [stepIndex, setStepIndex] = useState(0);
   const [report, setReport] = useState<PrerequisitesReport | null>(null);
   const [checking, setChecking] = useState(false);
@@ -75,6 +83,45 @@ export function FirstRunWizard() {
   const [iamError, setIamError] = useState<string | null>(null);
 
   const step = WIZARD_STEPS[stepIndex];
+
+  // Resume-on-mount: jump straight to the last-recorded step instead of
+  // always restarting at `prerequisites`, so closing and reopening the app
+  // mid-flow doesn't lose progress. Any failure (including a missing IPC
+  // bridge) leaves `stepIndex` at its default of 0.
+  useEffect(() => {
+    if (!window.gsd) return;
+    window.gsd.wizard
+      .getProgress()
+      .then((progress) => {
+        const index = WIZARD_STEPS.indexOf(progress.step);
+        if (index > 0) setStepIndex(index);
+      })
+      .catch(() => {
+        // Best-effort — starting over at step 1 is always a safe fallback.
+      });
+  }, []);
+
+  // Persists the current step on every change (including the resume-on-mount
+  // jump above) so `userData/wizard-state.json` stays in sync with what the
+  // operator is actually looking at. Fire-and-forget: a failed write here
+  // shouldn't block the wizard, only degrade resume on the next launch.
+  useEffect(() => {
+    if (!window.gsd) return;
+    window.gsd.wizard.saveProgress({ step }).catch(() => {});
+  }, [step]);
+
+  const backendConfig = useMemo<TerraformInitConfig>(
+    () => ({
+      bucket: resourceNames.stateBucket,
+      region: credentialMode === 'profile' ? region : pasteRegion,
+      dynamodbTable: resourceNames.lockTable,
+    }),
+    [resourceNames, credentialMode, region, pasteRegion],
+  );
+
+  function handleFinished() {
+    onComplete?.();
+  }
 
   const checkPrereqs = useCallback(async () => {
     if (!window.gsd) {
@@ -346,14 +393,19 @@ export function FirstRunWizard() {
             onRunIamCheck={runIamCheck}
           />
         )}
+        {step === 'terraform-init' && (
+          <TerraformInitStep backendConfig={backendConfig} onFinished={handleFinished} />
+        )}
 
         <div className="flex justify-between">
           <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0 || saving}>
             Back
           </Button>
-          <Button type="button" onClick={goNext} disabled={advanceDisabled || saving}>
-            Next
-          </Button>
+          {step !== 'terraform-init' && (
+            <Button type="button" onClick={goNext} disabled={advanceDisabled || saving}>
+              Next
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.test.tsx
@@ -67,8 +67,8 @@ describe('TerraformInitStep', () => {
   });
 
   it('should keep Finish setup disabled while the run is in progress', () => {
+    // eslint-disable-next-line require-yield -- generator intentionally never yields/returns to keep the run "in progress" for this test
     gsdMock.terraform.init.mockImplementation(async function* () {
-      // Never yields or completes within this test.
       await new Promise(() => {});
     });
 
@@ -93,6 +93,7 @@ describe('TerraformInitStep', () => {
 
   it('should re-invoke gsd.terraform.init when Retry is clicked after a failure', async () => {
     gsdMock.terraform.init
+      // eslint-disable-next-line require-yield -- generator must throw before yielding to simulate a failed first attempt
       .mockImplementationOnce(async function* () {
         throw new Error('first attempt failed');
       })

--- a/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { TerraformInitConfig } from '@hyveon/desktop-preload';
+
+const gsdMock = {
+  terraform: {
+    init: vi.fn(),
+  },
+  wizard: {
+    complete: vi.fn(),
+  },
+};
+vi.stubGlobal('gsd', gsdMock);
+
+import { TerraformInitStep } from './terraform-init-step.component.js';
+
+const BACKEND_CONFIG: TerraformInitConfig = {
+  bucket: 'hyveon-tfstate',
+  region: 'us-east-1',
+  dynamodbTable: 'hyveon-tflock',
+};
+
+beforeEach(() => {
+  gsdMock.terraform.init.mockReset();
+  gsdMock.wizard.complete.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TerraformInitStep', () => {
+  it('should stream chunks from gsd.terraform.init and render them', async () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      yield { stream: 'stdout', line: 'Initializing the backend...' };
+      yield { stream: 'stdout', line: 'Terraform has been successfully initialized!' };
+    });
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={vi.fn()} />);
+
+    expect(await screen.findByText('Initializing the backend...')).toBeInTheDocument();
+    expect(await screen.findByText('Terraform has been successfully initialized!')).toBeInTheDocument();
+    expect(gsdMock.terraform.init).toHaveBeenCalledWith(BACKEND_CONFIG, expect.any(AbortSignal));
+  });
+
+  it('should render ANSI-colored output', async () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      yield { stream: 'stdout', line: '\x1b[32msuccess\x1b[0m' };
+    });
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={vi.fn()} />);
+
+    const el = await screen.findByText('success');
+    expect(el).toHaveClass('text-[var(--color-green)]');
+  });
+
+  it('should enable Finish setup only once the run exits successfully', async () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      yield { stream: 'stdout', line: 'Terraform has been successfully initialized!' };
+    });
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+    expect(screen.getByText(/terraform init complete/i)).toBeInTheDocument();
+  });
+
+  it('should keep Finish setup disabled while the run is in progress', () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      // Never yields or completes within this test.
+      await new Promise(() => {});
+    });
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /finish setup/i })).toBeDisabled();
+  });
+
+  it('should show captured log and a retry affordance when the run fails (non-zero exit)', async () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      yield { stream: 'stderr', line: 'Error: failed to read backend config' };
+      throw new Error('terraform init exited with code 1');
+    });
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={vi.fn()} />);
+
+    expect(await screen.findByText('Error: failed to read backend config')).toBeInTheDocument();
+    expect(await screen.findByRole('alert')).toHaveTextContent('terraform init exited with code 1');
+    expect(screen.getByRole('button', { name: /finish setup/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('should re-invoke gsd.terraform.init when Retry is clicked after a failure', async () => {
+    gsdMock.terraform.init
+      .mockImplementationOnce(async function* () {
+        throw new Error('first attempt failed');
+      })
+      .mockImplementationOnce(async function* () {
+        yield { stream: 'stdout', line: 'Terraform has been successfully initialized!' };
+      });
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={vi.fn()} />);
+    await screen.findByRole('alert');
+
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+    expect(gsdMock.terraform.init).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call wizard.complete and onFinished when Finish setup is clicked', async () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      yield { stream: 'stdout', line: 'Terraform has been successfully initialized!' };
+    });
+    gsdMock.wizard.complete.mockResolvedValue({ wizardCompleted: true });
+    const onFinished = vi.fn();
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={onFinished} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+
+    await userEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+    await waitFor(() => expect(gsdMock.wizard.complete).toHaveBeenCalledTimes(1));
+    expect(onFinished).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show an error and not call onFinished when wizard.complete fails', async () => {
+    gsdMock.terraform.init.mockImplementation(async function* () {
+      yield { stream: 'stdout', line: 'Terraform has been successfully initialized!' };
+    });
+    gsdMock.wizard.complete.mockRejectedValue(new Error('disk full'));
+    const onFinished = vi.fn();
+
+    render(<TerraformInitStep backendConfig={BACKEND_CONFIG} onFinished={onFinished} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+
+    await userEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+    expect(await screen.findByText('disk full')).toBeInTheDocument();
+    expect(onFinished).not.toHaveBeenCalled();
+  });
+});

--- a/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react';
+import { CheckCircle2, Loader2, RotateCcw } from 'lucide-react';
+import type { TerraformInitConfig, TerraformRunChunk } from '@hyveon/desktop-preload';
+import { Button } from '@/components/ui/button.component';
+import { AnsiLogViewer } from '../ansi-log-viewer.component.js';
+
+/** Terminal state of a single `terraform init` attempt. */
+export type TerraformInitStatus = 'running' | 'success' | 'failed';
+
+/** Props for {@link TerraformInitStep}. */
+export interface TerraformInitStepProps {
+  /**
+   * Backend bucket/region/lock-table config, derived from the bootstrap
+   * step's resource names and the credentials step's region. Callers should
+   * memoize this so its identity is stable across renders — a new object
+   * reference on every render would re-trigger the streaming effect below.
+   */
+  backendConfig: TerraformInitConfig;
+  /** Invoked once `terraform init` succeeds and `wizard.complete` has been persisted. */
+  onFinished: () => void;
+}
+
+/**
+ * Fifth and final step of the first-run wizard (#210): runs `terraform init`
+ * against the backend resources bootstrapped in the previous step, streaming
+ * its ANSI-colored output live via the already-shipped `gsd.terraform.init`
+ * async iterable (reusing `AnsiLogViewer` rather than adding a second
+ * streaming side-channel, per design.md decision 2). The Finish button
+ * enables only once the run exits successfully (the iterable completes
+ * without throwing); a failed run shows the captured log plus a Retry
+ * button rather than silently blocking wizard progression.
+ */
+export function TerraformInitStep({ backendConfig, onFinished }: TerraformInitStepProps) {
+  const [chunks, setChunks] = useState<TerraformRunChunk[]>([]);
+  const [status, setStatus] = useState<TerraformInitStatus>('running');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!window.gsd) {
+      setStatus('failed');
+      setErrorMessage('IPC bridge (window.gsd) is not available in this context.');
+      return;
+    }
+    setChunks([]);
+    setStatus('running');
+    setErrorMessage(null);
+    const controller = new AbortController();
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        for await (const chunk of window.gsd!.terraform.init(backendConfig, controller.signal)) {
+          if (cancelled) break;
+          setChunks((prev) => [...prev, chunk]);
+        }
+        if (!cancelled) setStatus('success');
+      } catch (err) {
+        if (!cancelled) {
+          setStatus('failed');
+          setErrorMessage(err instanceof Error ? err.message : 'terraform init failed.');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [backendConfig, attempt]);
+
+  const retry = useCallback(() => setAttempt((a) => a + 1), []);
+
+  async function finish() {
+    if (!window.gsd) {
+      setFinishError('IPC bridge (window.gsd) is not available in this context.');
+      return;
+    }
+    setFinishing(true);
+    setFinishError(null);
+    try {
+      await window.gsd.wizard.complete();
+      onFinished();
+    } catch (err) {
+      setFinishError(err instanceof Error ? err.message : 'Failed to finish setup.');
+    } finally {
+      setFinishing(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Running <code>terraform init</code> against your new backend. This wires Terraform up to the state bucket
+        and lock table from the previous step.
+      </p>
+
+      <AnsiLogViewer chunks={chunks} emptyMessage="Waiting for terraform init output…" />
+
+      {status === 'running' && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Running…
+        </div>
+      )}
+
+      {status === 'failed' && (
+        <div className="space-y-2">
+          <p role="alert" className="text-sm text-[var(--color-red)]">
+            {errorMessage ?? 'terraform init failed — see the log above for details.'}
+          </p>
+          <Button type="button" variant="outline" onClick={retry}>
+            <RotateCcw className="size-4" />
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {status === 'success' && (
+        <div className="flex items-center gap-2 text-sm text-[var(--color-green)]">
+          <CheckCircle2 className="size-4" />
+          terraform init complete.
+        </div>
+      )}
+
+      {finishError && (
+        <p role="alert" className="text-sm text-[var(--color-red)]">
+          {finishError}
+        </p>
+      )}
+
+      <Button type="button" onClick={() => void finish()} disabled={status !== 'success' || finishing}>
+        {finishing && <Loader2 className="animate-spin" />}
+        Finish setup
+      </Button>
+    </div>
+  );
+}

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
@@ -7,10 +7,9 @@
 import type { PrerequisitesReport } from '@hyveon/desktop-preload';
 
 /**
- * Ordered wizard steps. Later PRs in this epic (#210 terraform-init) append
- * to this array.
+ * Ordered wizard steps.
  */
-export const WIZARD_STEPS = ['prerequisites', 'pick-cloud', 'credentials', 'bootstrap'] as const;
+export const WIZARD_STEPS = ['prerequisites', 'pick-cloud', 'credentials', 'bootstrap', 'terraform-init'] as const;
 
 /** A single step in {@link WIZARD_STEPS}. */
 export type WizardStep = (typeof WIZARD_STEPS)[number];

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
@@ -5,14 +5,9 @@
  * component.
  */
 import type { PrerequisitesReport } from '@hyveon/desktop-preload';
+import { WIZARD_STEPS, type WizardStep } from '@hyveon/shared';
 
-/**
- * Ordered wizard steps.
- */
-export const WIZARD_STEPS = ['prerequisites', 'pick-cloud', 'credentials', 'bootstrap', 'terraform-init'] as const;
-
-/** A single step in {@link WIZARD_STEPS}. */
-export type WizardStep = (typeof WIZARD_STEPS)[number];
+export { WIZARD_STEPS, type WizardStep };
 
 /** Operating systems the prerequisites step can tailor install instructions for. */
 export type DetectedOs = 'macos' | 'windows' | 'linux' | 'unknown';

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -101,12 +101,12 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 11. Issue #210 — wizard step: terraform init with live log (web, after #200/#203/#205)
 
-- [ ] 11.1 Create worktree: `git worktree add .worktrees/claude/issue-210-wizard-terraform-init -b claude/issue-210-wizard-terraform-init`
-- [ ] 11.2 Implement `terraform-init-step.component.tsx` consuming the existing `gsd.terraform.init` async iterable with `backendConfig` (bucket/region/dynamodbTable) from the bootstrap step; live log pane with ANSI rendering (reuse the existing ANSI-to-HTML helper)
-- [ ] 11.3 Completion button enabled only on exit code 0; non-zero exit shows error UI with the captured log and a retry affordance
-- [ ] 11.4 Wire wizard completion: `FirstRunWizardService` persists answers + `wizardCompleted: true` (`wizard.complete` IPC) and the app navigates to the dashboard; resumable `userData/state.json` updated per step
-- [ ] 11.5 RTL/jsdom specs (mock the async iterable): streaming render, ANSI colors, enable-on-zero, error + retry on non-zero, completion invoking `wizard.complete`; service specs for state.json resume + corrupt-file fallback
-- [ ] 11.6 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 11.1 Create worktree: `git worktree add .worktrees/claude/issue-210-wizard-terraform-init -b claude/issue-210-wizard-terraform-init`
+- [x] 11.2 Implement `terraform-init-step.component.tsx` consuming the existing `gsd.terraform.init` async iterable with `backendConfig` (bucket/region/dynamodbTable) from the bootstrap step; live log pane with ANSI rendering (reuse the existing ANSI-to-HTML helper)
+- [x] 11.3 Completion button enabled only on exit code 0; non-zero exit shows error UI with the captured log and a retry affordance
+- [x] 11.4 Wire wizard completion: `FirstRunWizardService` persists answers + `wizardCompleted: true` (`wizard.complete` IPC) and the app navigates to the dashboard; resumable `userData/wizard-state.json` updated per step
+- [x] 11.5 RTL/jsdom specs (mock the async iterable): streaming render, ANSI colors, enable-on-zero, error + retry on non-zero, completion invoking `wizard.complete`; service specs for state.json resume + corrupt-file fallback
+- [x] 11.6 Verify `npm run app:test` and `npm run app:lint` pass
 - [ ] 11.7 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #210`
 
 ## 12. Issue #211 — Reconfigure entry point in Settings (web)

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -107,7 +107,7 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 - [x] 11.4 Wire wizard completion: `FirstRunWizardService` persists answers + `wizardCompleted: true` (`wizard.complete` IPC) and the app navigates to the dashboard; resumable `userData/wizard-state.json` updated per step
 - [x] 11.5 RTL/jsdom specs (mock the async iterable): streaming render, ANSI colors, enable-on-zero, error + retry on non-zero, completion invoking `wizard.complete`; service specs for state.json resume + corrupt-file fallback
 - [x] 11.6 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 11.7 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #210`
+- [x] 11.7 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #210` — [PR #329](https://github.com/CoderCoco/Hyveon/pull/329)
 
 ## 12. Issue #211 — Reconfigure entry point in Settings (web)
 


### PR DESCRIPTION
Closes #210

## Summary
- `terraform-init-step.component.tsx` — the wizard's fifth and final step. Consumes the existing `gsd.terraform.init(backendConfig, signal)` async iterable, rendering live ANSI-colored output via the already-shipped `AnsiLogViewer`. "Finish setup" enables only once the run completes without throwing; a failed run (the iterable throwing) shows the captured log plus a Retry button that re-invokes `gsd.terraform.init`.
- `FirstRunWizardService` (new) — owns the wizard's resumable step-progress file (`userData/wizard-state.json`, per design.md decision 4), mirroring `ConfigService.readUserDataPath`'s Electron-vs-tmpdir seam. `getProgress()`/`recordStep()` degrade to the `prerequisites` step on any missing/corrupt/unrecognized state rather than throwing; `complete()` sets `wizardCompleted: true` in `ElectronStoreService`.
- Three new `wizard.*` IPC patterns + preload/`gsd-api.ts` mirrors: `wizard.progress.get`, `wizard.progress.save`, `wizard.complete`.
- Wizard shell: adds `terraform-init` as the fifth `WIZARD_STEPS` entry, computes `backendConfig` (bucket/region/dynamodbTable) from the bootstrap step's resource names + the credentials step's region, resumes to the last-recorded step on mount, and persists the current step via `wizard.progress.save` on every step change (fire-and-forget — a failed write only degrades resume, never blocks the wizard). The shared Next button is hidden on this last step in favor of the step's own Finish button.
- `app.component.tsx`: `FirstRunWizard` now takes an `onComplete` prop; `App` flips straight to the routed dashboard once it fires, without waiting on another `wizard.state.get` round-trip.

## Test plan
- [x] `npm run app:test` — 2080/2080 passing (new: `FirstRunWizardService` specs covering resume + corrupt-file fallback + `complete`; `WizardController` pattern-registration/delegation specs for the three new channels; `TerraformInitStep` RTL specs — streaming render, ANSI colors, enable-on-success, error+retry, Finish calling `wizard.complete`; wizard-shell specs for hiding Next on the last step, per-step `wizard.progress.save`, end-to-end Finish → `onComplete`, and resume-on-mount incl. a rejected `getProgress` degrading safely)
- [x] `npm run app:lint` — 0 errors (3 pre-existing warnings in an untouched file)
- [x] `npm run app:build` (full `tsc -b` + `vite build`) — clean
