### PR TITLE
chore: add OpenSpec proposal for HTTPS toggle in the game form

### DIFF
--- a/openspec/changes/add-https-toggle-to-game-form/.openspec.yaml
+++ b/openspec/changes/add-https-toggle-to-game-form/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/add-https-toggle-to-game-form/design.md
+++ b/openspec/changes/add-https-toggle-to-game-form/design.md
@@ -49,7 +49,7 @@ Concretely:
 |---|---|
 | `WizardDraft` | add `https: boolean` (non-optional in the draft, even though the wire type is optional) |
 | `createEmptyWizardDraft()` | seed `https: false` |
-| `draftFromGameServer()` | `https: game.https ?? false` |
+| `draftFromGameServer()` | `https: game.https === true` |
 | `draftToPayload()` | emit `https` into the config |
 | `toProposedEntry()` | include `https` so validation sees it |
 | `stepForIssuePath()` | map `ports`-rooted paths to the networking step |
@@ -97,7 +97,7 @@ Accessibility follows the `Field` helper already in `identity-step.component.tsx
 
 `@cdktf/hcl2json` does not evaluate expressions. A tfvars entry written by hand as `https = length("valheim") > 0 ? true : false` parses back as a *string*, and `TfvarsService.test.ts` documents exactly this. Such an entry already fails `z.boolean()` in `validateGameServer` today, so it cannot be saved through the app at all — with or without this change.
 
-`draftFromGameServer` therefore uses `game.https ?? false`, which yields `false` for a string value rather than a truthy checkbox. This is deliberate and worth stating: the form shows what it can honestly represent, and any save through the form replaces the expression with a literal. That is the only behaviour consistent with a checkbox, and the pre-existing zod rejection means the alternative is not "preserve the expression" but "cannot use the form on this game at all".
+`draftFromGameServer` therefore normalises with `game.https === true`, which yields `false` for a string value rather than a truthy checkbox. `?? false` would not do this — it only substitutes for `null` and `undefined`, so a parsed expression string would survive into the draft and render the checkbox as checked. This is deliberate and worth stating: the form shows what it can honestly represent, and any save through the form replaces the expression with a literal. That is the only behaviour consistent with a checkbox, and the pre-existing zod rejection means the alternative is not "preserve the expression" but "cannot use the form on this game at all".
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-https-toggle-to-game-form/design.md
+++ b/openspec/changes/add-https-toggle-to-game-form/design.md
@@ -1,0 +1,121 @@
+## Context
+
+Since `replace-alb-with-caddy-sidecar`, a game flagged `https = true` in the `game_servers` map gains a Caddy sidecar container that terminates TLS with Let's Encrypt and reverse-proxies to the game container over `localhost`. The flag is a per-game boolean in the tfvars declaration, and everything below the UI already handles it:
+
+- `GameServer.https?: boolean` in `@hyveon/shared/tfvars.ts`, with `https: z.boolean().optional()` in `gameServerValidator.ts`.
+- `hclEmit.ts` emits `https = <bool>` when the value is defined, and omits the attribute when it is `undefined`.
+- `TfvarsService.parseGameServers()` spreads raw entries, so the flag survives the read; `updateGameServer()` → `replaceGameServerEntry()` → `emitGameServerEntry()` carries it back out.
+- The IPC and HTTP write surfaces are typed `Omit<GameServer, 'name'>`, so the flag is already in the payload contract.
+- `game-detail.page.tsx` renders it read-only from the declared config.
+
+The gap is the web form. The add-game wizard (#99) defined `WizardDraft` without `https`, and the edit-game form reuses that exact type. To avoid silently wiping the flag on save, the edit form spreads the original value back in after `draftToPayload`:
+
+```ts
+config: { ...config, environment: game.environment, https: game.https },
+```
+
+That workaround is why an operator who wants HTTPS today has to hand-edit the tfvars object in S3.
+
+There is a second, quieter gap. Terraform's `game_servers` variable validation imposes four rules that only apply to `https = true` games, and the app's zod validator replicates none of them. Today that is harmless because the UI cannot set the flag. The moment it can, the UI becomes capable of saving a declaration that passes every app-side check and then fails `terraform validate` — after the operator has already committed it to the remote tfvars object.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `https` a first-class editable field in both the add-game wizard and the edit-game form, sharing one control and one draft field.
+- Close the validation gap so the app rejects an HTTPS configuration that Terraform would reject, on every write path rather than only in the browser.
+- Tell the operator what enabling HTTPS actually does to the stack, at the moment they enable it.
+- Remove the `https` carry-forward workaround and the comments that explain it, so the code stops describing a constraint that no longer exists.
+
+**Non-Goals:**
+
+- Making `environment` editable. It is excluded for the same historical reason but is a different shape (a list of name/value pairs), a larger surface, and is not what is being asked for here. Its carry-forward stays.
+- Any Terraform change. The variable validation already exists and is the source of truth being mirrored.
+- Surfacing `hosted_zone_name` or the resulting `https://{game}.{zone}` URL in the form. The app carries no `hosted_zone_name` in any TypeScript type today; plumbing it through is a separate change (see Open Questions).
+- Per-game ingress. The 443/80 security-group rule is stack-wide by Terraform's design, keyed on whether any HTTPS game exists. The form describes that behaviour; it does not change it.
+- Any change to the read-only HTTPS field on the game detail page. It reads declared config and already updates from the write result without a refetch.
+
+## Decisions
+
+### D1: Put `https` on the shared `WizardDraft` rather than a form-local field
+
+`WizardDraft` is the single draft shape behind both flows, and the whole draft pipeline (`createEmptyWizardDraft`, `draftFromGameServer`, `draftToPayload`, `toProposedEntry`, `validateStep`, `stepForIssuePath`) is written against it. Adding the field there means the wizard gets the capability essentially for free and the edit form's carry-forward hack can be deleted outright.
+
+The alternative — a field local to the edit form, with the wizard continuing to create HTTPS-off games — was rejected. It leaves two divergent draft paths, and it produces the obvious follow-up complaint ("why can I edit this but not set it at creation?"). The cost of doing both at once is one extra call site in `createEmptyWizardDraft` and one summary line in the review step.
+
+Concretely:
+
+| Function | Change |
+|---|---|
+| `WizardDraft` | add `https: boolean` (non-optional in the draft, even though the wire type is optional) |
+| `createEmptyWizardDraft()` | seed `https: false` |
+| `draftFromGameServer()` | `https: game.https ?? false` |
+| `draftToPayload()` | emit `https` into the config |
+| `toProposedEntry()` | include `https` so validation sees it |
+| `stepForIssuePath()` | map `ports`-rooted paths to the networking step |
+
+The draft field is a strict `boolean` while the wire type stays `boolean | undefined`. Normalising at the draft boundary keeps the checkbox a controlled component with no `undefined` state to reason about, and `draftToPayload` emitting an explicit `false` is harmless — `hclEmit` writes `https = false`, which is what Terraform defaults to anyway.
+
+### D2: Render the control in the Networking step
+
+The flag is a networking concern: it decides which ports are publicly reachable and introduces a second container listening on 443/80. The Networking step is also where the ports it constrains are edited, so a violation and its cause are visible together. Both flows already render this step, so one placement serves both.
+
+The alternative of a dedicated step or card was rejected as disproportionate for a single boolean, and it would have separated the flag from the port rows its validation points at.
+
+### D3: Mirror Terraform's four HTTPS rules in `validateGameServer`, not in the component
+
+Putting the rules in the shared validator means they run behind the IPC and HTTP write surfaces too, so the protection is not defeated by a direct `games.update` call. It also matches how every other business rule in this codebase is expressed (Fargate cpu/memory pairing, absolute volume paths, connect_message placeholders, port collisions all live there).
+
+The rules, transcribed from `terraform/aws/variables.tf`:
+
+1. `length(cfg.ports) > 0`
+2. `cfg.ports[0].protocol == "tcp"` — exact, lowercase
+3. every port protocol ∈ `{"tcp", "udp"}`
+4. no port may be 80 or 443
+
+Rule 2's exactness deserves a note: Terraform compares the literal string, so `TCP` fails there. Being lenient in the app would let a save through that Terraform then rejects, which is precisely the failure this decision exists to prevent. The validator matches Terraform's strictness rather than being helpful, and the message says why.
+
+Issue paths are anchored per entry (`ports[0]`, `ports[2]`) so `stepForIssuePath` routes them to the networking step and the offending row can be highlighted. Rule 1 has no entry to point at and is pathed at `ports`.
+
+All four rules are gated on `https === true`. A non-HTTPS game may keep using UDP on 443 if it wants to.
+
+### D4: An inline callout gated on the enabled state, not a confirm dialog
+
+The three consequences — stack-wide 443/80 exposure, loss of the raw port's public ingress, first-boot ACME issuance needing DNS — are things the operator needs to *read*, and a dialog that is dismissed to proceed gets clicked through. An always-visible callout beside an enabled toggle keeps the information present while they finish configuring ports, which is exactly when rules 1–4 are most likely to bite.
+
+A confirm dialog was considered and rejected: the action is not destructive at the moment of the click (nothing happens until `terraform apply`), so the `RemoveGameButton` alert-dialog pattern would be borrowing weight from a different kind of risk. Plain helper text was also rejected as too easy to skip for a change that reshapes the security group.
+
+The repo's existing amber warning pattern is reused — `AlertTriangle` with `border-[var(--color-amber)]/40 bg-[var(--color-amber)]/10`, as used by the Terraform page's busy banner and the first-run wizard's bootstrap step — rather than introducing a new visual treatment.
+
+### D5: Use the repo's raw-checkbox pattern, not a new UI primitive
+
+There is no `checkbox.component.tsx` in `components/ui/`. Existing boolean controls (the Discord page's per-action permission grid, the Logs page's autoscroll toggles) use a styled `<input type="checkbox">` inside a `<label>`. This change follows that rather than introducing a shared primitive, which would be a refactor with its own blast radius across those call sites. If a third or fourth consumer appears later, extracting the primitive is a clean, separate change.
+
+Accessibility follows the `Field` helper already in `identity-step.component.tsx`: an associated `<Label htmlFor>`, `aria-describedby` pointing at the callout when it is shown, and `aria-invalid` when a rule is violated.
+
+### D6: Coerce a non-boolean parsed `https` to `false` in the draft
+
+`@cdktf/hcl2json` does not evaluate expressions. A tfvars entry written by hand as `https = length("valheim") > 0 ? true : false` parses back as a *string*, and `TfvarsService.test.ts` documents exactly this. Such an entry already fails `z.boolean()` in `validateGameServer` today, so it cannot be saved through the app at all — with or without this change.
+
+`draftFromGameServer` therefore uses `game.https ?? false`, which yields `false` for a string value rather than a truthy checkbox. This is deliberate and worth stating: the form shows what it can honestly represent, and any save through the form replaces the expression with a literal. That is the only behaviour consistent with a checkbox, and the pre-existing zod rejection means the alternative is not "preserve the expression" but "cannot use the form on this game at all".
+
+## Risks / Trade-offs
+
+**Operator enables HTTPS on a game whose DNS does not resolve, and Caddy loops on failed ACME orders** → The callout names the `{game}.{hosted_zone_name}` requirement explicitly. Beyond that, this is inherent to the Caddy design from `replace-alb-with-caddy-sidecar` and is not made worse here; the sidecar retries with backoff and the game container is unaffected because Caddy proxies over localhost regardless of cert state.
+
+**Enabling HTTPS on one game opens 443/80 for the whole stack, which the per-game control may imply is per-game** → The callout says "for the whole stack, not only this game" in those terms. A per-game ingress model would require a Terraform change and is out of scope.
+
+**Validator rules drift from Terraform's if the variable validation is later edited** → The rules are transcribed, not shared — there is no mechanism to derive TypeScript checks from HCL validation blocks. Mitigation is a comment in `gameServerValidator.ts` naming `terraform/aws/variables.tf` as the source of truth, so a future edit to either side has a pointer to the other. Both copies of the Terraform variable (root and module) already have to be kept in sync by hand, so this is a third instance of an existing discipline rather than a new class of problem.
+
+**A game that is currently valid becomes invalid under the new rules** → Only possible for a game already declared `https = true` with a non-conforming port list, which Terraform would already be refusing to apply. Such a game is broken today; the change surfaces it in the UI. If one exists, the edit form will block saving until the ports are corrected, which is the desired outcome rather than a regression.
+
+**`draftToPayload` now always emits `https`, so entries that previously omitted the attribute gain an explicit `https = false` on their next save** → Cosmetic. `false` is the Terraform default, so the plan is unchanged; the diff on the tfvars object gains one line for games saved through the form after this ships.
+
+## Migration Plan
+
+None required. The change is additive to the form and to validation, ships in a single PR, and needs no data migration, no Terraform apply, and no coordination with a deploy. Rollback is a revert: the flag returns to being carried forward untouched, and any `https` value already written to the tfvars object stays valid because the declaration format does not change.
+
+## Open Questions
+
+- Should the form show the resulting URL (`https://{game}.{hosted_zone_name}`) once the flag is enabled? It would make the ACME/DNS requirement concrete rather than abstract. It needs `hosted_zone_name` plumbed into a TypeScript type — it exists in the Terraform outputs (`terraform/aws/outputs.tf`) but is not surfaced anywhere in the app today. Deferred; the callout describes the requirement in prose in the meantime.
+- Should the review step block, rather than merely display, an HTTPS game whose ports violate the rules? The validation gate already disables save, so this is a question about redundancy in the wizard's summary rather than about correctness.

--- a/openspec/changes/add-https-toggle-to-game-form/proposal.md
+++ b/openspec/changes/add-https-toggle-to-game-form/proposal.md
@@ -50,7 +50,7 @@ The tfvars types, `gamesWrite.ts` payloads, the preload bridge and `gsd-api.ts`,
 
 - `wizard-form.utils.test.ts`, `networking-step.component.test.tsx`, `edit-game-form.component.test.tsx`, `review-step.component.test.tsx`
 - `gameServerValidator.test.ts` — one case per new rule, plus a case proving the rules are inert when `https` is false or absent.
-- `TfvarsService.write.test.ts` — assert `https` survives an update and that flipping it `false → true` rewrites the entry.
+- `TfvarsService.write.test.ts` — assert `https` survives an update, that flipping it `false → true` rewrites the entry, and that enabling it on an entry with no `https` attribute at all emits `https = true`.
 
 **Operator-visible behaviour**
 

--- a/openspec/changes/add-https-toggle-to-game-form/proposal.md
+++ b/openspec/changes/add-https-toggle-to-game-form/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The `replace-alb-with-caddy-sidecar` change made HTTPS a per-game flag that any operator should be able to turn on: set `https = true` in the `game_servers` map and the game's ECS task gains a Caddy sidecar that terminates TLS via Let's Encrypt. Every layer below the UI already carries that flag end to end — the tfvars schema, the zod validator, the IPC and HTTP payloads, the HCL emitter, and the read-only HTTPS field on the game detail page.
+
+The web UI is the one gap. Neither the add-game wizard nor the edit-game form has a control for `https`, because the wizard's draft shape (#99) never had a field for it. The edit form works around this by carrying the existing value forward verbatim so a save doesn't wipe it out. The practical consequence: turning HTTPS on for a game means hand-editing the tfvars object in S3, which is exactly the workflow the games UI exists to replace.
+
+## What Changes
+
+- Add `https` to the shared `WizardDraft` shape so both the add-game wizard and the edit-game form carry the flag through their draft → payload round trip.
+- Render an HTTPS toggle in the Networking step, which both flows already use. Enabling it reveals an inline amber callout describing the infrastructure consequences.
+- Remove the `https` carry-forward workaround in the edit form's submit path; the draft now owns the value. `environment` keeps its carry-forward, since it is still not an editable field.
+- Port the four Terraform-level `https = true` validation rules into the shared `validateGameServer` business rules, so a configuration that would fail `terraform validate` is blocked at the form instead:
+  - the game must declare at least one port;
+  - `ports[0].protocol` must be exactly `tcp` (Caddy's `reverse-proxy` only speaks HTTP over TCP to the first port);
+  - every port protocol must be `tcp` or `udp`;
+  - no port may use 80 or 443, which are reserved for the sidecar on the task's shared ENI.
+- Issues are pathed at `ports[N]` so the offending port row highlights in the Networking step rather than surfacing as a generic review-step error.
+- Add `https` round-trip coverage to the tfvars write tests, which currently contain no `https` at all.
+
+No breaking changes. A game that omits `https` continues to behave exactly as before — the flag stays optional and defaults to `false`.
+
+## Capabilities
+
+### New Capabilities
+
+- `game-https-configuration`: Operator-facing configuration of a game's in-task TLS termination — how the `https` flag is presented, what constraints govern a valid HTTPS-enabled game, what the operator is told before enabling it, and how the value round-trips to the tfvars declaration.
+
+### Modified Capabilities
+
+None. No existing spec files live under `openspec/specs/` yet, so there are no published requirements to amend.
+
+## Impact
+
+**Web (`@hyveon/web`)**
+
+- `components/add-game-wizard/wizard-form.utils.ts` — `WizardDraft` gains `https`; `createEmptyWizardDraft`, `draftFromGameServer`, `draftToPayload`, `toProposedEntry`, and `stepForIssuePath` all need updating.
+- `components/add-game-wizard/networking-step.component.tsx` — the toggle plus the amber callout.
+- `components/edit-game-form/edit-game-form.component.tsx` — drop the `https` carry-forward from the submit payload; update the module doc and inline comment that explain the old workaround.
+- `components/add-game-wizard/review-step.component.tsx` — surface the flag in the Networking summary.
+
+**Shared (`@hyveon/shared`)**
+
+- `gameServerValidator.ts` — four new business rules in `validateGameServer`, active only when `https === true`. This runs on the IPC/HTTP surface too, so the protection is not UI-only.
+
+**Unchanged (verified)**
+
+The tfvars types, `gamesWrite.ts` payloads, the preload bridge and `gsd-api.ts`, `api.service.ts`, both games controllers, `GamesWriteService`, `hclEmit`, and the `TfvarsService` write path already handle `https` correctly. No IPC, DTO, or Terraform changes are required.
+
+**Tests**
+
+- `wizard-form.utils.test.ts`, `networking-step.component.test.tsx`, `edit-game-form.component.test.tsx`, `review-step.component.test.tsx`
+- `gameServerValidator.test.ts` — one case per new rule, plus a case proving the rules are inert when `https` is false or absent.
+- `TfvarsService.write.test.ts` — assert `https` survives an update and that flipping it `false → true` rewrites the entry.
+
+**Operator-visible behaviour**
+
+Enabling HTTPS opens 443 and 80 to the internet stack-wide (the Terraform rule is keyed on "any HTTPS game exists", not per game), removes the game's raw container port from public ingress, and makes first boot perform an ACME issuance that requires `{game}.{hosted_zone_name}` to resolve to the task. The callout has to state all three, because none of them are recoverable by simply unchecking the box after a `terraform apply`.

--- a/openspec/changes/add-https-toggle-to-game-form/specs/game-https-configuration/spec.md
+++ b/openspec/changes/add-https-toggle-to-game-form/specs/game-https-configuration/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Operators can set a game's HTTPS flag from the game form
+
+The web UI SHALL expose the `https` flag as an editable control in both the add-game wizard and the edit-game form. The control SHALL live in the Networking step, which both flows render. The flag SHALL default to disabled for a new game and SHALL reflect the game's current declared value when editing an existing game.
+
+#### Scenario: Creating a game with HTTPS enabled
+
+- **WHEN** an operator starts the add-game wizard, reaches the Networking step, and enables the HTTPS control
+- **THEN** the submitted create payload carries `https: true` in the game config
+
+#### Scenario: Creating a game without touching the control
+
+- **WHEN** an operator completes the add-game wizard without interacting with the HTTPS control
+- **THEN** the submitted create payload carries `https: false`
+
+#### Scenario: Editing a game that already has HTTPS enabled
+
+- **WHEN** an operator opens the edit form for a game whose declaration sets `https = true`
+- **THEN** the HTTPS control renders in the enabled state
+
+#### Scenario: Disabling HTTPS on an existing game
+
+- **WHEN** an operator opens the edit form for a game with `https = true`, disables the control, and saves
+- **THEN** the submitted update payload carries `https: false` rather than carrying the previous `true` forward
+
+#### Scenario: Saving an unrelated field does not disturb the flag
+
+- **WHEN** an operator edits only the container image on a game with `https = true` and saves
+- **THEN** the submitted update payload still carries `https: true`
+
+### Requirement: An HTTPS-enabled game must satisfy the Caddy sidecar's port constraints
+
+The shared game-server validator SHALL enforce, for any game whose `https` flag is true, the same four constraints that the Terraform `game_servers` variable validation enforces. Because the validator runs on the IPC and HTTP write surfaces as well as behind the form, these constraints SHALL apply to every write path, not only the UI.
+
+The constraints are:
+
+1. the game MUST declare at least one port;
+2. the first port entry MUST use protocol `tcp`, matched exactly and in lowercase;
+3. every port entry MUST use a protocol of either `tcp` or `udp`;
+4. no port entry may use container port 80 or 443.
+
+Each violation SHALL be reported with an issue path anchored to the offending port entry (`ports[N]`) where a specific entry is at fault, so the Networking step can highlight that row. A violation of constraint 1 SHALL be pathed at `ports`.
+
+#### Scenario: HTTPS game with no ports declared
+
+- **WHEN** a game config sets `https: true` and declares an empty `ports` array
+- **THEN** validation fails with an issue pathed at `ports` explaining that an HTTPS game must declare at least one port
+
+#### Scenario: HTTPS game whose first port is not TCP
+
+- **WHEN** a game config sets `https: true` and its first port entry uses protocol `udp`
+- **THEN** validation fails with an issue pathed at `ports[0]` explaining that the first port must use protocol `tcp`
+
+#### Scenario: HTTPS game whose first port protocol is uppercase
+
+- **WHEN** a game config sets `https: true` and its first port entry uses protocol `TCP`
+- **THEN** validation fails with an issue pathed at `ports[0]`, because Terraform matches the literal lowercase string
+
+#### Scenario: HTTPS game using a port reserved for the sidecar
+
+- **WHEN** a game config sets `https: true` and any port entry declares container port 443
+- **THEN** validation fails with an issue pathed at that port entry explaining that 80 and 443 are reserved for the Caddy sidecar
+
+#### Scenario: Port with an unsupported protocol
+
+- **WHEN** a game config sets `https: true` and any port entry uses a protocol other than `tcp` or `udp`
+- **THEN** validation fails with an issue pathed at that port entry
+
+#### Scenario: Constraints are inert when HTTPS is off
+
+- **WHEN** a game config sets `https: false` or omits the flag entirely, and declares a single `udp` port on container port 443
+- **THEN** validation does not report any of the four HTTPS constraints
+
+#### Scenario: A valid HTTPS game passes
+
+- **WHEN** a game config sets `https: true` and declares a first port of container 8080 protocol `tcp`
+- **THEN** validation reports no HTTPS-related issues
+
+### Requirement: The form blocks a save that Terraform would reject
+
+The game form SHALL surface HTTPS constraint violations as blocking validation issues, disabling the save action while any remain. Issues pathed at a port entry SHALL be attributed to the Networking step so the operator is directed to the control that caused them.
+
+#### Scenario: Save is blocked while a constraint is violated
+
+- **WHEN** an operator enables HTTPS on a game whose first port uses `udp`
+- **THEN** the save action is disabled and the Networking step shows the violation against the offending port row
+
+#### Scenario: Save unblocks once the configuration is corrected
+
+- **WHEN** the operator changes that first port's protocol to `tcp`
+- **THEN** the violation clears and the save action becomes available
+
+### Requirement: Operators are warned about the consequences of enabling HTTPS
+
+When the HTTPS control is enabled, the form SHALL display an inline warning callout adjacent to the control. The callout SHALL state all three infrastructure consequences, because none of them are undone by simply disabling the flag after a `terraform apply` has run:
+
+1. ports 443 and 80 become open to the internet for the whole stack, not only for this game;
+2. this game's raw container port loses its public ingress rule, and reaching the game goes through the sidecar;
+3. the task's first boot performs a Let's Encrypt (ACME) issuance, which requires `{game}.{hosted_zone_name}` to resolve to the running task.
+
+#### Scenario: Callout appears when the flag is enabled
+
+- **WHEN** an operator enables the HTTPS control
+- **THEN** a warning callout appears beside it covering the ingress change, the loss of direct port access, and the ACME/DNS requirement
+
+#### Scenario: Callout is absent when the flag is off
+
+- **WHEN** the HTTPS control is disabled
+- **THEN** no warning callout is rendered
+
+### Requirement: The HTTPS flag round-trips to the tfvars declaration
+
+A game's `https` value SHALL survive the full write path from form submission to the emitted HCL in the remote tfvars object, and SHALL be read back into the form on a subsequent edit.
+
+#### Scenario: Enabling HTTPS rewrites the declaration
+
+- **WHEN** a game previously declared without `https` is updated with `https: true`
+- **THEN** the rewritten tfvars entry emits `https = true`
+
+#### Scenario: Disabling HTTPS rewrites the declaration
+
+- **WHEN** a game declared with `https = true` is updated with `https: false`
+- **THEN** the rewritten tfvars entry emits `https = false` rather than omitting the attribute
+
+#### Scenario: Unrelated edits preserve the declared value
+
+- **WHEN** a game declared with `https = true` has only its memory value updated
+- **THEN** the rewritten tfvars entry still emits `https = true` and no other attribute is disturbed

--- a/openspec/changes/add-https-toggle-to-game-form/tasks.md
+++ b/openspec/changes/add-https-toggle-to-game-form/tasks.md
@@ -1,0 +1,43 @@
+# Tasks — add-https-toggle-to-game-form
+
+Single PR. Validation lands before the UI so the form has real rules to bind to, and so a
+half-finished branch never ships a control that can save a Terraform-invalid declaration.
+
+## 1. Shared validation (`@hyveon/shared`)
+
+- [ ] 1.1 In `app/packages/shared/src/gameServerValidator.ts`, add an HTTPS business-rule block to `validateGameServer`, gated on `https === true`. Transcribe the four rules from `terraform/aws/variables.tf`: at least one port (pathed `ports`); `ports[0].protocol === 'tcp'` matched exactly and lowercase (pathed `ports[0]`); every port protocol in `{'tcp','udp'}` (pathed at the offending entry); no port using 80 or 443 (pathed at the offending entry). Add a comment naming `terraform/aws/variables.tf` as the source of truth these rules mirror.
+- [ ] 1.2 Extend `gameServerValidator.test.ts`: one failing case per rule asserting both the message and the issue path, a case proving all four are inert when `https` is `false` and when it is omitted, and a passing case for a valid HTTPS game (first port `8080/tcp`). Include the uppercase-`TCP` case explicitly — it is the rule most likely to look like a bug later.
+
+## 2. Draft plumbing (`@hyveon/web`)
+
+- [ ] 2.1 In `app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts`, add `https: boolean` to `WizardDraft`; seed `https: false` in `createEmptyWizardDraft()`; read `https: game.https ?? false` in `draftFromGameServer()`; emit `https` from `draftToPayload()`; include it in `toProposedEntry()` so validation sees it.
+- [ ] 2.2 Update `stepForIssuePath()` so `ports`-rooted paths (`ports`, `ports[N]`) resolve to the `networking` step rather than falling through to `review`, and confirm existing port-collision issues still route correctly.
+- [ ] 2.3 Extend `wizard-form.utils.test.ts`: round-trip a `GameServer` with `https: true` through `draftFromGameServer` → `draftToPayload`; assert a game with no `https` yields a `false` draft and an explicit `https: false` payload; assert a string-valued `https` (the `hcl2json` expression case from design D6) coerces to `false`; assert `stepForIssuePath` maps `ports[1]` to `networking`.
+
+## 3. Networking step control (`@hyveon/web`)
+
+- [ ] 3.1 In `networking-step.component.tsx`, render the HTTPS checkbox using the repo's raw-checkbox pattern (styled `<input type="checkbox">` inside a `<label>`, per `discord.page.tsx`), with an associated `<Label htmlFor>` and `aria-invalid` when a rule is violated.
+- [ ] 3.2 Render the amber warning callout beside the control, shown only when the flag is enabled, using the existing `AlertTriangle` + `border-[var(--color-amber)]/40 bg-[var(--color-amber)]/10` pattern. Cover all three consequences: 443/80 open stack-wide (not per game), this game's raw container port loses public ingress, and first boot performs an ACME issuance requiring `{game}.{hosted_zone_name}` to resolve. Wire `aria-describedby` from the control to the callout while it is shown.
+- [ ] 3.3 Surface HTTPS port-rule issues against the offending port row so the operator sees which entry is at fault.
+- [ ] 3.4 Extend `networking-step.component.test.tsx`: toggling the control fires the change handler with the right value; the callout renders only when enabled; a violated rule marks the control/row invalid and the callout is referenced by `aria-describedby`.
+
+## 4. Edit form (`@hyveon/web`)
+
+- [ ] 4.1 In `edit-game-form.component.tsx`, drop `https` from the carry-forward spread in `handleSave()` so the draft owns the value; keep `environment`'s carry-forward untouched.
+- [ ] 4.2 Update the module doc comment and the inline submit comment so they describe only `environment` as non-editable — the current text explains a constraint that no longer applies to `https`.
+- [ ] 4.3 Extend `edit-game-form.component.test.tsx`: a game with `https: true` renders the control enabled; disabling and saving sends `https: false` rather than carrying `true` forward; editing only the image on an HTTPS game still sends `https: true`.
+
+## 5. Wizard review step (`@hyveon/web`)
+
+- [ ] 5.1 Add the HTTPS flag to the Networking summary in `review-step.component.tsx` so a wizard-created game's TLS setting is visible before submit.
+- [ ] 5.2 Extend `review-step.component.test.tsx` to cover both the enabled and disabled rendering.
+
+## 6. Write-path coverage (`@hyveon/desktop-main`)
+
+- [ ] 6.1 Add `https` coverage to `TfvarsService.write.test.ts`, which currently has none: an update that flips `false → true` emits `https = true`; an update that flips `true → false` emits `https = false` rather than dropping the attribute; an unrelated field edit on an HTTPS game leaves `https = true` and the surrounding attributes intact.
+
+## 7. Gates and PR
+
+- [ ] 7.1 Gate: `npm run app:test` and `npm run app:lint` pass from the repo root.
+- [ ] 7.2 Manually drive the flow in the app (`npm run app:dev`): enable HTTPS on a game, confirm the callout appears, confirm a `udp` first port blocks the save with the issue on the right row, correct it, save, and verify the game detail page's read-only HTTPS field flips to Enabled without a refetch.
+- [ ] 7.3 Open PR via `/pr`: title `feat(web): allow setting the HTTPS flag from the game form`, body first line `Closes #N` once the issue is filed.

--- a/openspec/changes/add-https-toggle-to-game-form/tasks.md
+++ b/openspec/changes/add-https-toggle-to-game-form/tasks.md
@@ -40,4 +40,4 @@ half-finished branch never ships a control that can save a Terraform-invalid dec
 
 - [ ] 7.1 Gate: `npm run app:test` and `npm run app:lint` pass from the repo root.
 - [ ] 7.2 Manually drive the flow in the app (`npm run app:dev`): enable HTTPS on a game, confirm the callout appears, confirm a `udp` first port blocks the save with the issue on the right row, correct it, save, and verify the game detail page's read-only HTTPS field flips to Enabled without a refetch.
-- [ ] 7.3 Open PR via `/pr`: title `feat(web): allow setting the HTTPS flag from the game form`, body first line `Closes #N` once the issue is filed.
+- [ ] 7.3 Open PR via `/pr`: title `feat(web): allow setting the HTTPS flag from the game form`, body first line `Closes #335`.

--- a/openspec/changes/add-https-toggle-to-game-form/tasks.md
+++ b/openspec/changes/add-https-toggle-to-game-form/tasks.md
@@ -10,7 +10,7 @@ half-finished branch never ships a control that can save a Terraform-invalid dec
 
 ## 2. Draft plumbing (`@hyveon/web`)
 
-- [ ] 2.1 In `app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts`, add `https: boolean` to `WizardDraft`; seed `https: false` in `createEmptyWizardDraft()`; read `https: game.https ?? false` in `draftFromGameServer()`; emit `https` from `draftToPayload()`; include it in `toProposedEntry()` so validation sees it.
+- [ ] 2.1 In `app/packages/web/src/components/add-game-wizard/wizard-form.utils.ts`, add `https: boolean` to `WizardDraft`; seed `https: false` in `createEmptyWizardDraft()`; read `https: game.https === true` in `draftFromGameServer()` — an explicit strict-equality normalisation, not `?? false`, so a non-boolean parsed value (design D6) becomes `false` rather than surviving as a truthy string; emit `https` from `draftToPayload()`; include it in `toProposedEntry()` so validation sees it.
 - [ ] 2.2 Update `stepForIssuePath()` so `ports`-rooted paths (`ports`, `ports[N]`) resolve to the `networking` step rather than falling through to `review`, and confirm existing port-collision issues still route correctly.
 - [ ] 2.3 Extend `wizard-form.utils.test.ts`: round-trip a `GameServer` with `https: true` through `draftFromGameServer` → `draftToPayload`; assert a game with no `https` yields a `false` draft and an explicit `https: false` payload; assert a string-valued `https` (the `hcl2json` expression case from design D6) coerces to `false`; assert `stepForIssuePath` maps `ports[1]` to `networking`.
 
@@ -34,7 +34,7 @@ half-finished branch never ships a control that can save a Terraform-invalid dec
 
 ## 6. Write-path coverage (`@hyveon/desktop-main`)
 
-- [ ] 6.1 Add `https` coverage to `TfvarsService.write.test.ts`, which currently has none: an update that flips `false → true` emits `https = true`; an update that flips `true → false` emits `https = false` rather than dropping the attribute; an unrelated field edit on an HTTPS game leaves `https = true` and the surrounding attributes intact.
+- [ ] 6.1 Add `https` coverage to `TfvarsService.write.test.ts`, which currently has none: an update that enables HTTPS on an entry omitting `https` entirely emits `https = true` (the common case, since the attribute is optional and most existing entries lack it); an update that flips `false → true` emits `https = true`; an update that flips `true → false` emits `https = false` rather than dropping the attribute; an unrelated field edit on an HTTPS game leaves `https = true` and the surrounding attributes intact.
 
 ## 7. Gates and PR
 


### PR DESCRIPTION
## Summary

Adds the OpenSpec change `add-https-toggle-to-game-form`. **Proposal only — no application code changes.**

The `replace-alb-with-caddy-sidecar` change turned HTTPS into a per-game flag: set `https = true` in the `game_servers` map and the game's ECS task gains a Caddy sidecar that terminates TLS via Let's Encrypt. Every layer below the UI already carries that flag end to end — the tfvars schema, the zod validator, the IPC and HTTP payloads, the HCL emitter, and the read-only HTTPS field on the game detail page.

The web UI is the one gap. Neither the add-game wizard nor the edit-game form exposes a control for `https`, because the wizard's draft shape (#99) never had a field for it; the edit form works around this by carrying the existing value forward verbatim so a save doesn't wipe it out. The practical consequence is that enabling HTTPS means hand-editing the tfvars object in S3 — exactly the workflow the games UI exists to replace.

## What's in this PR

| File | Contents |
|------|----------|
| `proposal.md` | Scope, impact, and the operator-visible consequences of enabling the flag |
| `design.md` | Design decisions behind the draft plumbing, the control, and the validation rules |
| `specs/game-https-configuration/spec.md` | New capability: how the flag is presented, constrained, explained, and round-tripped |
| `tasks.md` | Seven task groups, validation first |

## Proposed work (for the follow-up implementation PR)

- Add `https` to the shared `WizardDraft` shape so both the wizard and the edit form carry it through their draft → payload round trip, and drop the edit form's carry-forward workaround.
- Render an HTTPS toggle in the Networking step, with an inline amber callout covering all three consequences that a later uncheck cannot undo: 443/80 open stack-wide (the Terraform rule is keyed on "any HTTPS game exists", not per game), the game's raw container port losing public ingress, and first boot performing an ACME issuance that requires `{game}.{hosted_zone_name}` to resolve.
- Port the four Terraform-level `https = true` validation rules from `terraform/aws/variables.tf` into the shared `validateGameServer` business rules, so an invalid configuration is blocked at the form rather than at `terraform validate`. Issues are pathed at `ports[N]` so the offending port row highlights in the Networking step.
- Add `https` round-trip coverage to the tfvars write tests, which currently contain none.

No breaking changes — a game that omits `https` behaves exactly as before, and the flag stays optional and defaults to `false`.

## Test plan

- No code changed, so no test run applies to this PR.
- The proposal's own gates (`tasks.md` §7) require `npm run app:test` and `npm run app:lint` to pass, plus a manual pass through `npm run app:dev`, before the implementation PR merges.
- Task 7.3 notes the implementation PR needs a `Closes #N` line; the tracking issue has not been filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
