### PR TITLE
docs(openspec): propose migrating IaC from Terraform to Pulumi

### DIFF
--- a/openspec/changes/migrate-iac-to-pulumi/.openspec.yaml
+++ b/openspec/changes/migrate-iac-to-pulumi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/migrate-iac-to-pulumi/design.md
+++ b/openspec/changes/migrate-iac-to-pulumi/design.md
@@ -1,0 +1,453 @@
+## Context
+
+Hyveon provisions AWS infrastructure from a packaged Electron desktop app. Today
+that requires the operator to install the `terraform` binary manually:
+`TerraformService.resolveBinaryPath()` runs `which terraform` (or `where.exe`),
+throws `TerraformNotFoundError` on failure, and the first wizard step blocks
+progression on the result. A second, spurious gate blocks on `aws` being present
+on `PATH` even though no code path in the app has ever invoked the AWS CLI.
+
+The infrastructure itself is 21 `.tf` files, 2837 lines, 69 `resource` blocks,
+across a thin root composer, a `terraform/aws/` module, and a standalone
+`terraform/bootstrap/` module. The app couples to it in three ways: it spawns
+`terraform` for init/plan/apply/destroy/output, it parses `terraform.tfstate`
+from disk to discover deployed resources, and it reads and writes
+`terraform.tfvars` as the canonical `game_servers` configuration.
+
+That last coupling is expensive. Because configuration is HCL, the app carries
+`@cdktf/hcl2json` (with a `patch-package` patch, and a mandatory `external`
+marking in `electron.vite.config.ts` because bundling it prevents Electron from
+quitting) plus hand-rolled `hclSurgeon.ts` / `hclEmit.ts`, because the
+JSON round-trip is lossy and the write path cannot use it.
+
+Two constraints shape the solution. First, multi-cloud must remain possible:
+`CloudProviderModule` binds four DI tokens against cloud-agnostic contracts in
+`@hyveon/shared/cloud.ts`, and the intent to add a second provider is explicit
+even though `active_cloud` currently validates to `"aws"` only. Second, Hyveon
+is pre-release — nothing is deployed that needs its state preserved, so this is
+the cheapest moment to change IaC systems.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove the `terraform` install prerequisite. The app provisions and caches its
+  own engine.
+- Remove the `aws` CLI prerequisite, including the `aws s3api` / `aws dynamodb`
+  calls in the Makefile emitted by `scripts/init-parent.ts`.
+- Keep multi-cloud IaC possible without writing any of it now.
+- Delete the HCL-handling layer (`@cdktf/hcl2json`, its patch, `hclSurgeon.ts`,
+  `hclEmit.ts`) by making configuration typed TypeScript persisted as JSON.
+- Preserve the operator-facing safety model exactly: approve gate, 15-minute
+  approval window, plan-hash gate, durable apply lock, type-to-confirm destroy,
+  run history, rollback.
+- Fix the packaging defect where `electron-builder.yml` ships no `.tf` files, so
+  a packaged build has no infrastructure source to operate on.
+
+**Non-Goals:**
+
+- Writing any GCP resources. This change preserves the option only.
+- Importing existing Terraform state. Out of scope because nothing is deployed.
+- Renaming the `terraform-*` specs, the `terraform.*` IPC channels, the
+  `hyveon.terraform` preload namespace, or the `/terraform` route. Deferred to a
+  follow-up so this change's diff stays reviewable.
+- Changing the AWS architecture. Resource parity with the retired module is a
+  requirement, not an opportunity to redesign.
+
+## Decisions
+
+### Pulumi over AWS CDK and over CDK for Terraform
+
+CDK for Terraform was the natural "one language, both clouds" answer and is
+gone: HashiCorp archived `hashicorp/terraform-cdk` on 2025-12-10, last release
+0.21.0. It also never removed the binary requirement — it synthesized JSON and
+shelled out to `terraform`.
+
+AWS CDK would genuinely remove every binary, but it closes the multi-cloud door.
+There is no Google equivalent to migrate to later: Google Cloud Deployment
+Manager lost support on 2026-04-01 and shuts down 2027-06-30, and Google's
+replacement, Infrastructure Manager, is managed Terraform. Choosing CDK means
+committing to writing CDK for AWS and something else entirely for GCP — two IaC
+systems, two state models.
+
+Pulumi is the only remaining option that is multi-cloud, imports natively into
+TypeScript, and exposes a programmatic engine. Versions pinned: `@pulumi/pulumi`
+3.255.0, `@pulumi/aws` 7.39.0.
+
+**Alternative kept on the table:** auto-downloading an OpenTofu binary and
+keeping all the HCL. That achieves the prerequisite goal for a fraction of the
+cost, but keeps the HCL-handling layer and the lossy config round-trip. It
+remains the fallback if the Electron spikes below fail.
+
+### No operator-editable files on disk
+
+The operator surface is the app. Nothing on the operator's machine may be
+load-bearing configuration, for two reasons: a hand-edited file can silently
+diverge from what the app believes is deployed, and `TfvarsService`'s local mode
+writes through an unguarded synchronous `writeFileSync` with none of the
+optimistic locking or version history the S3 path carries — so the rollback
+capability is quietly unavailable in that mode.
+
+Local mode is therefore **removed, not ported**. The S3 configuration bucket
+becomes the only source; when no bucket is configured the app reports incomplete
+setup and routes to the wizard rather than falling back to a file. A silent
+fallback would reintroduce precisely the hand-editable file this is meant to
+eliminate.
+
+This is deliberately framed as a **supportability boundary, not a security
+boundary**. The application bundle is an asar archive, which `npx asar extract`
+opens in seconds, and any credential the app can decrypt a local user on the
+same OS account can decrypt too. Claiming tamper-proofing would be false. The
+honest guarantee is narrower and still worth having: there is no *supported*
+path by which editing a local file changes what gets deployed.
+
+**Alternative considered:** keep local mode and harden it — the
+`add-one-click-aws-bootstrap` proposal suggests writing a `.bak` copy before
+each splice. That treats the symptom. It leaves a second write path with weaker
+guarantees than the primary one, and leaves a file whose edits the app cannot
+detect.
+
+### Inline program, not a `workDir` program
+
+The Automation API offers `LocalWorkspace.createOrSelectStack` with either an
+inline `PulumiFn` closure or a `workDir` pointing at a real project directory.
+
+Inline is the right choice for a packaged app, for two independent reasons. The
+mechanical one: a `workDir` program needs a real, writable directory containing
+`Pulumi.yaml` and a `node_modules` the CLI populates with `npm install` — all
+hostile to an asar bundle. Inline needs nothing on disk, because provider SDKs
+resolve through our own module graph.
+
+The second reason follows from the previous decision. A seeded `workDir` is, by
+construction, a directory of editable infrastructure source sitting in
+`userData` — exactly the class of load-bearing local file this change is
+removing. Shipping the program inside the bundle keeps it out of the operator's
+way. This makes the inline approach a design commitment rather than merely a
+convenience, which raises the stakes on the asar spike below.
+
+The mechanism is worth stating precisely because it drives several decisions
+below. Inline does **not** mean in-process end to end. The SDK stands up an
+in-process gRPC `LanguageRuntimeService` on `127.0.0.1:0`, spawns the `pulumi`
+CLI as a child process with `--client=127.0.0.1:<port> --exec-kind inline`, and
+the CLI engine calls back into our process to execute the closure. So our
+program runs in our heap and is debuggable, but there is always a child process
+and always an ephemeral loopback listener for the duration of an operation.
+
+**Constraint to respect:** Pulumi documents that an inline program's lifecycle
+must be fully contained in the closure — work performed outside it is unsafe.
+
+### Engine cached under `userData`, not `~/.pulumi`
+
+`PulumiCommand.install({ version, root, skipVersionCheck })` accepts a `root`,
+threaded through to the installer as `--install-root` / `-InstallRoot`, with the
+binary landing at `<root>/bin/pulumi`. We point it at a directory under Electron
+`userData` rather than the default `~/.pulumi/versions/<version>`, so the app
+owns its engine and does not collide with an operator's own Pulumi install.
+
+`install()` calls `get()` first and returns early when a compatible CLI already
+exists at that root, so it is cheap and idempotent to call before every
+operation.
+
+Two things must be set explicitly or the custom root is silently useless:
+
+- `LocalWorkspaceOptions.pulumiCommand` must receive the returned
+  `PulumiCommand`. Omitted, the workspace falls back to `pulumi` on `PATH` —
+  reintroducing exactly the dependency this change removes.
+- `LocalWorkspaceOptions.pulumiHome` must also point under `userData`. The
+  install root holds only the binary; plugins, credentials, and workspace
+  metadata go to `$PULUMI_HOME`.
+
+The installer downloads and executes a shell script from `get.pulumi.com`
+(`install.sh` via `/bin/sh`, or `install.ps1` via `powershell.exe`). It passes
+`--no-edit-path`, so it will not modify the operator's `PATH`.
+
+### DIY S3 backend, configured by environment variable
+
+State goes in the operator's own S3 bucket — the one `BootstrapService` already
+creates — via `PULUMI_BACKEND_URL` in `LocalWorkspaceOptions.envVars`, avoiding
+any interactive `pulumi login`. No Pulumi Cloud account and no access token:
+`PULUMI_ACCESS_TOKEN` is a Pulumi Cloud concern, and the S3 backend authenticates
+through the standard AWS credential chain.
+
+**Verified empirically** (spike, 2026-07-28) against a `file://` backend: with a
+fresh, empty `PULUMI_HOME` and no prior login, `stack init`, `stack ls`, and
+`whoami` all succeed, and **no `credentials.json` is ever written** —
+`PULUMI_HOME` afterwards contains only `logs/` and `workspaces/`. The identity
+`whoami` reports is derived from the OS user, not from stored credentials. So
+the login-less mechanism works and leaves no credential state behind.
+
+The S3-specific half is still unverified: the spike machine had no S3 buckets,
+and creating one was out of scope. What remains open is narrow — whether the S3
+backend driver authenticates through the AWS credential chain without a login,
+not whether `PULUMI_BACKEND_URL` alone is honoured.
+
+The backend needs exactly four IAM actions: `s3:ListBucket` on the bucket, and
+`s3:GetObject` / `s3:PutObject` / `s3:DeleteObject` on objects. It writes under a
+`.pulumi/` prefix: `meta.yaml`, `stacks/`, `locks/`, `history/`.
+
+**Stack naming is a trap.** Non-legacy DIY backends accept
+`organization/<project>/<stack>` where `org` must be the literal string
+`organization`, or a bare stack name. Getting this wrong silently creates the
+wrong stack rather than erroring. We use bare stack names and pin the choice in
+one constant.
+
+### Keep secrets out of the stack, then take the free secrets provider
+
+`LocalWorkspaceOptions.secretsProvider` is a plain string passed through to
+`--secrets-provider`, and it is only applied on the `stack init` path — it is a
+no-op when selecting an existing stack. `pulumi stack change-secrets-provider`
+is not exposed through the Automation API in 3.255.0, so this must be right the
+first time.
+
+The framing that matters is not "which provider" but "how much secret material
+is in state at all". Auditing the current module answers it: the only genuinely
+secret values are `discord_bot_token` and `discord_public_key`
+(`terraform/aws/variables.tf`), which flow into `secret_string` on the two
+`aws_secretsmanager_secret_version` resources (`terraform/aws/discord_store.tf`).
+Both default to `""`, both carry `ignore_changes = [secret_string]`, and both
+are documented "Optional; empty to configure via UI" — so on the documented path
+state holds the literal string `"placeholder"`. The only other `sensitive = true`
+marking is `applied_game_servers`, which is ports, images, and memory limits,
+marked sensitive to keep diffs quiet rather than because it is secret.
+
+**Decision: drop both Discord variables from the infrastructure program.** The
+app's `DiscordConfigService` already writes these to Secrets Manager over the
+AWS SDK, and the standing rule is that neither secret is ever sent to the
+client. Making the SDK path the *only* path removes the one route by which a
+real token could reach state, and removes a configuration input that duplicates
+a UI the app already ships. The program declares the secrets and their
+placeholder versions; it never carries their values.
+
+With no secret material in the stack, the provider choice is low-stakes and we
+take the free `passphrase` provider, generating a passphrase and storing it via
+the existing `SafeStorageService` — the same mechanism that already encrypts
+pasted AWS keys.
+
+**The spike confirmed how unforgiving the passphrase requirement is.** With no
+`PULUMI_CONFIG_PASSPHRASE` set, `stack init` under `--non-interactive` — which
+the Automation API always passes — is a hard exit-1:
+
+```
+error: could not create secrets manager for new stack: passphrase must be set
+with PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE environment
+variables
+```
+
+Under a TTY it prompts and hangs instead. Passing `--secrets-provider=passphrase`
+explicitly changes nothing — it is already the DIY default — and
+`--secrets-provider=default` produces the identical error. There is no
+"no secrets provider" escape hatch on a DIY backend. The passphrase must
+therefore be generated and placed in `envVars` *before* the first stack is
+created, and must remain available for every subsequent operation.
+
+**Alternative considered:** a customer-managed KMS key created by
+`BootstrapService`, at roughly $1/month. It buys a recovery path that survives
+losing the machine, which `safeStorage` does not. Rejected because the audit
+shows nothing in the stack needs encrypting, and because standing idle cost is
+the thing this project's entire architecture exists to avoid — no persistent ECS
+service, no ALB, on-demand tasks only. Paying monthly to encrypt the string
+`"placeholder"` would be incoherent with that.
+
+**The residual risk must not be inherited silently.** A passphrase still
+encrypts any secret added to the stack later, and `safeStorage` is machine-bound
+with no recovery. Any future change that introduces genuine stack secrets must
+revisit this decision rather than assume it still holds — recorded as a spec
+requirement, not just a note here, so the constraint is testable.
+
+### Update plans preserve the existing apply gate
+
+This is the decision that changed most on investigation. Pulumi does have a
+plan-file equivalent: `PreviewOptions.plan` emits `--save-plan <path>` and
+`UpOptions.plan` emits `--plan <path>`, and a plan-constrained `up` fails
+immediately if reality diverges from what was reviewed.
+
+That maps almost exactly onto the existing seven-step gate, including
+`hasPlanArtifact` and `computePlanHash` re-hashing the on-disk artifact — the
+two methods that looked unmappable before this was verified.
+
+**Verified empirically against CLI 3.255.0** (spike, 2026-07-28): neither flag
+requires `PULUMI_EXPERIMENTAL`. `preview --save-plan` and `up --plan` both exit
+0 without it, and the constraint is genuinely enforced — adding a resource to
+the program and re-running `up --plan` against the stale plan fails with
+`error: create is not allowed by the plan: no steps were expected for this
+resource`. The env var only affects *discoverability*: `--plan` is hidden from
+`pulumi up --help` unless it is set. The flag works either way, so we do not set
+it, and we avoid the other experimental behaviour it would switch on.
+
+Four caveats drive the spec:
+
+1. **The plan format carries no stability guarantee.** Pulumi documents it as
+   experimental and subject to change. So the hash additionally covers the
+   configuration object's version id, and the staleness check must not depend on
+   the plan file being parseable.
+2. **The plan is stamped with the engine version.** `plan.json`'s top-level
+   `manifest` carries `version: "v3.255.0"` alongside `resourcePlans`. A plan
+   saved by one engine version is not guaranteed to be honoured by another, so
+   the engine version must participate in plan validity — an engine upgrade
+   between plan and apply must invalidate the plan rather than risk it being
+   reinterpreted.
+3. **A plan-constrained apply is not all-or-nothing.** Operations run in batches
+   as the program executes, so a divergence found partway through leaves earlier
+   changes applied. Unlike `terraform apply tfplan`, "the plan was rejected"
+   does not imply "nothing happened". Run states must distinguish a partial
+   apply, and the UI must direct the operator to re-plan rather than retry.
+4. **Destroy cannot be plan-constrained.** `pulumi destroy` exposes neither
+   `--plan` nor `--save-plan` at 3.255.0. The destroy path therefore relies
+   entirely on the confirmation-token gate and the type-to-confirm UI for its
+   safety, with no plan artifact behind it. This is not a regression — the
+   Terraform destroy path used `-auto-approve` with the same token gate as its
+   only guard — but it means the token gate is load-bearing in a way the apply
+   path's is not.
+
+### Structured summaries, not scraped stdout
+
+`PreviewResult.changeSummary` is an `OpMap` — counts keyed by `OpType`
+(`create`, `update`, `replace`, `delete`, `same`, …). `UpResult` and
+`DestroyResult` carry the same counts at `summary.resourceChanges`. These come
+from the engine's `summaryEvent` captured over `onEvent`, not from parsing
+stdout, which retires `PLAN_SUMMARY_PATTERN`, `APPLY_SUMMARY_PATTERN`,
+`DESTROY_SUMMARY_PATTERN` and their duplicates in `terraform.page.tsx`.
+
+**One sharp edge:** when the SDK misses the summary event it logs a warning and
+returns `{}`. An empty `changeSummary` is therefore indistinguishable from "no
+changes", and the UI must not treat it as such.
+
+Note also that `PreviewOptions` has no `json` option, so `stdout` is
+human-readable text. Resource-level diffs come from `onEvent`
+(`StepEventMetadata.detailedDiff`), not from parsing output.
+
+### Streaming and cancellation
+
+`onOutput` / `onError` deliver raw stdout/stderr chunks from the child process —
+**unbounded chunks, not lines**. The existing line-splitting logic in
+`spawnAndStream` (accumulate, split on `/\r?\n/`, hold back the trailing
+partial, flush on close) is reused rather than rewritten.
+
+Cancellation has two independent mechanisms and they are not interchangeable:
+
+- **`AbortSignal`** on the operation options is the user-facing Cancel. It sends
+  `SIGINT` to the CLI child with `forceKillAfterTimeout: false` — it never
+  escalates to `SIGKILL`. A wedged engine would keep the Electron main process
+  alive forever, so we add our own escalation timer.
+- **`stack.cancel()`** shells out `pulumi cancel` against the backend. Pulumi
+  documents it as "very dangerous" and liable to leave the stack inconsistent.
+  We reserve it exclusively for clearing a stale DIY lock, behind explicit
+  operator confirmation.
+
+Stale locks need first-class handling. DIY locks have no server-side expiry, so
+a crash or force-quit leaves a lock that blocks everything indefinitely. The SDK
+surfaces this as a typed `ConcurrentUpdateError`, matched on `"[409] Conflict"`
+or `"the stack is currently locked by"`.
+
+### `@pulumi/pulumi` must be `external`, not bundled
+
+The repo has already been burned by this exact failure mode: bundling
+`@cdktf/hcl2json` into the Electron main bundle prevented Electron from quitting
+and broke every e2e teardown, fixed by marking it `external` in the rollup
+config plus listing it in `electron-builder.yml` `files`.
+
+`@pulumi/pulumi` pulls in `@grpc/grpc-js`, which owns sockets, and the repo
+already carries a `@grpc/proto-loader` dependency note from an earlier CI
+incident. We follow the established precedent from the start rather than
+discovering it in CI.
+
+Sizes: `@pulumi/aws` is 60 MB unpacked, `@pulumi/pulumi` 15 MB. Both ship
+unpacked via `electron-builder.yml` `files`.
+
+## Risks / Trade-offs
+
+**Inline program inside `app.asar` is unverified** → No Pulumi documentation
+covers running an inline program from a bundler's output. Mechanically it should
+work, since the CLI reads nothing from disk and reaches back over gRPC. Spike
+this before any other implementation work; if it fails, fall back to seeding a
+program directory into `userData` (the pattern `seedTerraformWorkspace()`
+already implements) or to the OpenTofu alternative.
+
+**Electron may not quit cleanly after an operation** → Source review found no
+daemon, no persistent listener, and no polling timer between operations; every
+gRPC server and temp resource is torn down in a `finally`. But this is exactly
+the class of failure the hcl2json incident produced. Mark `@pulumi/pulumi`
+external from the first commit and add an explicit "app quits cleanly after an
+`up`" e2e check early, not at the end.
+
+**First run downloads hundreds of megabytes** → The engine plus the AWS provider
+plugin are both fetched on first use. Reported as distinct wizard phases so it
+does not read as a hang; the operation itself must not appear to stall.
+
+**Partial applies are a new failure mode** → `terraform apply tfplan` was
+all-or-nothing; a plan-constrained `up` is not. Run states and UI copy must make
+"failed partway through" legible, or operators will retry into a worse state.
+
+**Stale DIY locks block everything with no expiry** → Detect
+`ConcurrentUpdateError`, distinguish it from in-app busy, and offer explicit
+operator-confirmed recovery. Never clear automatically.
+
+**The passphrase secrets provider has no recovery path** → It is stored via
+`safeStorage`, which is machine-bound; losing the machine means losing it. This
+is acceptable only because the stack holds no secret material, which is itself
+enforced by the "No secret material enters the stack" requirement. The two
+constraints are load-bearing together: weaken either and state becomes
+unrecoverable. Any change that adds secrets to the stack must revisit the
+provider first.
+
+**`process.setMaxListeners` is mutated globally** → `LanguageServer.run` raises
+the Electron main process's global listener limit for the process lifetime.
+Benign, but it will look like a leak if anyone audits listener counts.
+
+**Temp workspace directories leak** → A `LocalWorkspace` created with no
+`workDir` makes an `os.tmpdir()/automation-*` directory that is never removed.
+Pass an explicit `workDir` under `userData`.
+
+**Leaked-promise check throws on the success path** → If the inline program
+leaves dangling promises, `onPulumiExit` throws *after* an otherwise successful
+operation. Handle "succeeded then threw" so a successful apply is not reported
+as a failure.
+
+**Scope** → This is a large change: 69 resources, a 2741-line service, 13 IPC
+channels, and the test fixtures that shim a fake binary onto `PATH`. It should
+land as a sequence of PRs behind the phases in `tasks.md`, not one merge.
+
+## Migration Plan
+
+No state import. Hyveon is pre-release, so the migration for the only existing
+deployment is `terraform destroy` on the old stack followed by a fresh deploy.
+This must be stated plainly in `docs/docs/setup.md`, because a user who deploys
+the new stack without destroying the old one gets duplicate infrastructure —
+two VPCs, two EFS file systems, two of every Lambda — silently, since the two
+systems share no state.
+
+Rollback strategy during development: the `terraform/` tree is deleted only in
+the final phase, so every phase before that can be abandoned by reverting the
+branch with working infrastructure still described in HCL.
+
+## Open Questions
+
+1. **Does the S3 backend driver authenticate without a prior login?** The
+   login-less mechanism itself is verified — `PULUMI_BACKEND_URL` alone works
+   with a fresh `PULUMI_HOME` and writes no `credentials.json` (see the DIY
+   backend decision). What is untested is the `s3://` driver specifically,
+   because the spike machine had no bucket and creating one was out of scope.
+   Close this during the first bootstrap run: point `PULUMI_BACKEND_URL` at the
+   bucket `BootstrapService` just created and run a read-only `stack ls`. If it
+   fails, the workspace seam needs a login step before any stack operation.
+2. **Does the inline program work from inside `app.asar`?** See Risks. This is
+   the highest-value spike and gates the rest of the work. Note that the
+   "no operator-editable files" decision removed the obvious fallback: seeding a
+   `workDir` into `userData` would put editable infrastructure source back on
+   disk. If the spike fails, the fallback is a seeded workDir *and* an accepted
+   weakening of that guarantee, or the OpenTofu alternative — either way it is a
+   decision to bring back, not a silent substitution.
+3. **Is `pulumi refresh --preview-only` still locking DIY state**
+   (pulumi/pulumi#22384) at 3.255.0? Only matters if a refresh path is added;
+   note it before adding one.
+4. **Does the runs table belong in the Pulumi stack at all?** It stores run
+   records for the tool that manages the stack, which is a mild circularity that
+   already exists under Terraform. Worth revisiting, but not in this change.
+
+*(Two earlier open questions are now resolved. The `PULUMI_EXPERIMENTAL`
+question is answered — the flags do not require it; see the update-plans
+decision. The secrets-provider question is resolved — see "Keep secrets out
+of the stack, then take the free secrets provider" under Decisions. The audit it
+called for was done: the only secret values in the module are the two optional
+Discord variables, which default to placeholders on the documented path, so the
+answer was to remove the inputs rather than pay to encrypt them.)*

--- a/openspec/changes/migrate-iac-to-pulumi/design.md
+++ b/openspec/changes/migrate-iac-to-pulumi/design.md
@@ -396,7 +396,10 @@ Benign, but it will look like a leak if anyone audits listener counts.
 
 **Temp workspace directories leak** → A `LocalWorkspace` created with no
 `workDir` makes an `os.tmpdir()/automation-*` directory that is never removed.
-Pass an explicit `workDir` under `userData`.
+Passing an explicit `workDir` under `userData` only relocates the leak unless
+lifecycle is also defined, so the workspace is one stable directory per stack,
+reused across operations rather than created per operation. Repeated
+previews/applies must not grow the directory count.
 
 **Leaked-promise check throws on the success path** → If the inline program
 leaves dangling promises, `onPulumiExit` throws *after* an otherwise successful
@@ -409,12 +412,22 @@ land as a sequence of PRs behind the phases in `tasks.md`, not one merge.
 
 ## Migration Plan
 
-No state import. Hyveon is pre-release, so the migration for the only existing
-deployment is `terraform destroy` on the old stack followed by a fresh deploy.
-This must be stated plainly in `docs/docs/setup.md`, because a user who deploys
-the new stack without destroying the old one gets duplicate infrastructure —
-two VPCs, two EFS file systems, two of every Lambda — silently, since the two
-systems share no state.
+No state import. Hyveon is pre-release, so no operator has a Terraform
+deployment to preserve; the only one that exists is the maintainer's own
+development stack.
+
+Tearing that stack down is `terraform destroy` followed by a fresh deploy, and
+it is a **maintainer task performed out of band, once**. It must not be written
+into `docs/docs/setup.md` or any other operator-facing page: this change's
+`desktop-only-operator-surface` requirement forbids instructing an operator to
+run an infrastructure CLI, and there is no operator for whom the step would even
+apply. It belongs in maintainer/contributor notes, which the operator-surface
+requirement explicitly scopes out.
+
+The reason it must be recorded *somewhere* is that the two systems share no
+state, so deploying the Pulumi stack without first destroying the Terraform one
+produces duplicate infrastructure silently — two VPCs, two EFS file systems, two
+of every Lambda. That is a maintainer-facing hazard, not an operator-facing one.
 
 Rollback strategy during development: the `terraform/` tree is deleted only in
 the final phase, so every phase before that can be abandoned by reverting the

--- a/openspec/changes/migrate-iac-to-pulumi/proposal.md
+++ b/openspec/changes/migrate-iac-to-pulumi/proposal.md
@@ -17,9 +17,11 @@ Removing both prerequisites is the goal. Pulumi is the way we get there without
 giving up multi-cloud:
 
 - **Pulumi can install its own engine.** `PulumiCommand.install()` from
-  `@pulumi/pulumi/automation` downloads a version-matched CLI into
-  `~/.pulumi/versions/<version>` from inside our Node process. The operator
-  installs nothing.
+  `@pulumi/pulumi/automation` downloads a version-matched CLI from inside our
+  Node process, into an install root this app owns under Electron `userData`.
+  (`~/.pulumi/versions/<version>` is the SDK's default, which we override so the
+  app never depends on, nor writes to, a shared user-level tool directory.) The
+  operator installs nothing.
 - **It keeps the multi-cloud door open.** AWS CDK would close it: there is no
   Google equivalent to migrate to later. Google Cloud Deployment Manager lost
   support on 2026-04-01 and shuts down 2027-06-30, and Google's replacement
@@ -35,16 +37,20 @@ giving up multi-cloud:
   the JSON round-trip is lossy. With a TypeScript infra program the `game_servers`
   config becomes an ordinary shared type and all of that disappears.
 
-Now is the cheapest this will ever be: Hyveon is pre-release with no deployments
-in the wild, so we migrate by destroying and redeploying rather than importing
-69 resources into a new state model.
+Now is the cheapest this will ever be: Hyveon is pre-release, so no operator has
+a Terraform deployment to preserve. The only one that exists is the maintainer's
+own development stack, so we migrate by destroying and redeploying rather than
+importing 69 resources into a new state model.
 
 ## What Changes
 
 - **BREAKING**: The `terraform/` tree (21 `.tf` files, 2837 lines, 69 `resource`
   blocks) is replaced by a TypeScript Pulumi program in a new
-  `app/packages/infra` workspace. Existing deployments are not migrated —
-  operators run `terraform destroy` on the old stack and deploy fresh.
+  `app/packages/infra` workspace. No state is migrated. Tearing down the
+  maintainer's pre-existing Terraform stack is a one-off **maintainer** task
+  performed out of band; it is explicitly not an operator workflow and MUST NOT
+  appear in operator documentation, which would contradict the app-only operator
+  boundary this same change establishes.
 - **BREAKING**: `terraform.tfvars` stops being the configuration source of
   truth. `game_servers` and the top-level deployment settings become a typed
   object in `@hyveon/shared` persisted as JSON, and the versioned-S3 tfvars

--- a/openspec/changes/migrate-iac-to-pulumi/proposal.md
+++ b/openspec/changes/migrate-iac-to-pulumi/proposal.md
@@ -1,0 +1,206 @@
+# Migrate infrastructure-as-code from Terraform to Pulumi
+
+## Why
+
+Hyveon is a packaged desktop app, but it cannot provision anything until the
+operator has manually installed the `terraform` binary and put it on `PATH`.
+`TerraformService.resolveBinaryPath()` shells out to `which terraform` and
+throws `TerraformNotFoundError` when that fails, and the first-run wizard hard
+blocks on the result. Telling a desktop-app user to go install a CLI before the
+app works is the single largest onboarding cliff we have.
+
+The AWS CLI is a second, weaker instance of the same problem: nothing in the app
+actually uses it — every AWS call already goes through `@aws-sdk/*` — yet
+`wizard.utils.ts` still refuses to advance unless `aws` is found on `PATH`.
+
+Removing both prerequisites is the goal. Pulumi is the way we get there without
+giving up multi-cloud:
+
+- **Pulumi can install its own engine.** `PulumiCommand.install()` from
+  `@pulumi/pulumi/automation` downloads a version-matched CLI into
+  `~/.pulumi/versions/<version>` from inside our Node process. The operator
+  installs nothing.
+- **It keeps the multi-cloud door open.** AWS CDK would close it: there is no
+  Google equivalent to migrate to later. Google Cloud Deployment Manager lost
+  support on 2026-04-01 and shuts down 2027-06-30, and Google's replacement
+  (Infrastructure Manager) is managed Terraform. CDK for Terraform — the one
+  tool that would have spanned both — was archived by HashiCorp on 2025-12-10.
+  Pulumi is the only remaining option that is multi-cloud, imports natively into
+  TypeScript, and exposes a programmatic engine.
+- **It deletes a layer we only maintain because infra is HCL.** The app has to
+  read and write `terraform.tfvars`, so it carries `@cdktf/hcl2json` (plus a
+  `patch-package` patch, plus a mandatory `external` marking in
+  `electron.vite.config.ts` because bundling it prevents Electron from quitting)
+  and hand-rolled `hclSurgeon.ts` / `hclEmit.ts` for surgical text edits, because
+  the JSON round-trip is lossy. With a TypeScript infra program the `game_servers`
+  config becomes an ordinary shared type and all of that disappears.
+
+Now is the cheapest this will ever be: Hyveon is pre-release with no deployments
+in the wild, so we migrate by destroying and redeploying rather than importing
+69 resources into a new state model.
+
+## What Changes
+
+- **BREAKING**: The `terraform/` tree (21 `.tf` files, 2837 lines, 69 `resource`
+  blocks) is replaced by a TypeScript Pulumi program in a new
+  `app/packages/infra` workspace. Existing deployments are not migrated —
+  operators run `terraform destroy` on the old stack and deploy fresh.
+- **BREAKING**: `terraform.tfvars` stops being the configuration source of
+  truth. `game_servers` and the top-level deployment settings become a typed
+  object in `@hyveon/shared` persisted as JSON, and the versioned-S3 tfvars
+  bucket becomes a versioned-S3 JSON config object.
+- **BREAKING**: `TfvarsService`'s local-file mode is removed, not ported. The S3
+  configuration bucket becomes the only configuration source. No file on the
+  operator's machine is load-bearing, so there is no supported way to change
+  what gets deployed by hand-editing a file — and no unguarded `writeFileSync`
+  path that bypasses the remote store's optimistic locking and version history.
+- **BREAKING**: State moves from the Terraform S3 backend + DynamoDB lock table
+  to a Pulumi DIY backend (`s3://`) in the same bucket. No Pulumi Cloud account
+  or access token is required.
+- The `terraform` prerequisite is removed. `PulumiEngineService` resolves the
+  engine from a cache under Electron `userData`, downloading and verifying it on
+  first use via `PulumiCommand.install()`.
+- The AWS CLI prerequisite is removed. The `aws` PATH probe and its wizard gate
+  are deleted, and the `aws s3api` / `aws dynamodb` calls in the Makefile emitted
+  by `scripts/init-parent.ts` are ported to `@aws-sdk/client-s3` and
+  `@aws-sdk/client-dynamodb`.
+- `TerraformService` (2741 lines) is replaced by `PulumiService` driving the
+  Automation API. Plan becomes `preview`, apply becomes `up`, destroy stays
+  `destroy`, and `output -json` becomes `stack.outputs()`.
+- Run summaries stop being scraped out of stdout with regexes
+  (`PLAN_SUMMARY_PATTERN`, `APPLY_SUMMARY_PATTERN`, `DESTROY_SUMMARY_PATTERN`)
+  and are read from the structured `changeSummary` the Automation API returns.
+- `@cdktf/hcl2json`, its patch, its `external` marking, its `electron-builder`
+  unpacked-files entries, `hclSurgeon.ts`, and `hclEmit.ts` are all removed.
+- Every bucket the bootstrap service creates gains all four S3
+  public-access-block settings. The SDK bootstrap path currently applies none,
+  while the `terraform/bootstrap/` module it mirrors applies all four — this
+  change makes the SDK path the only path, so it is the right moment to close
+  the gap.
+- The packaging defect is fixed as a side effect: `electron-builder.yml`
+  currently ships only `terraform.tfstate` and the icon in `extraResources` and
+  none of the 21 `.tf` files, so `getTerraformDir()` seeds a directory with no
+  HCL in it. The Pulumi program compiles into the main-process bundle instead.
+
+### Non-goals
+
+- Adding a GCP provider. This change only preserves the *option*; no
+  `@pulumi/gcp` resources are written.
+- Importing existing Terraform state into Pulumi. Explicitly out of scope
+  because there is nothing deployed that needs preserving.
+- Renaming the `terraform-*` capability specs to `iac-*`. Their requirements
+  change here; the rename is deferred to a follow-up to keep this change's diff
+  reviewable.
+- Renaming the `terraform.*` IPC channels, the `hyveon.terraform` preload
+  namespace, or the `/terraform` route. They keep their names through this
+  change for the same reason, and are renamed in the same follow-up as the
+  specs. Renaming them here would touch the controller, preload, typed API,
+  every page object, and every e2e mock for no behavioral gain.
+
+## Capabilities
+
+### New Capabilities
+
+- `pulumi-engine-runtime`: Resolving, downloading, version-pinning, and caching
+  the Pulumi engine inside the app, plus the Automation API seam
+  (`LocalWorkspace`, inline program, DIY S3 backend, secrets provider) that
+  every IaC operation goes through.
+- `pulumi-infra-program`: The TypeScript infrastructure program that replaces
+  the HCL — stack structure, the typed `game_servers` configuration model, and
+  the resource-level parity contract with the retired Terraform module.
+
+### Modified Capabilities
+
+- `prerequisite-detection`: Both binary probes are removed. `terraform` is no
+  longer detected or required because the app manages the engine itself, and
+  `aws` is no longer detected or required because nothing uses it.
+- `cloud-bootstrap`: The Terraform lock table is no longer created (Pulumi's DIY
+  backend locks with objects in the state bucket). The state bucket and the
+  config bucket remain, with the latter holding JSON instead of tfvars.
+- `wizard-flow`: The "Install prerequisites" step is removed and the
+  "Terraform init step with live log" step becomes a Pulumi stack-select and
+  engine-provisioning step.
+- `terraform-plan-apply-page`: Plan is driven by `stack.preview()` and its
+  summary comes from structured `changeSummary` data rather than scraped stdout.
+  The plan-hash gate is rebased onto the preview's structured diff.
+- `terraform-destroy-flow`: Destroy is driven by `stack.destroy()`. The
+  confirmation-token gate and type-to-confirm UI are unchanged.
+- `terraform-rollback`: Version listing and rollback operate on versions of the
+  JSON config object rather than of `terraform.tfvars`.
+- `terraform-run-history`: Persisted run records carry structured change
+  summaries instead of regex-derived counts.
+- `desktop-only-operator-surface`: Extends the existing "the desktop app is the
+  whole operator surface" guarantee from transport and deployment artifacts to
+  configuration and tooling — no operator-editable configuration files, and
+  nothing but the app itself needs to be run in a terminal.
+
+`aws-credentials` is deliberately **not** modified. It already specifies how
+credentials are discovered, encrypted, and selected, and none of that changes.
+What changes is that the selected credentials must actually reach the engine —
+today they do not, because `spawn()` in `TerraformService` passes no `env`,
+`AWS_PROFILE` is never set anywhere in the repo, and safeStorage-pasted keys are
+unreachable by the subprocess, so Terraform silently resolves credentials
+through its own default chain instead of the operator's choice. That guarantee
+belongs to the engine, so it is specified once in `pulumi-engine-runtime` rather
+than duplicated here.
+
+## Relationship to `add-one-click-aws-bootstrap`
+
+That change (proposed, unimplemented) targets the same goal — zero manual steps
+outside the app — and overlaps this one directly. This change lands first, and
+`add-one-click-aws-bootstrap` is then re-proposed against a Pulumi codebase:
+
+- Its `terraform-settings-management` capability is **dropped entirely**. It
+  exists to extend `hclSurgeon.ts` and `hclEmit.ts` with attribute-level
+  splicing so top-level variables can be edited without hand-editing HCL. This
+  change deletes both files and makes the whole configuration a typed object, so
+  editing top-level settings becomes a form binding. Building the HCL surgery
+  first would mean discarding it weeks later.
+- Its credential-plumbing fix to `TerraformService.spawnAndStream()` is
+  **dropped**, because `TerraformService` is deleted. The underlying bug is real
+  and is fixed here instead, in `pulumi-engine-runtime`'s "Wizard-selected
+  credentials reach the engine" requirement.
+- Its public-access-block hardening is **absorbed** into this change's
+  `cloud-bootstrap` delta, since bucket creation moves here.
+- Its `guided-iam-provisioning` capability **survives unchanged in shape** — the
+  CloudFormation template, the console handoff, and the mint-then-revoke key
+  rotation are all orthogonal to which IaC engine runs. Only the generated
+  policy's contents shift: the four DIY-backend S3 actions are added, and the
+  lock-table DynamoDB actions are removed.
+
+## Impact
+
+**New workspace**: `app/packages/infra` (`@hyveon/infra`) holding the Pulumi
+program. New dependencies `@pulumi/pulumi` 3.255.0 and `@pulumi/aws` 7.39.0.
+`@pulumi/aws` is 60 MB unpacked and `@pulumi/pulumi` is 15 MB, so both must be
+marked `external` in `electron.vite.config.ts` and listed in
+`electron-builder.yml` `files`, following the precedent already set for
+`@cdktf/hcl2json`.
+
+**Removed**: the `terraform/` tree; `TerraformService.ts` (2741 lines) and its
+spec; `TfvarsService`'s HCL paths, `hclSurgeon.ts`, `hclEmit.ts`;
+`@cdktf/hcl2json` and `patches/@cdktf+hcl2json+0.21.0.patch`; the `terraform`
+and `aws` branches of `PrerequisiteService`; `terraform/bootstrap/`;
+`terraform/moved.tf` (376 lines of `moved` blocks with nothing left to move).
+
+**Rewritten**: `terraform.controller.ts` IPC surface (9 channels);
+`terraform.page.tsx` including its three duplicated summary regexes;
+`ConfigService.getTfOutputs()` / `getTfStatePath()` / `getTerraformDir()` /
+`seedTerraformWorkspace()`; `BootstrapService`'s lock-table path;
+`scripts/init-parent.ts`'s generated Makefile.
+
+**Test surface**: `app/test/fake-terraform.mjs` and the
+`terraform-shim.ts` / `terraform-fixtures.ts` Playwright fixtures need Pulumi
+equivalents. Automation API operations are in-process, which removes the need to
+shim a binary onto `PATH` for most specs.
+
+**Docs**: `docs/docs/setup.md` (prerequisites table, "Configure the AWS CLI"
+section, the bootstrap-tfvars CLI walkthrough), `docs/docs/components/terraform.md`
+(full rewrite), `docs/docs/architecture.md`, `docs/docs/guides/user.md`,
+`docs/docs/guides/submodule.md`, `README.md`, and the `HyveonDeployAll` IAM
+policy, which no longer needs DynamoDB lock-table permissions.
+
+**Deferred risk**: the Automation API drives the engine as a subprocess. We
+already know from `@cdktf/hcl2json` that a misbehaving native/bundled dependency
+can prevent Electron from quitting, so engine-process lifecycle and teardown
+under Playwright must be verified early rather than at the end.

--- a/openspec/changes/migrate-iac-to-pulumi/specs/cloud-bootstrap/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/cloud-bootstrap/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: SDK-only bootstrap in the main process
+
+All backend bootstrap operations (state bucket, configuration bucket, IAM simulation) SHALL be performed via AWS SDK v3 clients in the desktop main process — never by shelling out to a CLI and never by invoking the infrastructure engine, which cannot provision the backend it is configured to read from. The renderer MUST NOT import any `@aws-sdk/*` package; an ESLint rule SHALL enforce this ban for `@hyveon/web`. SDK clients MUST be constructed with the credentials and region selected in the credentials step (profile via the SDK credential chain, or paste-flow values decrypted in the main process).
+
+#### Scenario: Bootstrap uses SDK clients only
+
+- **WHEN** any wizard bootstrap step runs
+- **THEN** the work is done through `@aws-sdk/client-s3` / `@aws-sdk/client-iam` calls in the main process, with no child-process shell-out and no engine invocation
+
+#### Scenario: Renderer AWS SDK import is a lint error
+
+- **WHEN** a file under `app/packages/web/` imports from `@aws-sdk/*`
+- **THEN** `npm run app:lint` fails on that import
+
+### Requirement: Bootstrap IPC and progress reporting
+
+Each bootstrap operation (state bucket, configuration bucket, IAM check) SHALL be invocable from the renderer through IPC-only controller message patterns under a `wizard.bootstrap.*` namespace, mirrored in the typed preload API, reporting per-resource status (`pending` / `creating` / `exists` / `created` / `failed` with an error message) so the wizard step can render granular progress.
+
+#### Scenario: Renderer runs the bootstrap step
+
+- **WHEN** the renderer invokes the bootstrap IPC methods for the two buckets and the IAM check
+- **THEN** each resolves with a per-resource status the step renders, and a failure in one resource reports `failed` with its error message without masking the others
+
+## ADDED Requirements
+
+### Requirement: State backend bucket bootstrap
+
+The bootstrap service SHALL create the S3 bucket that backs the self-managed infrastructure state backend when it does not exist, then enable bucket versioning and default server-side encryption. The operation MUST be idempotent: an already-existing bucket owned by the caller (`BucketAlreadyOwnedByYou`, or a successful existence check) is a success no-op, while a bucket owned by another account surfaces a clear error. Versioning is required so a corrupted or unwanted state write can be recovered.
+
+#### Scenario: Fresh state bucket
+
+- **WHEN** the state bucket does not exist
+- **THEN** the service creates it and enables versioning and SSE, and the step reports success
+
+#### Scenario: Bucket already exists and is owned by the caller
+
+- **WHEN** the state bucket already exists in the caller's account
+- **THEN** the step succeeds without error and versioning and SSE are ensured
+
+#### Scenario: Bucket name taken by another account
+
+- **WHEN** `CreateBucket` fails because the name is owned elsewhere
+- **THEN** the wizard surfaces an actionable error and does not mark the step complete
+
+### Requirement: Configuration bucket bootstrap
+
+The bootstrap service SHALL create the versioned configuration bucket when missing, enable versioning, and apply a lifecycle configuration expiring noncurrent object versions after 90 days, so the bucket is usable as the canonical `RemoteFileStore` holding the JSON game-server configuration. The operation MUST be idempotent. Noncurrent-version retention is what the rollback flow depends on.
+
+#### Scenario: Fresh configuration bucket
+
+- **WHEN** the configuration bucket does not exist
+- **THEN** the service creates it with versioning enabled and a 90-day noncurrent-version-expiration lifecycle rule
+
+#### Scenario: Configuration bucket already exists
+
+- **WHEN** the configuration bucket already exists in the caller's account
+- **THEN** the step succeeds and versioning plus the lifecycle rule are ensured
+
+### Requirement: Buckets block public access
+
+Every bucket the bootstrap service creates SHALL have all four S3 public-access-block settings applied — `BlockPublicAcls`, `IgnorePublicAcls`, `BlockPublicPolicy`, `RestrictPublicBuckets`. This applies to the state backend bucket and the configuration bucket alike. The SDK bootstrap path MUST NOT be weaker than the infrastructure-defined path it replaces, and both buckets hold data an operator would never want publicly reachable: infrastructure state and deployment configuration.
+
+#### Scenario: New bucket blocks public access
+
+- **WHEN** the bootstrap service creates either bucket
+- **THEN** all four public-access-block settings are applied before the step reports success
+
+#### Scenario: Existing bucket is hardened too
+
+- **WHEN** the bootstrap service encounters a bucket that already exists
+- **THEN** the public-access-block settings are still applied, so a bucket created by an earlier version is brought up to the current standard
+
+## REMOVED Requirements
+
+### Requirement: Terraform lock table bootstrap
+
+**Reason**: The DynamoDB `LockID` table exists solely to satisfy the Terraform S3 backend's locking protocol. The self-managed Pulumi backend performs concurrency control with lock objects written into the state bucket itself, so the table has no consumer. Keeping it would mean provisioning, paying for, and granting IAM permissions on a resource nothing reads.
+
+**Migration**: Remove `ensureLockTable` from `BootstrapService`, its `wizard.bootstrap.lockTable` IPC channel and preload mirror, and the lock-table row from the bootstrap wizard step. Drop `dynamodb:CreateTable` / `DescribeTable` on the lock table from the `HyveonDeployAll` policy in `docs/docs/setup.md`. Operators upgrading from a Terraform-era install may delete the orphaned table manually; the app does not delete it for them.
+
+### Requirement: Terraform state bucket bootstrap
+
+**Reason**: Renamed and rescoped — the bucket now backs the Pulumi self-managed backend rather than the Terraform S3 backend, and versioning changes from "nice to have" to load-bearing for state recovery.
+
+**Migration**: Replaced by the "State backend bucket bootstrap" requirement above. The bucket name and the SDK calls are unchanged, so no operator action is required.
+
+### Requirement: Tfvars bucket bootstrap
+
+**Reason**: Renamed — the bucket now stores the JSON game-server configuration rather than `terraform.tfvars`, and it is no longer described in terms of a `terraform/bootstrap/` module that this change deletes.
+
+**Migration**: Replaced by the "Configuration bucket bootstrap" requirement above. The bucket, its versioning, and its lifecycle rule are unchanged; only the object key and content type change.

--- a/openspec/changes/migrate-iac-to-pulumi/specs/desktop-only-operator-surface/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/desktop-only-operator-surface/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: No operator-editable configuration files
+
+The app SHALL be the only supported way to read or change Hyveon's configuration. No configuration file on the operator's machine may be load-bearing: the canonical game-server and deployment configuration lives in the operator's versioned S3 configuration bucket, the infrastructure program ships inside the application bundle, and infrastructure state lives in the self-managed S3 backend. There MUST NOT be a local-file configuration mode — reading configuration from a path on disk when a bucket is not configured is removed, not retained as a fallback, because a silent fallback reintroduces exactly the hand-editable file this requirement exists to eliminate.
+
+This is a supportability boundary, not a security boundary. The application bundle is not tamper-proof and is not claimed to be; the guarantee is that there is no *supported* path by which hand-editing a local file changes what gets deployed, so no such edit can silently diverge from what the app believes is deployed.
+
+#### Scenario: No local configuration fallback exists
+
+- **WHEN** the configuration source is resolved and no configuration bucket is configured
+- **THEN** the app reports that setup is incomplete and directs the operator to the wizard, rather than falling back to reading a configuration file from disk
+
+#### Scenario: Configuration changes go through the app
+
+- **WHEN** the operator changes any deployment setting or game-server entry
+- **THEN** the change is written as a new version of the configuration object in S3 through the app, and no file on the operator's machine needs to be edited
+
+#### Scenario: No unguarded local writes remain
+
+- **WHEN** the desktop main process is searched for synchronous filesystem writes of configuration content
+- **THEN** none exist — every configuration write goes through the remote store's conditional-write path, which carries optimistic locking and version history
+
+#### Scenario: Deployment settings are editable in the UI
+
+- **WHEN** the operator opens the deployment settings section
+- **THEN** every setting that previously required hand-editing a variables file is presented as a form control, validated before write
+
+### Requirement: Nothing but the app runs in a terminal
+
+Provisioning, updating, inspecting, and destroying infrastructure SHALL be achievable entirely from the desktop app. No operator-facing workflow may require running an infrastructure CLI, a cloud provider CLI, a build tool, or a shell script. Operator-facing documentation MUST NOT instruct the operator to run any command other than launching the app itself.
+
+#### Scenario: Clean machine reaches a deployed cluster through the app alone
+
+- **WHEN** an operator installs the app on a machine with no infrastructure tooling, no cloud CLI, and no repository checkout, and completes the wizard
+- **THEN** infrastructure is deployed without their having run any command in a terminal
+
+#### Scenario: Documentation prescribes no CLI steps
+
+- **WHEN** operator-facing documentation is searched for instructions to run an infrastructure or cloud CLI
+- **THEN** no such instruction exists outside sections explicitly labelled as maintainer or contributor workflow

--- a/openspec/changes/migrate-iac-to-pulumi/specs/desktop-only-operator-surface/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/desktop-only-operator-surface/spec.md
@@ -39,3 +39,8 @@ Provisioning, updating, inspecting, and destroying infrastructure SHALL be achie
 
 - **WHEN** operator-facing documentation is searched for instructions to run an infrastructure or cloud CLI
 - **THEN** no such instruction exists outside sections explicitly labelled as maintainer or contributor workflow
+
+#### Scenario: Legacy Terraform teardown is maintainer-only
+
+- **WHEN** operator-facing documentation is searched for the one-off teardown of a pre-existing Terraform deployment
+- **THEN** the step does not appear there, because no operator has such a deployment; it exists only in maintainer or contributor material, where the CLI exception is explicitly scoped

--- a/openspec/changes/migrate-iac-to-pulumi/specs/prerequisite-detection/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/prerequisite-detection/spec.md
@@ -1,0 +1,25 @@
+## REMOVED Requirements
+
+### Requirement: Binary detection service
+
+**Reason**: Neither binary is a prerequisite any more. The `terraform` probe is obsolete because the app now provisions and caches its own infrastructure engine (see the `pulumi-engine-runtime` capability), so there is nothing on `PATH` to detect. The `aws` probe was always spurious — no code path in the app has ever invoked the AWS CLI; every AWS call goes through `@aws-sdk/*` clients — yet its result hard-blocked wizard progression.
+
+**Migration**: Delete `PrerequisiteService` and its IPC channel. Callers that need to know whether infrastructure operations can run consult the engine-status surface defined by `pulumi-engine-runtime`'s "App-managed engine provisioning" requirement instead. `lookupCommandFor` is retained only if another consumer still needs it; otherwise it is removed with `TerraformService`.
+
+### Requirement: Version parsing
+
+**Reason**: There are no external tool versions left to parse. The infrastructure engine version is pinned by the app rather than discovered from a machine-local install, so there is no version string to scrape and no minimum-version comparison to perform against an operator-supplied binary.
+
+**Migration**: The pinned engine version constant defined by `pulumi-engine-runtime`'s "Pinned engine version" requirement replaces `MINIMUM_TERRAFORM_VERSION` and the parsing helpers. Settings displays the resolved engine version from the engine service.
+
+### Requirement: Prerequisite check IPC
+
+**Reason**: The `wizard.prereqs.check` channel exists only to serve the two removed probes.
+
+**Migration**: Remove the channel, its preload mirror `hyveon.wizard.checkPrereqs()`, and its `hyveon-api.ts` types. The wizard's readiness signal comes from the engine-status surface instead.
+
+### Requirement: Install-prerequisites wizard step
+
+**Reason**: The step's entire purpose is to block the operator until they have manually installed two binaries. With the engine app-managed and the AWS CLI unused, there is nothing for the operator to install, and the step would always pass.
+
+**Migration**: Delete the step and its component. `wizard-flow`'s step list drops `prerequisites`, which also removes the special-casing that excluded it from the Settings "Reconfigure" flow.

--- a/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-engine-runtime/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-engine-runtime/spec.md
@@ -66,6 +66,8 @@ When engine provisioning fails — no network, a download or integrity-verificat
 
 All infrastructure operations SHALL go through a single main-process seam that constructs the Pulumi workspace and stack, rather than each caller building its own. The seam MUST configure the self-managed state backend, the secrets provider, and the AWS credentials for every operation, and MUST NOT require a Pulumi Cloud account or access token. The state backend SHALL be the operator's own S3 bucket, provisioned by the existing bootstrap flow.
 
+The workspace directory SHALL be a single stable location per stack under `userData`, reused across operations rather than created per operation. Creating one per operation would reproduce, in a new location, the unbounded temporary-directory growth that motivated setting an explicit path in the first place.
+
 The secrets passphrase MUST be present in the engine environment before the first stack is created and for every operation thereafter. On a self-managed backend the engine has no interactive fallback under the non-interactive mode the automation interface always uses — a missing passphrase is a hard failure at stack creation, not a prompt — and there is no option to run without a secrets provider. The seam MUST therefore generate the passphrase, persist it through the OS-level encrypted store, and supply it on every invocation. Losing it makes the stack unusable, so the seam MUST fail loudly rather than silently generating a second passphrase for a stack that already exists.
 
 #### Scenario: Operations use the self-managed backend
@@ -77,6 +79,11 @@ The secrets passphrase MUST be present in the engine environment before the firs
 
 - **WHEN** an infrastructure operation is attempted before the state bucket exists
 - **THEN** the seam surfaces an actionable error directing the operator to the bootstrap step rather than creating the bucket implicitly
+
+#### Scenario: Workspace is reused, not accumulated
+
+- **WHEN** many operations run against the same stack over the app's lifetime
+- **THEN** they share one stable workspace directory under `userData` rather than creating a new one per operation, and the number of workspace directories does not grow with the number of operations
 
 #### Scenario: Passphrase is present before stack creation
 
@@ -92,6 +99,8 @@ The secrets passphrase MUST be present in the engine environment before the firs
 
 The AWS credentials selected in the wizard SHALL be the credentials the engine uses. When the operator selected a named profile, the engine environment MUST carry that profile. When the operator pasted keys through the safeStorage flow, the decrypted values MUST be passed to the engine environment in the main process. The engine MUST NOT be left to resolve credentials through its own default chain, because that silently ignores the operator's choice.
 
+The selected source MUST be **exclusive**. Every operation SHALL start from a sanitized environment in which the credential variables belonging to the *other* source are cleared, not merely left unset: a profile run MUST clear any inherited `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`, and a paste-flow run MUST clear any inherited `AWS_PROFILE` and `AWS_DEFAULT_PROFILE`. The engine inherits the Electron process environment by default, so without this an ambient variable — set by the operator's shell, a launcher, or another tool — silently outranks the wizard's selection and deploys under an identity the operator never chose.
+
 #### Scenario: Named profile is honored
 
 - **WHEN** the operator selected the profile `personal` in the wizard and an infrastructure operation runs
@@ -102,6 +111,16 @@ The AWS credentials selected in the wizard SHALL be the credentials the engine u
 - **WHEN** the operator supplied credentials through the paste flow and an infrastructure operation runs
 - **THEN** the decrypted key material is supplied to the engine environment from the main process and never crosses the IPC boundary to the renderer
 
+#### Scenario: Ambient keys cannot override a selected profile
+
+- **WHEN** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are present in the Electron process environment and the operator has selected a named profile
+- **THEN** those variables are cleared from the engine environment and the operation runs under the selected profile
+
+#### Scenario: Ambient profile cannot override pasted keys
+
+- **WHEN** `AWS_PROFILE` is present in the Electron process environment and the operator supplied credentials through the paste flow
+- **THEN** `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` are cleared from the engine environment and the operation runs under the pasted keys
+
 #### Scenario: Credentials are not logged
 
 - **WHEN** an infrastructure operation runs with any credential source
@@ -109,22 +128,34 @@ The AWS credentials selected in the wizard SHALL be the credentials the engine u
 
 ### Requirement: Stale backend lock recovery
 
-The self-managed backend serializes updates with lock objects it writes into the state bucket, and those locks have no server-side expiry — a run killed by a crash, a force-quit, or a machine losing power leaves a lock that blocks every subsequent operation indefinitely. The app SHALL detect this condition, distinguish it from a legitimately concurrent in-app operation, and offer the operator an explicit, clearly-worded recovery action that clears the stale lock. Clearing MUST be operator-initiated and MUST NOT happen automatically, because a lock held by a genuinely running update is load-bearing.
+The self-managed backend serializes updates with lock objects it writes into the state bucket, and those locks have no server-side expiry — a run killed by a crash, a force-quit, or a machine losing power leaves a lock that blocks every subsequent operation indefinitely.
 
-#### Scenario: Stale lock is surfaced, not swallowed
+Recovery SHALL be governed by **provable ownership**, not by the absence of local activity. The app MUST record the identity of every lock it causes to be taken, so it can later distinguish two cases:
 
-- **WHEN** an operation fails because the backend reports the stack is locked, and no operation is in flight within this app instance
-- **THEN** the failure is presented as a stale-lock condition naming the stack, with an explicit recovery action, rather than as a generic engine error
+- **A lock the app can prove it owns** — recorded against a run of this installation that has since terminated. The app MAY reclaim it without prompting, because it is cleaning up after itself rather than overriding another party. This is what makes the forceful-termination path in "Engine process lifecycle" safe: a force-killed engine can orphan its lock, and that orphan MUST be reclaimable.
+- **A lock the app cannot prove it owns** — written by another installation, another machine, or an unrecognised run. Clearing it requires explicit operator confirmation, and the prompt MUST show the lock's recorded holder and age so the operator is not confirming blind.
 
-#### Scenario: Recovery is never automatic
+The absence of an in-flight operation within this app instance MUST NOT be treated as evidence that a lock is stale. Another machine may be mid-update against the same stack, and clearing its lock would permit concurrent updates and risk corrupting state.
 
-- **WHEN** a stale-lock condition is detected
-- **THEN** no lock is cleared until the operator explicitly confirms the recovery action
+#### Scenario: Force-terminated run reclaims its own lock
+
+- **WHEN** an engine invocation is forcefully terminated and leaves its backend lock behind, and the next operation encounters that lock
+- **THEN** the app recognises the lock as its own from the recorded identity and reclaims it without prompting, so a force-kill does not wedge the stack
+
+#### Scenario: Unrecognised lock requires confirmation with evidence
+
+- **WHEN** an operation fails because the stack is locked and the app cannot prove it owns the lock
+- **THEN** the failure is presented as a possible stale-lock condition naming the stack, the recorded holder, and the lock's age, and nothing is cleared until the operator explicitly confirms
+
+#### Scenario: Another machine's active lock is not presented as stale
+
+- **WHEN** a lock is held by a different installation whose update is still running
+- **THEN** the app does not clear it, and does not describe it as stale merely because no operation is in flight locally
 
 #### Scenario: In-app concurrency is reported as busy, not stale
 
 - **WHEN** an operation is requested while this app instance already holds the workspace
-- **THEN** it is refused as busy through the existing conflict path, and the stale-lock recovery action is not offered
+- **THEN** it is refused as busy through the existing conflict path, and no lock recovery action is offered
 
 ### Requirement: Engine process lifecycle
 

--- a/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-engine-runtime/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-engine-runtime/spec.md
@@ -1,0 +1,151 @@
+## ADDED Requirements
+
+### Requirement: App-managed engine provisioning
+
+The desktop main process SHALL provide a `PulumiEngineService` that resolves a usable Pulumi engine without requiring the operator to install anything. The service MUST NOT probe `PATH` for a `pulumi` binary as its primary resolution strategy; it SHALL resolve the engine from an app-owned cache directory under Electron `userData`, and when the cache is empty or holds a version other than the pinned one, it SHALL download and install the pinned engine into that cache before the first infrastructure operation. Engine resolution MUST be memoized so concurrent callers share a single provisioning attempt, and the service constructor MUST NOT throw on a machine with no engine present, so the Nest DI container still builds.
+
+#### Scenario: First run on a machine with no engine
+
+- **WHEN** an infrastructure operation is requested and the engine cache under `userData` is empty
+- **THEN** the service downloads the pinned engine version into the cache, reports provisioning progress to the caller, and completes the operation without the operator having installed anything
+
+#### Scenario: Subsequent runs reuse the cache
+
+- **WHEN** an infrastructure operation is requested and the pinned engine version is already present in the cache
+- **THEN** no download is performed and the cached engine is used
+
+#### Scenario: Concurrent callers share one provisioning attempt
+
+- **WHEN** two infrastructure operations are requested before engine provisioning has completed
+- **THEN** exactly one download is performed and both callers resolve against the same engine
+
+#### Scenario: Provider plugins are reported as their own phase
+
+- **WHEN** the first infrastructure operation runs on a machine whose plugin cache is empty, so the engine downloads the cloud provider plugin
+- **THEN** the plugin download is reported to the caller as a distinct phase from engine provisioning and from the operation itself, so a multi-minute first run is not presented as a hang
+
+#### Scenario: Engine and plugin caches live under app-owned directories
+
+- **WHEN** the engine and its plugins are provisioned
+- **THEN** both land under app-owned directories derived from Electron `userData`, so the app does not write into or depend on a shared user-level tool directory
+
+#### Scenario: Container builds without an engine
+
+- **WHEN** the Nest application context is constructed on a machine with no engine installed and no network access
+- **THEN** `PulumiEngineService` instantiates successfully and the failure surfaces only when an operation is actually attempted
+
+### Requirement: Pinned engine version
+
+The engine version SHALL be pinned to a single constant exported from `@hyveon/shared`, and the service MUST provision exactly that version rather than "latest". The resolved version SHALL be readable through a service accessor so the Settings page can display it. When the cache holds a different version than the pin, the pinned version MUST be provisioned and used.
+
+#### Scenario: Cache holds a stale version
+
+- **WHEN** the engine cache contains a version other than the pinned constant
+- **THEN** the pinned version is provisioned and used, and the stale version is not used for the operation
+
+#### Scenario: Resolved version is observable
+
+- **WHEN** the renderer requests the engine status after provisioning
+- **THEN** it receives the resolved engine version matching the pinned constant
+
+### Requirement: Engine provisioning failure is actionable
+
+When engine provisioning fails — no network, a download or integrity-verification failure, or an unwritable cache directory — the service SHALL surface a distinct, typed error naming the cause, and MUST NOT leave a partially written engine in the cache that a later run would treat as valid. The failure MUST be reportable to the wizard and to the Plan/Apply page rather than crashing the main process.
+
+#### Scenario: Provisioning fails with no network
+
+- **WHEN** engine provisioning is attempted on a machine with no network connectivity
+- **THEN** a typed provisioning error naming the cause is surfaced to the renderer, the cache is left with no partially written engine, and a retry is offered
+
+#### Scenario: Interrupted download leaves no usable partial
+
+- **WHEN** a download is interrupted partway through
+- **THEN** the next provisioning attempt does not treat the partial content as an installed engine and re-downloads it
+
+### Requirement: Automation API workspace seam
+
+All infrastructure operations SHALL go through a single main-process seam that constructs the Pulumi workspace and stack, rather than each caller building its own. The seam MUST configure the self-managed state backend, the secrets provider, and the AWS credentials for every operation, and MUST NOT require a Pulumi Cloud account or access token. The state backend SHALL be the operator's own S3 bucket, provisioned by the existing bootstrap flow.
+
+The secrets passphrase MUST be present in the engine environment before the first stack is created and for every operation thereafter. On a self-managed backend the engine has no interactive fallback under the non-interactive mode the automation interface always uses — a missing passphrase is a hard failure at stack creation, not a prompt — and there is no option to run without a secrets provider. The seam MUST therefore generate the passphrase, persist it through the OS-level encrypted store, and supply it on every invocation. Losing it makes the stack unusable, so the seam MUST fail loudly rather than silently generating a second passphrase for a stack that already exists.
+
+#### Scenario: Operations use the self-managed backend
+
+- **WHEN** any infrastructure operation runs
+- **THEN** it reads and writes state in the operator's own S3 bucket and no Pulumi Cloud login or access token is required
+
+#### Scenario: Backend is not yet bootstrapped
+
+- **WHEN** an infrastructure operation is attempted before the state bucket exists
+- **THEN** the seam surfaces an actionable error directing the operator to the bootstrap step rather than creating the bucket implicitly
+
+#### Scenario: Passphrase is present before stack creation
+
+- **WHEN** the stack is created for the first time
+- **THEN** the passphrase is already generated and supplied in the engine environment, so creation does not fail on a missing secrets provider
+
+#### Scenario: Missing passphrase for an existing stack fails loudly
+
+- **WHEN** an operation runs against an existing stack and the stored passphrase cannot be retrieved
+- **THEN** the seam reports that the stack's passphrase is unavailable and does not generate a replacement, because a new passphrase cannot decrypt existing state
+
+### Requirement: Wizard-selected credentials reach the engine
+
+The AWS credentials selected in the wizard SHALL be the credentials the engine uses. When the operator selected a named profile, the engine environment MUST carry that profile. When the operator pasted keys through the safeStorage flow, the decrypted values MUST be passed to the engine environment in the main process. The engine MUST NOT be left to resolve credentials through its own default chain, because that silently ignores the operator's choice.
+
+#### Scenario: Named profile is honored
+
+- **WHEN** the operator selected the profile `personal` in the wizard and an infrastructure operation runs
+- **THEN** the engine executes against the `personal` profile's credentials, not the ambient default profile
+
+#### Scenario: Pasted keys are honored
+
+- **WHEN** the operator supplied credentials through the paste flow and an infrastructure operation runs
+- **THEN** the decrypted key material is supplied to the engine environment from the main process and never crosses the IPC boundary to the renderer
+
+#### Scenario: Credentials are not logged
+
+- **WHEN** an infrastructure operation runs with any credential source
+- **THEN** no access key id, secret access key, or session token appears in the streamed output, the persisted run log, or application logs
+
+### Requirement: Stale backend lock recovery
+
+The self-managed backend serializes updates with lock objects it writes into the state bucket, and those locks have no server-side expiry — a run killed by a crash, a force-quit, or a machine losing power leaves a lock that blocks every subsequent operation indefinitely. The app SHALL detect this condition, distinguish it from a legitimately concurrent in-app operation, and offer the operator an explicit, clearly-worded recovery action that clears the stale lock. Clearing MUST be operator-initiated and MUST NOT happen automatically, because a lock held by a genuinely running update is load-bearing.
+
+#### Scenario: Stale lock is surfaced, not swallowed
+
+- **WHEN** an operation fails because the backend reports the stack is locked, and no operation is in flight within this app instance
+- **THEN** the failure is presented as a stale-lock condition naming the stack, with an explicit recovery action, rather than as a generic engine error
+
+#### Scenario: Recovery is never automatic
+
+- **WHEN** a stale-lock condition is detected
+- **THEN** no lock is cleared until the operator explicitly confirms the recovery action
+
+#### Scenario: In-app concurrency is reported as busy, not stale
+
+- **WHEN** an operation is requested while this app instance already holds the workspace
+- **THEN** it is refused as busy through the existing conflict path, and the stale-lock recovery action is not offered
+
+### Requirement: Engine process lifecycle
+
+Engine invocations SHALL be terminated deterministically. Every operation MUST be cancellable, and cancellation MUST release the workspace and any durable lock the operation holds. Because a graceful interrupt is not guaranteed to stop a wedged engine process, cancellation MUST escalate to a forceful termination after a bounded timeout rather than waiting indefinitely. When the Electron app quits, no engine process or listener may remain that prevents the process from exiting.
+
+#### Scenario: Operation is cancelled
+
+- **WHEN** the operator cancels an in-flight operation
+- **THEN** the engine invocation is terminated, the run is recorded as aborted, and the workspace and apply lock are released
+
+#### Scenario: Unresponsive engine is force-terminated
+
+- **WHEN** a cancelled engine invocation does not exit within the bounded escalation timeout
+- **THEN** it is forcefully terminated so the app does not wait on it indefinitely, and the run still settles as aborted
+
+#### Scenario: App quits cleanly during idle
+
+- **WHEN** the app is quit after at least one infrastructure operation has completed
+- **THEN** the Electron process exits without hanging and no orphaned engine process remains
+
+#### Scenario: App quits with an operation in flight
+
+- **WHEN** the app is quit while an infrastructure operation is running
+- **THEN** the engine invocation is terminated during shutdown and the process exits rather than hanging

--- a/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-infra-program/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-infra-program/spec.md
@@ -80,10 +80,22 @@ Because the stack holds no secret material, the stack's secrets provider is chos
 - **WHEN** the operator configures Discord credentials through the app and infrastructure state is subsequently inspected
 - **THEN** the credential values do not appear in state, because the app wrote them directly to Secrets Manager
 
+Preservation MUST be enforced by the program's construction, not merely asserted. The secret's value SHALL be declared as create-only — written once when the secret version does not yet exist, and thereafter excluded from reconciliation — so a later deployment computes no diff against whatever value the app has since written. This is the equivalent of the `ignore_changes = [secret_string]` lifecycle rule the Terraform module relies on, and without it a re-deploy would silently revert working Discord credentials to `"placeholder"` and break the bot.
+
 #### Scenario: Re-deploying does not overwrite configured secrets
 
 - **WHEN** the operator has supplied real Discord credentials through the app and a later deployment runs
 - **THEN** the deployment does not reset those secret values back to placeholders
+
+#### Scenario: Secret values are excluded from reconciliation
+
+- **WHEN** a preview runs after the app has written real credential values to Secrets Manager
+- **THEN** the preview reports no change for the secret versions, because their values are not reconciled against the program
+
+#### Scenario: Preservation is covered by a test
+
+- **WHEN** the infra program's test suite runs
+- **THEN** it includes a case that writes real values through the app's Secrets Manager path, re-deploys, and asserts the values survive unchanged
 
 ### Requirement: Resource parity with the retired Terraform module
 

--- a/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-infra-program/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/pulumi-infra-program/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Infrastructure program workspace
+
+The infrastructure definition SHALL live in a dedicated npm workspace (`@hyveon/infra`) as TypeScript, replacing the `terraform/` HCL tree. The program MUST be consumable by the desktop main process without shipping loose source files as packaged resources, so that a packaged build carries its infrastructure definition in the application bundle rather than in `extraResources`. The program MUST be independently type-checked, linted, and unit-testable by the repo's existing root scripts.
+
+#### Scenario: Packaged build carries the program
+
+- **WHEN** the app is packaged and launched on a clean machine
+- **THEN** an infrastructure preview can be run without any infrastructure source files needing to be present outside the application bundle
+
+#### Scenario: Program is covered by root tooling
+
+- **WHEN** `npm run app:lint` and `npm run app:test` run from the repo root
+- **THEN** the infrastructure workspace is included in both
+
+### Requirement: Typed game-server configuration model
+
+The `game_servers` configuration SHALL be a typed structure exported from `@hyveon/shared` and consumed directly by both the infrastructure program and the desktop app, replacing the HCL `game_servers` map. Adding or removing an entry MUST remain the only edit required to add or remove a game — every per-game resource (task definition, save-data access point, log group, security-group ingress, and the certificate access point for HTTPS games) SHALL be derived from the map by iteration, not hand-written per game.
+
+#### Scenario: Adding a game requires only a config entry
+
+- **WHEN** a new entry is added to the game-server configuration
+- **THEN** a preview reports the full per-game resource set for it with no other source edits
+
+#### Scenario: Removing a game removes its resources
+
+- **WHEN** an entry is removed from the game-server configuration
+- **THEN** a preview reports deletion of exactly that game's resources and no others
+
+#### Scenario: Config type is shared, not duplicated
+
+- **WHEN** the game-server configuration shape changes
+- **THEN** both the infrastructure program and the desktop app fail to type-check until both are updated, because they import the same type
+
+### Requirement: Configuration persisted as versioned JSON
+
+The canonical game-server configuration SHALL be persisted as a JSON object in the operator's versioned S3 configuration bucket, replacing `terraform.tfvars`. The S3 configuration bucket MUST be the only configuration source — the local-file mode, in which configuration is read from and written to a path on disk when no bucket is configured, is removed rather than retained as a fallback. Reads and writes MUST go through the existing `RemoteFileStore` contract so every write inherits its conditional-write optimistic locking and version history; the unguarded synchronous local write path is deleted, not patched. Writing configuration MUST NOT require parsing or emitting HCL, and the app MUST NOT depend on any HCL parser.
+
+The configuration model SHALL cover the top-level deployment settings as well as the per-game map — project name, region, hosted zone, and the watchdog tunables — so that no setting anywhere requires editing a file by hand.
+
+#### Scenario: No local configuration fallback
+
+- **WHEN** configuration is read and no configuration bucket is configured
+- **THEN** the read reports that setup is incomplete rather than falling back to a file on disk
+
+#### Scenario: Editing a game writes JSON
+
+- **WHEN** the operator edits a game through the app
+- **THEN** a new version of the JSON configuration object is written to the configuration bucket and no HCL is parsed or emitted
+
+#### Scenario: Configuration round-trips losslessly
+
+- **WHEN** a configuration containing every supported field is written and read back
+- **THEN** the parsed result is deeply equal to what was written, including boolean and numeric fields
+
+#### Scenario: No HCL parser dependency remains
+
+- **WHEN** the dependency tree of the desktop main process is inspected
+- **THEN** no HCL parsing package is present
+
+### Requirement: No secret material enters the stack
+
+The infrastructure program SHALL NOT accept secret values as configuration inputs. It declares the Discord bot-token and public-key secrets and creates their initial placeholder versions, but never carries their real values — those reach Secrets Manager only through the app's existing AWS SDK path, which is already the documented route and already guarantees neither secret is sent to the renderer. The `discord_bot_token` and `discord_public_key` variables are removed rather than ported, closing the one path by which a real token could be written into infrastructure state.
+
+Because the stack holds no secret material, the stack's secrets provider is chosen for cost rather than recoverability. Any future change that introduces genuine secret values into the stack MUST revisit that choice before doing so — the current provider is machine-bound and has no recovery path if the operator's machine is lost, which is acceptable only while there is nothing to recover.
+
+#### Scenario: Program exposes no secret inputs
+
+- **WHEN** the infrastructure program's configuration inputs are inspected
+- **THEN** no input accepts a bot token, a signing key, or any other credential
+
+#### Scenario: Secrets are created as placeholders only
+
+- **WHEN** the program is deployed to a fresh account
+- **THEN** the Discord secrets exist with placeholder values, and the operator supplies the real values through the app
+
+#### Scenario: Real credentials never enter state
+
+- **WHEN** the operator configures Discord credentials through the app and infrastructure state is subsequently inspected
+- **THEN** the credential values do not appear in state, because the app wrote them directly to Secrets Manager
+
+#### Scenario: Re-deploying does not overwrite configured secrets
+
+- **WHEN** the operator has supplied real Discord credentials through the app and a later deployment runs
+- **THEN** the deployment does not reset those secret values back to placeholders
+
+### Requirement: Resource parity with the retired Terraform module
+
+The infrastructure program SHALL provision the same set of AWS resources the retired Terraform module provisioned, preserving the architectural decisions the system depends on: no long-running ECS service (tasks are run on demand), DNS records managed by the update-dns Lambda rather than by the infrastructure program, HTTPS terminated by a per-task Caddy sidecar with certificates persisted on a dedicated access point rather than by a load balancer, and watchdog idle state stored as tags on the ECS task.
+
+#### Scenario: No persistent ECS service is created
+
+- **WHEN** the program is previewed
+- **THEN** it declares per-game task definitions and no long-running ECS service
+
+#### Scenario: No DNS records are declared
+
+- **WHEN** the program is previewed
+- **THEN** it declares the hosted-zone lookup and the update-dns Lambda but no per-game DNS record resources, so the Lambda remains the sole writer
+
+#### Scenario: HTTPS games get a sidecar, not a load balancer
+
+- **WHEN** a game is configured with HTTPS enabled
+- **THEN** its task definition contains a reverse-proxy sidecar container with a persistent certificate volume, and no load balancer, target group, or managed certificate is declared
+
+#### Scenario: Lambda bundles are deployed from prebuilt output
+
+- **WHEN** the program is previewed after the Lambda bundles have been built
+- **THEN** each Lambda's code is sourced from its prebuilt bundle output without invoking a container runtime
+
+### Requirement: Stack outputs contract
+
+The program SHALL export the values the desktop app reads to discover deployed infrastructure, covering at minimum the cluster, networking, and security-group identifiers, the Discord table and secret locations, the interactions invoke URL, and the runs table name. The app MUST read these from the stack rather than from a state file on disk. A stack that has never been deployed MUST resolve as "not deployed yet" rather than raising.
+
+#### Scenario: App reads outputs from the stack
+
+- **WHEN** the app needs deployed infrastructure identifiers
+- **THEN** it reads them from the stack's outputs, not by parsing a state file from the filesystem
+
+#### Scenario: Never-deployed stack degrades gracefully
+
+- **WHEN** outputs are requested for a stack that has never been deployed
+- **THEN** the app treats the result as "not deployed yet" and renders its empty state without throwing
+
+#### Scenario: Output set covers every consumer
+
+- **WHEN** the app's infrastructure-dependent features are exercised against a deployed stack
+- **THEN** every identifier they need is present in the stack outputs

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-destroy-flow/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-destroy-flow/spec.md
@@ -23,6 +23,18 @@
 
 Every destroy attempt SHALL be gated on a fresh, server-minted, single-use, expiring confirmation token: the renderer requests a token via a plain-invoke IPC channel backed by a token-minting service method, and `terraform.destroy` passes the supplied token to the destroy service method, which refuses (per `DestroyNotConfirmedError`) when the token is absent, unknown, expired, or already consumed. The engine's automation interface is inherently non-interactive and offers no operator confirmation prompt of its own, so this gate is the only thing standing between an accidental invocation and the destruction of all managed infrastructure — it MUST NOT be bypassable by any code path, and tokens MUST NOT be reusable across attempts.
 
+The token SHALL be **bound to the destroy target**, not merely to the act of minting. A minted token records the workspace and stack it was issued for, and the destroy service MUST reject a token whose recorded target does not match the stack about to be destroyed. Consumption MUST be atomic — the token is marked spent before the engine is invoked, so two concurrent submissions cannot both pass on one token. Without binding, a token proves only that *some* token was issued, not that the operator confirmed destruction of *this* stack, which is precisely the assurance a destroy gate exists to provide.
+
+#### Scenario: Token bound to a different stack is rejected
+
+- **WHEN** a destroy is submitted with a valid, unexpired token that was minted for a different workspace or stack
+- **THEN** the submission is refused and no engine destroy is invoked
+
+#### Scenario: Concurrent submissions cannot share one token
+
+- **WHEN** two destroy submissions carrying the same token arrive concurrently
+- **THEN** at most one proceeds, because consumption is atomic and completes before the engine is invoked
+
 #### Scenario: Destroy without a fresh token is refused
 
 - **WHEN** `terraform.destroy` is invoked with a missing, expired, or previously consumed confirmation token

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-destroy-flow/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-destroy-flow/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Destroy IPC channel
+
+`TerraformController` SHALL expose a `terraform.destroy` IPC channel following the shipped `terraform.apply` streaming pattern: a self-bridged handler (registered via `onModuleInit` inside a real Electron main process, excluded from the generic bridge via `SELF_BRIDGED_PATTERNS` in `ipc-main-bridge.ts`) that resolves an immediate `{ started, runId?, error?, conflict? }` ack, streams every destroy output chunk on a chunk side channel tagged with the run's id, sends exactly one terminal end message, and refuses submission with a `conflict` ack when the shared workspace is busy. The handler MUST acquire the durable apply lock (`RunService.createRun`) before invoking the engine and release it on every exit path, record an audit entry for accepted submissions, and persist a run record so destroy runs appear in run history. Because the engine is invoked in-process through the automation seam rather than as a directly spawned command, the handler MUST also release the lock when the engine invocation is cancelled or the app shuts down mid-run.
+
+#### Scenario: Destroy streams output and completes
+
+- **WHEN** a valid destroy submission is accepted and the destroy runs to completion
+- **THEN** the renderer receives ordered chunk messages tagged with the run id followed by a single end message reporting success, and a `kind: 'destroy'` run record is persisted and visible in run history
+
+#### Scenario: Destroy refused while the workspace is busy
+
+- **WHEN** `terraform.destroy` is invoked while another operation is in flight
+- **THEN** the ack resolves `{ started: false, conflict }` naming the in-flight operation, no engine invocation is started, and no audit entry or run record is written
+
+#### Scenario: Lock is released when a destroy is cancelled
+
+- **WHEN** an accepted destroy run is cancelled before it reaches a terminal state
+- **THEN** the durable apply lock is released, the run record settles as aborted, and a subsequent operation is not refused as busy
+
+### Requirement: Fresh confirmation token gate
+
+Every destroy attempt SHALL be gated on a fresh, server-minted, single-use, expiring confirmation token: the renderer requests a token via a plain-invoke IPC channel backed by a token-minting service method, and `terraform.destroy` passes the supplied token to the destroy service method, which refuses (per `DestroyNotConfirmedError`) when the token is absent, unknown, expired, or already consumed. The engine's automation interface is inherently non-interactive and offers no operator confirmation prompt of its own, so this gate is the only thing standing between an accidental invocation and the destruction of all managed infrastructure — it MUST NOT be bypassable by any code path, and tokens MUST NOT be reusable across attempts.
+
+#### Scenario: Destroy without a fresh token is refused
+
+- **WHEN** `terraform.destroy` is invoked with a missing, expired, or previously consumed confirmation token
+- **THEN** the submission is refused with the `DestroyNotConfirmedError`-derived error, and no engine destroy is invoked
+
+#### Scenario: Each attempt needs its own token
+
+- **WHEN** a destroy run completes (or fails) and the operator initiates another destroy
+- **THEN** a new token must be minted and confirmed — the prior token is rejected
+
+#### Scenario: No unguarded destroy path exists
+
+- **WHEN** the codebase is inspected for invocations of the engine's destroy operation
+- **THEN** every call site is reached only through the token-gated service method

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-plan-apply-page/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-plan-apply-page/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Live ANSI log stream
+
+The run view SHALL stream the run's output live by consuming `hyveon.terraform.runs.streamLogs(runId)` (which replays an in-flight run's buffered output then follows it live). ANSI escape sequences MUST be preserved end-to-end from the infrastructure engine and converted to styled HTML in the renderer — the main process and preload MUST NOT strip or rewrite them. The engine SHALL be invoked in a mode that emits human-readable progress output rather than a machine-only event stream, so the log pane remains meaningful to the operator.
+
+#### Scenario: Chunks render in order with ANSI colors
+
+- **WHEN** the plan run emits stdout/stderr chunks containing ANSI color escapes
+- **THEN** the log viewer appends each chunk in arrival order, rendering the ANSI escapes as styled HTML rather than showing raw escape bytes
+
+#### Scenario: Stream ends when the run settles
+
+- **WHEN** the run reaches a terminal state and the log stream's end message arrives
+- **THEN** the log viewer stops following and the page renders the run's terminal status
+
+### Requirement: Plan result summary
+
+When a plan run completes successfully, the run view SHALL display the resource-change summary (counts of resources to create, update, replace, and delete) prominently, with the full streamed plan output available in an expandable section. The counts MUST be taken from the structured change summary the engine returns, and MUST NOT be recovered by pattern-matching the human-readable log text. Exactly one implementation of the summary shape SHALL exist, shared between the main process and the renderer — the renderer MUST NOT re-derive counts from the stream.
+
+#### Scenario: Successful plan shows the change summary
+
+- **WHEN** a plan run ends successfully with a structured change summary
+- **THEN** the page shows the create/update/replace/delete counts as a summary and offers the full log text in an expandable view
+
+#### Scenario: Summary is not scraped from output
+
+- **WHEN** a plan run's human-readable output is altered (for example by an engine version whose wording differs)
+- **THEN** the displayed counts are unaffected, because they come from the structured summary rather than from the text
+
+#### Scenario: Missing summary is not reported as "no changes"
+
+- **WHEN** a plan run completes successfully but the engine's summary data is absent, so the change summary is empty
+- **THEN** the page MUST NOT report "no changes"; it reports that the summary was unavailable and still offers the full log, because an empty summary is indistinguishable from a dropped summary event
+
+### Requirement: Plan-hash-gated apply
+
+The "Apply" action SHALL call `hyveon.terraform.apply({ planRunId, planHash })` using the plan hash returned by the plan run, so the backend's gate decides whether the apply proceeds. The plan run SHALL persist an engine-produced update plan as a run artifact, and the apply SHALL be constrained by that saved plan so the engine itself refuses changes the operator did not review. The gate MUST verify, in order: the plan record exists, it is a plan run, it is approved, the approval is unexpired within the 15-minute window, the hash matches both the stored record and the re-hashed on-disk plan artifact, the engine version matches the one that produced the plan, the workspace is free, and the durable apply lock was acquired. Because the saved plan format carries no stability guarantee, the plan hash MUST additionally cover the version identifier of the configuration object the plan ran against, and the apply MUST refuse when that version has moved — the configuration check MUST NOT depend on the plan file being parseable.
+
+The saved plan is stamped with the engine version that produced it. A plan produced by one engine version MUST NOT be applied by another, because the plan format is explicitly unstable and a silently reinterpreted plan would defeat the review the gate exists to enforce. An engine upgrade between plan and apply SHALL invalidate outstanding plans with an error that names the version change.
+
+A plan-constrained apply is not all-or-nothing: the engine applies changes in batches as the program executes, so a divergence detected partway through leaves earlier changes applied. The apply run's terminal state MUST therefore distinguish "failed with no changes applied" from "failed partway through", and the UI MUST direct the operator to re-plan rather than retry blindly after a partial failure. A `{ started: false }` ack MUST be surfaced to the operator with its error text; an expired-approval rejection MUST prompt re-approval. On a successful apply the page SHALL show a success banner with a link back to the dashboard.
+
+#### Scenario: Approved plan applies end-to-end
+
+- **WHEN** the operator clicks "Apply" on an approved, unexpired plan and the ack resolves `{ started: true, runId }`
+- **THEN** the page streams the apply run's output live and, once it ends successfully, shows a success banner linking to the dashboard
+
+#### Scenario: Configuration changed since the plan
+
+- **WHEN** the configuration object has been written again since the plan ran, so its current version no longer matches the version recorded on the plan
+- **THEN** the apply is refused with an error explaining that the plan is stale, and the operator is directed to re-plan
+
+#### Scenario: Expired approval is rejected
+
+- **WHEN** the operator clicks "Apply" more than 15 minutes after approval and the ack resolves `{ started: false }` with an approval-expired error
+- **THEN** the page surfaces the error and prompts the operator to re-approve the plan before applying
+
+#### Scenario: Apply refused while the lock is held
+
+- **WHEN** the apply ack resolves `{ started: false, conflict }` because the workspace or the durable apply lock is held by another run
+- **THEN** the page shows the BUSY banner naming the conflict and does not stream any apply output
+
+#### Scenario: Engine upgraded between plan and apply
+
+- **WHEN** the operator applies a plan that was produced by a different engine version than the one now installed
+- **THEN** the apply is refused with an error naming the version change, and the operator is directed to re-plan
+
+#### Scenario: Apply fails partway through
+
+- **WHEN** a plan-constrained apply fails after some resource operations have already been applied
+- **THEN** the run settles in a state that identifies it as a partial apply, and the page directs the operator to re-plan rather than presenting a plain retry of the same plan

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-plan-apply-page/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-plan-apply-page/spec.md
@@ -35,7 +35,7 @@ When a plan run completes successfully, the run view SHALL display the resource-
 
 ### Requirement: Plan-hash-gated apply
 
-The "Apply" action SHALL call `hyveon.terraform.apply({ planRunId, planHash })` using the plan hash returned by the plan run, so the backend's gate decides whether the apply proceeds. The plan run SHALL persist an engine-produced update plan as a run artifact, and the apply SHALL be constrained by that saved plan so the engine itself refuses changes the operator did not review. The gate MUST verify, in order: the plan record exists, it is a plan run, it is approved, the approval is unexpired within the 15-minute window, the hash matches both the stored record and the re-hashed on-disk plan artifact, the engine version matches the one that produced the plan, the workspace is free, and the durable apply lock was acquired. Because the saved plan format carries no stability guarantee, the plan hash MUST additionally cover the version identifier of the configuration object the plan ran against, and the apply MUST refuse when that version has moved — the configuration check MUST NOT depend on the plan file being parseable.
+The "Apply" action SHALL call `hyveon.terraform.apply({ planRunId, planHash })` using the plan hash returned by the plan run, so the backend's gate decides whether the apply proceeds. The plan run SHALL persist an engine-produced update plan as a run artifact, and the apply SHALL be constrained by that saved plan so the engine itself refuses changes the operator did not review. The gate MUST verify, in order: the plan record exists, it is a plan run, it is approved, the approval is unexpired within the 15-minute window, the hash matches both the stored record and the re-hashed on-disk plan artifact, and the engine version matches the one that produced the plan. Acquiring the durable apply lock SHALL be the final and authoritative step, and it MUST be a single atomic compare-and-set whose conflict result decides the outcome. A preceding "is the workspace free" observation MUST NOT be relied on as the gate: two applies can both observe a free workspace before either acquires the lock, and only the atomic acquisition can order them. Because the saved plan format carries no stability guarantee, the plan hash MUST additionally cover the version identifier of the configuration object the plan ran against, and the apply MUST refuse when that version has moved — the configuration check MUST NOT depend on the plan file being parseable.
 
 The saved plan is stamped with the engine version that produced it. A plan produced by one engine version MUST NOT be applied by another, because the plan format is explicitly unstable and a silently reinterpreted plan would defeat the review the gate exists to enforce. An engine upgrade between plan and apply SHALL invalidate outstanding plans with an error that names the version change.
 
@@ -60,6 +60,11 @@ A plan-constrained apply is not all-or-nothing: the engine applies changes in ba
 
 - **WHEN** the apply ack resolves `{ started: false, conflict }` because the workspace or the durable apply lock is held by another run
 - **THEN** the page shows the BUSY banner naming the conflict and does not stream any apply output
+
+#### Scenario: Two simultaneous applies are ordered by the lock
+
+- **WHEN** two applies for the same approved plan are submitted close enough together that both observe a free workspace before either acquires the lock
+- **THEN** exactly one acquires the durable apply lock and proceeds, and the other is refused with a conflict — the outcome is decided by the atomic acquisition, not by the earlier observation
 
 #### Scenario: Engine upgraded between plan and apply
 

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-rollback/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-rollback/spec.md
@@ -16,12 +16,24 @@ The history view SHALL offer a "Rollback" action on apply runs that recorded the
 
 ### Requirement: Rollback restores the version and queues a tagged plan
 
-Confirming a rollback SHALL restore the selected historic configuration version's content as the new head of the configuration object (a new S3 version — history is never rewritten) and then start a plan against that restored version. The resulting plan run's record MUST carry `rolledBackFrom: <applyRunId>` (an optional `RunRecord` field in `@hyveon/shared/runs.ts`, plumbed through run-record persistence), and the history view MUST display the tag on rollback runs. Because the configuration is stored as JSON, restoration MUST be a byte-for-byte rewrite of the historic object content, with no parse-and-re-emit step that could alter it.
+Confirming a rollback SHALL restore the selected historic configuration version's content as the new head of the configuration object (a new S3 version — history is never rewritten) and then start a plan against that restored version.
+
+The restore and the plan's creation SHALL be performed as one guarded unit. The shared operation lock MUST be acquired **before** the restore is written and held until the plan run's record is persisted, so no other operation can interleave between the two. If plan creation nevertheless fails — engine provisioning, network, or persistence — the rollback MUST NOT leave the restored configuration as the head with no plan attached: it either restores the previous head or records the orphaned restore explicitly and surfaces it to the operator. Silently leaving a changed head that no plan describes is the failure mode this exists to prevent, because the next apply would then deploy a configuration nobody reviewed. The resulting plan run's record MUST carry `rolledBackFrom: <applyRunId>` (an optional `RunRecord` field in `@hyveon/shared/runs.ts`, plumbed through run-record persistence), and the history view MUST display the tag on rollback runs. Because the configuration is stored as JSON, restoration MUST be a byte-for-byte rewrite of the historic object content, with no parse-and-re-emit step that could alter it.
 
 #### Scenario: Rollback plan is tagged
 
 - **WHEN** the operator confirms a rollback of apply run `R`
 - **THEN** the historic configuration content is written as the new head version and a plan run starts whose persisted record has `rolledBackFrom: R`, visible as a tag in the history view
+
+#### Scenario: Plan creation fails after the restore
+
+- **WHEN** the historic content has been restored as the new head and the plan run then fails to start or persist
+- **THEN** the rollback does not leave a restored head with no plan describing it — either the previous head is restored or the orphaned restore is recorded and surfaced to the operator
+
+#### Scenario: No operation interleaves with a rollback
+
+- **WHEN** another plan, apply, or destroy is requested between a rollback's restore and its plan-record persistence
+- **THEN** it is refused as busy, because the rollback holds the shared operation lock across both steps
 
 #### Scenario: Restored content is byte-identical
 

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-rollback/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-rollback/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Rollback initiation from history
+
+The history view SHALL offer a "Rollback" action on apply runs that recorded the version identifier of the configuration object they ran against. Initiating a rollback MUST resolve the configuration version that was live before that run (using the complete version listing) and present it to the operator for confirmation before anything is written. The confirmation MUST identify the target version, and SHOULD summarize how the target configuration differs from the current one so the operator is not confirming an opaque version id.
+
+#### Scenario: Operator starts a rollback
+
+- **WHEN** the operator clicks "Rollback" on an apply run in history
+- **THEN** the app resolves the prior configuration version and shows a confirmation identifying the target version before proceeding
+
+#### Scenario: Runs without a configuration version offer no rollback
+
+- **WHEN** a history row is a run with no recorded configuration version id (or not an apply run)
+- **THEN** no Rollback action is offered for that row
+
+### Requirement: Rollback restores the version and queues a tagged plan
+
+Confirming a rollback SHALL restore the selected historic configuration version's content as the new head of the configuration object (a new S3 version — history is never rewritten) and then start a plan against that restored version. The resulting plan run's record MUST carry `rolledBackFrom: <applyRunId>` (an optional `RunRecord` field in `@hyveon/shared/runs.ts`, plumbed through run-record persistence), and the history view MUST display the tag on rollback runs. Because the configuration is stored as JSON, restoration MUST be a byte-for-byte rewrite of the historic object content, with no parse-and-re-emit step that could alter it.
+
+#### Scenario: Rollback plan is tagged
+
+- **WHEN** the operator confirms a rollback of apply run `R`
+- **THEN** the historic configuration content is written as the new head version and a plan run starts whose persisted record has `rolledBackFrom: R`, visible as a tag in the history view
+
+#### Scenario: Restored content is byte-identical
+
+- **WHEN** a historic configuration version is restored as the new head
+- **THEN** the new head's content is byte-for-byte identical to the historic version
+
+### Requirement: Missing historic version is a clear error
+
+If the historic configuration version no longer exists (e.g. removed by S3 lifecycle expiry after the 90-day noncurrent-version window), the rollback SHALL fail before any write occurs, surfacing an error that names the missing version, and MUST leave the current configuration head untouched.
+
+#### Scenario: Historic version expired
+
+- **WHEN** the operator confirms a rollback whose target version id no longer exists in S3
+- **THEN** the app surfaces an error identifying the missing version, no new configuration head is written, and no plan run is started

--- a/openspec/changes/migrate-iac-to-pulumi/specs/terraform-run-history/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/terraform-run-history/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Run listing API
+
+The system SHALL provide a run-listing API spanning every layer: a `listRuns` method on the `RunRecordStore` contract (`@hyveon/shared/cloud.ts`) implemented by `AwsRunRecordStore` as a DynamoDB query, a `RunRecordService.listRuns` service method, a `terraform.runs.list` IPC channel on `TerraformRunsController`, and a `hyveon.terraform.runs.list` preload bridge with a typed mirror in `hyveon-api.ts`. Results MUST be returned newest-first as the `RunPageResult` page shape already defined in `@hyveon/shared/runs.ts` (records plus an optional `nextBefore` cursor), and the API MUST support a page-size limit, cursor-based continuation, and optional filtering by run status (served by the runs table's `status-index` GSI on status + `startedAt`). The runs table name SHALL be resolved from the infrastructure stack's outputs.
+
+#### Scenario: First page of runs, newest first
+
+- **WHEN** a caller invokes `hyveon.terraform.runs.list({ limit: 20 })`
+- **THEN** it resolves a `RunPageResult` whose records are the 20 most recent runs ordered newest-first, with `nextBefore` set when older runs exist
+
+#### Scenario: Cursor fetches the next page
+
+- **WHEN** a caller passes the previous page's `nextBefore` value as the `before` cursor
+- **THEN** the resolved page contains only runs older than that cursor, still newest-first
+
+#### Scenario: Status-filtered listing uses the GSI
+
+- **WHEN** a caller lists runs filtered to a single status (e.g. `failed`)
+- **THEN** only runs with that status are returned, newest-first, without scanning the whole table
+
+#### Scenario: Runs table not configured
+
+- **WHEN** the runs table name is not present in the stack outputs, including when the stack has never been deployed
+- **THEN** `listRuns` resolves an empty page rather than throwing, matching `getByRunId`'s existing not-configured behavior
+
+## ADDED Requirements
+
+### Requirement: Structured change summary on run records
+
+Persisted run records SHALL carry the structured change summary the engine reports for the run (counts by operation type), rather than counts recovered by pattern-matching the run's human-readable output. The summary field SHALL be optional on the `RunRecord` type so records written before this change, and runs that fail before producing a summary, remain readable. The history table and the read-only run-detail view SHALL render the summary when present and omit it when absent, without erroring.
+
+#### Scenario: Completed run persists its summary
+
+- **WHEN** a plan or apply run completes and the engine reports a change summary
+- **THEN** the persisted run record carries that summary and the history view renders its counts
+
+#### Scenario: Run with no summary renders cleanly
+
+- **WHEN** a run record has no change summary, because it failed early or predates this change
+- **THEN** the history table and run-detail view render the row without a summary and without throwing
+
+#### Scenario: Summary is not derived from log text
+
+- **WHEN** a run's output wording differs from what earlier engine versions produced
+- **THEN** the persisted summary is unaffected, because it is taken from structured engine data rather than parsed from the log

--- a/openspec/changes/migrate-iac-to-pulumi/specs/wizard-flow/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/wizard-flow/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### Requirement: Reconfigure entry point in Settings
+
+The Settings page SHALL surface a "Reconfigure" button that relaunches the wizard against the existing electron-store state, re-running every step in the flow (cloud, credentials, bootstrap, stack initialization). Because prerequisite detection no longer exists as a step, there is no step excluded from Reconfigure and no special-casing in the step list. Steps already satisfied by existing state SHALL render as completed with a per-step "Edit" affordance rather than forcing re-entry. Reconfigure MUST preserve existing configuration except the fields the operator changes, and cancelling mid-flow MUST leave the pre-reconfigure configuration intact and the app usable.
+
+#### Scenario: Reconfigure with one change
+
+- **WHEN** the operator opens Reconfigure and edits only the region in the credentials step
+- **THEN** the region updates while every other stored setting is preserved
+
+#### Scenario: Completed steps are skippable
+
+- **WHEN** Reconfigure opens with all steps previously completed
+- **THEN** each step shows as completed with an "Edit" affordance and the operator can jump straight to finishing
+
+#### Scenario: Reconfigure covers the whole flow
+
+- **WHEN** Reconfigure opens
+- **THEN** every wizard step is present in the flow, with no step filtered out of the reconfigure step list
+
+#### Scenario: Mid-flow cancel
+
+- **WHEN** the operator cancels Reconfigure partway through
+- **THEN** no partial changes are committed and the app returns to Settings in its prior working state
+
+## ADDED Requirements
+
+### Requirement: Stack initialization step with live log
+
+The final configuration step SHALL provision the infrastructure engine (per `pulumi-engine-runtime`) and select or create the stack against the bootstrapped self-managed backend, streaming progress live into a wizard log pane over a streaming IPC channel exposed as an async iterable, following the same shape the previous init step used. ANSI escape sequences in the output MUST render as styled HTML. Because the first run downloads both the engine and the cloud provider plugin, the step MUST report "provisioning the engine", "downloading provider plugins", and "initializing the stack" as distinct phases so a multi-minute first run is not mistaken for a hang. The step MUST also set the stack's secrets provider at creation time, because it cannot be changed afterwards through the automation interface and a stack created without one would have to be recreated to correct it. The completion control SHALL enable only on success; a failure SHALL surface an error state with the captured log and allow retry.
+
+#### Scenario: Successful initialization on a clean machine
+
+- **WHEN** the step runs on a machine with no engine cached and the stack does not yet exist
+- **THEN** the pane reports engine provisioning, then provider plugin download, then stack initialization, the stack is created against the operator's own S3 backend with its secrets provider set, and the completion button becomes enabled
+
+#### Scenario: Engine already cached
+
+- **WHEN** the step runs on a machine where the pinned engine version is already cached
+- **THEN** no download is reported and the step proceeds directly to stack initialization
+
+#### Scenario: Failed initialization
+
+- **WHEN** engine provisioning or stack initialization fails
+- **THEN** the step shows an error UI with the log and the failure cause, keeps the completion button disabled, and offers a retry
+
+#### Scenario: ANSI output renders
+
+- **WHEN** the streamed output contains ANSI color escapes
+- **THEN** the log pane renders them as styled HTML rather than raw escape bytes
+
+### Requirement: Resolved engine version in Settings
+
+Settings SHALL display the infrastructure engine version the app resolved alongside the version it pins, so operators can confirm what their deployments run against. Because the app provisions the engine itself, these values normally match; a mismatch indicates a failed or pending provisioning and SHALL be shown as such rather than silently hidden.
+
+#### Scenario: Settings shows the engine version
+
+- **WHEN** the operator opens Settings after wizard completion
+- **THEN** the resolved engine version and the pinned version are both visible
+
+#### Scenario: Engine not yet provisioned
+
+- **WHEN** the operator opens Settings before any infrastructure operation has run and no engine is cached
+- **THEN** Settings reports the engine as not yet provisioned rather than showing a blank or stale version
+
+## REMOVED Requirements
+
+### Requirement: Terraform init step with live log
+
+**Reason**: `TerraformService.init({ backendConfig: { bucket, region, dynamodbTable } })` no longer exists. There is no `terraform init` to run, no `.terraform` directory to populate, and no DynamoDB lock table to point a backend at.
+
+**Migration**: Replaced by the "Stack initialization step with live log" requirement above. The streaming IPC shape and the ANSI log pane are reused; only the underlying operation and the backend-config inputs change.
+
+### Requirement: Resolved Terraform version in Settings
+
+**Reason**: There is no operator-installed Terraform binary whose version could be resolved, and no minimum-version gate to display it against.
+
+**Migration**: Replaced by the "Resolved engine version in Settings" requirement above, sourced from the engine service rather than from prerequisite detection.

--- a/openspec/changes/migrate-iac-to-pulumi/specs/wizard-flow/spec.md
+++ b/openspec/changes/migrate-iac-to-pulumi/specs/wizard-flow/spec.md
@@ -28,17 +28,22 @@ The Settings page SHALL surface a "Reconfigure" button that relaunches the wizar
 
 ### Requirement: Stack initialization step with live log
 
-The final configuration step SHALL provision the infrastructure engine (per `pulumi-engine-runtime`) and select or create the stack against the bootstrapped self-managed backend, streaming progress live into a wizard log pane over a streaming IPC channel exposed as an async iterable, following the same shape the previous init step used. ANSI escape sequences in the output MUST render as styled HTML. Because the first run downloads both the engine and the cloud provider plugin, the step MUST report "provisioning the engine", "downloading provider plugins", and "initializing the stack" as distinct phases so a multi-minute first run is not mistaken for a hang. The step MUST also set the stack's secrets provider at creation time, because it cannot be changed afterwards through the automation interface and a stack created without one would have to be recreated to correct it. The completion control SHALL enable only on success; a failure SHALL surface an error state with the captured log and allow retry.
+The final configuration step SHALL provision the infrastructure engine (per `pulumi-engine-runtime`) and select or create the stack against the bootstrapped self-managed backend, streaming progress live into a wizard log pane over a streaming IPC channel exposed as an async iterable, following the same shape the previous init step used. ANSI escape sequences in the output MUST render as styled HTML. Because the first run downloads both the engine and the cloud provider plugin, the step MUST report "provisioning the engine", "downloading provider plugins", and "initializing the stack" as distinct phases so a multi-minute first run is not mistaken for a hang. The engine cache and the provider-plugin cache MUST be checked independently: they populate separately, so an engine that is already present says nothing about whether the plugin is, and a cached engine MUST NOT cause the plugin phase to be skipped or its download to happen silently inside stack initialization. The step MUST also set the stack's secrets provider at creation time, because it cannot be changed afterwards through the automation interface and a stack created without one would have to be recreated to correct it. The completion control SHALL enable only on success; a failure SHALL surface an error state with the captured log and allow retry.
 
 #### Scenario: Successful initialization on a clean machine
 
 - **WHEN** the step runs on a machine with no engine cached and the stack does not yet exist
 - **THEN** the pane reports engine provisioning, then provider plugin download, then stack initialization, the stack is created against the operator's own S3 backend with its secrets provider set, and the completion button becomes enabled
 
-#### Scenario: Engine already cached
+#### Scenario: Engine cached but provider plugin missing
 
-- **WHEN** the step runs on a machine where the pinned engine version is already cached
-- **THEN** no download is reported and the step proceeds directly to stack initialization
+- **WHEN** the step runs on a machine where the pinned engine version is already cached but the cloud provider plugin is not
+- **THEN** the engine-provisioning phase is skipped and the provider-plugin download is still reported as its own phase, rather than the step appearing to stall during stack initialization
+
+#### Scenario: Engine and plugin both cached
+
+- **WHEN** the step runs on a machine where both the pinned engine version and the provider plugin are already cached
+- **THEN** neither download phase is reported and the step proceeds directly to stack initialization
 
 #### Scenario: Failed initialization
 

--- a/openspec/changes/migrate-iac-to-pulumi/tasks.md
+++ b/openspec/changes/migrate-iac-to-pulumi/tasks.md
@@ -1,0 +1,121 @@
+## 1. Spikes (gate everything else)
+
+- [ ] 1.1 Add `@pulumi/pulumi@3.255.0` and `@pulumi/aws@7.39.0` to a scratch workspace; mark `@pulumi/pulumi` `external` in `electron.vite.config.ts` and add it plus `@pulumi/aws` to `electron-builder.yml` `files`, following the `@cdktf/hcl2json` precedent
+- [ ] 1.2 Spike: run `PulumiCommand.install({ root: <userData>/pulumi })` from the Electron main process and confirm the binary lands at `<root>/bin/pulumi` and that a second call short-circuits
+- [ ] 1.3 Spike: run a trivial inline program from inside a packaged `app.asar` build and confirm the `--client` gRPC callback executes the closure — this is the highest-risk unknown and gates the whole approach
+- [ ] 1.4 During the first bootstrap run, point `PULUMI_BACKEND_URL` at the newly created bucket and run a read-only `stack ls` to confirm the `s3://` driver authenticates without a login (Open Question 1); if it fails, add a login step to the workspace seam
+- [ ] 1.5 Spike: after one `preview` and one `up`, confirm the Electron app quits cleanly with no orphaned `pulumi` process; add this as a permanent e2e check rather than a one-off
+- [ ] 1.6 If 1.3 fails, stop and re-evaluate against the OpenTofu auto-download fallback recorded in `design.md` before continuing
+
+## 2. Infra workspace scaffold
+
+- [ ] 2.1 Create the `app/packages/infra` workspace (`@hyveon/infra`) with its `package.json`, `tsconfig.json`, and ESLint wiring so root `app:lint` / `app:test` pick it up
+- [ ] 2.2 Define the typed configuration model in `@hyveon/shared`, covering both the `game_servers` map and the top-level deployment settings (project name, region, hosted zone, watchdog tunables), with TSDoc on every field
+- [ ] 2.3 Add unit tests for the configuration model covering every field, including the `https` flag that HCL round-tripping previously corrupted
+- [ ] 2.4 Define the stack-outputs type in `@hyveon/shared`, covering cluster, subnet, security-group, Discord table and secret locations, interactions invoke URL, and runs table name
+
+## 3. Infra program — resource parity
+
+- [ ] 3.1 Port networking: VPC, subnet, internet gateway, route table, association
+- [ ] 3.2 Port EFS: file system, mount target, per-game save-data access points, per-HTTPS-game certificate access points
+- [ ] 3.3 Port ECS: cluster and per-game task definitions derived by iteration over the config map, including the Caddy sidecar container for `https = true` games
+- [ ] 3.4 Port security groups, including the deduplicated per-game port ingress and the 443/80 opening for HTTPS games
+- [ ] 3.5 Port IAM roles and policies (6 roles, 5 inline policies, 1 attachment)
+- [ ] 3.6 Port the five Lambda functions with code sourced from prebuilt `dist/handler.cjs` bundles, plus their log groups, permissions, and the function URL
+- [ ] 3.7 Port EventBridge rules and targets for the DNS updater and the watchdog
+- [ ] 3.8 Port DynamoDB tables (discord, runs, audit) and the Secrets Manager secrets, declaring placeholder versions only — drop the `discord_bot_token` / `discord_public_key` inputs so no secret value can enter the stack, and ensure a re-deploy never resets a configured secret back to its placeholder
+- [ ] 3.9 Port Route53: hosted-zone lookup and the updater Lambda only — assert no per-game DNS record resources exist, since the Lambda is the sole writer
+- [ ] 3.10 Port the remaining imperative escapes (`aws_dynamodb_table_item` ×2, `aws_lambda_invocation`, `terraform_data`, `aws_secretsmanager_secret_version` ×2) as explicit constructs, and document why each is not a plain resource
+- [ ] 3.11 Export the stack outputs defined in 2.4
+- [ ] 3.12 Diff the synthesized resource inventory against the 69 Terraform resources and record any intentional omission with its reason
+
+## 4. Engine runtime
+
+- [ ] 4.1 Add the pinned engine version constant to `@hyveon/shared`
+- [ ] 4.2 Implement `PulumiEngineService`: memoized resolution, install into `<userData>`, non-throwing constructor, typed provisioning errors, no partial-install reuse
+- [ ] 4.3 Implement the workspace seam: `pulumiCommand`, `pulumiHome`, explicit `workDir` under `userData` (avoiding the never-cleaned tmpdir leak), `PULUMI_BACKEND_URL`, bare stack name
+- [ ] 4.4 Generate a passphrase, store it via `SafeStorageService`, and supply it on every invocation — it must exist before the first stack is created (a missing passphrase is a hard exit-1 under `--non-interactive`, not a prompt), and a missing passphrase for an existing stack must fail loudly rather than generate a replacement
+- [ ] 4.5 Propagate wizard-selected credentials into `envVars` — named profile via `AWS_PROFILE`, pasted keys decrypted in the main process — and add a test asserting no key material reaches streamed output or logs
+- [ ] 4.6 Report engine provisioning, provider plugin download, and the operation itself as distinct phases
+- [ ] 4.7 Implement cancellation: `AbortSignal` for user cancel plus a bounded escalation timer to forceful termination, since the SDK never escalates past `SIGINT`
+- [ ] 4.8 Implement stale-lock detection from `ConcurrentUpdateError`, distinguished from in-app busy, with operator-confirmed recovery via `stack.cancel()`
+- [ ] 4.9 Handle the "succeeded then threw" leaked-promise path so a successful apply is not reported as a failure
+
+## 5. Bootstrap
+
+- [ ] 5.1 Remove `ensureLockTable`, its `wizard.bootstrap.lockTable` IPC channel, its preload mirror, and its bootstrap-step row
+- [ ] 5.2 Rename the tfvars bucket concept to the configuration bucket throughout `BootstrapService` and the wizard step, preserving the versioning and 90-day noncurrent-expiry behavior
+- [ ] 5.3 Apply all four S3 public-access-block settings to both buckets, on creation and on an already-existing bucket — `BootstrapService` currently applies none, while the `terraform/bootstrap/` module it mirrors applies all four
+- [ ] 5.4 Update the `HyveonDeployAll` policy in `docs/docs/setup.md`: add the four DIY-backend S3 actions and `s3:PutPublicAccessBlock`, remove the lock-table DynamoDB actions
+- [ ] 5.5 Update `BootstrapService` tests for the added, removed, and renamed operations
+
+## 6. Configuration store
+
+- [ ] 6.1 Replace `TfvarsService`'s HCL read path with JSON parsing against the shared config type
+- [ ] 6.2 Replace the write path with JSON serialization, deleting `hclSurgeon.ts`, `hclEmit.ts`, and their tests
+- [ ] 6.3 Delete local-file mode: remove the disk read path, the unguarded `writeFileSync`, and `ConfigService.getTfvarsPath()`, so the S3 bucket is the only configuration source
+- [ ] 6.4 Make an unconfigured bucket report incomplete setup and route to the wizard — assert in a test that no disk fallback is reachable
+- [ ] 6.5 Add a round-trip test proving a config containing every field, top-level and per-game, survives write-then-read deeply equal
+- [ ] 6.6 Remove `@cdktf/hcl2json`, `patches/@cdktf+hcl2json+0.21.0.patch`, its `external` marking, and its `electron-builder.yml` `files` entries; confirm no HCL parser remains in the dependency tree
+
+## 7. Service replacement
+
+- [ ] 7.1 Implement `PulumiService.preview` returning structured `changeSummary`, saving the update plan as a run artifact, reusing the existing chunk line-splitting for `onOutput`/`onError`
+- [ ] 7.2 Implement `PulumiService.up` constrained by the saved plan, distinguishing clean failure from partial apply in the run's terminal state
+- [ ] 7.3 Implement `PulumiService.destroy` behind the existing confirmation-token gate; assert no untokened call site exists
+- [ ] 7.4 Implement stack output reads replacing `ConfigService.getTfOutputs()`, degrading to "not deployed yet" for a never-deployed stack
+- [ ] 7.5 Port the plan-hash gate: hash over the saved plan artifact plus the config object's version id, with the staleness check independent of plan-file parseability, and refuse to apply a plan produced by a different engine version (`plan.json`'s `manifest.version`)
+- [ ] 7.6 Port `resolveRollbackTarget` / `confirmRollback` to the JSON config object, restoring historic content byte-for-byte
+- [ ] 7.7 Add the optional structured change summary to `RunRecord` in `@hyveon/shared/runs.ts` and persist it, keeping older records readable
+- [ ] 7.8 Port the 12 typed error classes, dropping the ones with no Pulumi analogue and adding stale-lock and partial-apply errors
+- [ ] 7.9 Delete `TerraformService.ts` and its tests
+
+## 8. Controllers and preload
+
+- [ ] 8.1 Repoint all 13 `terraform.*` / `terraform.runs.*` IPC channels at `PulumiService`, keeping channel names unchanged per the stated non-goal
+- [ ] 8.2 Update `ConfigService`: remove `getTfStatePath`, `getTerraformDir`, `seedTerraformWorkspace`, and the tfstate cache; keep the env seams tests rely on
+- [ ] 8.3 Update the preload bridge and `hyveon-api.ts` types for the changed payload shapes (structured summary, partial-apply state, stale-lock recovery)
+- [ ] 8.4 Update controller unit tests, including the channel-name registration guard
+
+## 9. Renderer
+
+- [ ] 9.1 Render the change summary from structured data on the Plan/Apply page; delete the three duplicated summary regexes in `terraform.page.tsx`
+- [ ] 9.2 Handle the missing-summary case explicitly — never present an empty summary as "no changes"
+- [ ] 9.3 Surface partial-apply failures with re-plan guidance rather than a plain retry
+- [ ] 9.4 Add the stale-lock recovery UI with explicit confirmation
+- [ ] 9.5 Update the run-history table and read-only detail view to render the structured summary when present and omit it cleanly when absent
+- [ ] 9.6 Update the rollback confirmation to identify the target config version and summarize how it differs from current
+- [ ] 9.7 Add a deployment-settings section to Settings for the top-level configuration, so no setting requires editing a file — validated before write, sharing the game-form validation patterns
+
+## 10. Wizard and prerequisites
+
+- [ ] 10.1 Delete `PrerequisiteService`, the `wizard.prereqs.check` channel, its preload mirror and types, and the prerequisites wizard step
+- [ ] 10.2 Remove `prerequisites` from the wizard step list and drop the Reconfigure special-casing that excluded it
+- [ ] 10.3 Replace the Terraform-init step with the stack-initialization step, reporting the three provisioning phases and setting the secrets provider at creation
+- [ ] 10.4 Replace the Settings Terraform-version row with the resolved engine version plus the pinned version, including a not-yet-provisioned state
+- [ ] 10.5 Remove `MINIMUM_TERRAFORM_VERSION` and the version-parsing helpers
+
+## 11. Test surface
+
+- [ ] 11.1 Replace `app/test/fake-terraform.mjs` and the `terraform-shim.ts` / `terraform-fixtures.ts` Playwright fixtures with Pulumi equivalents, or delete them where in-process stubbing of `PulumiService` is now sufficient
+- [ ] 11.2 Update the integration harness so `ipc` specs resolve stack outputs from a fixture instead of `TF_STATE_PATH`
+- [ ] 11.3 Update Electron e2e mocks for the changed IPC payload shapes
+- [ ] 11.4 Keep the 1.6 clean-quit check green in CI
+
+## 12. Removal and documentation
+
+- [ ] 12.1 Delete the `terraform/` tree, including `terraform/bootstrap/` and the 376-line `moved.tf`
+- [ ] 12.2 Remove the `terraform.tfstate` `extraResources` entry from `electron-builder.yml` and the `.github/workflows/package.yml` step that fabricates a placeholder state file
+- [ ] 12.3 Port the generated Makefile in `scripts/init-parent.ts` from `aws s3api` / `aws dynamodb` to `@aws-sdk/client-s3` and `@aws-sdk/client-dynamodb`
+- [ ] 12.4 Rewrite `docs/docs/components/terraform.md` for the Pulumi program
+- [ ] 12.5 Update `docs/docs/setup.md`: drop both prerequisites and the "Configure the AWS CLI" section, drop the bootstrap-tfvars CLI walkthrough, and add the explicit warning that an existing Terraform deployment must be destroyed first or infrastructure will be duplicated
+- [ ] 12.6 Update `docs/docs/architecture.md`, `docs/docs/guides/user.md`, `docs/docs/guides/submodule.md`, `docs/docs/intro.md`, and `README.md`
+- [ ] 12.7 Update `CLAUDE.md`: commands, architecture, the `game_servers` source-of-truth section, and the Terraform-variable checklist
+- [ ] 12.8 Assert in docs and tests that no operator-facing instruction requires running any command other than launching the app
+- [ ] 12.9 Confirm `npm run app:lint`, `npm run app:test`, `npm run app:test:e2e`, and `npm run app:test:integration` all pass
+
+## 13. Follow-up coordination
+
+- [ ] 13.1 Re-propose `add-one-click-aws-bootstrap` against the Pulumi codebase: drop its `terraform-settings-management` capability and its `TerraformService` credential fix, keep `guided-iam-provisioning`
+- [ ] 13.2 Update the CloudFormation-generated policy in that change for the DIY backend — add the four S3 backend actions, drop the lock-table DynamoDB actions
+- [ ] 13.3 Record the deferred follow-up to rename the `terraform-*` specs, the `terraform.*` IPC channels, the `hyveon.terraform` preload namespace, and the `/terraform` route

--- a/openspec/changes/migrate-iac-to-pulumi/tasks.md
+++ b/openspec/changes/migrate-iac-to-pulumi/tasks.md
@@ -33,13 +33,14 @@
 
 - [ ] 4.1 Add the pinned engine version constant to `@hyveon/shared`
 - [ ] 4.2 Implement `PulumiEngineService`: memoized resolution, install into `<userData>`, non-throwing constructor, typed provisioning errors, no partial-install reuse
-- [ ] 4.3 Implement the workspace seam: `pulumiCommand`, `pulumiHome`, explicit `workDir` under `userData` (avoiding the never-cleaned tmpdir leak), `PULUMI_BACKEND_URL`, bare stack name
+- [ ] 4.3 Implement the workspace seam: `pulumiCommand`, `pulumiHome`, one stable reused `workDir` per stack under `userData` (relocating the tmpdir leak is not fixing it — reuse, do not create per operation), `PULUMI_BACKEND_URL`, bare stack name
 - [ ] 4.4 Generate a passphrase, store it via `SafeStorageService`, and supply it on every invocation — it must exist before the first stack is created (a missing passphrase is a hard exit-1 under `--non-interactive`, not a prompt), and a missing passphrase for an existing stack must fail loudly rather than generate a replacement
 - [ ] 4.5 Propagate wizard-selected credentials into `envVars` — named profile via `AWS_PROFILE`, pasted keys decrypted in the main process — and add a test asserting no key material reaches streamed output or logs
 - [ ] 4.6 Report engine provisioning, provider plugin download, and the operation itself as distinct phases
 - [ ] 4.7 Implement cancellation: `AbortSignal` for user cancel plus a bounded escalation timer to forceful termination, since the SDK never escalates past `SIGINT`
-- [ ] 4.8 Implement stale-lock detection from `ConcurrentUpdateError`, distinguished from in-app busy, with operator-confirmed recovery via `stack.cancel()`
+- [ ] 4.8 Implement lock recovery keyed on provable ownership: record the identity of every lock the app causes to be taken, reclaim the app's own orphans (including after forceful termination) without prompting, and require operator confirmation showing holder and age for any lock it cannot prove it owns
 - [ ] 4.9 Handle the "succeeded then threw" leaked-promise path so a successful apply is not reported as a failure
+- [ ] 4.10 Add a repeated-operation test asserting the workspace directory count under `userData` does not grow across many previews and applies
 
 ## 5. Bootstrap
 
@@ -47,7 +48,8 @@
 - [ ] 5.2 Rename the tfvars bucket concept to the configuration bucket throughout `BootstrapService` and the wizard step, preserving the versioning and 90-day noncurrent-expiry behavior
 - [ ] 5.3 Apply all four S3 public-access-block settings to both buckets, on creation and on an already-existing bucket — `BootstrapService` currently applies none, while the `terraform/bootstrap/` module it mirrors applies all four
 - [ ] 5.4 Update the `HyveonDeployAll` policy in `docs/docs/setup.md`: add the four DIY-backend S3 actions and `s3:PutPublicAccessBlock`, remove the lock-table DynamoDB actions
-- [ ] 5.5 Update `BootstrapService` tests for the added, removed, and renamed operations
+- [ ] 5.5 Update the `wizard.bootstrap.*` IPC surface for the changed resource set — drop the lock-table channel, add the public-access-block outcome to per-resource status — and mirror it in the preload and typed API
+- [ ] 5.6 Update `BootstrapService` tests and the bootstrap wizard-step tests for the added, removed, and renamed operations, including per-resource `failed` status not masking sibling resources
 
 ## 6. Configuration store
 
@@ -65,10 +67,11 @@
 - [ ] 7.3 Implement `PulumiService.destroy` behind the existing confirmation-token gate; assert no untokened call site exists
 - [ ] 7.4 Implement stack output reads replacing `ConfigService.getTfOutputs()`, degrading to "not deployed yet" for a never-deployed stack
 - [ ] 7.5 Port the plan-hash gate: hash over the saved plan artifact plus the config object's version id, with the staleness check independent of plan-file parseability, and refuse to apply a plan produced by a different engine version (`plan.json`'s `manifest.version`)
-- [ ] 7.6 Port `resolveRollbackTarget` / `confirmRollback` to the JSON config object, restoring historic content byte-for-byte
-- [ ] 7.7 Add the optional structured change summary to `RunRecord` in `@hyveon/shared/runs.ts` and persist it, keeping older records readable
-- [ ] 7.8 Port the 12 typed error classes, dropping the ones with no Pulumi analogue and adding stale-lock and partial-apply errors
-- [ ] 7.9 Delete `TerraformService.ts` and its tests
+- [ ] 7.6 Port `resolveRollbackTarget` / `confirmRollback` to the JSON config object, restoring historic content byte-for-byte, holding the shared lock across restore and plan-record persistence, with compensating semantics when plan creation fails
+- [ ] 7.7 Make apply-lock acquisition a single atomic compare-and-set that is the authoritative gate, not a preceding "workspace is free" check
+- [ ] 7.8 Add the optional structured change summary to `RunRecord` in `@hyveon/shared/runs.ts` and persist it, keeping older records readable
+- [ ] 7.9 Port the 12 typed error classes, dropping the ones with no Pulumi analogue and adding stale-lock and partial-apply errors
+- [ ] 7.10 Delete `TerraformService.ts` and its tests
 
 ## 8. Controllers and preload
 
@@ -106,13 +109,15 @@
 
 - [ ] 12.1 Delete the `terraform/` tree, including `terraform/bootstrap/` and the 376-line `moved.tf`
 - [ ] 12.2 Remove the `terraform.tfstate` `extraResources` entry from `electron-builder.yml` and the `.github/workflows/package.yml` step that fabricates a placeholder state file
-- [ ] 12.3 Port the generated Makefile in `scripts/init-parent.ts` from `aws s3api` / `aws dynamodb` to `@aws-sdk/client-s3` and `@aws-sdk/client-dynamodb`
-- [ ] 12.4 Rewrite `docs/docs/components/terraform.md` for the Pulumi program
-- [ ] 12.5 Update `docs/docs/setup.md`: drop both prerequisites and the "Configure the AWS CLI" section, drop the bootstrap-tfvars CLI walkthrough, and add the explicit warning that an existing Terraform deployment must be destroyed first or infrastructure will be duplicated
-- [ ] 12.6 Update `docs/docs/architecture.md`, `docs/docs/guides/user.md`, `docs/docs/guides/submodule.md`, `docs/docs/intro.md`, and `README.md`
-- [ ] 12.7 Update `CLAUDE.md`: commands, architecture, the `game_servers` source-of-truth section, and the Terraform-variable checklist
-- [ ] 12.8 Assert in docs and tests that no operator-facing instruction requires running any command other than launching the app
-- [ ] 12.9 Confirm `npm run app:lint`, `npm run app:test`, `npm run app:test:e2e`, and `npm run app:test:integration` all pass
+- [ ] 12.3 Replace the `aws s3api` / `aws dynamodb` recipes in the Makefile generated by `scripts/init-parent.ts` with a Node/TypeScript helper the Makefile invokes, which uses `@aws-sdk/client-s3` and `@aws-sdk/client-dynamodb` — a Makefile cannot import an SDK, it can only shell out, so the SDK work has to live in a program
+- [ ] 12.4 Confirm whether the generated-Makefile workflow is maintainer-only; if it is operator-facing, it falls under the app-only operator boundary and the recipe should be removed rather than ported
+- [ ] 12.5 Rewrite `docs/docs/components/terraform.md` for the Pulumi program
+- [ ] 12.6 Update `docs/docs/setup.md`: drop both prerequisites, the "Configure the AWS CLI" section, and the bootstrap-tfvars CLI walkthrough — and add no CLI steps in their place, since this page is operator-facing
+- [ ] 12.7 Record the one-off legacy Terraform teardown in maintainer/contributor notes only, including the duplicate-infrastructure hazard if the Pulumi stack is deployed before the Terraform one is destroyed
+- [ ] 12.8 Update `docs/docs/architecture.md`, `docs/docs/guides/user.md`, `docs/docs/guides/submodule.md`, `docs/docs/intro.md`, and `README.md`
+- [ ] 12.9 Update `CLAUDE.md`: commands, architecture, the `game_servers` source-of-truth section, and the Terraform-variable checklist
+- [ ] 12.10 Assert in docs and tests that no operator-facing instruction requires running any command other than launching the app
+- [ ] 12.11 Confirm `npm run app:lint`, `npm run app:test`, `npm run app:test:e2e`, and `npm run app:test:integration` all pass
 
 ## 13. Follow-up coordination
 


### PR DESCRIPTION
OpenSpec change artifacts only — no code changes. 14 files, +1495 lines.

## Why

Hyveon is a packaged desktop app that cannot provision anything until the operator manually installs the `terraform` binary. `TerraformService.resolveBinaryPath()` shells out to `which terraform` and the first wizard step hard-blocks on the result. A second gate blocks on `aws` being on `PATH` even though **no code path in the app has ever invoked the AWS CLI** — every AWS call already goes through `@aws-sdk/*`.

This proposes removing both prerequisites by moving IaC to Pulumi, whose Automation API can provision its own engine via `PulumiCommand.install()` into a cache under Electron `userData`. The operator installs nothing.

## Why Pulumi and not CDK

| Option | Verdict |
|---|---|
| **CDK for Terraform** | Archived by HashiCorp on 2025-12-10. Also never removed the binary — it synthesized JSON and shelled out to `terraform`. |
| **AWS CDK** | Removes every binary, but closes the multi-cloud door. Google Cloud Deployment Manager lost support 2026-04-01 and Google's replacement is managed Terraform, so a future GCP story would mean a second IaC system, two state models. |
| **Pulumi** | The only remaining option that is multi-cloud, imports natively into TypeScript, and exposes a programmatic engine. |

`@pulumi/pulumi` 3.255.0, `@pulumi/aws` 7.39.0.

## What else this deletes

The app only carries `@cdktf/hcl2json` — plus a `patch-package` patch, a mandatory `external` marking (bundling it prevents Electron from quitting), and hand-rolled `hclSurgeon.ts` / `hclEmit.ts` — because configuration is HCL and the JSON round-trip is lossy. Making configuration a typed object persisted as JSON removes all of it.

`TfvarsService`'s local-file mode is **removed rather than ported**. It writes through an unguarded `writeFileSync` with none of the optimistic locking or version history the S3 path carries, so rollback is quietly unavailable in that mode. S3 becomes the only configuration source; no file on the operator's machine is load-bearing.

This is framed in the design as a **supportability boundary, not a security boundary** — asar is not tamper-proof and the design says so explicitly. The guarantee is that there is no *supported* path by which hand-editing a local file changes what gets deployed.

Side effect: fixes the existing packaging defect where `electron-builder.yml` ships zero `.tf` files, so `getTerraformDir()` currently seeds a directory with no HCL in it.

## Verified, not assumed

Two design facts were checked empirically against CLI 3.255.0 rather than taken from docs:

- **`preview --save-plan` / `up --plan` do NOT require `PULUMI_EXPERIMENTAL`.** All cases exit 0, and the constraint is genuinely enforced — applying a stale plan fails with `error: create is not allowed by the plan`. The env var only gates discoverability (`--plan` is hidden from `--help` without it). **The existing seven-step apply gate survives intact**, including re-hashing an on-disk plan artifact. The plan is engine-version-stamped (`manifest.version`), so an engine upgrade must invalidate outstanding plans — added to the gate.
- **A missing `PULUMI_CONFIG_PASSPHRASE` is a hard exit-1 at stack creation** under `--non-interactive`, which the Automation API always passes. `--secrets-provider=passphrase` and `=default` both produce the identical error; there is no escape hatch on a self-managed backend.

Also found: `pulumi destroy` exposes no `--plan`, so the destroy path's confirmation-token gate is load-bearing in a way the apply path's is not.

## Secrets: audited, not guessed

An audit of what reaches state showed the only secret values are `discord_bot_token` / `discord_public_key` — both `default = ""`, both `ignore_changes = [secret_string]`, both documented "Optional; empty to configure via UI". On the documented path state holds the literal string `"placeholder"`.

So those inputs are **dropped entirely**, making the app's existing SDK path the only route to Secrets Manager. With nothing secret in the stack, the free passphrase provider suffices — no KMS key, no standing monthly cost, which matters for a project whose whole architecture exists to avoid idle spend.

The residual risk is written as two load-bearing constraints rather than a footnote: the passphrase is only safe *because* the stack holds no secrets, and both the design and a spec requirement state that any future change adding stack secrets must revisit the provider first.

## Relationship to #355

`add-one-click-aws-bootstrap` targets the same goal and overlaps directly. This lands first; #355 is then re-proposed:

- Its `terraform-settings-management` capability is **dropped** — it exists to extend `hclSurgeon.ts` / `hclEmit.ts`, which this deletes. Building it first means discarding it later.
- Its `TerraformService.spawnAndStream()` credential fix is **dropped** — that service is deleted. The underlying bug is real and is fixed here instead.
- Its public-access-block hardening is **absorbed** here, since bucket creation moves.
- Its `guided-iam-provisioning` capability **survives unchanged in shape**; only the generated policy's contents shift.

## Scope and risk

Large: 69 resources, a 2741-line service, 13 IPC channels. Structured as **71 tasks across 13 phases**, spikes first, intended to land as a sequence of PRs.

The gating unknown is task 1.3 — **no Pulumi documentation covers running an inline program from inside `app.asar`**. Task 1.6 routes to the OpenTofu auto-download fallback if it fails. That fallback is recorded in the design rather than left implicit.

Migration is destroy-and-redeploy: Hyveon is pre-release, so no state import is needed. The design flags that an operator who deploys without destroying first gets duplicate infrastructure silently, since the two systems share no state.

## Test plan

- `openspec validate migrate-iac-to-pulumi` passes
- Artifacts only — no code, no tests to run, no behaviour change
- Every empirical claim above came from a scratchpad spike that created no AWS resources and left the repo untouched

## Open questions carried into the change

1. Does the `s3://` backend driver authenticate without a login? (Login-less mechanism verified for `file://`; S3 half untested — closable with a read-only `stack ls` during first bootstrap)
2. Does the inline program work from inside `app.asar`? — gates everything
3. `pulumi refresh --preview-only` DIY locking (only matters if a refresh path is added)
4. Does the runs table belong in the stack it manages? (pre-existing circularity, inherited from Terraform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)