### PR TITLE
docs: drop the accept-rate prediction from PR review guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ fetch the skill body from the marketplace repo and follow it manually.
 
 ## PR review workflow
 
-Most suggestions are not actionable — expect to apply roughly one in three.
+Judge each suggestion on its merits.
 
 - **Fix** if genuinely buggy, insecure, crashing, or logically wrong.
 - **Decline** if stylistic, naming, "consider…", or a minor nit — reply with a concrete reason,


### PR DESCRIPTION
One line in `CLAUDE.md`.

```diff
-Most suggestions are not actionable — expect to apply roughly one in three.
+Judge each suggestion on its merits.
```

## Why

The ratio anchored an expectation that doesn't hold across review types. A round on mature code really is mostly nitpicks; a round on freshly written specs can be almost entirely valid, because the findings are internal contradictions rather than style preferences.

This surfaced concretely on #356, where 12 of 13 CodeRabbit findings were sound — including a spec that forbade automatic lock clearing while also mandating a force-kill that orphans locks, and a task instructing a Makefile to import an SDK.

Carrying a numeric prior invites two failure modes: declining sound findings to stay near the ratio, and reading a high accept rate as rubber-stamping rather than as evidence of an early-draft diff. The Fix / Decline / Ask criteria immediately below already say how to judge a suggestion.

## Note on scope

I replaced the sentence rather than deleting it, since the heading would otherwise run straight into the bullet list. The replacement carries no numeric expectation. Happy to drop the line entirely instead if you'd prefer nothing there.

## Test plan

- Documentation only; no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)