### PR TITLE
docs: remove stale "Copilot runs on every push" claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ If the plugin isn't loaded in the current environment, fetch the skill body from
 
 ## PR Review Workflow
 
-Copilot runs automatically on every push. Most suggestions are not actionable — expect to apply ~1 in 3.
+Most suggestions are not actionable — expect to apply ~1 in 3.
 
 - **Fix** if: genuinely buggy, insecure, crashes, or incorrect logic.
 - **Decline** if: style, naming, "consider", missing non-essential comment, minor nit — one-line reply ("Declined — stylistic, leaving as-is.") then resolve the thread.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,4 +285,4 @@ Most suggestions are not actionable — expect to apply ~1 in 3.
 - **Ask** (`AskUserQuestion`) if: ambiguous or architecturally significant. Don't silently dismiss.
 - **Stop pushing** when the round is all nitpicks — the PR is ready. Reply to each thread and move on.
 
-Always reply on the thread (fix applied + SHA, or reason for decline) and resolve it with `mcp__github__resolve_review_thread`. Copilot's system behaviour is tuned via `.github/copilot-instructions.md` — keep that file and this section in sync.
+Every comment must resolve to an explicit **Fix** or **Decline** — never leave a thread open with a noncommittal reply like "tracking this" or "will consider." Always reply on the thread (fix applied + SHA, or reason for decline) and resolve it with `mcp__github__resolve_review_thread`.


### PR DESCRIPTION
Removes the "Copilot runs automatically on every push" line from CLAUDE.md's PR Review Workflow section — no longer accurate. The rest of the section (fix/decline/ask triage rules) is unaffected.

## Test plan

- [x] Single-line doc removal, no code impact.