### PR TITLE
chore(openspec): sync ALB→Caddy change task state

### DIFF
--- a/openspec/changes/replace-alb-with-caddy-sidecar/tasks.md
+++ b/openspec/changes/replace-alb-with-caddy-sidecar/tasks.md
@@ -19,6 +19,12 @@ Two PRs (see design.md D8). PR 1 is terraform-focused and self-contained (deploy
 
 ## 2. Migration verification (after PR 1 merges, before PR 2)
 
+> **Operator-only — cannot be automated.** These steps need live AWS credentials, a
+> real `terraform apply` against the deployed stack, and a running HTTPS-flagged game.
+> Section 3 landed ahead of them (PR #316) because the code removal is independently
+> safe: the deployed Lambdas already ignore the removed env vars. This change cannot be
+> archived until an operator works through 2.1–2.5 against the live stack.
+
 - [ ] 2.1 With HTTPS game(s) stopped: `npm run app:build:lambdas`, then `terraform apply`
 - [ ] 2.2 Verify no orphans: `aws elbv2 describe-load-balancers` and `aws elbv2 describe-target-groups` are empty for the stack; the stack ACM certificate and ALB security group are gone
 - [ ] 2.3 Start the HTTPS game; confirm the update-dns Lambda upserts the `{game}.{zone}` A record and `https://{game}.{zone}` serves a valid certificate within ~2 min of RUNNING (first boot allows extra time for ACME issuance)
@@ -27,11 +33,11 @@ Two PRs (see design.md D8). PR 1 is terraform-focused and self-contained (deploy
 
 ## 3. PR 2 — Lambda/app dead-code removal + docs (branch `claude/issue-292-remove-alb-code`)
 
-- [ ] 3.1 Create worktree: `git worktree add .worktrees/claude/issue-292-remove-alb-code -b claude/issue-292-remove-alb-code`
-- [ ] 3.2 `app/packages/lambda/update-dns`: delete `handleHttps`, `registerAlb`/`deregisterAlb`, the ELBv2 client and `ALB_TARGET_GROUPS`/`HTTPS_GAMES` parsing; route all games through `handleDirect`; restore public-IP inclusion in the Discord pending-interaction message for HTTPS games; update `handler.test.ts` (drop ALB describe/register specs, add a spec that an HTTPS-flagged game follows the plain A-record path)
-- [ ] 3.3 `app/packages/lambda/watchdog`: delete the ALB deregistration step and `ALB_TARGET_GROUPS`/`HTTPS_GAMES` parsing; update `handler.test.ts` accordingly
-- [ ] 3.4 Remove `alb_dns_name` / `acm_certificate_arn` from `TfOutputs` in `app/packages/desktop-main/src/services/ConfigService.ts` (declaration + parse), the mirror type in `app/packages/desktop-preload/src/gsd-api.ts`, and any references in tests (`ConfigService.test.ts`, `preload.test.ts`) and the e2e `tfstate.fixture.json`
-- [ ] 3.5 Trim `elasticloadbalancing:*` and `acm:*` from the `GameServerDeployAll` policy JSON in `docs/docs/setup.md` (only valid now that the destroy apply from task 2.1 has run)
-- [ ] 3.6 Update `CLAUDE.md` architecture notes: HTTPS is in-task (Caddy sidecar + Let's Encrypt on EFS), no ALB; DNS path is uniform for all games
-- [ ] 3.7 Gate: `npm run app:test` and `npm run app:lint` pass; `terraform fmt -check -recursive`, `terraform validate`, `tflint` still clean (no terraform edits expected, cheap to confirm)
-- [ ] 3.8 Open PR via `/pr`: title `refactor: remove ALB code paths after Caddy sidecar cutover`, body first line `Closes #292`
+- [x] 3.1 Create worktree: `git worktree add .worktrees/claude/issue-292-remove-alb-code -b claude/issue-292-remove-alb-code`
+- [x] 3.2 `app/packages/lambda/update-dns`: delete `handleHttps`, `registerAlb`/`deregisterAlb`, the ELBv2 client and `ALB_TARGET_GROUPS`/`HTTPS_GAMES` parsing; route all games through `handleDirect`; restore public-IP inclusion in the Discord pending-interaction message for HTTPS games; update `handler.test.ts` (drop ALB describe/register specs, add a spec that an HTTPS-flagged game follows the plain A-record path)
+- [x] 3.3 `app/packages/lambda/watchdog`: delete the ALB deregistration step and `ALB_TARGET_GROUPS`/`HTTPS_GAMES` parsing; update `handler.test.ts` accordingly
+- [x] 3.4 Remove `alb_dns_name` / `acm_certificate_arn` from `TfOutputs` in `app/packages/desktop-main/src/services/ConfigService.ts` (declaration + parse), the mirror type in `app/packages/desktop-preload/src/gsd-api.ts`, and any references in tests (`ConfigService.test.ts`, `preload.test.ts`) and the e2e `tfstate.fixture.json`
+- [x] 3.5 Trim `elasticloadbalancing:*` and `acm:*` from the `GameServerDeployAll` policy JSON in `docs/docs/setup.md` (only valid now that the destroy apply from task 2.1 has run)
+- [x] 3.6 Update `CLAUDE.md` architecture notes: HTTPS is in-task (Caddy sidecar + Let's Encrypt on EFS), no ALB; DNS path is uniform for all games
+- [x] 3.7 Gate: `npm run app:test` and `npm run app:lint` pass; `terraform fmt -check -recursive`, `terraform validate`, `tflint` still clean (no terraform edits expected, cheap to confirm)
+- [x] 3.8 Open PR via `/pr`: title `refactor: remove ALB code paths after Caddy sidecar cutover`, body first line `Closes #292` — [PR #316](https://github.com/CoderCoco/Hyveon/pull/316)


### PR DESCRIPTION
Follows #292 (already closed by #316). Documentation-only — no code or infrastructure changes.

## Summary

The `replace-alb-with-caddy-sidecar` OpenSpec change still showed section 3 (Lambda/app dead-code removal + docs) as entirely unstarted, even though that work shipped in #316. This flips those checkboxes, records the PR link for 3.8 to match the convention already used by 1.12, and makes the status of section 2 explicit.

## What changed

- **Marked 3.1–3.8 complete.** Each item was verified against `main` before being checked off, not taken on faith from the merged PR title:
  - `app/packages/lambda/update-dns/src/handler.ts` has no `handleHttps`, `registerAlb`, `deregisterAlb`, or ELBv2 client; every game routes through `handleDirect`, and `handler.test.ts` carries a spec asserting an HTTPS-flagged game follows the plain A-record path.
  - `app/packages/lambda/watchdog` has no ALB deregistration step and no `ALB_TARGET_GROUPS` / `HTTPS_GAMES` parsing.
  - `ConfigService.ts` and `gsd-api.ts` no longer declare `alb_dns_name` or `acm_certificate_arn`.
  - The `GameServerDeployAll` policy in `docs/docs/setup.md` grants no `elasticloadbalancing` or `acm` actions.
  - `CLAUDE.md` documents the in-task Caddy sidecar and the uniform, no-special-casing DNS path.
- **Added a note to section 2** stating that the migration-verification steps are operator-only. They require live AWS credentials, a real `terraform apply` against the deployed stack, and a running HTTPS-flagged game, so they cannot be automated from a development session.

## Why section 3 landed before section 2

The original plan sequenced the code removal after the live cutover. In practice the removal is independently safe — the deployed Lambdas already tolerate the removed environment variables — so #316 merged first. The note now records that ordering rather than leaving it as an unexplained gap in the task list.

## Consequence

`replace-alb-with-caddy-sidecar` still cannot be archived. Tasks 2.1–2.5 remain genuinely outstanding and need an operator to work through them against the live stack.

## Test plan

- `openspec validate replace-alb-with-caddy-sidecar` passes.
- No source, test, or Terraform files are touched, so the existing suites and Terraform gates are unaffected by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)