### PR TITLE
fix(docs): stop the diagram CSS from breaking the navbar logo

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -31,11 +31,19 @@
 }
 
 /* ── Diagrams ─────────────────────────────────────────────────────────────── */
-img[src$='.svg'] {
+/*
+ * Scoped to `.markdown` (the rendered page body) on purpose. An unscoped
+ * `img[src$='.svg']` also matches the navbar brand image, and both rules break
+ * it: `height: auto` beats Infima's `.navbar__logo img { height: 2rem }` — same
+ * specificity, but this stylesheet loads last — so the 1024×1024 `logo.svg`
+ * renders at full size, and the dark-mode filter inverts its palette. Every
+ * diagram is embedded from markdown, so nothing here needs the wider reach.
+ */
+.markdown img[src$='.svg'] {
   max-width: 100%;
   height: auto;
 }
 
-[data-theme='dark'] img[src$='.svg'] {
+[data-theme='dark'] .markdown img[src$='.svg'] {
   filter: invert(0.85) hue-rotate(180deg);
 }


### PR DESCRIPTION
## Why

The navbar logo added in #345 renders at 1024×1024 on the deployed site, covering the homepage, and its palette is inverted in dark mode.

Neither is a problem with `logo.svg`. Both come from the diagram rules in `docs/src/css/custom.css`, which were written for the architecture SVGs but selected on `img[src$='.svg']` with no scope, so they also matched the navbar brand image:

- `height: auto` beat Infima's `.navbar__logo img { height: 2rem }`. Same specificity, but `custom.css` is injected last, so the logo fell back to the SVG's intrinsic 1024px.
- `filter: invert(0.85) hue-rotate(180deg)`, meant to make the dark-on-light diagrams legible against the dark theme, turned the mark's deep purple into washed-out lavender with a cyan core.

## What changed

Scoped both rules to `.markdown` — the rendered page body. Every diagram is embedded from a markdown page, so nothing loses coverage, and any future navbar or footer artwork is protected by the same boundary. Added a comment recording why the selector is scoped, so the next person doesn't widen it back.

## Test plan

Verified against `docusaurus start` with Playwright, in both colour schemes:

- Navbar logo: `32×32`, `filter: none` (was 1024×1024 with the invert filter applied).
- Architecture diagrams: `max-width: 100%` still honoured (868px in a 900px viewport), dark-mode `invert(0.85) hue-rotate(180deg)` still applied.
- `npm ci && npm run build` in `docs/` completes with `[SUCCESS] Generated static files in "build"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)