### PR TITLE
feat(web): Reconfigure entry point in Settings

### DIFF
--- a/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.test.ts
@@ -38,7 +38,12 @@ function makeAwsProfiles(profiles: AwsProfileSummary[] = SAMPLE_PROFILES): AwsPr
  * real service, instead of always returning a fixed value.
  */
 function makeStore(
-  seed: { wizardCompleted?: boolean; activeCloud?: 'aws'; aws?: { profile?: string; region?: string } } = {},
+  seed: {
+    wizardCompleted?: boolean;
+    activeCloud?: 'aws';
+    aws?: { profile?: string; region?: string };
+    bootstrap?: { stateBucket: string; lockTable: string; tfvarsBucket: string };
+  } = {},
 ): ElectronStoreService {
   const data: Record<string, unknown> = { ...seed };
   return {
@@ -256,6 +261,13 @@ describe('WizardController', () => {
         aws: { profile: 'default', region: 'us-east-1' },
       });
     });
+
+    it('should include the stored bootstrap resource names when present', () => {
+      const bootstrap = { stateBucket: 'my-tfstate', lockTable: 'my-tflock', tfvarsBucket: 'my-tfvars' };
+      const store = makeStore({ wizardCompleted: true, bootstrap });
+      const result = makeController({ store }).getState();
+      expect(result).toEqual({ wizardCompleted: true, activeCloud: undefined, bootstrap });
+    });
   });
 
   describe('saveState', () => {
@@ -319,6 +331,30 @@ describe('WizardController', () => {
       controller.saveState({});
 
       expect(store.set).not.toHaveBeenCalled();
+    });
+
+    it('should persist the bootstrap resource names and return them in the updated state', () => {
+      const store = makeStore({ wizardCompleted: true });
+      const controller = makeController({ store });
+      const bootstrap = { stateBucket: 'my-tfstate', lockTable: 'my-tflock', tfvarsBucket: 'my-tfvars' };
+
+      const result = controller.saveState({ bootstrap });
+
+      expect(store.set).toHaveBeenCalledWith('bootstrap', bootstrap);
+      expect(result).toEqual({ wizardCompleted: true, activeCloud: undefined, aws: undefined, bootstrap });
+    });
+
+    it('should replace the stored bootstrap resource names wholesale rather than merging', () => {
+      const store = makeStore({
+        wizardCompleted: true,
+        bootstrap: { stateBucket: 'old-tfstate', lockTable: 'old-tflock', tfvarsBucket: 'old-tfvars' },
+      });
+      const controller = makeController({ store });
+      const bootstrap = { stateBucket: 'new-tfstate', lockTable: 'old-tflock', tfvarsBucket: 'old-tfvars' };
+
+      controller.saveState({ bootstrap });
+
+      expect(store.set).toHaveBeenCalledWith('bootstrap', bootstrap);
     });
   });
 

--- a/app/packages/desktop-main/src/controllers/wizard.controller.ts
+++ b/app/packages/desktop-main/src/controllers/wizard.controller.ts
@@ -44,6 +44,19 @@ export interface WizardAwsChoice {
   region?: string;
 }
 
+/**
+ * The bootstrap step's last-submitted resource names, as persisted to
+ * `ElectronStoreService.bootstrap`. Names are operator-editable, so Settings'
+ * Reconfigure flow (#211) needs these on record to run `terraform init`
+ * against the resources that actually exist rather than
+ * `defaultBootstrapResourceNames()`.
+ */
+export interface WizardBootstrapNames {
+  stateBucket: string;
+  lockTable: string;
+  tfvarsBucket: string;
+}
+
 /** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
 export interface WizardState {
   wizardCompleted: boolean;
@@ -51,12 +64,15 @@ export interface WizardState {
   activeCloud?: 'aws';
   /** The credential source chosen in the credentials step (#192), if any. */
   aws?: WizardAwsChoice;
+  /** The bootstrap step's last-submitted resource names, if any. */
+  bootstrap?: WizardBootstrapNames;
 }
 
 /** Payload accepted by {@link WizardController.saveState}. */
 export interface SaveWizardStateInput {
   activeCloud?: 'aws';
   aws?: WizardAwsChoice;
+  bootstrap?: WizardBootstrapNames;
 }
 
 /**
@@ -103,18 +119,26 @@ export class WizardController {
   getState(): WizardState {
     const stored = this.store.get('wizardCompleted');
     const wizardCompleted = stored !== undefined ? stored : this.isTestMode();
-    return { wizardCompleted, activeCloud: this.store.get('activeCloud'), aws: this.store.get('aws') };
+    return {
+      wizardCompleted,
+      activeCloud: this.store.get('activeCloud'),
+      aws: this.store.get('aws'),
+      bootstrap: this.store.get('bootstrap'),
+    };
   }
 
   /**
    * Persists wizard-flow answers into `ElectronStoreService`. `activeCloud`
-   * (pick-cloud step) and `aws` (credentials step, #192 — the chosen
-   * profile/region) exist so far; later PRs in this epic extend the payload
-   * as more steps need to durably save a choice. `aws` is merged onto any
-   * existing stored value so unrelated fields (e.g. encrypted key material
-   * written by other flows) survive. Returns the same shape as
-   * {@link getState} so the renderer can update its local state directly
-   * from the response.
+   * (pick-cloud step), `aws` (credentials step, #192 — the chosen
+   * profile/region), and `bootstrap` (bootstrap step, #211 — the last
+   * submitted resource names) exist so far; later PRs in this epic extend
+   * the payload as more steps need to durably save a choice. `aws` is merged
+   * onto any existing stored value so unrelated fields (e.g. encrypted key
+   * material written by other flows) survive; `bootstrap` is replaced
+   * wholesale since a caller always submits all three resource names
+   * together (there's no partial-name concept to preserve). Returns the same
+   * shape as {@link getState} so the renderer can update its local state
+   * directly from the response.
    */
   @MessagePattern('wizard.state.save')
   saveState(@Payload() body: SaveWizardStateInput): WizardState {
@@ -130,6 +154,9 @@ export class WizardController {
     if (body.aws !== undefined) {
       const current = this.store.get('aws') ?? {};
       this.store.set('aws', { ...current, ...body.aws });
+    }
+    if (body.bootstrap !== undefined) {
+      this.store.set('bootstrap', body.bootstrap);
     }
     return this.getState();
   }

--- a/app/packages/desktop-main/src/services/ElectronStoreService.ts
+++ b/app/packages/desktop-main/src/services/ElectronStoreService.ts
@@ -52,6 +52,19 @@ export interface AppStoreSchema {
     secretAccessKey?: string;
   };
   /**
+   * The bootstrap step's resource names, as last submitted (whether that
+   * submission succeeded or is still `pending`/`failed` for a given
+   * resource — this just records what the operator asked for). Names are
+   * operator-editable, so without this the Settings "Reconfigure" flow
+   * (#211) would have no way to rehydrate a non-default name and would run
+   * `terraform init` against the wrong bucket/table.
+   */
+  bootstrap?: {
+    stateBucket: string;
+    lockTable: string;
+    tfvarsBucket: string;
+  };
+  /**
    * Pasted-credentials profiles from the wizard's credentials step, keyed by
    * profile name (default `gsd-pasted` — see `AwsProfileService`). Separate
    * from `aws` above, which holds the *selected* profile/region for the

--- a/app/packages/desktop-preload/src/gsd-api.ts
+++ b/app/packages/desktop-preload/src/gsd-api.ts
@@ -1106,6 +1106,18 @@ export interface WizardAwsChoice {
   region?: string;
 }
 
+/**
+ * The bootstrap step's last-submitted resource names, as persisted to
+ * `ElectronStoreService.bootstrap`. Needed so Settings' Reconfigure flow
+ * (#211) can rehydrate a non-default name — resource names are
+ * operator-editable — before running `terraform init`.
+ */
+export interface WizardBootstrapNames {
+  stateBucket: string;
+  lockTable: string;
+  tfvarsBucket: string;
+}
+
 /** Minimal wizard-progress summary the renderer needs to decide whether to show the wizard route. */
 export interface WizardState {
   wizardCompleted: boolean;
@@ -1113,12 +1125,15 @@ export interface WizardState {
   activeCloud?: 'aws';
   /** The credential source chosen in the credentials step (#192), if any. */
   aws?: WizardAwsChoice;
+  /** The bootstrap step's last-submitted resource names, if any. */
+  bootstrap?: WizardBootstrapNames;
 }
 
 /** Payload accepted by {@link GsdWizardApi.saveState}. */
 export interface SaveWizardStateInput {
   activeCloud?: 'aws';
   aws?: WizardAwsChoice;
+  bootstrap?: WizardBootstrapNames;
 }
 
 /** Drift detection: compares declared (tfvars) config against deployed (tfstate) state. */

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.test.tsx
@@ -42,7 +42,12 @@ const SAMPLE_PROFILES: AwsProfileSummary[] = [
 
 beforeEach(() => {
   gsdMock.wizard.checkPrereqs.mockReset();
-  gsdMock.wizard.saveState.mockReset();
+  // Defaulted (not just reset): the bootstrap step's fire-and-forget
+  // `wizard.state.save({ bootstrap })` call (see `goNext`) uses a bare
+  // `.catch()`, not an awaited try/catch, so an unmocked call (returning
+  // `undefined`) would throw synchronously. Individual tests still override
+  // this with a more specific resolved value where the response shape matters.
+  gsdMock.wizard.saveState.mockReset().mockResolvedValue({ wizardCompleted: false });
   gsdMock.wizard.listAwsProfiles.mockReset().mockResolvedValue(SAMPLE_PROFILES);
   gsdMock.wizard.saveCredentials.mockReset();
   gsdMock.wizard.bootstrapStateBucket.mockReset();
@@ -427,6 +432,24 @@ describe('FirstRunWizard', () => {
 
       expect(await screen.findByText(/some permissions are missing/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+    });
+
+    it('should persist the current resource names via wizard.state.save when advancing past bootstrap', async () => {
+      gsdMock.wizard.bootstrapStateBucket.mockResolvedValue({ status: 'created' });
+      gsdMock.wizard.bootstrapLockTable.mockResolvedValue({ status: 'created' });
+      gsdMock.wizard.bootstrapTfvarsBucket.mockResolvedValue({ status: 'created' });
+      gsdMock.wizard.saveState.mockResolvedValue({ wizardCompleted: false });
+      await advanceToBootstrap();
+      await userEvent.click(screen.getByRole('button', { name: /bootstrap aws resources/i }));
+      await waitFor(() => expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled());
+
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+      await waitFor(() =>
+        expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({
+          bootstrap: { stateBucket: 'hyveon-tfstate', lockTable: 'hyveon-tflock', tfvarsBucket: 'hyveon-tfvars' },
+        }),
+      );
     });
   });
 

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -11,6 +11,7 @@
  * wizard).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2 } from 'lucide-react';
 import type { AwsProfileSummary, IamCheckResult, PrerequisitesReport, TerraformInitConfig } from '@hyveon/desktop-preload';
 import { Button } from '@/components/ui/button.component';
 import { PrerequisitesStep } from './prerequisites-step.component.js';
@@ -22,6 +23,7 @@ import {
   WIZARD_STEPS,
   arePrerequisitesSatisfied,
   defaultBootstrapResourceNames,
+  reconfigureSteps,
   type BootstrapResourceKey,
   type BootstrapResourceState,
   type WizardStep,
@@ -36,10 +38,33 @@ const STEP_LABELS: Record<WizardStep, string> = {
   'terraform-init': 'Finish setup',
 };
 
+/**
+ * Steps in this list start collapsed to a completed summary (with an Edit
+ * affordance) in `mode: 'reconfigure'`, since Settings only offers
+ * Reconfigure once the wizard has already completed once — every one of
+ * these already has a real answer on record. `terraform-init` is excluded:
+ * it has no standalone "answer" to summarize, and reaching it is itself the
+ * explicit re-run the operator asked for by clicking through to it.
+ */
+const RECONFIGURE_PRE_COMPLETED_STEPS: WizardStep[] = ['pick-cloud', 'credentials', 'bootstrap'];
+
 /** Props for {@link FirstRunWizard}. */
 export interface FirstRunWizardProps {
   /** Invoked once the terraform-init step's `wizard.complete` call succeeds. */
   onComplete?: () => void;
+  /**
+   * `'first-run'` (default) gates the whole app and runs all five steps,
+   * persisting `pick-cloud`/`credentials` answers immediately via
+   * `wizard.state.save` as the operator advances. `'reconfigure'` (#211,
+   * launched from Settings) skips `prerequisites`, pre-marks
+   * `pick-cloud`/`credentials`/`bootstrap` as completed with a per-step Edit
+   * affordance, and buffers any edited answers locally — committed in one
+   * `wizard.state.save` call right before `wizard.complete` runs, so a
+   * mid-flow Cancel writes nothing.
+   */
+  mode?: 'first-run' | 'reconfigure';
+  /** `'reconfigure'`-only: invoked when the operator cancels without finishing. Never called in `'first-run'` mode. */
+  onCancel?: () => void;
 }
 
 /**
@@ -49,7 +74,8 @@ export interface FirstRunWizardProps {
  * paste form). Fetches an initial prerequisites check and AWS profile list
  * on mount.
  */
-export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
+export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: FirstRunWizardProps = {}) {
+  const steps = useMemo(() => (mode === 'reconfigure' ? reconfigureSteps() : WIZARD_STEPS), [mode]);
   const [stepIndex, setStepIndex] = useState(0);
   const [report, setReport] = useState<PrerequisitesReport | null>(null);
   const [checking, setChecking] = useState(false);
@@ -83,7 +109,14 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
   const [iamChecking, setIamChecking] = useState(false);
   const [iamError, setIamError] = useState<string | null>(null);
 
-  const step = WIZARD_STEPS[stepIndex];
+  // Reconfigure-only: which pre-completed steps are collapsed to a summary
+  // (present in the set) vs. expanded for editing (removed from it). Empty —
+  // and unused — in `'first-run'` mode.
+  const [completedSteps, setCompletedSteps] = useState<Set<WizardStep>>(
+    () => new Set(mode === 'reconfigure' ? RECONFIGURE_PRE_COMPLETED_STEPS : []),
+  );
+
+  const step = steps[stepIndex];
 
   // Guards the save-progress effect below until the resume-on-mount effect
   // has settled (resolved or rejected) — otherwise the two effects race to
@@ -104,7 +137,14 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
   // safe by comparison: its IPC calls read the region from the credentials
   // step's already-persisted `wizard.state.save` call, and worst case the
   // operator just has to re-click "Bootstrap AWS resources".
+  //
+  // Both this effect and the save-progress effect below are `'first-run'`-only:
+  // `userData/wizard-state.json` tracks resumable progress through the
+  // *gating* wizard, which is meaningless for Reconfigure (the app is already
+  // past the gate, and Reconfigure has its own pre-completed-steps/Cancel
+  // model instead of resume).
   useEffect(() => {
+    if (mode !== 'first-run') return;
     if (!window.gsd) {
       resumeSettledRef.current = true;
       return;
@@ -125,7 +165,7 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
         // Best-effort — starting over at step 1 is always a safe fallback.
         resumeSettledRef.current = true;
       });
-  }, []);
+  }, [mode]);
 
   // Persists the current step on every change (including the resume-on-mount
   // jump above) so `userData/wizard-state.json` stays in sync with what the
@@ -134,9 +174,43 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
   // Gated on `resumeSettledRef` so this can never race the resume effect's
   // own read of the same file (see that effect's comment).
   useEffect(() => {
-    if (!window.gsd || !resumeSettledRef.current) return;
+    if (mode !== 'first-run' || !window.gsd || !resumeSettledRef.current) return;
     window.gsd.wizard.saveProgress({ step }).catch(() => {});
-  }, [step]);
+  }, [mode, step]);
+
+  // Reconfigure-only: prefills the pick-cloud/credentials answers from the
+  // durably-stored `wizard.state.get` so the collapsed step summaries (and
+  // any step the operator opens for editing) reflect what's actually
+  // configured, not the first-run defaults. Runs once; if it fails, the
+  // steps simply keep their first-run defaults and the operator can still
+  // fill them in via Edit like any other value.
+  useEffect(() => {
+    if (mode !== 'reconfigure' || !window.gsd) return;
+    window.gsd.wizard
+      .getState()
+      .then((state) => {
+        if (state.activeCloud) setSelectedCloud(state.activeCloud);
+        if (state.aws?.profile) {
+          const knownProfile = profiles?.some((p) => p.profileName === state.aws!.profile);
+          if (knownProfile) {
+            setCredentialMode('profile');
+            setSelectedProfileName(state.aws.profile);
+            setRegion(state.aws.region ?? '');
+          } else {
+            // Not in `~/.aws` — must be a `creds.aws.<profile>` pasted-key
+            // entry from a prior paste-flow save (see `AwsProfileService`).
+            setCredentialMode('paste');
+            setPastedProfileName(state.aws.profile);
+            setPasteRegion(state.aws.region ?? '');
+          }
+        }
+      })
+      .catch(() => {
+        // Best-effort — the step just falls back to first-run defaults.
+      });
+    // Depends on `profiles` too, so this re-runs once the list resolves and
+    // the `knownProfile` check above isn't stuck on `null` from before it loaded.
+  }, [mode, profiles]);
 
   const backendConfig = useMemo<TerraformInitConfig>(
     () => ({
@@ -169,8 +243,11 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
   }, []);
 
   useEffect(() => {
+    // `prerequisites` isn't a Reconfigure step — skip the check entirely
+    // rather than running it for no visible step.
+    if (mode !== 'first-run') return;
     void checkPrereqs();
-  }, [checkPrereqs]);
+  }, [mode, checkPrereqs]);
 
   useEffect(() => {
     async function fetchProfiles() {
@@ -305,8 +382,14 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
       ? selectedProfileName !== '' && region !== ''
       : pastedProfileName !== null && pasteRegion !== '';
 
-  const advanceDisabled =
-    step === 'prerequisites'
+  // A collapsed (completed, not being edited) Reconfigure step already has a
+  // real answer on record — Next should never be gated on this render's
+  // local form state, which for an unopened step may not even be prefilled yet.
+  const stepCollapsed = mode === 'reconfigure' && completedSteps.has(step);
+
+  const advanceDisabled = stepCollapsed
+    ? false
+    : step === 'prerequisites'
       ? !arePrerequisitesSatisfied(report)
       : step === 'credentials'
         ? !credentialsChosen
@@ -315,13 +398,15 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
           : false;
 
   /**
-   * Advances past the current step. When leaving `pick-cloud` or
-   * `credentials`, persists the choice via `wizard.state.save` first and
-   * stays put if that fails — every other step advances immediately
-   * (nothing to persist yet).
+   * Advances past the current step. In `'first-run'` mode, leaving
+   * `pick-cloud` or `credentials` persists the choice via `wizard.state.save`
+   * immediately and stays put if that fails. In `'reconfigure'` mode these
+   * answers are buffered in local state instead — see
+   * {@link commitReconfigureAnswers}, called once from the terraform-init
+   * step's Finish button — so a mid-flow Cancel never has anything to undo.
    */
   async function goNext() {
-    if (step === 'pick-cloud') {
+    if (mode === 'first-run' && step === 'pick-cloud') {
       if (!window.gsd) {
         setSaveError('IPC bridge (window.gsd) is not available in this context.');
         return;
@@ -337,7 +422,7 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
       }
       setSaving(false);
     }
-    if (step === 'credentials') {
+    if (mode === 'first-run' && step === 'credentials') {
       if (!window.gsd) {
         setSaveError('IPC bridge (window.gsd) is not available in this context.');
         return;
@@ -355,86 +440,133 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
       }
       setSaving(false);
     }
-    setStepIndex((index) => Math.min(index + 1, WIZARD_STEPS.length - 1));
+    setStepIndex((index) => Math.min(index + 1, steps.length - 1));
   }
 
   function goBack() {
     setStepIndex((index) => Math.max(index - 1, 0));
   }
 
+  /**
+   * Reconfigure-only: commits the buffered `pick-cloud`/`credentials`
+   * answers in one `wizard.state.save` call, passed to {@link TerraformInitStep}
+   * as `onBeforeFinish` so it runs right before `wizard.complete` on the
+   * Finish click — the single commit point for this whole flow.
+   */
+  async function commitReconfigureAnswers() {
+    if (!window.gsd) {
+      throw new Error('IPC bridge (window.gsd) is not available in this context.');
+    }
+    const profile = credentialMode === 'profile' ? selectedProfileName : (pastedProfileName ?? undefined);
+    const chosenRegion = credentialMode === 'profile' ? region : pasteRegion;
+    await window.gsd.wizard.saveState({
+      activeCloud: selectedCloud,
+      aws: { profile, region: chosenRegion || undefined },
+    });
+  }
+
+  /** Reconfigure-only: expands a pre-completed step's summary into its normal editable form. */
+  function startEdit(target: WizardStep) {
+    setCompletedSteps((current) => {
+      const next = new Set(current);
+      next.delete(target);
+      return next;
+    });
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center p-6">
       <div className="w-full max-w-xl rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface-1)] p-8 space-y-6">
         <div>
-          <h1 className="text-xl font-semibold">Welcome to Hyveon</h1>
+          <h1 className="text-xl font-semibold">{mode === 'reconfigure' ? 'Reconfigure Hyveon' : 'Welcome to Hyveon'}</h1>
           <p className="text-sm text-muted-foreground">
-            Step {stepIndex + 1} of {WIZARD_STEPS.length}: {STEP_LABELS[step]}
+            Step {stepIndex + 1} of {steps.length}: {STEP_LABELS[step]}
           </p>
         </div>
 
         {step === 'prerequisites' && (
           <PrerequisitesStep report={report} checking={checking} error={error} onRecheck={checkPrereqs} />
         )}
-        {step === 'pick-cloud' && (
-          <>
-            <PickCloudStep selectedCloud={selectedCloud} onSelect={setSelectedCloud} />
-            {saveError && (
-              <p role="alert" className="text-sm text-[var(--color-red)]">
-                {saveError}
-              </p>
-            )}
-          </>
-        )}
-        {step === 'credentials' && (
-          <>
-            <CredentialsStep
-              mode={credentialMode}
-              onModeChange={setCredentialMode}
-              profiles={profiles}
-              profilesLoading={profilesLoading}
-              profilesError={profilesError}
-              selectedProfileName={selectedProfileName}
-              onSelectProfile={selectProfile}
-              region={region}
-              onRegionChange={setRegion}
-              pasteAccessKeyId={pasteAccessKeyId}
-              pasteSecretAccessKey={pasteSecretAccessKey}
-              pasteRegion={pasteRegion}
-              onPasteFieldChange={pasteFieldChange}
-              onSubmitPaste={submitPaste}
-              pasteSaving={pasteSaving}
-              pasteError={pasteError}
-              pastedProfileName={pastedProfileName}
+        {step === 'pick-cloud' &&
+          (stepCollapsed ? (
+            <CompletedStepSummary label={STEP_LABELS['pick-cloud']} onEdit={() => startEdit('pick-cloud')} />
+          ) : (
+            <>
+              <PickCloudStep selectedCloud={selectedCloud} onSelect={setSelectedCloud} />
+              {saveError && (
+                <p role="alert" className="text-sm text-[var(--color-red)]">
+                  {saveError}
+                </p>
+              )}
+            </>
+          ))}
+        {step === 'credentials' &&
+          (stepCollapsed ? (
+            <CompletedStepSummary label={STEP_LABELS['credentials']} onEdit={() => startEdit('credentials')} />
+          ) : (
+            <>
+              <CredentialsStep
+                mode={credentialMode}
+                onModeChange={setCredentialMode}
+                profiles={profiles}
+                profilesLoading={profilesLoading}
+                profilesError={profilesError}
+                selectedProfileName={selectedProfileName}
+                onSelectProfile={selectProfile}
+                region={region}
+                onRegionChange={setRegion}
+                pasteAccessKeyId={pasteAccessKeyId}
+                pasteSecretAccessKey={pasteSecretAccessKey}
+                pasteRegion={pasteRegion}
+                onPasteFieldChange={pasteFieldChange}
+                onSubmitPaste={submitPaste}
+                pasteSaving={pasteSaving}
+                pasteError={pasteError}
+                pastedProfileName={pastedProfileName}
+              />
+              {saveError && (
+                <p role="alert" className="text-sm text-[var(--color-red)]">
+                  {saveError}
+                </p>
+              )}
+            </>
+          ))}
+        {step === 'bootstrap' &&
+          (stepCollapsed ? (
+            <CompletedStepSummary label={STEP_LABELS['bootstrap']} onEdit={() => startEdit('bootstrap')} />
+          ) : (
+            <BootstrapStep
+              names={resourceNames}
+              statuses={resourceStatuses}
+              messages={resourceMessages}
+              onNameChange={resourceNameChange}
+              onRunBootstrap={runBootstrap}
+              bootstrapping={bootstrapping}
+              iamCheck={iamCheck}
+              iamChecking={iamChecking}
+              iamError={iamError}
+              onRunIamCheck={runIamCheck}
             />
-            {saveError && (
-              <p role="alert" className="text-sm text-[var(--color-red)]">
-                {saveError}
-              </p>
-            )}
-          </>
-        )}
-        {step === 'bootstrap' && (
-          <BootstrapStep
-            names={resourceNames}
-            statuses={resourceStatuses}
-            messages={resourceMessages}
-            onNameChange={resourceNameChange}
-            onRunBootstrap={runBootstrap}
-            bootstrapping={bootstrapping}
-            iamCheck={iamCheck}
-            iamChecking={iamChecking}
-            iamError={iamError}
-            onRunIamCheck={runIamCheck}
-          />
-        )}
+          ))}
         {step === 'terraform-init' && (
-          <TerraformInitStep backendConfig={backendConfig} onFinished={handleFinished} />
+          <TerraformInitStep
+            backendConfig={backendConfig}
+            onFinished={handleFinished}
+            onBeforeFinish={mode === 'reconfigure' ? commitReconfigureAnswers : undefined}
+          />
         )}
 
         <div className="flex justify-between">
-          <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0 || saving}>
-            Back
-          </Button>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0 || saving}>
+              Back
+            </Button>
+            {mode === 'reconfigure' && (
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                Cancel
+              </Button>
+            )}
+          </div>
           {step !== 'terraform-init' && (
             <Button type="button" onClick={goNext} disabled={advanceDisabled || saving}>
               Next
@@ -442,6 +574,21 @@ export function FirstRunWizard({ onComplete }: FirstRunWizardProps = {}) {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+/** Reconfigure-only: collapsed view of a step that already has a stored answer, with an Edit affordance. */
+function CompletedStepSummary({ label, onEdit }: { label: string; onEdit: () => void }) {
+  return (
+    <div className="flex items-center justify-between rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-2)] p-4">
+      <span className="flex items-center gap-2 text-sm">
+        <CheckCircle2 className="size-4 text-[var(--color-green)]" />
+        {label} is already configured.
+      </span>
+      <Button type="button" variant="outline" size="sm" onClick={onEdit}>
+        Edit
+      </Button>
     </div>
   );
 }

--- a/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/first-run-wizard.component.tsx
@@ -54,13 +54,20 @@ export interface FirstRunWizardProps {
   onComplete?: () => void;
   /**
    * `'first-run'` (default) gates the whole app and runs all five steps,
-   * persisting `pick-cloud`/`credentials` answers immediately via
+   * persisting `pick-cloud`/`credentials`/`bootstrap` answers immediately via
    * `wizard.state.save` as the operator advances. `'reconfigure'` (#211,
    * launched from Settings) skips `prerequisites`, pre-marks
    * `pick-cloud`/`credentials`/`bootstrap` as completed with a per-step Edit
-   * affordance, and buffers any edited answers locally — committed in one
-   * `wizard.state.save` call right before `wizard.complete` runs, so a
-   * mid-flow Cancel writes nothing.
+   * affordance, and buffers *edited* answers locally — a single
+   * `wizard.state.save` call, containing only the steps actually opened via
+   * Edit, commits right before `wizard.complete` runs. A step left collapsed
+   * is never included in that call, so Cancel never has anything to undo for
+   * it. This covers the durable answer data only, not every side effect: the
+   * credentials step's "paste keys instead" form and the bootstrap step's
+   * "Run bootstrap"/"Check permissions" buttons already perform real,
+   * idempotent IPC calls the moment they're clicked (same as `'first-run'`)
+   * — Cancel doesn't undo those either, it just never points the *active*
+   * `aws`/`bootstrap` config at their result.
    */
   mode?: 'first-run' | 'reconfigure';
   /** `'reconfigure'`-only: invoked when the operator cancels without finishing. Never called in `'first-run'` mode. */
@@ -178,14 +185,31 @@ export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: Fir
     window.gsd.wizard.saveProgress({ step }).catch(() => {});
   }, [mode, step]);
 
-  // Reconfigure-only: prefills the pick-cloud/credentials answers from the
-  // durably-stored `wizard.state.get` so the collapsed step summaries (and
-  // any step the operator opens for editing) reflect what's actually
-  // configured, not the first-run defaults. Runs once; if it fails, the
-  // steps simply keep their first-run defaults and the operator can still
-  // fill them in via Edit like any other value.
+  // Guards the reconfigure-prefill effect below so it applies exactly once,
+  // never re-running over an operator's in-progress edits once it has fired.
+  const prefillAppliedRef = useRef(false);
+
+  // Reconfigure-only: prefills the pick-cloud/credentials/bootstrap answers
+  // from the durably-stored `wizard.state.get` so the collapsed step
+  // summaries — and the `terraform-init` step's `backendConfig`, which reads
+  // `resourceNames` regardless of whether the bootstrap step was ever opened
+  // — reflect what's actually configured, not the first-run defaults.
+  // Without this, Reconfigure would always run `terraform init` against
+  // `defaultBootstrapResourceNames()` even when the operator renamed the
+  // bootstrap resources during first run.
+  //
+  // Waits for the `listAwsProfiles` fetch below to settle (`profiles` or
+  // `profilesError` set) before applying, rather than firing on mount: the
+  // `knownProfile` check needs a real list to tell an existing `~/.aws`
+  // profile apart from a `creds.aws.<profile>` pasted-key entry, and firing
+  // early would misclassify every profile as "pasted" on the first pass.
+  // `prefillAppliedRef` then ensures it only ever applies once — otherwise a
+  // later re-run (e.g. if `profiles` changed for some other reason) could
+  // clobber an edit the operator has already started making.
   useEffect(() => {
-    if (mode !== 'reconfigure' || !window.gsd) return;
+    if (mode !== 'reconfigure' || !window.gsd || prefillAppliedRef.current) return;
+    if (profiles === null && profilesError === null) return;
+    prefillAppliedRef.current = true;
     window.gsd.wizard
       .getState()
       .then((state) => {
@@ -204,13 +228,15 @@ export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: Fir
             setPasteRegion(state.aws.region ?? '');
           }
         }
+        if (state.bootstrap) setResourceNames(state.bootstrap);
       })
       .catch(() => {
-        // Best-effort — the step just falls back to first-run defaults.
+        // Best-effort — the steps just fall back to first-run defaults, and
+        // `commitReconfigureAnswers` below never sends an unedited step's
+        // (now-defaulted) values, so a failed prefill can't clobber what's
+        // actually stored.
       });
-    // Depends on `profiles` too, so this re-runs once the list resolves and
-    // the `knownProfile` check above isn't stuck on `null` from before it loaded.
-  }, [mode, profiles]);
+  }, [mode, profiles, profilesError]);
 
   const backendConfig = useMemo<TerraformInitConfig>(
     () => ({
@@ -399,11 +425,14 @@ export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: Fir
 
   /**
    * Advances past the current step. In `'first-run'` mode, leaving
-   * `pick-cloud` or `credentials` persists the choice via `wizard.state.save`
-   * immediately and stays put if that fails. In `'reconfigure'` mode these
-   * answers are buffered in local state instead — see
-   * {@link commitReconfigureAnswers}, called once from the terraform-init
-   * step's Finish button — so a mid-flow Cancel never has anything to undo.
+   * `pick-cloud`, `credentials`, or `bootstrap` persists the choice via
+   * `wizard.state.save` immediately and stays put if that fails (the
+   * `bootstrap` save is fire-and-forget, matching how `resourceNames` itself
+   * has no failure UI — the resource-creation calls it feeds are what
+   * actually gate progression). In `'reconfigure'` mode these answers are
+   * buffered in local state instead — see {@link commitReconfigureAnswers},
+   * called once from the terraform-init step's Finish button — so a
+   * mid-flow Cancel never has anything to undo.
    */
   async function goNext() {
     if (mode === 'first-run' && step === 'pick-cloud') {
@@ -440,6 +469,14 @@ export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: Fir
       }
       setSaving(false);
     }
+    if (mode === 'first-run' && step === 'bootstrap' && window.gsd) {
+      // Durably records the (possibly operator-renamed) resource names so a
+      // later Reconfigure can rehydrate them instead of falling back to
+      // `defaultBootstrapResourceNames()`. Best-effort: nothing in this step
+      // depends on the save succeeding, so a failure here doesn't block
+      // progression the way the pick-cloud/credentials saves above do.
+      window.gsd.wizard.saveState({ bootstrap: resourceNames }).catch(() => {});
+    }
     setStepIndex((index) => Math.min(index + 1, steps.length - 1));
   }
 
@@ -448,21 +485,35 @@ export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: Fir
   }
 
   /**
-   * Reconfigure-only: commits the buffered `pick-cloud`/`credentials`
-   * answers in one `wizard.state.save` call, passed to {@link TerraformInitStep}
+   * Reconfigure-only: commits whichever answers were actually opened via
+   * Edit in one `wizard.state.save` call, passed to {@link TerraformInitStep}
    * as `onBeforeFinish` so it runs right before `wizard.complete` on the
-   * Finish click — the single commit point for this whole flow.
+   * Finish click. A step left collapsed (never opened) is omitted from the
+   * payload entirely, not sent with its current — possibly still-default,
+   * possibly prefill-failed-and-empty — local state: `saveState` only
+   * touches the fields it's given, so this is what actually makes "Cancel
+   * never has anything to undo" and "editing one field preserves the rest"
+   * true, rather than merely re-submitting a (hopefully unchanged) copy of
+   * everything on every Finish.
    */
   async function commitReconfigureAnswers() {
     if (!window.gsd) {
       throw new Error('IPC bridge (window.gsd) is not available in this context.');
     }
-    const profile = credentialMode === 'profile' ? selectedProfileName : (pastedProfileName ?? undefined);
-    const chosenRegion = credentialMode === 'profile' ? region : pasteRegion;
-    await window.gsd.wizard.saveState({
-      activeCloud: selectedCloud,
-      aws: { profile, region: chosenRegion || undefined },
-    });
+    const payload: { activeCloud?: CloudOption; aws?: { profile?: string; region?: string }; bootstrap?: typeof resourceNames } = {};
+    if (!completedSteps.has('pick-cloud')) {
+      payload.activeCloud = selectedCloud;
+    }
+    if (!completedSteps.has('credentials')) {
+      const profile = credentialMode === 'profile' ? selectedProfileName : (pastedProfileName ?? undefined);
+      const chosenRegion = credentialMode === 'profile' ? region : pasteRegion;
+      payload.aws = { profile, region: chosenRegion || undefined };
+    }
+    if (!completedSteps.has('bootstrap')) {
+      payload.bootstrap = resourceNames;
+    }
+    if (Object.keys(payload).length === 0) return;
+    await window.gsd.wizard.saveState(payload);
   }
 
   /** Reconfigure-only: expands a pre-completed step's summary into its normal editable form. */
@@ -561,7 +612,7 @@ export function FirstRunWizard({ onComplete, mode = 'first-run', onCancel }: Fir
             <Button type="button" variant="outline" onClick={goBack} disabled={stepIndex === 0 || saving}>
               Back
             </Button>
-            {mode === 'reconfigure' && (
+            {mode === 'reconfigure' && onCancel && (
               <Button type="button" variant="ghost" onClick={onCancel}>
                 Cancel
               </Button>

--- a/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.tsx
+++ b/app/packages/web/src/components/first-run-wizard/terraform-init-step.component.tsx
@@ -18,6 +18,16 @@ export interface TerraformInitStepProps {
   backendConfig: TerraformInitConfig;
   /** Invoked once `terraform init` succeeds and `wizard.complete` has been persisted. */
   onFinished: () => void;
+  /**
+   * Awaited before `wizard.complete` runs, on the same "Finish" click. Used
+   * by Settings' Reconfigure flow (#211) to commit its buffered
+   * `wizard.state.save` call in one shot rather than persisting each step as
+   * the operator advances — a rejection here surfaces via the same
+   * `finishError` path as a `wizard.complete` failure, and `wizard.complete`
+   * is never called if it rejects. Omitted (and skipped) during the regular
+   * first-run flow, which already persists `pick-cloud`/`credentials` as it goes.
+   */
+  onBeforeFinish?: () => Promise<void>;
 }
 
 /**
@@ -30,7 +40,7 @@ export interface TerraformInitStepProps {
  * without throwing); a failed run shows the captured log plus a Retry
  * button rather than silently blocking wizard progression.
  */
-export function TerraformInitStep({ backendConfig, onFinished }: TerraformInitStepProps) {
+export function TerraformInitStep({ backendConfig, onFinished, onBeforeFinish }: TerraformInitStepProps) {
   const [chunks, setChunks] = useState<TerraformRunChunk[]>([]);
   const [status, setStatus] = useState<TerraformInitStatus>('running');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -81,6 +91,7 @@ export function TerraformInitStep({ backendConfig, onFinished }: TerraformInitSt
     setFinishing(true);
     setFinishError(null);
     try {
+      await onBeforeFinish?.();
       await window.gsd.wizard.complete();
       onFinished();
     } catch (err) {

--- a/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
+++ b/app/packages/web/src/components/first-run-wizard/wizard.utils.ts
@@ -35,6 +35,15 @@ export function arePrerequisitesSatisfied(report: PrerequisitesReport | null): b
   return report.terraform.found && report.terraform.minimumVersionSatisfied !== false && report.aws.found;
 }
 
+/**
+ * `WIZARD_STEPS` minus `prerequisites`, for Settings' "Reconfigure" entry
+ * point (#211): prerequisite detection isn't repeated once the app is
+ * already installed and working, per the wizard-flow spec.
+ */
+export function reconfigureSteps(): WizardStep[] {
+  return WIZARD_STEPS.filter((step) => step !== 'prerequisites');
+}
+
 /** A backend bootstrap resource the wizard's bootstrap step creates. */
 export type BootstrapResourceKey = 'stateBucket' | 'lockTable' | 'tfvarsBucket';
 

--- a/app/packages/web/src/pages/settings.page.test.tsx
+++ b/app/packages/web/src/pages/settings.page.test.tsx
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AwsProfileSummary, PrerequisitesReport } from '@hyveon/desktop-preload';
 
 const apiMock = vi.hoisted(() => ({
   status: vi.fn(),
@@ -14,8 +16,38 @@ vi.mock('../components/DiagnosticsPanel.js', () => ({
   DiagnosticsPanel: () => <div data-testid="diagnostics-panel">DiagnosticsPanel</div>,
 }));
 
+const gsdMock = {
+  wizard: {
+    checkPrereqs: vi.fn(),
+    getState: vi.fn(),
+    saveState: vi.fn(),
+    listAwsProfiles: vi.fn(),
+    saveCredentials: vi.fn(),
+    bootstrapStateBucket: vi.fn(),
+    bootstrapLockTable: vi.fn(),
+    bootstrapTfvarsBucket: vi.fn(),
+    simulateIamPermissions: vi.fn(),
+    getProgress: vi.fn(),
+    saveProgress: vi.fn(),
+    complete: vi.fn(),
+  },
+  terraform: {
+    init: vi.fn(),
+  },
+};
+vi.stubGlobal('gsd', gsdMock);
+
 import { SettingsPage } from './settings.page.js';
 import { renderPage } from '../test-utils/render-page.utils.js';
+
+/** Satisfies the prerequisites step so the version row has something to render. */
+const SATISFIED: PrerequisitesReport = {
+  terraform: { found: true, path: '/usr/local/bin/terraform', version: '1.9.0', minimumVersionSatisfied: true },
+  aws: { found: true, path: '/usr/local/bin/aws', version: '2.15.30' },
+};
+
+/** A single discovered `~/.aws` profile matching the stored Reconfigure state below. */
+const SAMPLE_PROFILES: AwsProfileSummary[] = [{ profileName: 'default', region: 'us-east-1' }];
 
 describe('SettingsPage', () => {
   beforeEach(() => {
@@ -26,6 +58,27 @@ describe('SettingsPage', () => {
       watchdog_idle_checks: 4,
       watchdog_min_packets: 100,
     });
+    gsdMock.wizard.checkPrereqs.mockReset().mockResolvedValue(SATISFIED);
+    gsdMock.wizard.getState
+      .mockReset()
+      .mockResolvedValue({ wizardCompleted: true, activeCloud: 'aws', aws: { profile: 'default', region: 'us-east-1' } });
+    gsdMock.wizard.saveState.mockReset().mockResolvedValue({ wizardCompleted: true });
+    gsdMock.wizard.listAwsProfiles.mockReset().mockResolvedValue(SAMPLE_PROFILES);
+    gsdMock.wizard.saveCredentials.mockReset();
+    gsdMock.wizard.bootstrapStateBucket.mockReset().mockResolvedValue({ status: 'exists' });
+    gsdMock.wizard.bootstrapLockTable.mockReset().mockResolvedValue({ status: 'exists' });
+    gsdMock.wizard.bootstrapTfvarsBucket.mockReset().mockResolvedValue({ status: 'exists' });
+    gsdMock.wizard.simulateIamPermissions.mockReset();
+    gsdMock.wizard.getProgress.mockReset().mockResolvedValue({ step: 'prerequisites' });
+    gsdMock.wizard.saveProgress.mockReset().mockResolvedValue(undefined);
+    gsdMock.wizard.complete.mockReset().mockResolvedValue({ wizardCompleted: true });
+    gsdMock.terraform.init.mockReset().mockImplementation(async function* () {
+      // No chunks needed by default — the Reconfigure tests below just need it to succeed.
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('should render the Settings heading', () => {
@@ -51,5 +104,78 @@ describe('SettingsPage', () => {
   it('should render the DiagnosticsPanel inside the Diagnostics section', () => {
     renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
     expect(screen.getByTestId('diagnostics-panel')).toBeInTheDocument();
+  });
+
+  it('should show the resolved Terraform version alongside the pinned minimum', async () => {
+    renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+    expect(await screen.findByText(/detected v1\.9\.0/i)).toBeInTheDocument();
+    expect(screen.getByText(/minimum v1\.5\.0/)).toBeInTheDocument();
+  });
+
+  it('should show "Not detected" when the Terraform prerequisite check fails', async () => {
+    gsdMock.wizard.checkPrereqs.mockRejectedValue(new Error('terraform not on PATH'));
+    renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+    expect(await screen.findByText(/not detected/i)).toBeInTheDocument();
+  });
+
+  describe('Reconfigure', () => {
+    it('should render a Reconfigure entry point in the Cloud Setup section', () => {
+      renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+      expect(screen.getByRole('button', { name: /^reconfigure$/i })).toBeInTheDocument();
+    });
+
+    it('should open the wizard on pick-cloud (skipping prerequisites) with completed steps showing an Edit affordance', async () => {
+      renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+
+      await userEvent.click(screen.getByRole('button', { name: /^reconfigure$/i }));
+
+      expect(await screen.findByText(/choose your cloud is already configured/i)).toBeInTheDocument();
+      expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
+    });
+
+    it('should preserve every other stored setting when only the credentials-step region is edited', async () => {
+      renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+      await userEvent.click(screen.getByRole('button', { name: /^reconfigure$/i }));
+      await screen.findByText(/choose your cloud is already configured/i);
+
+      // pick-cloud: leave collapsed, advance to credentials.
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/aws credentials is already configured/i);
+
+      // credentials: open for editing, change only the region.
+      await userEvent.click(screen.getByRole('button', { name: /^edit$/i }));
+      const regionInput = await screen.findByLabelText('Region');
+      await waitFor(() => expect(regionInput).toHaveValue('us-east-1'));
+      await userEvent.clear(regionInput);
+      await userEvent.type(regionInput, 'eu-west-1');
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+
+      // bootstrap: leave collapsed, advance to terraform-init and finish.
+      await screen.findByText(/bootstrap aws resources is already configured/i);
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+      await userEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+      await waitFor(() =>
+        expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({
+          activeCloud: 'aws',
+          aws: { profile: 'default', region: 'eu-west-1' },
+        }),
+      );
+      expect(gsdMock.wizard.saveState).toHaveBeenCalledTimes(1);
+    });
+
+    it('should commit nothing and return to Settings when Reconfigure is cancelled mid-flow', async () => {
+      renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+      await userEvent.click(screen.getByRole('button', { name: /^reconfigure$/i }));
+      await screen.findByText(/choose your cloud is already configured/i);
+
+      await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+      expect(gsdMock.wizard.saveState).not.toHaveBeenCalled();
+      expect(gsdMock.wizard.complete).not.toHaveBeenCalled();
+      expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+    });
   });
 });

--- a/app/packages/web/src/pages/settings.page.test.tsx
+++ b/app/packages/web/src/pages/settings.page.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { screen, cleanup, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { AwsProfileSummary, PrerequisitesReport } from '@hyveon/desktop-preload';
 
@@ -75,10 +75,6 @@ describe('SettingsPage', () => {
     gsdMock.terraform.init.mockReset().mockImplementation(async function* () {
       // No chunks needed by default — the Reconfigure tests below just need it to succeed.
     });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   it('should render the Settings heading', () => {
@@ -159,11 +155,61 @@ describe('SettingsPage', () => {
 
       await waitFor(() =>
         expect(gsdMock.wizard.saveState).toHaveBeenCalledWith({
-          activeCloud: 'aws',
           aws: { profile: 'default', region: 'eu-west-1' },
         }),
       );
+      // pick-cloud and bootstrap were never opened via Edit — omitted from
+      // the payload entirely, not resubmitted with their current (unedited)
+      // values, so the stored `activeCloud`/`bootstrap` are untouched.
       expect(gsdMock.wizard.saveState).toHaveBeenCalledTimes(1);
+    });
+
+    it('should commit only the edited step, and rehydrate stored bootstrap resource names into terraform init, when the bootstrap step is left collapsed', async () => {
+      gsdMock.wizard.getState.mockResolvedValue({
+        wizardCompleted: true,
+        activeCloud: 'aws',
+        aws: { profile: 'default', region: 'us-east-1' },
+        bootstrap: { stateBucket: 'renamed-tfstate', lockTable: 'renamed-tflock', tfvarsBucket: 'renamed-tfvars' },
+      });
+      renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+      await userEvent.click(screen.getByRole('button', { name: /^reconfigure$/i }));
+      await screen.findByText(/choose your cloud is already configured/i);
+
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/aws credentials is already configured/i);
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/bootstrap aws resources is already configured/i);
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+      await userEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+      await waitFor(() => expect(gsdMock.wizard.complete).toHaveBeenCalledTimes(1));
+      expect(gsdMock.wizard.saveState).not.toHaveBeenCalled();
+      expect(gsdMock.terraform.init).toHaveBeenCalledWith(
+        { bucket: 'renamed-tfstate', region: 'us-east-1', dynamodbTable: 'renamed-tflock' },
+        expect.anything(),
+      );
+    });
+
+    it('should not clobber stored config on Finish when the prefill itself fails and nothing was edited', async () => {
+      gsdMock.wizard.getState.mockRejectedValue(new Error('IPC unavailable'));
+      renderPage(<SettingsPage />, { initialEntries: ['/settings'] });
+      await userEvent.click(screen.getByRole('button', { name: /^reconfigure$/i }));
+      await screen.findByText(/choose your cloud is already configured/i);
+
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/aws credentials is already configured/i);
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await screen.findByText(/bootstrap aws resources is already configured/i);
+      await userEvent.click(screen.getByRole('button', { name: /^next$/i }));
+      await waitFor(() => expect(screen.getByRole('button', { name: /finish setup/i })).toBeEnabled());
+      await userEvent.click(screen.getByRole('button', { name: /finish setup/i }));
+
+      await waitFor(() => expect(gsdMock.wizard.complete).toHaveBeenCalledTimes(1));
+      // Every step stayed collapsed (never opened via Edit), so even though
+      // the prefill never populated real values, nothing gets sent to
+      // overwrite what's actually stored.
+      expect(gsdMock.wizard.saveState).not.toHaveBeenCalled();
     });
 
     it('should commit nothing and return to Settings when Reconfigure is cancelled mid-flow', async () => {

--- a/app/packages/web/src/pages/settings.page.tsx
+++ b/app/packages/web/src/pages/settings.page.tsx
@@ -1,12 +1,44 @@
+import { useEffect, useState } from 'react';
+import { MINIMUM_TERRAFORM_VERSION } from '@hyveon/shared';
+import type { PrerequisitesReport } from '@hyveon/desktop-preload';
 import { DiagnosticsPanel } from '../components/DiagnosticsPanel.js';
 import { WatchdogPanel } from '../components/watchdog-panel.component.js';
 import { PollingIndicator } from '../polling/polling-indicator.component.js';
+import { FirstRunWizard } from '../components/first-run-wizard/first-run-wizard.component.js';
+import { Button } from '../components/ui/button.component.js';
 
 /**
  * Settings route (`/settings`) — watchdog config + general settings skeleton.
  * Per the issue spec, the watchdog panel moves here from the dashboard.
+ *
+ * While `reconfiguring` is true, this page renders only
+ * {@link FirstRunWizard} in `mode: 'reconfigure'` (#211) — mirroring how
+ * `app.component.tsx` swaps the whole routed shell out for the first-run
+ * wizard while `wizardCompleted` is false. Both `onComplete` and `onCancel`
+ * just flip `reconfiguring` back to `false`; nothing about the surrounding
+ * page (route, layout) needs to change either way.
  */
 export function SettingsPage() {
+  const [reconfiguring, setReconfiguring] = useState(false);
+  const [prereqs, setPrereqs] = useState<PrerequisitesReport | null>(null);
+
+  useEffect(() => {
+    if (!window.gsd?.wizard) return;
+    window.gsd.wizard.checkPrereqs().then(setPrereqs).catch(() => {
+      // Best-effort — the version row just falls back to "Not detected".
+    });
+  }, []);
+
+  if (reconfiguring) {
+    return (
+      <FirstRunWizard
+        mode="reconfigure"
+        onComplete={() => setReconfiguring(false)}
+        onCancel={() => setReconfiguring(false)}
+      />
+    );
+  }
+
   return (
     <div className="max-w-5xl mx-auto">
       <div className="mb-6 flex items-center justify-between">
@@ -18,6 +50,23 @@ export function SettingsPage() {
       <div className="mb-8">
         <h3 className="text-lg font-medium mb-4">Watchdog Configuration</h3>
         <WatchdogPanel />
+      </div>
+
+      {/* Cloud setup section */}
+      <div className="mb-8">
+        <h3 className="text-lg font-medium mb-4">Cloud Setup</h3>
+        <div className="flex items-center justify-between rounded-[var(--radius-md)] border border-[var(--color-border)] p-4">
+          <div>
+            <p className="text-sm font-medium">Terraform</p>
+            <p className="text-sm text-muted-foreground">
+              {prereqs?.terraform.version ? `Detected v${prereqs.terraform.version}` : 'Not detected'} · minimum v
+              {MINIMUM_TERRAFORM_VERSION}
+            </p>
+          </div>
+          <Button type="button" variant="outline" onClick={() => setReconfiguring(true)}>
+            Reconfigure
+          </Button>
+        </div>
       </div>
 
       {/* General settings placeholder */}

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -111,9 +111,9 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 
 ## 12. Issue #211 — Reconfigure entry point in Settings (web)
 
-- [ ] 12.1 Create worktree: `git worktree add .worktrees/claude/issue-211-settings-reconfigure -b claude/issue-211-settings-reconfigure`
-- [ ] 12.2 Add a "Reconfigure" section to `settings.page.tsx` (alongside Watchdog + Diagnostics) launching the wizard shell in `mode: 'reconfigure'` (steps 2–5; prerequisites not repeated); also surface the resolved Terraform version + pinned minimum in Settings
-- [ ] 12.3 Reconfigure semantics: steps pre-marked complete from stored state with per-step "Edit" affordances; edits buffered in component state and committed in a single IPC on finish so mid-flow cancel writes nothing and preserves all unchanged config
-- [ ] 12.4 RTL/jsdom specs (via `renderPage()` for the Settings page): Reconfigure entry renders, completed-step Edit affordances, single-field edit preserves everything else, mid-flow cancel commits nothing, version display
-- [ ] 12.5 Verify `npm run app:test` and `npm run app:lint` pass
+- [x] 12.1 Create worktree: `git worktree add .worktrees/claude/issue-211-settings-reconfigure -b claude/issue-211-settings-reconfigure`
+- [x] 12.2 Add a "Reconfigure" section to `settings.page.tsx` (alongside Watchdog + Diagnostics) launching the wizard shell in `mode: 'reconfigure'` (steps 2–5; prerequisites not repeated); also surface the resolved Terraform version + pinned minimum in Settings
+- [x] 12.3 Reconfigure semantics: steps pre-marked complete from stored state with per-step "Edit" affordances; edits buffered in component state and committed in a single IPC on finish so mid-flow cancel writes nothing and preserves all unchanged config
+- [x] 12.4 RTL/jsdom specs (via `renderPage()` for the Settings page): Reconfigure entry renders, completed-step Edit affordances, single-field edit preserves everything else, mid-flow cancel commits nothing, version display
+- [x] 12.5 Verify `npm run app:test` and `npm run app:lint` pass
 - [ ] 12.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #211`; if this PR completes the last open child of epic #139, also include `Closes #139` on its own line

--- a/openspec/changes/add-first-run-wizard/tasks.md
+++ b/openspec/changes/add-first-run-wizard/tasks.md
@@ -116,4 +116,4 @@ One PR per GitHub issue (12 issues → 12 PRs). Groups 1–3 (#182, #189, #197) 
 - [x] 12.3 Reconfigure semantics: steps pre-marked complete from stored state with per-step "Edit" affordances; edits buffered in component state and committed in a single IPC on finish so mid-flow cancel writes nothing and preserves all unchanged config
 - [x] 12.4 RTL/jsdom specs (via `renderPage()` for the Settings page): Reconfigure entry renders, completed-step Edit affordances, single-field edit preserves everything else, mid-flow cancel commits nothing, version display
 - [x] 12.5 Verify `npm run app:test` and `npm run app:lint` pass
-- [ ] 12.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #211`; if this PR completes the last open child of epic #139, also include `Closes #139` on its own line
+- [x] 12.6 Open PR via `/pr` with Conventional Commits title (<70 chars); PR body FIRST line `Closes #211`; if this PR completes the last open child of epic #139, also include `Closes #139` on its own line — [PR #331](https://github.com/CoderCoco/Hyveon/pull/331)


### PR DESCRIPTION
Closes #211
Closes #139

## Summary

- `FirstRunWizard` gains a `mode: 'first-run' | 'reconfigure'` prop. In `'reconfigure'` mode it skips the `prerequisites` step, prefills `pick-cloud`/`credentials` from the durably-stored `wizard.state.get`, and pre-marks `pick-cloud`/`credentials`/`bootstrap` as completed with a per-step "Edit" affordance (reaching `terraform-init` always re-runs it, since that's the explicit re-run the operator asked for by navigating there).
- Edits made while reconfiguring are buffered in local component state rather than persisted per-step — a single `wizard.state.save` call (via a new `onBeforeFinish` hook on `TerraformInitStep`) commits everything right before `wizard.complete` runs on the Finish click, so a mid-flow Cancel writes nothing and the pre-existing configuration is untouched.
- Settings gets a new "Cloud Setup" section: the Terraform version resolved by `wizard.prereqs.check` alongside the pinned `MINIMUM_TERRAFORM_VERSION`, and a "Reconfigure" button that swaps the page body for the wizard shell in `mode="reconfigure"`.
- This is the last child of epic #139 (first-run wizard + credentials UX) — all 11 sibling issues are already closed.

## Test plan

- [x] `npm run app:test` — 2096/2096 tests pass, including new specs covering: Reconfigure entry renders, completed-step Edit affordances, single-field edit preserving every other stored setting, mid-flow Cancel committing nothing, and the Terraform version display.
- [x] `npm run app:lint` — clean (pre-existing unrelated warnings in `ConfigService.ts` only).
- [x] `npm run app:build` — full `shared → cloud-aws → desktop-main → web` pipeline compiles cleanly.
