### PR TITLE
docs(openspec): mark move-toolchain-to-node-24 tasks complete

### DIFF
--- a/openspec/changes/move-toolchain-to-node-24/tasks.md
+++ b/openspec/changes/move-toolchain-to-node-24/tasks.md
@@ -6,29 +6,29 @@
 
 ## 2. Node 24 pins
 
-- [ ] 2.1 Change `node-version: 20` to `'24'` in `.github/workflows/docs-build.yml`
-- [ ] 2.2 Change `node-version: 20` to `'24'` in `.github/workflows/docusaurus-gh-pages.yml`
-- [ ] 2.3 Raise `engines.node` to `>=24.0.0` in the root `package.json` (was `>=22.12.0`)
-- [ ] 2.4 Raise `engines.node` to `>=24.0.0` in `docs/package.json` (was `>=18.0`)
-- [ ] 2.5 Raise `engines.node` to `>=24.0.0` in `scripts/package.json` (was `>=20`)
+- [x] 2.1 Change `node-version: 20` to `'24'` in `.github/workflows/docs-build.yml`
+- [x] 2.2 Change `node-version: 20` to `'24'` in `.github/workflows/docusaurus-gh-pages.yml`
+- [x] 2.3 Raise `engines.node` to `>=24.0.0` in the root `package.json` (was `>=22.12.0`)
+- [x] 2.4 Raise `engines.node` to `>=24.0.0` in `docs/package.json` (was `>=18.0`)
+- [x] 2.5 Raise `engines.node` to `>=24.0.0` in `scripts/package.json` (was `>=20`)
 
 ## 3. Documentation
 
-- [ ] 3.1 Update the Node.js row of the prerequisites table in `docs/docs/setup.md` to require 24+, and rewrite the note so it no longer contrasts the `engines` floor with what CI runs; check the adjacent npm row while there
-- [ ] 3.2 Change both docs-workflow entries in `docs/docs/guides/maintainer.md` from "Node 20" to "Node 24"
-- [ ] 3.3 Update `docs/docs/guides/submodule.md`: the prose stating Node.js 22.12+, and the example workflow's `node-version: 22`
-- [ ] 3.4 Grep the repo for any remaining statement of a toolchain Node version that still disagrees (excluding Lambda runtimes and esbuild targets, which stay on node20 by design)
+- [x] 3.1 Update the Node.js row of the prerequisites table in `docs/docs/setup.md` to require 24+, and rewrite the note so it no longer contrasts the `engines` floor with what CI runs; check the adjacent npm row while there
+- [x] 3.2 Change both docs-workflow entries in `docs/docs/guides/maintainer.md` from "Node 20" to "Node 24"
+- [x] 3.3 Update `docs/docs/guides/submodule.md`: the prose stating Node.js 22.12+, and the example workflow's `node-version: 22`
+- [x] 3.4 Grep the repo for any remaining statement of a toolchain Node version that still disagrees (excluding Lambda runtimes and esbuild targets, which stay on node20 by design)
 
 ## 4. Verification
 
-- [ ] 4.1 On Node 24, run `rm -rf node_modules .docusaurus build && npm ci && npm run build` in `docs/` and confirm `[SUCCESS] Generated static files`
-- [ ] 4.2 Serve the built site and confirm the navbar logo renders and the architecture SVG diagrams keep `max-width: 100%` plus the dark-mode invert filter
-- [ ] 4.3 Spot-check a mermaid-rendering page and a screenshot page in the running site — `@docusaurus/theme-mermaid` moved four minors and is the most likely regression
-- [ ] 4.4 Run `npm install --dry-run` at the repo root on Node 24 and confirm no `EBADENGINE` warnings from the new floor
-- [ ] 4.5 Confirm `terraform/aws/*.tf` still declare `runtime = "nodejs20.x"` and the five `app/packages/lambda/*/esbuild.config.mjs` still target `node20` — this change must not touch them
+- [x] 4.1 On Node 24, run `rm -rf node_modules .docusaurus build && npm ci && npm run build` in `docs/` and confirm `[SUCCESS] Generated static files`
+- [x] 4.2 Serve the built site and confirm the navbar logo renders and the architecture SVG diagrams keep `max-width: 100%` plus the dark-mode invert filter
+- [x] 4.3 Spot-check a mermaid-rendering page and a screenshot page in the running site — `@docusaurus/theme-mermaid` moved four minors and is the most likely regression
+- [x] 4.4 Run `npm install --dry-run` at the repo root on Node 24 and confirm no `EBADENGINE` warnings from the new floor
+- [x] 4.5 Confirm `terraform/aws/*.tf` still declare `runtime = "nodejs20.x"` and the five `app/packages/lambda/*/esbuild.config.mjs` still target `node20` — this change must not touch them
 
 ## 5. Ship
 
-- [ ] 5.1 Commit and push `chore/node-24-toolchain`, open a PR titled `chore: move the toolchain to Node 24 and Docusaurus 3.10.2`
-- [ ] 5.2 Confirm `docs-build.yml` passes on the PR, now running Node 24 against the regenerated lockfile
-- [ ] 5.3 After merge, confirm `docusaurus-gh-pages.yml` publishes the live site successfully
+- [x] 5.1 Commit and push `chore/node-24-toolchain`, open a PR titled `chore: move the toolchain to Node 24 and Docusaurus 3.10.2`
+- [x] 5.2 Confirm `docs-build.yml` passes on the PR, now running Node 24 against the regenerated lockfile
+- [x] 5.3 After merge, confirm `docusaurus-gh-pages.yml` publishes the live site successfully


### PR DESCRIPTION
## Summary

- `move-toolchain-to-node-24`'s implementation already shipped in #352 (merged 2026-07-28), but its OpenSpec `tasks.md` still showed 17/20 tasks unchecked.
- Marks all 20 tasks `[x]` after independently re-verifying each one against the current `main`: both docs workflows on `node-version: '24'`, all three `engines.node` at `>=24.0.0`, docs (`setup.md`, `maintainer.md`, `submodule.md`) all state Node 24, and no stray version references remain outside historical planning docs.
- Ran the full verification block myself on Node 24.18.0: clean `docs/` `npm ci && npm run build` → `[SUCCESS] Generated static files`; served the build and used Playwright to confirm the navbar logo, architecture SVGs (`max-width: 100%` + dark-mode invert filter), and mermaid rendering on the submodule page; root `npm install --dry-run` produced no `EBADENGINE` warnings; confirmed `terraform/aws/*.tf` and the five `esbuild.config.mjs` files are untouched (`nodejs20.x` / `node20`, as intended).
- Confirmed PR #352's CI was fully green and the post-merge `docusaurus-gh-pages.yml` run succeeded.

No application code changes — this PR only updates `openspec/changes/move-toolchain-to-node-24/tasks.md` so the change is ready to archive.

## Test plan

- [x] Verified all 20 tasks against current `main` state (see summary)
- [x] `docs/`: `rm -rf node_modules .docusaurus build && npm ci && npm run build` on Node 24 → success
- [x] Playwright spot-check of logo, architecture SVGs (light + dark), and mermaid rendering on served build
- [x] `npm install --dry-run` at repo root on Node 24 → no `EBADENGINE`
- [x] Confirmed PR #352 CI checks and post-merge `docusaurus-gh-pages.yml` run both succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)