### PR TITLE
docs(openspec): propose bumping the Lambda runtime to nodejs24.x

### DIFF
--- a/openspec/changes/bump-lambda-runtime-to-nodejs24/.openspec.yaml
+++ b/openspec/changes/bump-lambda-runtime-to-nodejs24/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/bump-lambda-runtime-to-nodejs24/design.md
+++ b/openspec/changes/bump-lambda-runtime-to-nodejs24/design.md
@@ -1,0 +1,56 @@
+## Context
+
+Five `aws_lambda_function` resources declare `runtime = "nodejs20.x"`; five matching `esbuild.config.mjs` files emit `target: 'node20'`. AWS deprecated `nodejs20.x` on 30 April 2026. The functions keep running — deprecation is not a shutdown — but the runtime stops receiving patches, and `terraform apply` loses the ability to update these functions on 3 March 2027.
+
+Two facts were established experimentally before this design was written, not inferred:
+
+1. **Provider 5 cannot express `nodejs24.x`.** A minimal config pinned at `~> 5.0` resolves to 5.100.0 (the last 5.x) and fails `terraform validate` with `expected runtime to be one of [... "nodejs20.x" ... "nodejs22.x"], got nodejs24.x`. The provider validates against a list compiled into it, so this fails locally, before any AWS call.
+2. **The real module validates under provider 6 with `nodejs24.x`.** Bumping both constraints to `~> 6.0` and all five runtimes to `nodejs24.x`, then running `terraform init -backend=false && terraform validate` against `terraform/`, returns `Success! The configuration is valid` with provider 6.56.0 — plus two deprecation warnings, both `hash_key is deprecated. Use key_schema instead.`, on `aws_dynamodb_table.runs` and `aws_dynamodb_table.audit`.
+
+`terraform validate` is not `terraform plan`. Validation proves the configuration is expressible; only a plan against real state shows whether provider 6 wants to change or replace anything.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move all five Lambdas onto a runtime AWS supports, with enough runway to avoid repeating the exercise within the year.
+- Keep the esbuild targets in lockstep with the runtime in the same change.
+- Raise the AWS provider only as far as the runtime requires, and review the resulting plan rather than assume it is empty.
+
+**Non-Goals:**
+- Changing any Lambda's behaviour, handler signature, dependencies, or IAM. This is a runtime and provider change only.
+- Migrating `hash_key` → `key_schema`. See the decision below.
+- Touching the developer/CI toolchain Node version, which is handled by `move-toolchain-to-node-24`.
+- Modernising anything else the provider 6 upgrade happens to make available.
+
+## Decisions
+
+**Target `nodejs24.x`, not `nodejs22.x`.** Node 22 is supported until 30 April 2027 and Node 24 until 30 April 2028. Choosing 22 avoids the provider upgrade entirely — it is on provider 5's accepted list — but buys nine months, at which point the same work recurs plus the provider upgrade that was deferred. Node 24 also matches the Node major the repo now uses for development and CI, so contributors run locally what the Lambdas run in AWS. The cost is that the provider upgrade becomes mandatory rather than optional; that cost is paid once either way.
+
+**Raise the provider to `~> 6.0` in the same change, not a preceding one.** Splitting it would produce a provider-only PR whose entire justification is a runtime change that isn't in it, and whose plan output could not be evaluated against the thing it exists to enable. Keeping them together means one plan review covering both. The constraint moves in `terraform/main.tf` and `terraform/aws/versions.tf` together — they are duplicated declarations of the same dependency and drift between them is its own bug.
+
+**Leave `hash_key` alone; treat the warnings as a follow-up.** Provider 6 deprecates `hash_key` in favour of `key_schema` on `aws_dynamodb_table`. Deprecation warnings do not block apply, and `key_schema` restructures how the table's key is declared — on a table holding live Discord config, run history, and audit rows, a botched key declaration risks a replacement, which destroys data. That belongs in a change whose plan is read specifically for it, not bundled into a runtime bump where a `~` on a DynamoDB table would be easy to skim past. The warnings are recorded here so the next person knows they are known rather than missed.
+
+**Verify against the live functions, not just the plan.** Each bundle is built with `external: ['@aws-sdk/*']`, meaning the AWS SDK v3 the code calls is the one baked into the Lambda runtime image. Moving the runtime moves that SDK by two majors of Node and an unknown number of SDK minors, with no lockfile recording it. The failure mode is a call that still compiles and still bundles but behaves differently at runtime, which only an invocation catches — hence the post-apply invocation checks in tasks.md rather than a purely static review.
+
+## Risks / Trade-offs
+
+- **Provider 6 wants to change resources unrelated to Lambda.** → The plan is generated and read in full before apply. Any non-empty diff outside the five Lambda functions is triaged before proceeding; if a resource would be *replaced* rather than updated in place, the change stops and that resource is handled deliberately. This is the single largest risk in the change and the reason a plan review is a task rather than a formality.
+- **The runtime-provided AWS SDK changes underneath the Lambdas.** → Exercise every AWS-calling path after apply: a Discord slash command end-to-end (interactions → followup → ECS), a task start and stop to drive the DNS UPSERT and DELETE, and a watchdog cycle for the CloudWatch and ECS-tag paths.
+- **`nodejs24.x` is not available in a region the project deploys to.** → AWS withholds soon-to-deprecate runtimes from new regions, not new runtimes from established ones; `nodejs24.x` on Amazon Linux 2023 is generally available. The plan surfaces this immediately if it is wrong for the configured region.
+- **Rolling back after apply means another apply.** → Reverting the commit restores `nodejs20.x` and the provider constraint, and a fresh apply puts it back. `nodejs20.x` remains deployable until 3 March 2027, so the rollback path stays open for the foreseeable window — which is precisely the window this change exists to get ahead of.
+- **Two Terraform files declare the provider constraint.** → Both are changed in the same commit; a grep for `~> 5.0` is part of the task list so neither is missed.
+
+## Migration Plan
+
+1. Change `runtime` in all five Lambda resources and `target` in all five esbuild configs.
+2. Raise the AWS provider constraint to `~> 6.0` in `terraform/main.tf` and `terraform/aws/versions.tf`.
+3. `npm run app:build:lambdas` — Terraform's `archive_file` data sources read `dist/handler.cjs`, so the bundles must exist and must be the newly targeted ones before planning.
+4. `terraform init -upgrade`, then `terraform validate`, then `terraform plan`. Read the whole plan; confirm the only changes are the five functions plus whatever the provider upgrade legitimately introduces, and that nothing is being replaced.
+5. `terraform apply`.
+6. Exercise the live paths (Discord command, task start/stop for DNS, watchdog cycle) and check CloudWatch logs for runtime-level errors.
+
+Rollback: revert the commit, rebuild the bundles, re-apply. Available until AWS blocks updates to `nodejs20.x` on 3 March 2027.
+
+## Open Questions
+
+- Does `terraform plan` under provider 6 show diffs beyond the five Lambdas? Unknown until run against real state with credentials — `validate` cannot answer it. This is the first task in the verification group and gates the apply.

--- a/openspec/changes/bump-lambda-runtime-to-nodejs24/proposal.md
+++ b/openspec/changes/bump-lambda-runtime-to-nodejs24/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+All five Lambdas (`interactions`, `followup`, `update-dns`, `watchdog`, `efs-seeder`) declare `runtime = "nodejs20.x"`, and AWS deprecated that runtime on **30 April 2026** — it is listed under "Deprecated runtimes", not "Supported runtimes". Deprecated functions keep running and keep receiving invocations, but AWS stops patching the runtime, and two hard cutoffs are already scheduled: **function creation blocked 1 February 2027** and **function updates blocked 3 March 2027**. After the second date, `terraform apply` can no longer push new Lambda code at all, which would leave the Discord bot, the DNS updater, the watchdog, and the EFS seeder frozen at whatever version was last deployed.
+
+The runtime is not automatically dragged along by a developer-toolchain change — the companion `move-toolchain-to-node-24` change explicitly excludes it — so it needs its own change and its own deploy.
+
+## What Changes
+
+- All five Lambdas move from `runtime = "nodejs20.x"` to `runtime = "nodejs24.x"` in `terraform/aws/{interactions,followup,route53,watchdog,efs-seeder}.tf`. Node 24 (not 22) because it is supported until 30 April 2028 against Node 22's 30 April 2027 — targeting 22 would mean repeating this exercise in nine months — and because it matches the Node 24 the repo now uses for development and CI.
+- The esbuild `target` in all five `app/packages/lambda/*/esbuild.config.mjs` files moves from `'node20'` to `'node24'`, in the same change. The bundle's output syntax and the runtime executing it must stay in lockstep.
+- **BREAKING** (infrastructure, not API): the AWS provider constraint goes from `~> 5.0` to `~> 6.0` in both `terraform/main.tf` and `terraform/aws/versions.tf`. This is forced, not optional — provider 5.100.0, the last 5.x release, rejects `nodejs24.x` at `terraform validate` because the runtime postdates it. A major provider upgrade touches every resource in the module, so the plan output is reviewed as part of this change rather than assumed clean.
+- Two `hash_key` arguments (`aws_dynamodb_table.runs`, `aws_dynamodb_table.audit`) become deprecation warnings under provider 6 and should move to `key_schema`. Whether that happens here or in a follow-up is a scoping call recorded in design.md.
+- Any documentation stating the Lambda runtime version is updated to match.
+
+## Capabilities
+
+### New Capabilities
+
+- `lambda-runtime-currency`: the deployed Lambda runtime is a version AWS still supports, the esbuild target that produces each bundle matches the runtime that executes it, and the Terraform AWS provider is new enough to express the chosen runtime. Covers the standing rule that these three move together.
+
+### Modified Capabilities
+
+None. No existing spec in `openspec/specs/` states a Lambda runtime version.
+
+## Impact
+
+- **Terraform**: `terraform/aws/interactions.tf`, `followup.tf`, `route53.tf`, `watchdog.tf`, `efs-seeder.tf` (runtime), plus `terraform/main.tf` and `terraform/aws/versions.tf` (provider constraint).
+- **Build**: the five `app/packages/lambda/*/esbuild.config.mjs` files.
+- **Deploy**: requires `npm run app:build:lambdas` followed by a reviewed `terraform plan` and a `terraform apply`. This is the first change in this sequence that alters live AWS resources — the toolchain change did not.
+- **Runtime behaviour**: each Lambda bundles with `external: ['@aws-sdk/*']`, so the AWS SDK v3 they execute against is the copy shipped inside the Lambda runtime image, not one in the bundle. Changing the runtime therefore also changes the SDK version at runtime — a dependency that is invisible in `package.json` and is called out in design.md as the main behavioural risk.
+- **Not affected**: no application, desktop, or renderer code; no game task definitions; no DNS, ECS, or Discord behaviour beyond the Lambdas being redeployed.

--- a/openspec/changes/bump-lambda-runtime-to-nodejs24/specs/lambda-runtime-currency/spec.md
+++ b/openspec/changes/bump-lambda-runtime-to-nodejs24/specs/lambda-runtime-currency/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Lambdas run a supported AWS runtime
+Every Lambda function provisioned by this project SHALL declare a `runtime` that appears in AWS's *Supported runtimes* table at the time of the change. A runtime listed under *Deprecated runtimes* SHALL NOT be introduced, and an existing runtime SHALL be moved off before AWS's "block function update" date for that runtime, after which code can no longer be deployed to it.
+
+#### Scenario: Runtime is declared in Terraform
+- **WHEN** any `aws_lambda_function` resource in `terraform/aws/` is inspected
+- **THEN** its `runtime` is `nodejs24.x`
+- **AND** no Lambda declares `nodejs20.x` or any other deprecated identifier
+
+#### Scenario: Deployed functions are inspected after apply
+- **WHEN** the five functions (`interactions`, `followup`, `update-dns`, `watchdog`, `efs-seeder`) are described in AWS after `terraform apply`
+- **THEN** each reports the supported runtime, and each still returns a successful invocation
+
+### Requirement: Bundle target matches the executing runtime
+The esbuild `target` used to produce each Lambda bundle SHALL name the same Node major as the `runtime` that executes it. The two SHALL be changed together in a single change, because a bundle emitted for a newer target can use syntax an older runtime cannot parse, and a bundle emitted for an older target silently forgoes the runtime's capabilities.
+
+#### Scenario: A Lambda's build config is inspected
+- **WHEN** any `app/packages/lambda/*/esbuild.config.mjs` is read
+- **THEN** its `target` names the same Node major as the `runtime` declared for that function in `terraform/aws/`
+
+#### Scenario: Either side is changed alone
+- **WHEN** a change modifies only the Terraform `runtime` or only the esbuild `target`
+- **THEN** it is incomplete and MUST NOT be merged until the other side moves with it
+
+### Requirement: Provider constraint can express the chosen runtime
+The Terraform AWS provider constraint SHALL permit a provider version that accepts the declared runtime identifier. Because the provider validates `runtime` against a fixed list compiled into it, a runtime released after the pinned provider major is rejected at `terraform validate`, before any AWS call is made.
+
+#### Scenario: Configuration is validated
+- **WHEN** `terraform init -backend=false && terraform validate` runs against `terraform/`
+- **THEN** validation succeeds with the declared runtime and the declared provider constraint
+
+#### Scenario: A future runtime postdates the pinned provider
+- **WHEN** a newer runtime identifier is rejected by the currently pinned provider major
+- **THEN** raising the provider constraint is treated as part of that runtime change, and the resulting `terraform plan` is reviewed for unrelated resource diffs introduced by the provider upgrade
+
+### Requirement: Runtime-provided SDK is treated as a dependency
+Lambda bundles that mark the AWS SDK as `external` SHALL be understood to execute against the SDK version shipped inside the Lambda runtime image. A runtime change therefore also changes that SDK version, and the change SHALL verify the affected Lambdas against their real AWS calls rather than assuming the bundle pins the SDK.
+
+#### Scenario: Runtime version changes
+- **WHEN** the Lambda runtime is moved to a different Node major
+- **THEN** each Lambda's AWS SDK calls (ECS `RunTask`/`StopTask`/`DescribeTasks`, Route 53 `ChangeResourceRecordSets`, DynamoDB reads and writes, Secrets Manager reads, CloudWatch `GetMetricStatistics`, ECS tag reads and writes) are exercised against the deployed functions before the change is considered complete

--- a/openspec/changes/bump-lambda-runtime-to-nodejs24/tasks.md
+++ b/openspec/changes/bump-lambda-runtime-to-nodejs24/tasks.md
@@ -1,0 +1,38 @@
+## 1. Provider constraint
+
+- [ ] 1.1 Raise the AWS provider constraint from `~> 5.0` to `~> 6.0` in `terraform/main.tf`
+- [ ] 1.2 Raise the same constraint in `terraform/aws/versions.tf` (note the different alignment — it also carries `configuration_aliases`)
+- [ ] 1.3 Grep `terraform/` for any remaining `~> 5.0` to confirm both declarations moved
+
+## 2. Runtime and build target
+
+- [ ] 2.1 Change `runtime = "nodejs20.x"` to `"nodejs24.x"` in `terraform/aws/interactions.tf`, `followup.tf`, `route53.tf`, `watchdog.tf`, and `efs-seeder.tf`
+- [ ] 2.2 Change `target: 'node20'` to `'node24'` in all five `app/packages/lambda/*/esbuild.config.mjs`
+- [ ] 2.3 Grep the repo for remaining `nodejs20`/`node20` references and update any documentation that states the Lambda runtime version
+
+## 3. Static verification
+
+- [ ] 3.1 Run `npm run app:build:lambdas` and confirm all five `dist/handler.cjs` bundles are produced — Terraform's `archive_file` data sources fail without them
+- [ ] 3.2 Run `terraform init -upgrade` in `terraform/` and confirm it installs an AWS provider in the 6.x line
+- [ ] 3.3 Run `terraform validate` and confirm success; expect two `hash_key is deprecated` warnings on `aws_dynamodb_table.runs` and `aws_dynamodb_table.audit`, which are known and deliberately not fixed here
+- [ ] 3.4 Run `terraform fmt -check -recursive` and `tflint` from `terraform/`
+
+## 4. Plan review (gate)
+
+- [ ] 4.1 Run `terraform plan` against real state and read the output in full
+- [ ] 4.2 Confirm the five Lambda functions show a runtime update in place
+- [ ] 4.3 Triage every other diff the provider 6 upgrade introduces; if any resource would be **replaced** rather than updated in place, stop and handle it deliberately before applying
+- [ ] 4.4 Record the plan summary in the PR so the apply is reviewable after the fact
+
+## 5. Apply and live verification
+
+- [ ] 5.1 Run `terraform apply`
+- [ ] 5.2 Confirm all five deployed functions report `nodejs24.x`
+- [ ] 5.3 Run a Discord slash command end-to-end (`/server-start` then `/server-status`) to exercise interactions → followup → ECS, including the DynamoDB pending-interaction write and the Secrets Manager reads
+- [ ] 5.4 Confirm the DNS record is UPSERTed on task RUNNING and DELETEd on task STOPPED — this exercises `update-dns` and its Route 53 calls
+- [ ] 5.5 Let one watchdog interval elapse and confirm it reads CloudWatch metrics and writes its idle-counter ECS task tag without error
+- [ ] 5.6 Check each function's CloudWatch log group for runtime-level errors (module resolution, SDK client construction) rather than only application errors
+
+## 6. Follow-up
+
+- [ ] 6.1 File a separate change for the `hash_key` → `key_schema` migration on `aws_dynamodb_table.runs` and `aws_dynamodb_table.audit`, to be planned and reviewed on its own — a mistake there can replace a table holding live data


### PR DESCRIPTION
Planning artifacts only — no Terraform or build config changes in this PR. Implementation follows via `/opsx:apply` once the approach is agreed, because it requires a reviewed `terraform plan` and a real `terraform apply`.

## Why now

All five Lambdas declare `runtime = "nodejs20.x"`. AWS **deprecated that runtime on 30 April 2026** — it sits under *Deprecated runtimes*, not *Supported runtimes*.

| Milestone | Date |
|---|---|
| Deprecated (patches stop) | 30 Apr 2026 — already passed |
| Function **create** blocked | 1 Feb 2027 |
| Function **update** blocked | 3 Mar 2027 |

Nothing breaks today, but after the last date `terraform apply` can no longer push code to these functions, freezing the Discord bot, DNS updater, watchdog, and EFS seeder at their last deployed version.

## Two findings that shape the plan

Both were established by running Terraform, not from memory:

1. **Provider 5 cannot express `nodejs24.x`.** `~> 5.0` resolves to 5.100.0, the last 5.x, which fails `terraform validate` with `expected runtime to be one of [... "nodejs20.x" ... "nodejs22.x"], got nodejs24.x`. Raising the constraint to `~> 6.0` is forced, not a nice-to-have.
2. **The real module validates under provider 6.** With both constraints at `~> 6.0` and all five runtimes at `nodejs24.x`, `terraform init -backend=false && terraform validate` against `terraform/` returns `Success! The configuration is valid` on provider 6.56.0 — with two `hash_key is deprecated. Use key_schema instead.` warnings, on `aws_dynamodb_table.runs` and `aws_dynamodb_table.audit`.

`validate` is not `plan`. Whether provider 6 wants to change anything beyond the five Lambdas is unknown until a plan runs against real state with credentials — that's the gating task in `tasks.md`, not an assumption.

## Why 24 and not 22

Node 22 is supported to 30 Apr 2027, Node 24 to 30 Apr 2028. Targeting 22 sidesteps the provider upgrade (it's on provider 5's list) but repeats this work in nine months *and* defers the same upgrade. 24 also matches the Node major the repo now uses for dev and CI (#352).

## Deliberately not included

`hash_key` → `key_schema` on the two DynamoDB tables. It restructures a live table's key declaration, and a mistake risks replacing tables holding Discord config, run history, and audit rows. That deserves a plan read specifically for it, not a skim inside a runtime bump — filed as a follow-up task.

Artifacts: `openspec/changes/bump-lambda-runtime-to-nodejs24/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)